### PR TITLE
New nosql metric

### DIFF
--- a/perfkitbenchmarker/benchmarks/aerospike_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/aerospike_benchmark.py
@@ -191,10 +191,11 @@ def Run(benchmark_spec):
     samples.append(sample.Sample('Average Latency', latency, 'ms', metadata))
     if latency < 1.0:
       max_throughput_for_completion_latency_under_1ms = tps
-      
-  samples.append(sample.Sample('max_throughput_for_completion_latency_under_1ms',
-                                max_throughput_for_completion_latency_under_1ms ,
-                                'req/s'))
+
+  samples.append(sample.Sample(
+                 'max_throughput_for_completion_latency_under_1ms',
+                 max_throughput_for_completion_latency_under_1ms,
+                 'req/s'))
 
   return samples
 

--- a/perfkitbenchmarker/benchmarks/aerospike_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/aerospike_benchmark.py
@@ -190,7 +190,9 @@ def Run(benchmark_spec):
       metadata['Disk Type'] = 'Local' if FLAGS.use_local_disk else 'Remote'
     samples.append(sample.Sample('Average Latency', latency, 'ms', metadata))
     if latency < 1.0:
-      max_throughput_for_completion_latency_under_1ms = tps
+      max_throughput_for_completion_latency_under_1ms = max(
+          max_throughput_for_completion_latency_under_1ms,
+          tps)
 
   samples.append(sample.Sample(
                  'max_throughput_for_completion_latency_under_1ms',

--- a/perfkitbenchmarker/benchmarks/aerospike_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/aerospike_benchmark.py
@@ -171,6 +171,7 @@ def Run(benchmark_spec):
                   (CLIENT_DIR, server.internal_ip))
   client.RemoteCommand(load_command, should_log=True)
 
+  max_throughput_for_completion_latency_under_1ms = 0.0
   for threads in range(MIN_THREADS, MAX_THREADS + 1, THREAD_STEP):
     load_command = ('timeout 15 ./%s/benchmarks/target/benchmarks '
                     '-z %s -n test -w RU,%s -o B:1000 -k 1000000 '
@@ -188,6 +189,12 @@ def Run(benchmark_spec):
     if FLAGS.aerospike_storage_type == DISK:
       metadata['Disk Type'] = 'Local' if FLAGS.use_local_disk else 'Remote'
     samples.append(sample.Sample('Average Latency', latency, 'ms', metadata))
+    if latency < 1.0:
+      max_throughput_for_completion_latency_under_1ms = tps
+      
+  samples.append(sample.Sample('max_throughput_for_completion_latency_under_1ms',
+                                max_throughput_for_completion_latency_under_1ms ,
+                                'req/s'))
 
   return samples
 

--- a/perfkitbenchmarker/benchmarks/redis_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/redis_benchmark.py
@@ -166,7 +166,9 @@ def Run(benchmark_spec):
       latency += result[1] * result[0] / throughput
 
     if latency < 1.0:
-        max_throughput_for_completion_latency_under_1ms = throughput
+        max_throughput_for_completion_latency_under_1ms = max(
+            max_throughput_for_completion_latency_under_1ms,
+            throughput)
     results.append(sample.Sample('throughput', throughput, 'req/s',
                                  {'latency': latency, 'threads': threads}))
     logging.info('Threads : %d  (%f, %f) < %f', threads, throughput, latency,

--- a/perfkitbenchmarker/benchmarks/redis_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/redis_benchmark.py
@@ -145,6 +145,8 @@ def Run(benchmark_spec):
   threads = 0
   results = []
   num_servers = redis_vm.num_cpus * FLAGS.redis_numprocesses
+  max_throughput_for_completion_latency_under_1ms = 0.0
+
   while latency < latency_threshold:
     iteration_results = {}
     threads += max(1, int(threads * .15))
@@ -163,12 +165,18 @@ def Run(benchmark_spec):
     for result in iteration_results.values():
       latency += result[1] * result[0] / throughput
 
+    if latency < 1.0:
+        max_throughput_for_completion_latency_under_1ms = throughput
     results.append(sample.Sample('throughput', throughput, 'req/s',
                                  {'latency': latency, 'threads': threads}))
     logging.info('Threads : %d  (%f, %f) < %f', threads, throughput, latency,
                  latency_threshold)
     if threads == 1:
       latency_threshold = latency * 20
+
+  results.append(sample.Sample('max_throughput_for_completion_latency_under_1ms',
+                                max_throughput_for_completion_latency_under_1ms ,
+                                'req/s'))
 
   return results
 

--- a/perfkitbenchmarker/benchmarks/redis_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/redis_benchmark.py
@@ -174,9 +174,10 @@ def Run(benchmark_spec):
     if threads == 1:
       latency_threshold = latency * 20
 
-  results.append(sample.Sample('max_throughput_for_completion_latency_under_1ms',
-                                max_throughput_for_completion_latency_under_1ms ,
-                                'req/s'))
+  results.append(sample.Sample(
+                 'max_throughput_for_completion_latency_under_1ms',
+                 max_throughput_for_completion_latency_under_1ms,
+                 'req/s'))
 
   return results
 


### PR DESCRIPTION
This pull requests adds new metrics for the Redis and Aerospike benchmarks. What those benchmarks publish today is a latency vs throughput series. That is very useful. What this adds is a decision point of publishing the max throughput using 1ms.

1ms was chosen because this is how many users rate and tune the system.

This does not modify the benchmark or any of the existing published metrics.