### PR TITLE
Clarify how to provide scratch disk for static VMs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,14 +227,16 @@ Next you will want to create a JSON file describing how to connect to the machin
  {"ip_address": "170.200.60.23",
   "user_name": "voellm",
   "keyfile_path": "/home/voellm/perfkitkeys/my_key_file.pem",
+  "scratch_disk_mountpoints": ["/scratch-disk"],
   "zone": "Siberia"}
 ]
 ```
 
-* The ip_address is the address where you want benchmarks to run.
-* The my_key_file.pem is the same key you pass to the ssh machine using the -i option.
-* keyfile_file is where to find the private ssh key.
-* zone can be anything you want.  It is used when publishing results.
+
+* The `ip_address` is the address where you want benchmarks to run.
+* `keyfile_file` is where to find the private ssh key.
+* `zone` can be anything you want.  It is used when publishing results.
+* `scratch_disk_mountpoints` is used by all benchmarks which use disk (i.e., `fio`, `bonnie++`, many others).
 
 I called my file Siberia.json and used it to run iperf from Siberia to a GCP VM in us-central1-f as follows:
 ```

--- a/perfkitbenchmarker/static_virtual_machine.py
+++ b/perfkitbenchmarker/static_virtual_machine.py
@@ -111,7 +111,7 @@ class StaticVirtualMachine(virtual_machine.BaseVirtualMachine):
       internal_ip: string, optional.
       zone: string, optional.
       local_disks: array of strings, optional.
-      scratch_disk_mountpoints: string, optional
+      scratch_disk_mountpoints: array of strings, optional
       os_type: string, optional (see package_managers)
 
     See the constructor for descriptions.
@@ -152,8 +152,15 @@ class StaticVirtualMachine(virtual_machine.BaseVirtualMachine):
       keyfile_path = item['keyfile_path']
       internal_ip = item.get('internal_ip')
       zone = item.get('zone')
-      local_disks = item.get('local_disks')
-      scratch_disk_mountpoints = item.get('scratch_disk_mountpoints')
+      local_disks = item.get('local_disks', [])
+      if not isinstance(local_disks, list):
+        raise ValueError('Expected a list of local disks, got: {0}'.format(
+            local_disks))
+      scratch_disk_mountpoints = item.get('scratch_disk_mountpoints', [])
+      if not isinstance(scratch_disk_mountpoints, list):
+        raise ValueError(
+            'Expected a list of disk mount points, got: {0}'.format(
+                scratch_disk_mountpoints))
       os_type = item.get('os_type')
       vm_class = GetStaticVirtualMachineClass(os_type)
       vm = vm_class(ip_address, user_name, keyfile_path, internal_ip, zone,


### PR DESCRIPTION
* Update README.md
* Throw an error when a user gives a string to
  `scratch_disk_mountpoints`.