### PR TITLE
Fix benchmark sequence order for single-threaded runs.

### DIFF
--- a/perfkitbenchmarker/pkb.py
+++ b/perfkitbenchmarker/pkb.py
@@ -294,14 +294,15 @@ def RunBenchmarks(publish=True):
   try:
     benchmark_list = benchmark_sets.GetBenchmarksFromFlags()
     total_benchmarks = len(benchmark_list)
-    sequence_range = range(total_benchmarks, 0, -1)
     if FLAGS.parallelism > 1:
+      sequence_range = range(total_benchmarks, 0, -1)
       args = [((benchmark, collector, sequence_counter, total_benchmarks), {})
               for benchmark, sequence_counter
               in zip(benchmark_list, sequence_range)]
       vm_util.RunThreaded(
           RunBenchmark, args, max_concurrent_threads=FLAGS.parallelism)
     else:
+      sequence_range = range(1, total_benchmarks + 1)
       for benchmark, sequence_counter in zip(benchmark_list, sequence_range):
         RunBenchmark(benchmark, collector, sequence_counter, total_benchmarks)
   finally:


### PR DESCRIPTION
Fix single-threaded runs so that the first executed benchmark is given
sequence number 1, and the last is given sequence number N.