### PR TITLE
Provides a flag to execute UnixBench with the > 16 cores patch

### DIFF
--- a/perfkitbenchmarker/benchmarks/unixbench_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/unixbench_benchmark.py
@@ -22,6 +22,7 @@ some memory bandwidth, and disk.
 
 import logging
 
+from perfkitbenchmarker import data
 from perfkitbenchmarker import flags
 from perfkitbenchmarker import regex_util
 from perfkitbenchmarker import sample
@@ -34,7 +35,11 @@ BENCHMARK_INFO = {'name': 'unixbench',
                   'scratch_disk': True,
                   'num_machines': 1}
 
+flags.DEFINE_boolean('unixbench_all_cores', default=False,
+                     help='Applies patch to UnixBench to fix limitation of '
+                     '16 cores limit.')
 
+UNIXBENCH_PATCH_FILE = 'unixbench-16core-limitation.patch'
 SYSTEM_SCORE_REGEX = r'\nSystem Benchmarks Index Score\s+([-+]?[0-9]*\.?[0-9]+)'
 RESULT_REGEX = (
     r'\n([A-Z][\w\-\(\) ]+)\s+([-+]?[0-9]*\.?[0-9]+) (\w+)\s+\('
@@ -50,6 +55,17 @@ def GetInfo():
   return BENCHMARK_INFO
 
 
+def CheckPrerequisites():
+  """Verifies that the required resources for UnixBench are present.
+
+  Raises:
+    perfkitbenchmarker.data.ResourceNotFound: On missing resource.
+  """
+
+  if FLAGS.unixbench_all_cores:
+    data.ResourcePath(UNIXBENCH_PATCH_FILE)
+
+
 def Prepare(benchmark_spec):
   """Install Unixbench on the target vm.
 
@@ -61,6 +77,13 @@ def Prepare(benchmark_spec):
   vm = vms[0]
   logging.info('Unixbench prepare on %s', vm)
   vm.Install('unixbench')
+
+  if FLAGS.unixbench_all_cores:
+    vm.PushDataFile(UNIXBENCH_PATCH_FILE)
+    vm.RemoteCommand('cp %s %s' %
+                     (UNIXBENCH_PATCH_FILE, unixbench.UNIXBENCH_DIR))
+    vm.RemoteCommand('cd %s && patch ./Run %s' %
+                     (unixbench.UNIXBENCH_DIR, UNIXBENCH_PATCH_FILE))
 
 
 def ParseResults(results):

--- a/perfkitbenchmarker/benchmarks/unixbench_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/unixbench_benchmark.py
@@ -36,8 +36,9 @@ BENCHMARK_INFO = {'name': 'unixbench',
                   'num_machines': 1}
 
 flags.DEFINE_boolean('unixbench_all_cores', default=False,
-                     help='Applies patch to UnixBench to fix limitation of '
-                     '16 cores limit.')
+                     help='Setting this flag changes the default behavior of '
+                     'Unix bench. It will now scale to the number of CPUs on '
+                     'the machine vs the limit of 16 CPUs today.')
 
 UNIXBENCH_PATCH_FILE = 'unixbench-16core-limitation.patch'
 SYSTEM_SCORE_REGEX = r'\nSystem Benchmarks Index Score\s+([-+]?[0-9]*\.?[0-9]+)'

--- a/perfkitbenchmarker/data/unixbench-16core-limitation.patch
+++ b/perfkitbenchmarker/data/unixbench-16core-limitation.patch
@@ -1,0 +1,32 @@
+changeset:   3:565c69c33f98
+tag:         tip
+user:        Steven Noonan <steven@uplinklabs.net>
+date:        Sun Mar 06 04:12:12 2011 -0800
+summary:     make maxCopies unbounded for 'system' and 'misc' suites
+
+diff -r b50d02e5c913 -r 565c69c33f98 Run
+--- a/Run	Sun Mar 06 02:03:57 2011 -0800
++++ b/Run	Sun Mar 06 04:12:12 2011 -0800
+@@ -105,10 +105,10 @@
+ 
+ # Configure the categories to which tests can belong.
+ my $testCats = {
+-    'system'    => { 'name' => "System Benchmarks", 'maxCopies' => 16 },
++    'system'    => { 'name' => "System Benchmarks", 'maxCopies' => 0 },
+     '2d'        => { 'name' => "2D Graphics Benchmarks", 'maxCopies' => 1 },
+     '3d'        => { 'name' => "3D Graphics Benchmarks", 'maxCopies' => 1 },
+-    'misc'      => { 'name' => "Non-Index Benchmarks", 'maxCopies' => 16 },
++    'misc'      => { 'name' => "Non-Index Benchmarks", 'maxCopies' => 0 },
+ };
+ 
+ 
+@@ -1328,7 +1328,7 @@
+         # If the benchmark doesn't want to run with this many copies, skip it.
+         my $cat = $params->{'cat'};
+         my $maxCopies = $testCats->{$cat}{'maxCopies'};
+-        next if ($copies > $maxCopies);
++        next if ($maxCopies > 0 && $copies > $maxCopies);
+ 
+         # Run the benchmark.
+         my $bresult = runBenchmark($bench, $params, $verbose, $logFile, $copies);
+


### PR DESCRIPTION
UnixBench by default is designed to only execute up to 16 jobs
concurrently. If your system has more than 16 CPUs available, UnixBench
will not execute enough jobs to fully utilize all the CPUs in the machine,
which will result in a lower score that what the system is capable of.
A patch was submitted to the UnixBench issues that addresses this issue.
This commit allows the user to optionally use this patch by setting the
following flag:

  --unixbench_all_cores

Official link to issue:
https://code.google.com/p/byte-unixbench/issues/detail?id=4