### PR TITLE
Make the default Azure machine type "Small"

### DIFF
--- a/perfkitbenchmarker/benchmark_spec.py
+++ b/perfkitbenchmarker/benchmark_spec.py
@@ -50,7 +50,7 @@ DEFAULTS = {
     AZURE: {
         IMAGE: ('b39f27a8b8c64d52b05eac6a62ebad85__Ubuntu-'
                 '14_04-LTS-amd64-server-20140724-en-us-30GB'),
-        MACHINE_TYPE: 'small',
+        MACHINE_TYPE: 'Small',
         ZONE: 'East US',
     },
     AWS: {


### PR DESCRIPTION
Newer versions of the Azure CLI have proper-case machine types.
