### PR TITLE
Add colored logging to stderr

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@
 python-gflags==2.0
 jinja2>=2.7
 setuptools
+colorlog==2.6.0


### PR DESCRIPTION
Adds an (optional) dependency on colorlog. If present and `sys.stderr` is
a TTY, logs will be colored based on severity.