### PR TITLE
Fio parser improvement

### DIFF
--- a/perfkitbenchmarker/benchmarks/block_storage_workloads_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/block_storage_workloads_benchmark.py
@@ -42,6 +42,7 @@ For AWS, where use PD, we should use EBS-GP and EBS Magnetic, for PD-SSD use
 EBS-GP and PIOPS.
 """
 
+import json
 import logging
 import re
 
@@ -102,70 +103,6 @@ def Prepare(benchmark_spec):
   vm.Install('fio')
 
 
-def ParseFioResult(res):
-  """Parse result from fio commands.
-
-  Args:
-    res: Result from fio commands in string format.
-  Returns:
-    A list of tuples represents latency. Each tuple contains unit and
-    latency number.
-    A list of tuples represents bandwidth. Each tuple contains aggrb,
-    unit of aggrb, minb, unit of minb, maxb, unit of maxb, mint, unit of mint,
-    maxt, unit of maxt.
-  """
-  latency = re.findall(r'\s+lat \((\w+)\)[\s:]+'
-                       r'min%smax%savg%sstdev%s' % (
-                           LATENCY_REGEX, LATENCY_REGEX,
-                           LATENCY_REGEX, LATENCY_REGEX), res)
-  bandwidth = re.findall(
-      r'aggrb=%s, minb=%s, maxb=%s, mint=%s, maxt=%s' % (
-          BANDWIDTH_REGEX, BANDWIDTH_REGEX, BANDWIDTH_REGEX, BANDWIDTH_REGEX,
-          BANDWIDTH_REGEX), res)
-  print latency, bandwidth
-  return latency, bandwidth
-
-
-def CreateSampleFromBandwidthTuple(result, test, iodepth, test_size):
-  """Create a sample from bandwidth result tuple.
-
-  Args:
-    result: A tuple, containing (aggrb, unit of aggrb, minb, unit of minb,
-        maxb, unit of maxb, mint, unit of mint, maxt, unit of maxt).
-    test: Name of test.
-    iodepth: IO depth parameter used by fio command.
-  Returns:
-    A sample.Sample.
-  """
-  return sample.Sample(test, float(result[0]), result[1],
-                       {'minb': result[2] + result[3],
-                        'maxb': result[4] + result[5],
-                        'mint': result[6] + result[7],
-                        'maxt': result[8] + result[9],
-                        'max_jobs': FLAGS.maxjobs,
-                        'iodepth': iodepth,
-                        'test_size': test_size})
-
-
-def CreateSampleFromLatencyTuple(result, test, iodepth, test_size):
-  """Create a sample from latency result tuple.
-
-  Args:
-    result: A tuple, containing (unit, min, max, avg, stdev).
-    test: Name of test.
-    iodepth: IO depth parameter used by fio command.
-  Returns:
-    A sample.Sample.
-  """
-  return sample.Sample(test, float(result[3]), result[0],
-                       {'min': result[1] + result[0],
-                        'max': result[2] + result[0],
-                        'stdev': result[4] + result[0],
-                        'max_jobs': FLAGS.maxjobs,
-                        'iodepth': iodepth,
-                        'test_size': test_size})
-
-
 def RunSimulatedLogging(vm):
   """Spawn fio to simulate logging and gather the results.
   Args:
@@ -175,7 +112,7 @@ def RunSimulatedLogging(vm):
   """
   test_size = vm.total_memory_kb
   cmd = (
-      '%s '
+      '%s --output-format=json '
       '--filesize=10g '
       '--directory=%s '
       '--ioengine=libaio '
@@ -204,21 +141,7 @@ def RunSimulatedLogging(vm):
       '--rw=read ') % (test_size / 10)
   logging.info('FIO Results for simulated %s', LOGGING)
   res, _ = vm.RemoteCommand(cmd, should_log=True)
-  latency, bandwidth = ParseFioResult(res)
-  results = [
-      CreateSampleFromBandwidthTuple(bandwidth[0],
-                                     'sequential_write:bandwidth',
-                                     DEFAULT_IODEPTH, test_size),
-      CreateSampleFromBandwidthTuple(bandwidth[1], 'random_read:bandwidth',
-                                     DEFAULT_IODEPTH, test_size),
-      CreateSampleFromBandwidthTuple(bandwidth[2], 'sequential_read:bandwidth',
-                                     DEFAULT_IODEPTH, test_size),
-      CreateSampleFromLatencyTuple(latency[0], 'sequential_write:latency',
-                                   DEFAULT_IODEPTH, test_size),
-      CreateSampleFromLatencyTuple(latency[1], 'random_read:latency',
-                                   DEFAULT_IODEPTH, test_size),
-      CreateSampleFromLatencyTuple(latency[2], 'sequential_read:latency',
-                                   DEFAULT_IODEPTH, test_size)]
+  fio.ParseResults(cmd, json.loads(res))
   return results
 
 

--- a/perfkitbenchmarker/benchmarks/block_storage_workloads_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/block_storage_workloads_benchmark.py
@@ -146,7 +146,8 @@ def RunSimulatedLogging(vm):
       '--stonewall '
       '--rw=read ') % (test_size / 10)
   logging.info('FIO Results for simulated %s', LOGGING)
-  res, _ = vm.RemoteCommand(fio.FIO_CMD_PREFIX + cmd, should_log=True)
+  res, _ = vm.RemoteCommand('%s %s' % (fio.FIO_CMD_PREFIX, cmd),
+                            should_log=True)
   results = fio.ParseResults(fio.FioParametersToJob(cmd), json.loads(res))
   UpdateWorkloadMetadata(results)
   return results
@@ -194,7 +195,8 @@ def RunSimulatedDatabase(vm):
         '--rwmixwrite=10 '
         '--end_fsync=1 ')
     logging.info('FIO Results for simulated %s, iodepth %s', DATABASE, depth)
-    res, _ = vm.RemoteCommand(fio.FIO_CMD_PREFIX + cmd, should_log=True)
+    res, _ = vm.RemoteCommand('%s %s' % (fio.FIO_CMD_PREFIX, cmd),
+                              should_log=True)
     results.extend(
         fio.ParseResults(fio.FioParametersToJob(cmd), json.loads(res)))
   UpdateWorkloadMetadata(results)
@@ -237,7 +239,8 @@ def RunSimulatedStreaming(vm):
         '--stonewall '
         '--rw=read ')
     logging.info('FIO Results for simulated %s', STREAMING)
-    res, _ = vm.RemoteCommand(fio.FIO_CMD_PREFIX + cmd, should_log=True)
+    res, _ = vm.RemoteCommand('%s %s' % (fio.FIO_CMD_PREFIX, cmd),
+                              should_log=True)
     results.extend(
         fio.ParseResults(fio.FioParametersToJob(cmd), json.loads(res)))
   UpdateWorkloadMetadata(results)

--- a/perfkitbenchmarker/packages/fio.py
+++ b/perfkitbenchmarker/packages/fio.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 """Module containing fio installation, cleanup, parsing functions."""
+import ConfigParser
+import io
+
 from perfkitbenchmarker import regex_util
 from perfkitbenchmarker import sample
 from perfkitbenchmarker import vm_util
@@ -21,12 +24,16 @@ FIO_DIR = '%s/fio' % vm_util.VM_TMP_DIR
 GIT_REPO = 'git://git.kernel.dk/fio.git'
 GIT_TAG = 'fio-2.1.14'
 FIO_PATH = FIO_DIR + '/fio'
-FIO_CMD_PREFIX = '%s --output-format=json ' % FIO_PATH
+FIO_CMD_PREFIX = '%s --output-format=json' % FIO_PATH
 SECTION_REGEX = r'\[(\w+)\]\n([\w\d\n=*$/]+)'
 PARAMETER_REGEX = r'(\w+)=([/\w\d$*]+)\n'
 GLOBAL = 'global'
 CMD_SECTION_REGEX = r'--name=(\w+)\s+'
-JOB_SECTION_REGEX = r'[\1]\n'
+JOB_SECTION_REPL_REGEX = r'[\1]\n'
+CMD_PARAMETER_REGEX = r'--(\w+=[/\w\d]+)\n'
+CMD_PARAMETER_REPL_REGEX = r'\1\n'
+CMD_STONEWALL_PARAMETER = '--stonewall\n'
+JOB_STONEWALL_PARAMETER = 'stonewall\n'
 
 
 def _Install(vm):
@@ -49,31 +56,6 @@ def AptInstall(vm):
   _Install(vm)
 
 
-def ExtractFioParameters(fio_parameter):
-  """Extract fio parameters from raw string.
-
-  Sample parameter_string:
-  overwrite=0
-  rw=write
-  blocksize=512k
-  size=10*10*1000*$mb_memory
-  iodepth=64
-  direct=1
-  end_fsync=1
-
-  Args:
-    fio_parameter: string. Parameters in string format.
-  Returns:
-    A dictionary of parameters.
-  """
-  parameters = regex_util.ExtractAllMatches(
-      PARAMETER_REGEX, fio_parameter)
-  param_dict = {}
-  for parameter in parameters:
-    param_dict[parameter[0]] = parameter[1]
-  return param_dict
-
-
 def ParseJobFile(job_file):
   """Parse fio job file as dictionaries of sample metadata.
 
@@ -84,44 +66,51 @@ def ParseJobFile(job_file):
     A dictionary of dictionaries of sample metadata, using test name as keys,
         dictionaries of sample metadata as value.
   """
-  parameter_metadata = {}
+  job_file = job_file.replace(JOB_STONEWALL_PARAMETER, '')
+  config = ConfigParser.ConfigParser()
+  config.readfp(io.BytesIO(job_file))
+  sections = config.__dict__['_sections']
   global_metadata = {}
-  section_match = regex_util.ExtractAllMatches(SECTION_REGEX, job_file)
-  for section in section_match:
-    if section[0] == GLOBAL:
-      global_metadata = ExtractFioParameters(section[1])
-      break
-  for section in section_match:
-    section_name = section[0]
-    if section_name == GLOBAL:
-      continue
-    parameter_metadata[section_name] = {}
-    parameter_metadata[section_name].update(global_metadata)
-    parameter_metadata[section_name].update(ExtractFioParameters(section[1]))
-
-  return parameter_metadata
+  if GLOBAL in sections:
+    global_metadata = dict(sections[GLOBAL])
+    del sections[GLOBAL]
+  for section in sections:
+    if section != GLOBAL:
+      sections[section] = dict(sections[section])
+      sections[section].update(global_metadata)
+    del sections[section]['__name__']
+  return dict(sections)
 
 
 def FioParametersToJob(fio_parameters):
-  """Translate fio parameters into a job file in raw string.
+  """Translate fio parameters into a job config file.
 
   Sample fio parameters:
   --filesize=10g --directory=/scratch0
-  --ioengine=libaio --filename=fio_test_file --invalidate=1
-  --randrepeat=0 --direct=0 --size=3790088k --iodepth=8
-  --name=sequential_write --overwrite=0 --rw=write --end_fsync=1
+  --name=sequential_write --overwrite=0 --rw=write
+
+  Output:
+  [global]
+  filesize=10g
+  directory=/scratch0
+  [sequential_write]
+  overwrite=0
+  rw=write
 
   Args:
     fio_parameter: string. Fio parameters in string format.
 
   Returns:
-    A raw string representing a job file can be read by fio binary.
+    A string representing a fio job config file.
   """
   fio_parameters = fio_parameters.replace(' ', '\n')
   fio_parameters = regex_util.Substitute(
-      CMD_SECTION_REGEX, JOB_SECTION_REGEX, fio_parameters)
+      CMD_SECTION_REGEX, JOB_SECTION_REPL_REGEX, fio_parameters)
   fio_parameters = '[%s]\n%s' % (GLOBAL, fio_parameters)
-  return fio_parameters.replace('--', '')
+  fio_parameters = regex_util.Substitute(
+      CMD_PARAMETER_REGEX, CMD_PARAMETER_REPL_REGEX, fio_parameters)
+  return fio_parameters.replace(CMD_STONEWALL_PARAMETER,
+                                JOB_STONEWALL_PARAMETER)
 
 
 def ParseResults(job_file, fio_json_result):

--- a/perfkitbenchmarker/packages/fio.py
+++ b/perfkitbenchmarker/packages/fio.py
@@ -22,11 +22,13 @@ FIO_DIR = '%s/fio' % vm_util.VM_TMP_DIR
 GIT_REPO = 'git://git.kernel.dk/fio.git'
 GIT_TAG = 'fio-2.1.14'
 FIO_PATH = FIO_DIR + '/fio'
+FIO_CMD_PREFIX = '%s --output-format=json ' % FIO_PATH
 SECTION_REGEX = r'\[(\w+)\]\n([\w\d\n=*$/]+)'
 PARAMETER_REGEX = r'(\w+)=([/\w\d$*]+)\n'
 GLOBAL = 'global'
 CMD_SECTION_REGEX = r'--name=(\w+)\s+'
 JOB_SECTION_REGEX = r'[\1]\n'
+
 
 def _Install(vm):
   """Installs the fio package on the VM."""

--- a/perfkitbenchmarker/packages/fio.py
+++ b/perfkitbenchmarker/packages/fio.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 """Module containing fio installation, cleanup, parsing functions."""
-import re
 from perfkitbenchmarker import regex_util
 from perfkitbenchmarker import sample
 from perfkitbenchmarker import vm_util
@@ -119,7 +118,7 @@ def FioParametersToJob(fio_parameters):
     A raw string representing a job file can be read by fio binary.
   """
   fio_parameters = fio_parameters.replace(' ', '\n')
-  fio_parameters = re.sub(
+  fio_parameters = regex_util.Substitute(
       CMD_SECTION_REGEX, JOB_SECTION_REGEX, fio_parameters)
   fio_parameters = '[%s]\n%s' % (GLOBAL, fio_parameters)
   return fio_parameters.replace('--', '')

--- a/tests/packages/fio_test.py
+++ b/tests/packages/fio_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests for perfkitbenchmarker.benchmarks.util.fio."""
+"""Tests for perfkitbenchmarker.packages.fio."""
 
 import json
 import os
@@ -110,6 +110,40 @@ class FioTestCase(unittest.TestCase):
       expected_result = [sample.Sample(*sample_tuple)
                          for sample_tuple in expected_result]
       self.assertEqual(result, expected_result)
+
+  def testFioCommandToJob(self):
+    fio_parameters = (
+        '--filesize=10g --directory=/scratch0 --ioengine=libaio '
+        '--filename=fio_test_file --invalidate=1 --randrepeat=0 '
+        '--direct=0 --size=3790088k --iodepth=8 '
+        '--name=sequential_write --overwrite=0 --rw=write --end_fsync=1 '
+        '--name=random_read --size=379008k --stonewall --rw=randread '
+        '--name=sequential_read --stonewall --rw=read ')
+    expected_result = (
+        '[global]\n'
+        'filesize=10g\n'
+        'directory=/scratch0\n'
+        'ioengine=libaio\n'
+        'filename=fio_test_file\n'
+        'invalidate=1\n'
+        'randrepeat=0\n'
+        'direct=0\n'
+        'size=3790088k\n'
+        'iodepth=8\n'
+        '[sequential_write]\n'
+        'overwrite=0\n'
+        'rw=write\n'
+        'end_fsync=1\n'
+        '[random_read]\n'
+        'size=379008k\n'
+        'stonewall\n'
+        'rw=randread\n'
+        '[sequential_read]\n'
+        'stonewall\n'
+        'rw=read\n')
+    result = fio.FioParametersToJob(fio_parameters)
+    print result
+    self.assertEqual(expected_result, result)
 
 
 if __name__ == '__main__':

--- a/tests/packages/fio_test.py
+++ b/tests/packages/fio_test.py
@@ -142,7 +142,6 @@ class FioTestCase(unittest.TestCase):
         'stonewall\n'
         'rw=read\n')
     result = fio.FioParametersToJob(fio_parameters)
-    print result
     self.assertEqual(expected_result, result)
 
 


### PR DESCRIPTION
Use the parser in fio_benchmark.py which 
1) Includes additional metadata used in fio command.
2) The metric name changes from job_name:bandwidth/latency to job_name:read/write:bandwidth/latency.

Sample output:
{'timestamp': 1427325228.840838, 'metric': u'sequential_write:write:bandwidth', 'official': False, 'value': 84343.59, 'owner': 'yuyanting', 'run_uri': '58b5ed0a-879d-4d73-a0f6-5d4cb3a03b5f', 'test': 'block_storage_workload', 'sample_uri'
: '6bf7e31c-e598-460e-b1ef-d7b3f1628bd3', 'product_name': 'PerfKitBenchmarker', 'unit': 'KB/s', 'metadata': {'invalidate': '1', 'workload_mode': 'logging', 'end_fsync': '1', 'perfkitbenchmarker_version': 'v0.11.1-46-g21a83b1', 'direct': 
'0', 'zones': 'us-central1-a', 'cloud': 'GCP', 'machine_type': 'n1-standard-1', 'ioengine': 'libaio', 'iodepth': '8', 'bw_min': 63169, 'size': '3790088k', 'rw': 'write', 'filename': 'fio_test_file', 'bw_max': 458840, 'randrepeat': '0', '
filesize': '10g', 'overwrite': '0', 'directory': '/scratch0', 'bw_agg': 100.0, 'image': 'ubuntu-14-04', 'bw_dev': 60636.38}}

