### PR TITLE
Use relative paths to data files in unit tests.

### DIFF
--- a/tests/benchmarks/bonnie_benchmark_test.py
+++ b/tests/benchmarks/bonnie_benchmark_test.py
@@ -24,13 +24,10 @@ from perfkitbenchmarker.benchmarks import bonnie_benchmark
 class BonnieBenchmarkTestCase(unittest.TestCase):
 
   def setUp(self):
-    path = os.path.join('tests/data',
+    path = os.path.join(os.path.dirname(__file__), '..', 'data',
                         'bonnie-plus-plus-sample.txt')
     with open(path) as fp:
       self.contents = fp.read()
-
-  def tearDown(self):
-    pass
 
   def testParseCSVResults(self):
     result = bonnie_benchmark.ParseCSVResults(self.contents)

--- a/tests/benchmarks/mongodb_benchmark_test.py
+++ b/tests/benchmarks/mongodb_benchmark_test.py
@@ -25,13 +25,10 @@ class MongoDbBenchmarkTestCase(unittest.TestCase):
   maxDiff = None
 
   def setUp(self):
-    path = os.path.join('tests/data',
+    path = os.path.join(os.path.dirname(__file__), '..', 'data',
                         'mongodb-sample-result.txt')
     with open(path) as fp:
       self.contents = fp.read()
-
-  def tearDown(self):
-    pass
 
   def testParseResult(self):
     result = mongodb_benchmark.ParseResults(self.contents)

--- a/tests/benchmarks/unixbench_benchmark_test.py
+++ b/tests/benchmarks/unixbench_benchmark_test.py
@@ -25,7 +25,7 @@ class UnixBenchBenchmarkTestCase(unittest.TestCase):
   maxDiff = None
 
   def setUp(self):
-    path = os.path.join('tests/data',
+    path = os.path.join(os.path.dirname(__file__), '..', 'data',
                         'unix-bench-sample-result.txt')
     with open(path) as fp:
       self.contents = fp.read()

--- a/tests/packages/fio_test.py
+++ b/tests/packages/fio_test.py
@@ -28,14 +28,11 @@ class FioTestCase(unittest.TestCase):
   maxDiff = None
 
   def setUp(self):
-    result_path = os.path.join(
-        os.path.join(os.path.dirname(__file__)),
-        '..', 'data', 'fio-parser-sample-result.json')
+    data_dir = os.path.join(os.path.dirname(__file__), '..', 'data')
+    result_path = os.path.join(data_dir, 'fio-parser-sample-result.json')
     with open(result_path) as result_file:
       self.result_contents = json.loads(result_file.read())
-    job_file_path = os.path.join(
-        os.path.join(os.path.dirname(__file__)),
-        '..', 'data', 'fio.job')
+    job_file_path = os.path.join(data_dir, 'fio.job')
     with open(job_file_path) as job_file:
       self.job_contents = job_file.read()
 


### PR DESCRIPTION
Allows running tests from locations other than the root of the
repository.

Also removed some empty tearDown methods.
