### PR TITLE
Modifies default logging behavior for IssueCommand

### DIFF
--- a/perfkitbenchmarker/azure/azure_disk.py
+++ b/perfkitbenchmarker/azure/azure_disk.py
@@ -83,7 +83,7 @@ class AzureDisk(disk.BaseDisk):
                 'show',
                 '--json',
                 self.name]
-    stdout, _, _ = vm_util.IssueCommand(show_cmd)
+    stdout, _, _ = vm_util.IssueCommand(show_cmd, suppress_warning=True)
     try:
       json.loads(stdout)
     except ValueError:

--- a/perfkitbenchmarker/azure/azure_network.py
+++ b/perfkitbenchmarker/azure/azure_network.py
@@ -103,7 +103,7 @@ class AzureAffinityGroup(resource.BaseResource):
                 'show',
                 '--json',
                 self.name]
-    stdout, _, _ = vm_util.IssueCommand(show_cmd)
+    stdout, _, _ = vm_util.IssueCommand(show_cmd, suppress_warning=True)
     try:
       json.loads(stdout)
     except ValueError:
@@ -146,7 +146,7 @@ class AzureStorageAccount(resource.BaseResource):
                 'show',
                 '--json',
                 self.name]
-    stdout, _, _ = vm_util.IssueCommand(show_cmd)
+    stdout, _, _ = vm_util.IssueCommand(show_cmd, suppress_warning=True)
     try:
       json.loads(stdout)
     except ValueError:
@@ -189,7 +189,7 @@ class AzureVirtualNetwork(resource.BaseResource):
                 'show',
                 '--json',
                 self.name]
-    stdout, _, _ = vm_util.IssueCommand(show_cmd)
+    stdout, _, _ = vm_util.IssueCommand(show_cmd, suppress_warning=True)
     try:
       json.loads(stdout)
     except ValueError:

--- a/perfkitbenchmarker/azure/azure_virtual_machine.py
+++ b/perfkitbenchmarker/azure/azure_virtual_machine.py
@@ -73,7 +73,7 @@ class AzureService(resource.BaseResource):
                 'show',
                 '--json',
                 self.name]
-    stdout, _, _ = vm_util.IssueCommand(show_cmd)
+    stdout, _, _ = vm_util.IssueCommand(show_cmd, suppress_warning=True)
     try:
       json.loads(stdout)
     except ValueError:
@@ -140,7 +140,7 @@ class AzureVirtualMachine(virtual_machine.BaseVirtualMachine):
                 'show',
                 '--json',
                 self.name]
-    stdout, _, _ = vm_util.IssueCommand(show_cmd)
+    stdout, _, _ = vm_util.IssueCommand(show_cmd, suppress_warning=True)
     try:
       json.loads(stdout)
     except ValueError:

--- a/perfkitbenchmarker/gcp/gce_disk.py
+++ b/perfkitbenchmarker/gcp/gce_disk.py
@@ -71,7 +71,7 @@ class GceDisk(disk.BaseDisk):
                    'compute', 'disks',
                    'describe', self.name]
     getdisk_cmd.extend(util.GetDefaultGcloudFlags(self))
-    stdout, _, _ = vm_util.IssueCommand(getdisk_cmd)
+    stdout, _, _ = vm_util.IssueCommand(getdisk_cmd, suppress_warning=True)
     try:
       json.loads(stdout)
     except ValueError:

--- a/perfkitbenchmarker/gcp/gce_virtual_machine.py
+++ b/perfkitbenchmarker/gcp/gce_virtual_machine.py
@@ -145,7 +145,7 @@ class GceVirtualMachine(virtual_machine.BaseVirtualMachine):
                        'instances',
                        'describe', self.name]
     getinstance_cmd.extend(util.GetDefaultGcloudFlags(self))
-    stdout, _, _ = vm_util.IssueCommand(getinstance_cmd)
+    stdout, _, _ = vm_util.IssueCommand(getinstance_cmd, suppress_warning=True)
     try:
       json.loads(stdout)
     except ValueError:

--- a/perfkitbenchmarker/virtual_machine.py
+++ b/perfkitbenchmarker/virtual_machine.py
@@ -151,7 +151,7 @@ class BaseVirtualMachine(resource.BaseResource):
   @vm_util.Retry(log_errors=False, poll_interval=1)
   def WaitForBootCompletion(self):
     """Waits until VM is has booted."""
-    resp, _ = self.RemoteCommand('hostname', retries=1)
+    resp, _ = self.RemoteCommand('hostname', retries=1, suppress_warning=True)
     if self.bootable_time is None:
       self.bootable_time = time.time()
     if self.hostname is None:
@@ -263,7 +263,8 @@ class BaseVirtualMachine(resource.BaseResource):
 
   def RemoteCommand(self, command, remote_port=22,
                     should_log=False, retries=SSH_RETRIES,
-                    ignore_failure=False, login_shell=False):
+                    ignore_failure=False, login_shell=False,
+                    suppress_warning=False):
     """Runs a command on the VM.
 
     Args:
@@ -276,6 +277,8 @@ class BaseVirtualMachine(resource.BaseResource):
           when it receives a 255 return code.
       ignore_failure: Ignore any failure if set to true.
       login_shell: Run command in a login shell.
+      suppress_warning: Suppress the result logging from IssueCommand when the
+          return code is non-zero.
 
     Returns:
       A tuple of stdout and stderr from running the command.
@@ -295,7 +298,8 @@ class BaseVirtualMachine(resource.BaseResource):
 
       for _ in range(retries):
         stdout, stderr, retcode = vm_util.IssueCommand(
-            ssh_cmd, should_log=should_log)
+            ssh_cmd, force_info_log=should_log,
+            suppress_warning=suppress_warning)
         if retcode != 255:  # Retry on 255 because this indicates an SSH failure
           break
     finally:

--- a/perfkitbenchmarker/vm_util.py
+++ b/perfkitbenchmarker/vm_util.py
@@ -318,15 +318,19 @@ def Retry(poll_interval=POLL_INTERVAL, max_retries=MAX_RETRIES,
   return Wrap
 
 
-def IssueCommand(cmd, should_log=False):
+def IssueCommand(cmd, force_info_log=False, suppress_warning=False):
   """Tries running the provided command once.
 
   Args:
     cmd: A list of strings such as is given to the subprocess.Popen()
         constructor.
-    should_log: A boolean indicating whether the command result should be
-        logged at the info level. Even if it is false, the results will
-        still be logged at the debug level.
+    force_info_log: A boolean indicating whether the command result should
+        always be logged at the info level. Command results will always be
+        logged at the debug level if they aren't logged at another level.
+    suppress_warning: A boolean indicating whether the results should
+        not be logged at the info level in the event of a non-zero
+        return code. When force_info_log is True, the output is logged
+        regardless of suppress_warning's value.
 
   Returns:
     A tuple of stdout, stderr, and retcode from running the provided command.
@@ -343,7 +347,7 @@ def IssueCommand(cmd, should_log=False):
 
   debug_text = ('Ran %s. Got return code (%s). STDOUT: %sSTDERR: %s' %
                 (full_cmd, process.returncode, stdout, stderr))
-  if should_log:
+  if force_info_log or (process.returncode and not suppress_warning):
     logging.info(debug_text)
   else:
     logging.debug(debug_text)
@@ -379,10 +383,8 @@ def IssueRetryableCommand(cmd):
   """
   stdout, stderr, retcode = IssueCommand(cmd)
   if retcode:
-    full_cmd = ' '.join(cmd)
-    error_text = ('Command %s returned a non-zero exit code (%d).\n'
-                  'STDOUT: %sSTDERR: %s') % (full_cmd, retcode, stdout, stderr)
-    raise errors.VmUtil.CalledProcessException(error_text)
+    raise errors.VmUtil.CalledProcessException(
+        'Command returned a non-zero exit code.\n')
   return stdout, stderr
 
 


### PR DESCRIPTION
Modifies logging so that command results with non-zero return codes will  be printed by default. This gives immediate feedback when something goes
wrong rather than forcing the user to go through the log file.