### PR TITLE
Open jdk fix

### DIFF
--- a/perfkitbenchmarker/package_managers.py
+++ b/perfkitbenchmarker/package_managers.py
@@ -206,7 +206,11 @@ class AptMixin(BasePackageMixin):
                          '/usr/bin/apt-get -y install %s' % (packages))
       self.RemoteCommand(install_command)
     except errors.VmUtil.SshConnectionError as e:
-      self.RemoteCommand('sudo sed -i "s/azure.//g" /etc/apt/sources.list')
+      # TODO(user): Remove code below after Azure fix their package repository,
+      # or add code to recover the sources.list
+      self.RemoteCommand(
+          'sudo sed -i.bk "s/azure.archive.ubuntu.com/archive.ubuntu.com/g" '
+          '/etc/apt/sources.list')
       self.AptUpdate()
       raise e
 

--- a/perfkitbenchmarker/package_managers.py
+++ b/perfkitbenchmarker/package_managers.py
@@ -206,6 +206,7 @@ class AptMixin(BasePackageMixin):
                          '/usr/bin/apt-get -y install %s' % (packages))
       self.RemoteCommand(install_command)
     except errors.VmUtil.SshConnectionError as e:
+      self.RemoteCommand('sudo sed -i "s/azure.//g" /etc/apt/sources.list')
       self.AptUpdate()
       raise e
 

--- a/perfkitbenchmarker/packages/openjdk7.py
+++ b/perfkitbenchmarker/packages/openjdk7.py
@@ -14,7 +14,7 @@
 
 
 """Module containing OpenJDK7 installation and cleanup functions."""
-
+from perfkitbenchmarker import errors
 
 def YumInstall(vm):
   """Installs the OpenJDK7 package on the VM."""
@@ -23,4 +23,9 @@ def YumInstall(vm):
 
 def AptInstall(vm):
   """Installs the OpenJDK7 package on the VM."""
-  vm.InstallPackages('openjdk-7-jdk')
+  try:
+    vm.InstallPackages('openjdk-7-jdk')
+  except errors.VmUtil.SshConnectionError as e:
+    # Using Ubuntu official repository and retry installation later.
+    vm.RemoteCommand('sudo sed -i "s/azure.//g" /etc/apt/sources.list')
+    raise e

--- a/perfkitbenchmarker/packages/openjdk7.py
+++ b/perfkitbenchmarker/packages/openjdk7.py
@@ -14,7 +14,7 @@
 
 
 """Module containing OpenJDK7 installation and cleanup functions."""
-from perfkitbenchmarker import errors
+
 
 def YumInstall(vm):
   """Installs the OpenJDK7 package on the VM."""
@@ -23,9 +23,4 @@ def YumInstall(vm):
 
 def AptInstall(vm):
   """Installs the OpenJDK7 package on the VM."""
-  try:
-    vm.InstallPackages('openjdk-7-jdk')
-  except errors.VmUtil.SshConnectionError as e:
-    # Using Ubuntu official repository and retry installation later.
-    vm.RemoteCommand('sudo sed -i "s/azure.//g" /etc/apt/sources.list')
-    raise e
+  vm.InstallPackages('openjdk-7-jdk')


### PR DESCRIPTION
Fix openjdk-7 and fio package installations on Azure Ubuntu. It replace the addresses in source.list on Azure vms  with official Ubuntu addresses after failed installation.