### PR TITLE
Add benchmark as instance metadata for AWS/GCE.

### DIFF
--- a/perfkitbenchmarker/aws/aws_virtual_machine.py
+++ b/perfkitbenchmarker/aws/aws_virtual_machine.py
@@ -272,6 +272,10 @@ class AwsVirtualMachine(virtual_machine.BaseVirtualMachine):
     return super(AwsVirtualMachine, self).SetupLocalDrives(
         mount_path=mount_path)
 
+  def AddMetadata(self, **kwargs):
+    """Adds metadata to the VM."""
+    util.AddTags(self.id, self.region, **kwargs)
+
 
 class DebianBasedAwsVirtualMachine(AwsVirtualMachine,
                                    package_managers.AptMixin):

--- a/perfkitbenchmarker/aws/util.py
+++ b/perfkitbenchmarker/aws/util.py
@@ -55,4 +55,4 @@ def AddDefaultTags(resource_id, region):
     region: The AWS region 'resource_id' was created in.
   """
   tags = {'owner': FLAGS.owner, 'perfkitbenchmarker-run': FLAGS.run_uri}
-  return AddTags(resource_id, region, **tags)
+  AddTags(resource_id, region, **tags)

--- a/perfkitbenchmarker/aws/util.py
+++ b/perfkitbenchmarker/aws/util.py
@@ -21,6 +21,28 @@ AWS_PATH = 'aws'
 FLAGS = flags.FLAGS
 
 
+def AddTags(resource_id, region, **kwargs):
+  """Adds tags to an AWS resource created by PerfKitBenchmarker.
+
+  Args:
+    resource_id: An extant AWS resource to operate on.
+    region: The AWS region 'resource_id' was created in.
+    **kwargs: dict. Key-value pairs to set on the instance.
+  """
+  if not kwargs:
+    return
+
+  tag_cmd = [AWS_PATH,
+             'ec2',
+             'create-tags',
+             '--region=%s' % region,
+             '--resources', resource_id,
+             '--tags']
+  for key, value in kwargs.iteritems():
+    tag_cmd.append('Key={0},Value={1}'.format(key, value))
+  vm_util.IssueRetryableCommand(tag_cmd)
+
+
 def AddDefaultTags(resource_id, region):
   """Adds tags to an AWS resource created by PerfKitBenchmarker.
 
@@ -32,12 +54,5 @@ def AddDefaultTags(resource_id, region):
     resource_id: An extant AWS resource to operate on.
     region: The AWS region 'resource_id' was created in.
   """
-  tag_cmd = [AWS_PATH,
-             'ec2',
-             'create-tags',
-             '--region=%s' % region,
-             '--resources', resource_id,
-             '--tags',
-             'Key=owner,Value="{0}"'.format(FLAGS.owner),
-             'Key=perfkitbenchmarker-run,Value="{0}"'.format(FLAGS.run_uri)]
-  vm_util.IssueRetryableCommand(tag_cmd)
+  tags = {'owner': FLAGS.owner, 'perfkitbenchmarker-run': FLAGS.run_uri}
+  return AddTags(resource_id, region, **tags)

--- a/perfkitbenchmarker/benchmark_spec.py
+++ b/perfkitbenchmarker/benchmark_spec.py
@@ -124,6 +124,7 @@ class BenchmarkSpec(object):
     self.vms = []
     self.vm_dict = {'default': []}
     self.networks = {}
+    self.benchmark_name = benchmark_info['name']
     if hasattr(self, 'config'):
       config_dict = {}
       for section in self.config._config.sections():
@@ -273,6 +274,7 @@ class BenchmarkSpec(object):
     logging.info('VM: %s', vm.ip_address)
     logging.info('Waiting for boot completion.')
     firewall.AllowPort(vm, SSH_PORT)
+    vm.AddMetadata(benchmark=self.benchmark_name)
     vm.WaitForBootCompletion()
     vm.Startup()
     for disk_spec in vm.disk_specs:

--- a/perfkitbenchmarker/gcp/gce_virtual_machine.py
+++ b/perfkitbenchmarker/gcp/gce_virtual_machine.py
@@ -168,7 +168,6 @@ class GceVirtualMachine(virtual_machine.BaseVirtualMachine):
     self.FormatDisk(scratch_disk.GetDevicePath())
     self.MountDisk(scratch_disk.GetDevicePath(), disk_spec.mount_point)
 
-
   def GetName(self):
     """Get a GCE VM's unique name."""
     return self.name
@@ -202,6 +201,16 @@ class GceVirtualMachine(virtual_machine.BaseVirtualMachine):
       self.RemoteCommand(
           'chmod +rx set-interrupts.sh; sudo ./set-interrupts.sh')
     return ret
+
+  def AddMetadata(self, **kwargs):
+    """Adds metadata to the VM via 'gcloud compute instances add-metadata'."""
+    if not kwargs:
+      return
+    cmd = [FLAGS.gcloud_path, 'compute', 'instances', 'add-metadata',
+           '--zone', self.zone, self.name, '--metadata']
+    for key, value in kwargs.iteritems():
+      cmd.append('{0}={1}'.format(key, value))
+    vm_util.IssueCommand(cmd)
 
 
 class DebianBasedGceVirtualMachine(GceVirtualMachine,

--- a/perfkitbenchmarker/virtual_machine.py
+++ b/perfkitbenchmarker/virtual_machine.py
@@ -521,3 +521,18 @@ class BaseVirtualMachine(resource.BaseResource):
       self.FormatDisk(device_path)
       self.MountDisk(device_path, mount_path)
     return True
+
+  def AddMetadata(self, **kwargs):
+    """Add key/value metadata to the instance.
+
+    Adds metadata in the form of key value pairs to the instance. Useful for
+    debugging / introspection.
+
+    The default implementation is a noop. Cloud providers supporting instance
+    metadata should override.
+
+    Args:
+      **kwargs: dict. (tag name, tag value) pairs to set as metadata on the
+        instance.
+    """
+    pass


### PR DESCRIPTION
Tested by running netperf on AWS, GCE; verified that instance metadata was set
correctly.