### PR TITLE
Remove FLAGS.json_output.

### DIFF
--- a/perfkitbenchmarker/publisher.py
+++ b/perfkitbenchmarker/publisher.py
@@ -37,16 +37,11 @@ flags.DEFINE_boolean(
     'default is False. Official test results are treated and queried '
     'differently from non-official test results.')
 
-flags.DEFINE_boolean(
-    'json_output',
-    True,
-    'A boolean indicating whether to write newline-delimited '
-    'JSON results to the run-specific temporary directory.')
-
 flags.DEFINE_string(
     'json_path',
     None,
-    'A path to write newline-delimited JSON results')
+    'A path to write newline-delimited JSON results '
+    'Default: write to a run-specific temporary directory')
 
 flags.DEFINE_string(
     'bigquery_table',
@@ -402,10 +397,9 @@ class SampleCollector(object):
   def _DefaultPublishers(cls):
     """Gets a list of default publishers."""
     publishers = [LogPublisher(), PrettyPrintStreamPublisher()]
-    if FLAGS.json_output or FLAGS.json_path:
-      default_json_path = vm_util.PrependTempDir(DEFAULT_JSON_OUTPUT_NAME)
-      publishers.append(NewlineDelimitedJSONPublisher(
-          FLAGS.json_path or default_json_path))
+    default_json_path = vm_util.PrependTempDir(DEFAULT_JSON_OUTPUT_NAME)
+    publishers.append(NewlineDelimitedJSONPublisher(
+        FLAGS.json_path or default_json_path))
     if FLAGS.bigquery_table:
       publishers.append(BigQueryPublisher(
           FLAGS.bigquery_table,


### PR DESCRIPTION
Change the behavior to always write a JSON file with samples.  Samples are written to a user-specified location (`--json_path`) or the run-specific temp dir, by default.
