### PR TITLE
Adjust cassandra num key parameter, benchmarks:cassandra

### DIFF
--- a/perfkitbenchmarker/benchmarks/cassandra_stress_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/cassandra_stress_benchmark.py
@@ -33,7 +33,7 @@ from perfkitbenchmarker import sample
 from perfkitbenchmarker import vm_util
 
 
-NUM_KEYS_PER_CORE = 5000000
+NUM_KEYS_PER_CORE = 2000000
 
 flags.DEFINE_integer('num_keys', 0,
                      'Number of keys used in cassandra-stress tool. '


### PR DESCRIPTION
1. Adjusts cassandra benchmark num_keys parameter. With n1-standard-1, it runs for 40-50 minutes. With n1-standard-8, it takes 10 minutes to run. On AWS and Azure, it runs for about 1 hour. With resource creation and deletion, it will take more than 1 hour to finish.
2. Fixed a bug that on ubuntu systems when using casandra-stress tool multiple times, it will report Keyspace1 creation failed and stop the benchmark.
3. Fixed a bug that when data node dies, the loader node hangs without any progress. It will now copy the results file to cassandra-data folder and raise error.
