### PR TITLE
Adjust cassandra num key parameter

### DIFF
--- a/perfkitbenchmarker/benchmarks/cassandra_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/cassandra_benchmark.py
@@ -264,7 +264,7 @@ def RunTestOnLoader(vm, data_nodes_ip_addresses):
       '--num-keys %s -K %s -t %s' % (
           CASSANDRA_DIR, vm.hostname, data_nodes_ip_addresses,
           REPLICATION_FACTOR, CONSISTENCY_LEVEL,
-          FLAGS.num_keys, RETRIES, THREADS))
+          FLAGS.num_keys, RETRIES, THREADS), ignore_failure=True)
 
 
 def InsertTest(benchmark_spec, vm):
@@ -304,6 +304,10 @@ def WaitLoaderForFinishing(vm):
     resp, _ = vm.RemoteCommand('tail -n 1 *results')
     if re.findall(r'END', resp):
       break
+    if re.findall(r'FAILURE', resp):
+      vm.PullFile(RESULTS_DIR, '*results')
+      raise errors.Benchmarks.RunError(
+          'cassandra-stress tool failed, check %s/ for details.' % RESULTS_DIR)
     time.sleep(SLEEP_BETWEEN_CHECK_IN_SECONDS)
 
 


### PR DESCRIPTION
1. Adjusts cassandra benchmark num_keys parameter.
   With n1-standard-1, it runs for 40-50 minutes. With n1-standard-8, it takes 10 minutes to run.
   On AWS and Azure, it runs for about 1 hour. With resource creation and deletion, it will take more than 1 hour to finish.
2. Fixed a bug that on ubuntu systems when using casandra-stress tool multiple times, it will report Keyspace1 creation failed and stop the benchmark.
3. Fixed a bug that when data node dies, the loader node hangs without any progress. It will now copy the results file to cassandra-data folder and raise error.
