### PR TITLE
Add unit tests for scratch disks, vm_util, and static vms.

### DIFF
--- a/tests/hpcc_benchmark_test.py
+++ b/tests/hpcc_benchmark_test.py
@@ -24,19 +24,13 @@ from perfkitbenchmarker.benchmarks import hpcc_benchmark
 class HPCCTestCase(unittest.TestCase):
 
   def setUp(self):
-    self.patches = []
-    self.patches.append(mock.patch(hpcc_benchmark.__name__ + '.FLAGS'))
-
-    for p in self.patches:
-      p.start()
+    p = mock.patch(hpcc_benchmark.__name__ + '.FLAGS')
+    p.start()
+    self.addCleanup(p.stop)
 
     path = os.path.join(os.path.dirname(__file__), 'data', 'hpcc-sample.txt')
     with open(path) as fp:
       self.contents = fp.read()
-
-  def tearDown(self):
-    for p in self.patches:
-      p.stop()
 
   def testParseHpcc(self):
     benchmark_spec = mock.MagicMock()

--- a/tests/scratch_disk_test.py
+++ b/tests/scratch_disk_test.py
@@ -1,0 +1,159 @@
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for PerfKitBenchmarker' scratchdisks."""
+
+import abc
+import unittest
+
+import mock
+
+from perfkitbenchmarker import pkb  # NOQA
+from perfkitbenchmarker import disk
+from perfkitbenchmarker import virtual_machine
+from perfkitbenchmarker.aws import aws_disk
+from perfkitbenchmarker.aws import aws_virtual_machine
+from perfkitbenchmarker.aws import util as aws_util
+from perfkitbenchmarker.azure import azure_disk
+from perfkitbenchmarker.azure import azure_network
+from perfkitbenchmarker.azure import azure_virtual_machine
+from perfkitbenchmarker.gcp import gce_disk
+from perfkitbenchmarker.gcp import gce_virtual_machine
+
+
+class ScratchDiskTestMixin(object):
+  """Sets up and tears down some of the mocks needed to test scratch disks."""
+
+  @abc.abstractmethod
+  def _PatchCloudSpecific(self):
+    """Adds any cloud specific patches to self.patches."""
+    pass
+
+  @abc.abstractmethod
+  def _CreateVm(self):
+    """Creates and returns a VM object of the correct type for the cloud."""
+    pass
+
+  @abc.abstractmethod
+  def _GetDiskClass(self):
+    """Returns the disk class for the given cloud."""
+    pass
+
+  def setUp(self):
+    self.patches = []
+
+    vm_prefix = virtual_machine.__name__ + '.BaseVirtualMachine'
+    self.patches.append(
+        mock.patch(vm_prefix + '.FormatDisk'))
+    self.patches.append(
+        mock.patch(vm_prefix + '.MountDisk'))
+
+    # Patch subprocess.Popen to make sure we don't issue any commands to spin up
+    # resources.
+    self.patches.append(mock.patch('subprocess.Popen'))
+
+    self._PatchCloudSpecific()
+
+    for p in self.patches:
+      p.start()
+      self.addCleanup(p.stop)
+
+    # We need the disk class mocks to return new mocks each time they are
+    # called. Otherwise all "disks" instantiated will be the same object.
+    self._GetDiskClass().side_effect = lambda *args, **kwargs: mock.MagicMock()
+
+  def testScratchDisks(self):
+    """Test for creating and deleting scratch disks.
+
+    This test creates two scratch disks on a vm and deletes them, ensuring
+    that the proper calls to create, format, mount, and delete are made.
+    """
+
+    vm = self._CreateVm()
+
+    disk_spec = disk.BaseDiskSpec(None, None, '/mountpoint0')
+    vm.CreateScratchDisk(disk_spec)
+
+    assert len(vm.scratch_disks) == 1, 'Disk not added to scratch disks.'
+
+    scratch_disk = vm.scratch_disks[0]
+
+    scratch_disk.Create.assert_called_once_with()
+    vm.FormatDisk.assert_called_once_with(scratch_disk.GetDevicePath())
+    vm.MountDisk.assert_called_once_with(
+        scratch_disk.GetDevicePath(), '/mountpoint0')
+
+    disk_spec = disk.BaseDiskSpec(None, None, '/mountpoint1')
+    vm.CreateScratchDisk(disk_spec)
+
+    assert len(vm.scratch_disks) == 2, 'Disk not added to scratch disks.'
+
+    scratch_disk = vm.scratch_disks[1]
+
+    scratch_disk.Create.assert_called_once_with()
+    vm.FormatDisk.assert_called_with(scratch_disk.GetDevicePath())
+    vm.MountDisk.assert_called_with(
+        scratch_disk.GetDevicePath(), '/mountpoint1')
+
+    vm.DeleteScratchDisks()
+
+    vm.scratch_disks[0].Delete.assert_called_once_with()
+    vm.scratch_disks[1].Delete.assert_called_once_with()
+
+
+class AzureScratchDiskTest(ScratchDiskTestMixin, unittest.TestCase):
+
+  def _PatchCloudSpecific(self):
+    self.patches.append(mock.patch(azure_disk.__name__ + '.AzureDisk'))
+
+  def _CreateVm(self):
+    network = azure_network.AzureNetwork(None)
+    vm_spec = virtual_machine.BaseVirtualMachineSpec(
+        None, None, None, None, network)
+    return azure_virtual_machine.AzureVirtualMachine(vm_spec)
+
+  def _GetDiskClass(self):
+    return azure_disk.AzureDisk
+
+
+class GceScratchDiskTest(ScratchDiskTestMixin, unittest.TestCase):
+
+  def _PatchCloudSpecific(self):
+    self.patches.append(mock.patch(gce_disk.__name__ + '.GceDisk'))
+
+  def _CreateVm(self):
+    vm_spec = virtual_machine.BaseVirtualMachineSpec(
+        None, None, None, None, None)
+    return gce_virtual_machine.GceVirtualMachine(vm_spec)
+
+  def _GetDiskClass(self):
+    return gce_disk.GceDisk
+
+
+class AwsScratchDiskTest(ScratchDiskTestMixin, unittest.TestCase):
+
+  def _PatchCloudSpecific(self):
+    self.patches.append(mock.patch(aws_disk.__name__ + '.AwsDisk'))
+    self.patches.append(mock.patch(aws_util.__name__ + '.AddDefaultTags'))
+
+  def _CreateVm(self):
+    vm_spec = virtual_machine.BaseVirtualMachineSpec(
+        None, 'zone', None, 'image', None)
+    return aws_virtual_machine.AwsVirtualMachine(vm_spec)
+
+  def _GetDiskClass(self):
+    return aws_disk.AwsDisk
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tests/static_virtual_machine_test.py
+++ b/tests/static_virtual_machine_test.py
@@ -1,0 +1,92 @@
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for PerfKitBenchmarker' StaticVirtualMachine."""
+
+from io import BytesIO
+import unittest
+
+import mock
+
+from perfkitbenchmarker import vm_util
+from perfkitbenchmarker.static_virtual_machine import StaticVirtualMachine
+
+
+class StaticVirtualMachineTest(unittest.TestCase):
+
+  def setUp(self):
+    self._initial_pool = StaticVirtualMachine.vm_pool
+    StaticVirtualMachine.vm_pool = []
+    p = mock.patch(vm_util.__name__ + '.GetTempDir')
+    p.start()
+    self.addCleanup(p.stop)
+
+  def tearDown(self):
+    StaticVirtualMachine.vm_pool = self._initial_pool
+
+  def _AssertStaticVMsEqual(self, vm1, vm2):
+    self.assertEqual(vm1.ip_address, vm2.ip_address)
+    self.assertEqual(vm1.internal_ip, vm2.internal_ip)
+    self.assertEqual(vm1.user_name, vm2.user_name)
+    self.assertEqual(vm1.zone, vm2.zone)
+    self.assertEqual(vm1.ssh_private_key, vm2.ssh_private_key)
+    self.assertEqual(vm1.has_private_key, vm2.has_private_key)
+
+  def testReadFromFile_WrongFormat(self):
+    fp = BytesIO('{}')
+    self.assertRaises(ValueError,
+                      StaticVirtualMachine.ReadStaticVirtualMachineFile,
+                      fp)
+
+  def testReadFromFile_MissingKey(self):
+    fp = BytesIO('[{"ip_address": "10.10.10.3"}]')
+    self.assertRaises(ValueError,
+                      StaticVirtualMachine.ReadStaticVirtualMachineFile,
+                      fp)
+
+  def testReadFromFile_Empty(self):
+    fp = BytesIO('[]')
+    StaticVirtualMachine.ReadStaticVirtualMachineFile(fp)
+    self.assertEqual([], StaticVirtualMachine.vm_pool)
+
+  def testReadFromFile_NoErr(self):
+    s = ('[{'
+         '  "ip_address": "174.12.14.1", '
+         '  "user_name": "perfkitbenchmarker", '
+         '  "keyfile_path": "perfkitbenchmarker.pem" '
+         '}, '
+         '{ '
+         '   "ip_address": "174.12.14.121", '
+         '   "user_name": "ubuntu", '
+         '   "keyfile_path": "rackspace.pem", '
+         '   "internal_ip": "10.10.10.2", '
+         '   "zone": "rackspace_dallas" '
+         '}] ')
+    fp = BytesIO(s)
+    StaticVirtualMachine.ReadStaticVirtualMachineFile(fp)
+
+    vm_pool = StaticVirtualMachine.vm_pool
+    self.assertEqual(2, len(vm_pool))
+    self._AssertStaticVMsEqual(
+        StaticVirtualMachine(
+            '174.12.14.1', 'perfkitbenchmarker',
+            'perfkitbenchmarker.pem'), vm_pool[0])
+    self._AssertStaticVMsEqual(
+        StaticVirtualMachine('174.12.14.121', 'ubuntu', 'rackspace.pem',
+                             '10.10.10.2', 'rackspace_dallas'),
+        vm_pool[1])
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tests/vm_util_test.py
+++ b/tests/vm_util_test.py
@@ -1,0 +1,71 @@
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for perfkitbenchmarker.vm_util."""
+
+import unittest
+
+import mock
+
+from perfkitbenchmarker import vm_util
+
+
+class ShouldRunOnInternalIpAddressTestCase(unittest.TestCase):
+
+  def setUp(self):
+    p = mock.patch(vm_util.__name__ + '.FLAGS')
+    self.flags = p.start()
+    self.flags_patch = p
+    self.sending_vm = mock.MagicMock()
+    self.receiving_vm = mock.MagicMock()
+
+  def tearDown(self):
+    self.flags_patch.stop()
+
+  def _RunTest(self, expectation, ip_addresses, is_reachable=True):
+    self.flags.ip_addresses = ip_addresses
+    self.sending_vm.IsReachable.return_value = is_reachable
+    self.assertEqual(
+        expectation,
+        vm_util.ShouldRunOnInternalIpAddress(
+            self.sending_vm, self.receiving_vm))
+
+  def testExternal_Reachable(self):
+    self._RunTest(False, vm_util.IpAddressSubset.EXTERNAL, True)
+
+  def testExternal_Unreachable(self):
+    self._RunTest(False, vm_util.IpAddressSubset.EXTERNAL, False)
+
+  def testInternal_Reachable(self):
+    self._RunTest(True, vm_util.IpAddressSubset.INTERNAL, True)
+
+  def testInternal_Unreachable(self):
+    self._RunTest(True, vm_util.IpAddressSubset.INTERNAL, False)
+
+  def testBoth_Reachable(self):
+    self._RunTest(True, vm_util.IpAddressSubset.BOTH, True)
+
+  def testBoth_Unreachable(self):
+    self._RunTest(True, vm_util.IpAddressSubset.BOTH, False)
+
+  def testReachable_Reachable(self):
+    self._RunTest(True, vm_util.IpAddressSubset.REACHABLE, True)
+
+  def testReachable_Unreachable(self):
+    self._RunTest(
+        False, vm_util.IpAddressSubset.REACHABLE, False)
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
Also remove patches via `unittest.TestCase.addCleanup(patch.stop)`.
