### PR TITLE
Specify scratch directory on the command line in fio_benchmark

### DIFF
--- a/perfkitbenchmarker/benchmarks/fio_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/fio_benchmark.py
@@ -92,8 +92,8 @@ def Run(benchmark_spec):
   vms = benchmark_spec.vms
   vm = vms[0]
   logging.info('FIO running on %s', vm)
-  fio_command = '%s --output-format=json %s' % (
-      fio.FIO_PATH, flags.FLAGS.fio_jobfile)
+  fio_command = '%s --output-format=json --directory=%s %s' % (
+      fio.FIO_PATH, vm.GetScratchDir(), flags.FLAGS.fio_jobfile)
   # TODO(user): This only gives results at the end of a job run
   #      so the program pauses here with no feedback to the user.
   #      This is a pretty lousy experience.

--- a/perfkitbenchmarker/data/fio.job
+++ b/perfkitbenchmarker/data/fio.job
@@ -15,7 +15,6 @@
 [global]
 filesize=10*10*1000*$mb_memory
 filename=fio_test_file
-directory=/scratch0
 ioengine=libaio
 
 [sequential_write]


### PR DESCRIPTION
Rather than hard-coding a value in `fio.job`.

Tested on GCP with PD-SSD and standard PD.

See #161.