### PR TITLE
Add Silo benchmark

### DIFF
--- a/perfkitbenchmarker/benchmark_sets.py
+++ b/perfkitbenchmarker/benchmark_sets.py
@@ -111,7 +111,7 @@ BENCHMARK_SETS = {
     },
     'mit_set': {
         MESSAGE: 'Massachusetts Institute of Technology benchmark set.',
-        BENCHMARK_LIST: ['silo']
+        BENCHMARK_LIST: [STANDARD_SET, 'silo']
     }
 }
 

--- a/perfkitbenchmarker/benchmark_sets.py
+++ b/perfkitbenchmarker/benchmark_sets.py
@@ -111,7 +111,7 @@ BENCHMARK_SETS = {
     },
     'mit_set': {
         MESSAGE: 'Massachusetts Institute of Technology benchmark set.',
-        BENCHMARK_LIST: [STANDARD_SET]
+        BENCHMARK_LIST: ['silo']
     }
 }
 

--- a/perfkitbenchmarker/benchmarks/silo_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/silo_benchmark.py
@@ -1,0 +1,154 @@
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Runs Silo.
+
+Silo is a high performance, scalable in-memory database for modern multicore
+machines
+
+Documentation & code: https://github.com/stephentu/silo
+"""
+
+import logging
+
+from perfkitbenchmarker import flags
+from perfkitbenchmarker import regex_util
+from perfkitbenchmarker import sample
+from perfkitbenchmarker.packages import silo
+
+FLAGS = flags.FLAGS
+
+BENCHMARK_INFO = {'name': 'silo',
+                  'description': 'Runs Silo',
+                  'scratch_disk': False,
+                  'num_machines': 1}
+
+flags.DEFINE_string('silo_benchmark', 'tpcc', 'benchmark to run with silo')
+
+AGG_THPUT_REGEX = r'(agg_throughput):\s+([\d.]+)\s+([a-z/]+)'
+PER_CORE_THPUT_REGEX = r'(avg_per_core_throughput):\s+([\d.]+)\s+([a-z/]+)'
+LAT_REGEX = r'(avg_latency):\s+([\d.]+)\s+([a-z]+)'
+
+
+def GetInfo():
+  return BENCHMARK_INFO
+
+
+def Prepare(benchmark_spec):
+  """Install Silo on the target vm.
+
+  Args:
+    benchmark_spec: The benchmark specification. Contains all data that is
+        required to run the benchmark.
+  """
+  vms = benchmark_spec.vms
+  vm = vms[0]
+  logging.info('Silo prepare on %s', vm)
+  vm.Install('silo')
+
+
+def ParseResults(results):
+  """Result parser for Silo.
+
+  This is what a smaple output looks like:
+  --- table statistics ---
+  table customer_0 size 30000 (+0 records)
+  table customer_name_idx_0 size 30000 (+0 records)
+  table district_0 size 10 (+0 records)
+  table history_0 size 792182 (+762182 records)
+  table item_0 size 100000 (+0 records)
+  table new_order_0 size 122238 (+113238 records)
+  table oorder_0 size 829578 (+799578 records)
+  table oorder_c_id_idx_0 size 829578 (+799578 records)
+  table order_line_0 size 8300509 (+8000949 records)
+  table stock_0 size 100000 (+0 records)
+  table stock_data_0 size 100000 (+0 records)
+  table warehouse_0 size 1 (+0 records)
+  --- benchmark statistics ---
+  runtime: 30.0007 sec
+  memory delta: 768.336 MB
+  memory delta rate: 25.6106 MB/sec
+  logical memory delta: 112.705 MB
+  logical memory delta rate: 3.75673 MB/sec
+  agg_nosync_throughput: 59150.1 ops/sec
+  avg_nosync_per_core_throughput: 59150.1 ops/sec/core
+  agg_throughput: 59150.1 ops/sec
+  avg_per_core_throughput: 59150.1 ops/sec/core
+  agg_persist_throughput: 59150.1 ops/sec
+  avg_per_core_persist_throughput: 59150.1 ops/sec/core
+  avg_latency: 0.0168378 ms
+  avg_persist_latency: 0 ms
+  agg_abort_rate: 0 aborts/sec
+  avg_per_core_abort_rate: 0 aborts/sec/core
+  txn breakdown: [[Delivery, 70967], [NewOrder, 799578], [OrderStatus, 70813],
+  [Payment, 762182], [StockLevel, 71006]]
+  --- system counters (for benchmark) ---
+  --- perf counters (if enabled, for benchmark) ---
+  --- allocator stats ---
+  [allocator] ncpus=0
+  ---------------------------------------
+  """
+  samples = []
+
+  # agg throughput
+  match = regex_util.ExtractAllMatches(AGG_THPUT_REGEX, results)[0]
+  samples.append(sample.Sample(
+      match[0], float(match[1]), match[2]))
+
+  # per core throughput
+  match = regex_util.ExtractAllMatches(PER_CORE_THPUT_REGEX, results)[0]
+  samples.append(sample.Sample(
+      match[0], float(match[1]), match[2]))
+
+  # avg latency
+  match = regex_util.ExtractAllMatches(LAT_REGEX, results)[0]
+  samples.append(sample.Sample(
+      match[0], float(match[1]), match[2]))
+
+  return samples
+
+
+def Run(benchmark_spec):
+  """Run Silo on the target vm.
+
+  Args:
+    benchmark_spec: The benchmark specification. Contains all data that is
+        required to run the benchmark.
+
+  Returns:
+    A list of sample.Sample objects.
+  """
+  vms = benchmark_spec.vms
+  vm = vms[0]
+  nthreads = vm.num_cpus
+  logging.info('Silo running on %s', vm)
+  command = 'cd {0} && '\
+            'out-perf.masstree/benchmarks/dbtest '\
+            '--bench {1} --num-threads {2} --verbose'.format(
+                silo.SILO_DIR,
+                FLAGS.silo_benchmark,
+                nthreads)
+  logging.info('Silo Results:')
+  stdout, stderr = vm.RemoteCommand(command, should_log=True)
+  return ParseResults(stderr)
+
+
+def Cleanup(benchmark_spec):
+  """Cleanup Silo on the target vm.
+
+  Args:
+    benchmark_spec: The benchmark specification. Contains all data that is
+        required to run the benchmark.
+  """
+  pass

--- a/perfkitbenchmarker/benchmarks/silo_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/silo_benchmark.py
@@ -1,5 +1,3 @@
-# Copyright 2014 Google Inc. All rights reserved.
-#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -34,11 +32,15 @@ BENCHMARK_INFO = {'name': 'silo',
                   'scratch_disk': False,
                   'num_machines': 1}
 
-flags.DEFINE_string('silo_benchmark', 'tpcc', 'benchmark to run with silo')
+flags.DEFINE_string('silo_benchmark', 'tpcc',
+                    'benchmark to run with silo. Options include tpcc, ycsb,'
+                    ' queue, bid')
 
-AGG_THPUT_REGEX = r'(agg_throughput):\s+([\d.]+)\s+([a-z/]+)'
-PER_CORE_THPUT_REGEX = r'(avg_per_core_throughput):\s+([\d.]+)\s+([a-z/]+)'
-LAT_REGEX = r'(avg_latency):\s+([\d.]+)\s+([a-z]+)'
+AGG_THPUT_REGEX = \
+    r'(agg_throughput):\s+(\d+\.?\d*e?[+-]?\d*)\s+([a-z/]+)'
+PER_CORE_THPUT_REGEX = \
+    r'(avg_per_core_throughput):\s+(\d+\.?\d*e?[+-]?\d*)\s+([a-z/]+)'
+LAT_REGEX = r'(avg_latency):\s+(\d+\.?\d*e?[+-]?\d*)\s+([a-z]+)'
 
 
 def GetInfo():
@@ -54,7 +56,7 @@ def Prepare(benchmark_spec):
   """
   vms = benchmark_spec.vms
   vm = vms[0]
-  logging.info('Silo prepare on %s', vm)
+  logging.info('Preparing Silo on %s', vm)
   vm.Install('silo')
 
 

--- a/perfkitbenchmarker/packages/silo.py
+++ b/perfkitbenchmarker/packages/silo.py
@@ -1,0 +1,49 @@
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Module containing Silo installation and cleanup functions."""
+
+from perfkitbenchmarker import vm_util
+
+GIT_REPO = 'https://github.com/stephentu/silo.git'
+GIT_TAG = '62d2d498984bf69d3b46a74e310e1fd12fd1f692'
+SILO_DIR = '%s/silo' % vm_util.VM_TMP_DIR
+APT_PACKAGES = ('libjemalloc-dev libnuma-dev libdb++-dev '
+                'libmysqld-dev libaio-dev libssl-dev')
+YUM_PACKAGES = ('jemalloc-devel numactl-devel libdb-cxx-devel mysql-devel '
+                'libaio-devel openssl-devel')
+
+
+def _Install(vm):
+  """Installs the Silo package on the VM."""
+  nthreads = vm.num_cpus * 2
+  vm.Install('build_tools')
+  vm.RemoteCommand('git clone {0} {1}'.format(GIT_REPO, SILO_DIR))
+  vm.RemoteCommand('cd {0} && git checkout {1}'.format(SILO_DIR,
+                                                       GIT_TAG))
+  vm.RemoteCommand('cd {0} && MODE=perf DEBUG=0 CHECK_INVARIANTS=0 make\
+          -j{1} dbtest'.format(SILO_DIR, nthreads))
+
+
+def YumInstall(vm):
+  """Installs the Silo package on the VM."""
+  vm.InstallPackages(YUM_PACKAGES)
+  _Install(vm)
+
+
+def AptInstall(vm):
+  """Installs the Silo package on the VM."""
+  vm.InstallPackages(APT_PACKAGES)
+  _Install(vm)


### PR DESCRIPTION
Added benchmark silo (https://github.com/stephentu/silo) to the mit set. Silo is a fast, scalable in-memory database for multicores.