### PR TITLE
Pass '-P' to df.

### DIFF
--- a/perfkitbenchmarker/virtual_machine.py
+++ b/perfkitbenchmarker/virtual_machine.py
@@ -395,12 +395,12 @@ class BaseVirtualMachine(resource.BaseResource):
 
     Args:
       path: The function will return the amount of space on the file system
-            that conatins this file name.
+            that contains this file name.
 
     Returns:
       The size in 1K blocks of the file system containing the file.
     """
-    df_command = 'df -k | grep %s | awk \'{ print $2 }\'' % (path)
+    df_command = "df -k -P %s | tail -n +2 | awk '{ print $2 }'" % path
     stdout, _ = self.RemoteCommand(df_command)
     return int(stdout)
 


### PR DESCRIPTION
Which enforces the output format as described at
http://pubs.opengroup.org/onlinepubs/007904975/utilities/df.html

Fix for #159. Tested on GCE against Ubuntu {14.04,12.04,14.10}, CentOS{6,7}, RHEL7.