### PR TITLE
Adds unit test to check proper handling of scratch disk property

### DIFF
--- a/tests/static_virtual_machine_test.py
+++ b/tests/static_virtual_machine_test.py
@@ -87,6 +87,17 @@ class StaticVirtualMachineTest(unittest.TestCase):
                              '10.10.10.2', 'rackspace_dallas'),
         vm_pool[1])
 
+  def testReadFromFile_InvalidScratchDisksType(self):
+    s = ('[{'
+         '  "ip_address": "174.12.14.1", '
+         '  "user_name": "perfkitbenchmarker", '
+         '  "keyfile_path": "perfkitbenchmarker.pem", '
+         '  "scratch_disk_mountpoints": "/tmp/google-pkb" '
+         '}]')
+    fp = BytesIO(s)
+    self.assertRaises(ValueError,
+                      StaticVirtualMachine.ReadStaticVirtualMachineFile,
+                      fp)
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
Note: for some reason nosetests (in my laptop) doesn't run most of the tests in tests/static_virtual_machine_test.py

When executing the following to just run my test I get this error, am I missing something?

```
(perfkit)(λ) ⇒ ~/programming/github.com/GoogleCloudPlatform/PerfKitBenchmarker ⇒
$ nosetests tests/static_virtual_machine_test.py:testReadFromFile_InvalidScratchDisksType

ERROR: Unknown test
  vi +42 /home/carl6796/.virtualenvs/perfkit/local/lib/python2.7/site-packages/nose/failure.py  # runTest
    raise self.exc_class(self.exc_val)
ValueError: No such test testReadFromFile_InvalidScratchDisksType

1 test, 0 failures, 1 error in 0.0s
```

and running nosetests through the pre-hook doesn't seem to increase the total tests count (should be 87)
```
(perfkit)(λ) ⇒ ~/programming/github.com/GoogleCloudPlatform/PerfKitBenchmarker ⇒
$ git commit

OK!  86 tests, 0 failures, 0 errors in 0.1s
[bug/static_vm_scratch_disks 7cc00b4] Adds unit test to check proper handling of scratch disk property
 1 file changed, 11 insertions(+)

```

