### PR TITLE
Show metadata in StreamPublisher.

### DIFF
--- a/perfkitbenchmarker/publisher.py
+++ b/perfkitbenchmarker/publisher.py
@@ -165,19 +165,27 @@ class SamplePublisher(object):
 class PrettyPrintStreamPublisher(SamplePublisher):
   """Writes samples to an output stream, defaulting to stdout.
 
-  Samples are pretty-printed and summarized. Example output:
+  Samples are pretty-printed and summarized. Example output (truncated):
 
-    -------------------------PerfKitBenchmarker Results Summary----------------
-    NETPERF_SIMPLE:
-            TCP_RR_Transaction_Rate 714.72 transactions_per_second
-            TCP_RR_Transaction_Rate 2950.92 transactions_per_second
-            TCP_CRR_Transaction_Rate 201.6 transactions_per_second
-            TCP_CRR_Transaction_Rate 793.59 transactions_per_second
-            TCP_STREAM_Throughput 283.25 Mbits/sec
-            TCP_STREAM_Throughput 989.06 Mbits/sec
-            UDP_RR_Transaction_Rate 107.9 transactions_per_second
-            UDP_RR_Transaction_Rate 3018.51 transactions_per_second
-            End to End Runtime 471.35810709 seconds
+    -------------------------PerfKitBenchmarker Results Summary--------------
+    COREMARK:
+      num_cpus="4"
+      Coremark Score                    44145.237832
+      End to End Runtime                  289.477677 seconds
+    NETPERF:
+      client_machine_type="n1-standard-4" client_zone="us-central1-a" ....
+      TCP_RR_Transaction_Rate  1354.04 transactions_per_second (ip_type="ext ...
+      TCP_RR_Transaction_Rate  3972.70 transactions_per_second (ip_type="int ...
+      TCP_CRR_Transaction_Rate  449.69 transactions_per_second (ip_type="ext ...
+      TCP_CRR_Transaction_Rate 1271.68 transactions_per_second (ip_type="int ...
+      TCP_STREAM_Throughput    1171.04 Mbits/sec               (ip_type="ext ...
+      TCP_STREAM_Throughput    6253.24 Mbits/sec               (ip_type="int ...
+      UDP_RR_Transaction_Rate  1380.37 transactions_per_second (ip_type="ext ...
+      UDP_RR_Transaction_Rate  4336.37 transactions_per_second (ip_type="int ...
+      End to End Runtime        444.33 seconds
+
+    -------------------------
+    For all tests: cloud="GCP" image="ubuntu-14-04" machine_type="n1-standa ...
 
   Attributes:
     stream: File-like object. Output stream to print samples.

--- a/perfkitbenchmarker/publisher.py
+++ b/perfkitbenchmarker/publisher.py
@@ -182,25 +182,87 @@ class PrettyPrintStreamPublisher(SamplePublisher):
   Attributes:
     stream: File-like object. Output stream to print samples.
   """
+
   def __init__(self, stream=None):
     self.stream = stream or sys.stdout
 
   def __repr__(self):
     return '<{0} stream={1}>'.format(type(self).__name__, self.stream)
 
+  def _FindConstantMetadataKeys(self, samples):
+    """Finds metadata keys which are constant across a collection of samples.
+
+    Args:
+      samples: List of dicts, as passed to SamplePublisher.PublishSamples.
+
+    Returns:
+      The set of metadata keys for which all samples in 'samples' have the same
+      value.
+    """
+    unique_values = {}
+
+    for sample in samples:
+      for k, v in sample['metadata'].iteritems():
+        if len(unique_values.setdefault(k, set())) < 2:
+          unique_values[k].add(v)
+
+    # Find keys which are not present in all samples
+    for sample in samples:
+      for k in frozenset(unique_values) - frozenset(sample['metadata']):
+        unique_values[k].add(None)
+
+    return frozenset(k for k, v in unique_values.iteritems() if len(v) == 1)
+
+  def _FormatMetadata(self, metadata):
+    """Format 'metadata' as space-delimited key="value" pairs."""
+    return ' '.join('{0}="{1}"'.format(k, v)
+                    for k, v in sorted(metadata.iteritems()))
+
   def PublishSamples(self, samples):
+    dashes = '-' * 25
+    self.stream.write('\n' + dashes +
+                      'PerfKitBenchmarker Results Summary' +
+                      dashes + '\n')
+
+    if not samples:
+      return
+
     key = operator.itemgetter('test')
     samples = sorted(samples, key=key)
-    data = [
-        '\n' + '-' * 25 + 'PerfKitBenchmarker Results Summary' + '-' * 25 +
-        '\n']
+    globally_constant_keys = self._FindConstantMetadataKeys(samples)
+
     for benchmark, test_samples in itertools.groupby(samples, key):
-      data.append('%s:\n' % benchmark.upper())
+      test_samples = list(test_samples)
+      # Drop end-to-end runtime: it always has no metadata.
+      non_endtoend_samples = [i for i in test_samples
+                              if i['metric'] != 'End to End Runtime']
+      locally_constant_keys = (
+          self._FindConstantMetadataKeys(non_endtoend_samples) -
+          globally_constant_keys)
+      all_constant_meta = globally_constant_keys.union(locally_constant_keys)
+
+      benchmark_meta = {k: v for k, v in test_samples[0]['metadata'].iteritems()
+                        if k in locally_constant_keys}
+      self.stream.write('{0}:\n'.format(benchmark.upper()))
+
+      if benchmark_meta:
+        self.stream.write('  {0}\n'.format(
+            self._FormatMetadata(benchmark_meta)))
+
       for sample in test_samples:
-        data.append('\t%s %s %s\n' %
-                    (sample['metric'], sample['value'], sample['unit']))
-    data.append('\n')
-    self.stream.write(''.join(data))
+        meta = {k: v for k, v in sample['metadata'].iteritems()
+                if k not in all_constant_meta}
+        self.stream.write('  {0:<30s} {1:>15f} {2:<30s}'.format(
+            sample['metric'], sample['value'], sample['unit']))
+        if meta:
+          self.stream.write(' ({0})'.format(self._FormatMetadata(meta)))
+        self.stream.write('\n')
+
+    global_meta = {k: v for k, v in samples[0]['metadata'].iteritems()
+                   if k in globally_constant_keys}
+    self.stream.write('\n' + dashes + '\n')
+    self.stream.write('For all tests: {0}\n'.format(
+        self._FormatMetadata(global_meta)))
 
 
 class LogPublisher(SamplePublisher):

--- a/tests/publisher_test.py
+++ b/tests/publisher_test.py
@@ -44,9 +44,12 @@ class PrettyPrintStreamPublisherTestCase(unittest.TestCase):
   def testWritesToStream(self):
     stream = io.BytesIO()
     instance = publisher.PrettyPrintStreamPublisher(stream)
-    samples = [{'test': 'testb', 'metric': '1', 'value': 1.0, 'unit': 'MB'},
-               {'test': 'testb', 'metric': '2', 'value': 14.0, 'unit': 'MB'},
-               {'test': 'testa', 'metric': '3', 'value': 47.0, 'unit': 'us'}]
+    samples = [{'test': 'testb', 'metric': '1', 'value': 1.0, 'unit': 'MB',
+                'metadata': {}},
+               {'test': 'testb', 'metric': '2', 'value': 14.0, 'unit': 'MB',
+                'metadata': {}},
+               {'test': 'testa', 'metric': '3', 'value': 47.0, 'unit': 'us',
+                'metadata': {}}]
     instance.PublishSamples(samples)
 
     value = stream.getvalue()


### PR DESCRIPTION
This modifies the brief output printed at the end of a run to include sample metadata.

Example output for `pkb.py --benchmarks --machine_type n1-standard-4 --benchmarks coremark,netperf`:

```
-------------------------PerfKitBenchmarker Results Summary-------------------------
COREMARK:
  Coremark Score                    43766.070354                                (num_cpus="4")
  End to End Runtime                  233.149943 seconds                       
NETPERF:
  TCP_RR_Transaction_Rate            1522.960000 transactions_per_second        (client_machine_type="n1-standard-4" client_zone="us-central1-a" ip_type="external" receiving_zone="us-central1-a" sending_zone="us-central1-a" server_machine_type="n1-standard-4" server_zone="us-central1-a")
  TCP_RR_Transaction_Rate            4145.060000 transactions_per_second        (client_machine_type="n1-standard-4" client_zone="us-central1-a" ip_type="internal" receiving_zone="us-central1-a" sending_zone="us-central1-a" server_machine_type="n1-standard-4" server_zone="us-central1-a")
  TCP_CRR_Transaction_Rate            427.280000 transactions_per_second        (client_machine_type="n1-standard-4" client_zone="us-central1-a" ip_type="external" receiving_zone="us-central1-a" sending_zone="us-central1-a" server_machine_type="n1-standard-4" server_zone="us-central1-a")
  TCP_CRR_Transaction_Rate           1149.640000 transactions_per_second        (client_machine_type="n1-standard-4" client_zone="us-central1-a" ip_type="internal" receiving_zone="us-central1-a" sending_zone="us-central1-a" server_machine_type="n1-standard-4" server_zone="us-central1-a")
  TCP_STREAM_Throughput               988.530000 Mbits/sec                      (client_machine_type="n1-standard-4" client_zone="us-central1-a" ip_type="external" receiving_zone="us-central1-a" sending_zone="us-central1-a" server_machine_type="n1-standard-4" server_zone="us-central1-a")
  TCP_STREAM_Throughput              6052.190000 Mbits/sec                      (client_machine_type="n1-standard-4" client_zone="us-central1-a" ip_type="internal" receiving_zone="us-central1-a" sending_zone="us-central1-a" server_machine_type="n1-standard-4" server_zone="us-central1-a")
  UDP_RR_Transaction_Rate            1497.170000 transactions_per_second        (client_machine_type="n1-standard-4" client_zone="us-central1-a" ip_type="external" receiving_zone="us-central1-a" sending_zone="us-central1-a" server_machine_type="n1-standard-4" server_zone="us-central1-a")
  UDP_RR_Transaction_Rate            4983.690000 transactions_per_second        (client_machine_type="n1-standard-4" client_zone="us-central1-a" ip_type="internal" receiving_zone="us-central1-a" sending_zone="us-central1-a" server_machine_type="n1-standard-4" server_zone="us-central1-a")
  End to End Runtime                  434.152236 seconds                       

-------------------------
For all tests: cloud="GCP" image="ubuntu-14-04" machine_type="n1-standard-4" perfkitbenchmarker_version="v0.11.1-23-g101e433" zones="us-central1-a"
```