### PR TITLE
Add "--gcloud_scopes" flags: specifies "--scopes" to be added to GCE

### DIFF
--- a/perfkitbenchmarker/gcp/gce_virtual_machine.py
+++ b/perfkitbenchmarker/gcp/gce_virtual_machine.py
@@ -25,6 +25,7 @@ operate on the VM: boot, shutdown, etc.
 """
 
 import json
+import re
 import tempfile
 
 from perfkitbenchmarker import disk
@@ -39,6 +40,9 @@ flags.DEFINE_integer('gce_num_local_ssds', 0,
                      'The number of ssds that should be added to the VM. Note '
                      'that this is currently only supported in certain zones '
                      '(see https://cloud.google.com/compute/docs/local-ssd).')
+flags.DEFINE_string('gcloud_scopes', None, 'If set, space-separated list of '
+                    'scopes to apply to every created machine')
+
 FLAGS = flags.FLAGS
 
 SET_INTERRUPTS_SH = 'set-interrupts.sh'
@@ -104,6 +108,9 @@ class GceVirtualMachine(virtual_machine.BaseVirtualMachine):
       for _ in range(self.num_ssds):
         create_cmd.append('--local-ssd')
         create_cmd.append('interface=%s' % ssd_interface_option)
+      if FLAGS.gcloud_scopes:
+        create_cmd.extend(['--scopes'] +
+                          re.split(r'[,; ]', FLAGS.gcloud_scopes))
       create_cmd.extend(util.GetDefaultGcloudFlags(self))
       vm_util.IssueCommand(create_cmd)
 


### PR DESCRIPTION
Add "--gcloud_scopes" flag: specifies "--scopes" to be added to GCE instance creation commands.
