### PR TITLE
Modify hpcc to use 80% of available memory rather than

### DIFF
--- a/perfkitbenchmarker/benchmarks/hpcc_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/hpcc_benchmark.py
@@ -99,7 +99,7 @@ def CreateHpccinf(vm, benchmark_spec):
   if FLAGS.memory_size_mb:
     total_memory = FLAGS.memory_size_mb * 1024 * 1024 * num_vms
   else:
-    stdout, _ = vm.RemoteCommand('free | sed -n 3p | awk {\'print $4\'}')
+    stdout, _ = vm.RemoteCommand("free | sed -n 3p | awk {'print $4'}")
     available_memory = int(stdout)
     total_memory = available_memory * 1024 * num_vms
   total_cpus = vm.num_cpus * num_vms


### PR DESCRIPTION
Reduces HPL problem size to fit 80% of currently available memory rather than 80% of total memory on the system. Some VMs types with especially little memory were failing consistently.
