### PR TITLE
Add support for configurable SSH port

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,8 @@ If a benchmark requires two machines like iperf you can have two both machines i
     "user_name": "connormccoy",
     "keyfile_path": "/home/connormccoy/.ssh/google_compute_engine",
     "scratch_disk_mountpoints": ["/tmp/google-pkb"],
-    "internal_ip": "10.240.234.189"
+    "internal_ip": "10.240.234.189",
+    "ssh_port": 2222
   }
 ]
 ```

--- a/perfkitbenchmarker/benchmark_spec.py
+++ b/perfkitbenchmarker/benchmark_spec.py
@@ -108,7 +108,6 @@ FLAGS = flags.FLAGS
 
 flags.DEFINE_enum('cloud', GCP, [GCP, AZURE, AWS], 'Name of the cloud to use.')
 
-SSH_PORT = 22
 
 
 class BenchmarkSpec(object):
@@ -273,7 +272,7 @@ class BenchmarkSpec(object):
     vm.Create()
     logging.info('VM: %s', vm.ip_address)
     logging.info('Waiting for boot completion.')
-    firewall.AllowPort(vm, SSH_PORT)
+    firewall.AllowPort(vm, vm.ssh_port)
     vm.AddMetadata(benchmark=self.benchmark_name)
     vm.WaitForBootCompletion()
     vm.Startup()

--- a/perfkitbenchmarker/static_virtual_machine.py
+++ b/perfkitbenchmarker/static_virtual_machine.py
@@ -42,7 +42,8 @@ class StaticVirtualMachine(virtual_machine.BaseVirtualMachine):
   is_static = True
 
   def __init__(self, ip_address, user_name, keyfile_path, internal_ip=None,
-               zone=None, local_disks=None, scratch_disk_mountpoints=None):
+               zone=None, local_disks=None, scratch_disk_mountpoints=None,
+               ssh_port=22):
     """Initialize a static virtual machine.
 
     Args:
@@ -53,6 +54,7 @@ class StaticVirtualMachine(virtual_machine.BaseVirtualMachine):
       zone: The zone of the VM.
       local_disks: A list of the paths of local disks on the VM.
       scratch_disk_mountpoints: A list of scratch disk mountpoints.
+      ssh_port: The port number to use for SSH and SCP commands.
     """
     vm_spec = virtual_machine.BaseVirtualMachineSpec(
         None, None, None, None, None)
@@ -61,6 +63,7 @@ class StaticVirtualMachine(virtual_machine.BaseVirtualMachine):
     self.internal_ip = internal_ip
     self.zone = zone or ('Static - %s@%s' % (user_name, ip_address))
     self.user_name = user_name
+    self.ssh_port = ssh_port
     self.ssh_private_key = keyfile_path
     self.local_disks = local_disks or []
     self.scratch_disk_mountpoints = scratch_disk_mountpoints or []
@@ -100,7 +103,7 @@ class StaticVirtualMachine(virtual_machine.BaseVirtualMachine):
   def ReadStaticVirtualMachineFile(cls, file_obj):
     """Read a file describing the static VMs to use.
 
-    This function will read the static VM infomation from the provided file,
+    This function will read the static VM information from the provided file,
     instantiate VMs corresponding to the info, and add the VMs to the static
     VM pool. The provided file should contain a single array in JSON-format.
     Each element in the array must be an object with required format:
@@ -108,6 +111,7 @@ class StaticVirtualMachine(virtual_machine.BaseVirtualMachine):
       ip_address: string.
       user_name: string.
       keyfile_path: string.
+      ssh_port: integer, optional. Default 22
       internal_ip: string, optional.
       zone: string, optional.
       local_disks: array of strings, optional.
@@ -130,7 +134,8 @@ class StaticVirtualMachine(virtual_machine.BaseVirtualMachine):
 
     required_keys = frozenset(['ip_address', 'user_name', 'keyfile_path'])
     optional_keys = frozenset(['internal_ip', 'zone', 'local_disks',
-                               'scratch_disk_mountpoints', 'os_type'])
+                               'scratch_disk_mountpoints', 'os_type',
+                               'ssh_port'])
     allowed_keys = required_keys | optional_keys
 
     def VerifyItemFormat(item):
@@ -161,10 +166,11 @@ class StaticVirtualMachine(virtual_machine.BaseVirtualMachine):
         raise ValueError(
             'Expected a list of disk mount points, got: {0}'.format(
                 scratch_disk_mountpoints))
+      ssh_port = item.get('ssh_port', 22)
       os_type = item.get('os_type')
       vm_class = GetStaticVirtualMachineClass(os_type)
       vm = vm_class(ip_address, user_name, keyfile_path, internal_ip, zone,
-                    local_disks, scratch_disk_mountpoints)
+                    local_disks, scratch_disk_mountpoints, ssh_port)
       cls.vm_pool.append(vm)
 
   @classmethod


### PR DESCRIPTION
Adds the ability for a user to specify a port to be used for SSH and SCP
commmands when using static VMs. A port is specified using the key
'ssh_port' in the JSON static_vm file. If no port is specify, it defaults
to port 22.

Also, it makes the SSH port an instance variable for BaseVirtualMachine
instances, and removes it from the methods that took an SSH port as an
argument. Instead, it now uses the instance variable set at the object
initialization.