### PR TITLE
Improved docs to refer to project ID instead of project name for GCP.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ it lists, copy the access token and give it to the shell prompt.
 $ gcloud auth login
 ```
 
-You will need a project name before you can run. Please navigate to https://console.developers.google.com and
+You will need a project ID before you can run. Please navigate to https://console.developers.google.com and
 create one.
 
 ## Install AWS CLI and setup authentication
@@ -145,7 +145,7 @@ PerfKitBenchmarks can run benchmarks both on Cloud Providers (GCP, AWS, Azure) a
 
 ## Example run on GCP
 ```
-$ ./pkb.py --project=<GCP project name> --benchmarks=iperf --machine_type=f1-micro
+$ ./pkb.py --project=<GCP project ID> --benchmarks=iperf --machine_type=f1-micro
 ```
 
 ## Example run on AWS

--- a/perfkitbenchmarker/pkb.py
+++ b/perfkitbenchmarker/pkb.py
@@ -88,7 +88,7 @@ flags.DEFINE_integer('parallelism', 1,
                      'The number of benchmarks to run in parallel.')
 flags.DEFINE_list('benchmarks', [], 'Benchmarks that should be run, '
                   'default is all.')
-flags.DEFINE_string('project', None, 'Project name under which '
+flags.DEFINE_string('project', None, 'GCP project ID under which '
                     'to create the virtual machines')
 flags.DEFINE_list(
     'zones', None,


### PR DESCRIPTION
Using the project name instead of the project ID, causes an exception to be
thrown since `gcloud compute disks` expects a project ID and not its name.

This bit me when I tried to run a benchmark on GCP, was getting the following error when I ran `pkb.py`. 

<pre>
2014-12-16 16:25:18,645 INFO     Running: gcloud compute disks describe perfkit-88897fa0-0 --project perfkit --format json --quiet --zone us-central1-a
2014-12-16 16:25:20,014 ERROR    Got exception running _CreateResource: Creation of GceDisk failed.
</pre>


After I enabled debug level tracing, then the problem was obvious:

<pre>
2014-12-16 16:37:04,057 DEBUG    Ran gcloud compute disks describe perfkit-697e4d39-0 --project perfkit --format json --quiet --zone us-central1-f. Got return code (1). STDOUT: STDERR: ERROR: (gcloud.compute.disks.describe) Could not fetch resource:
 - Invalid value for project: perfkit
</pre>
