### PR TITLE
Netperf: Parse CSV output; add p50, p90, p99.

### DIFF
--- a/perfkitbenchmarker/vm_util.py
+++ b/perfkitbenchmarker/vm_util.py
@@ -352,7 +352,7 @@ def IssueCommand(cmd, force_info_log=False, suppress_warning=False):
   stdout = stdout.decode('ascii', 'ignore')
   stderr = stderr.decode('ascii', 'ignore')
 
-  debug_text = ('Ran %s. Got return code (%s). STDOUT: %sSTDERR: %s' %
+  debug_text = ('Ran %s. Got return code (%s).\nSTDOUT: %s\nSTDERR: %s' %
                 (full_cmd, process.returncode, stdout, stderr))
   if force_info_log or (process.returncode and not suppress_warning):
     logging.info(debug_text)

--- a/tests/data/netperf_results.json
+++ b/tests/data/netperf_results.json
@@ -1,0 +1,42 @@
+[
+  [
+    "MIGRATED TCP REQUEST/RESPONSE TEST from 0.0.0.0 (0.0.0.0) port 20001 AF_INET to 104.154.50.86 () port 20001 AF_INET : +/-2.500% @ 99% conf.  : first burst 0",
+    "Throughput,Throughput Units,Throughput Confidence Width (%),Confidence Iterations Run,Stddev Latency Microseconds,50th Percentile Latency Microseconds,90th Percentile Latency Microseconds,99th Percentile Latency Microseconds",
+    "1405.50,Trans/s,2.522,4,783.80,683,735,841"
+  ],
+  [
+    "MIGRATED TCP REQUEST/RESPONSE TEST from 0.0.0.0 (0.0.0.0) port 20001 AF_INET to 10.240.31.117 () port 20001 AF_INET : +/-2.500% @ 99% conf.  : first burst 0",
+    "Throughput,Throughput Units,Throughput Confidence Width (%),Confidence Iterations Run,Stddev Latency Microseconds,50th Percentile Latency Microseconds,90th Percentile Latency Microseconds,99th Percentile Latency Microseconds",
+    "3545.77,Trans/s,2.186,3,189.82,274,309,371"
+  ],
+  [
+    "MIGRATED TCP Connect/Request/Response TEST from 0.0.0.0 (0.0.0.0) port 20001 AF_INET to 104.154.50.86 () port 20001 AF_INET : +/-2.500% @ 99% conf.",
+    "Throughput,Throughput Units,Throughput Confidence Width (%),Confidence Iterations Run,Stddev Latency Microseconds,50th Percentile Latency Microseconds,90th Percentile Latency Microseconds,99th Percentile Latency Microseconds",
+    "343.35,Trans/s,11.837,20,8147.88,2048,2372,30029"
+  ],
+  [
+    "MIGRATED TCP Connect/Request/Response TEST from 0.0.0.0 (0.0.0.0) port 20001 AF_INET to 10.240.31.117 () port 20001 AF_INET : +/-2.500% @ 99% conf.",
+    "Throughput,Throughput Units,Throughput Confidence Width (%),Confidence Iterations Run,Stddev Latency Microseconds,50th Percentile Latency Microseconds,90th Percentile Latency Microseconds,99th Percentile Latency Microseconds",
+    "1078.07,Trans/s,7.512,20,551.07,871,996,2224"
+  ],
+  [
+    "MIGRATED TCP STREAM TEST from 0.0.0.0 (0.0.0.0) port 20001 AF_INET to 104.154.50.86 () port 20001 AF_INET : +/-2.500% @ 99% conf.",
+    "Throughput,Throughput Units,Throughput Confidence Width (%),Confidence Iterations Run,Stddev Latency Microseconds,50th Percentile Latency Microseconds,90th Percentile Latency Microseconds,99th Percentile Latency Microseconds",
+    "1187.94,10^6bits/s,10.100,20,1084.37,2,6,3374"
+  ],
+  [
+    "MIGRATED TCP STREAM TEST from 0.0.0.0 (0.0.0.0) port 20001 AF_INET to 10.240.31.117 () port 20001 AF_INET : +/-2.500% @ 99% conf.",
+    "Throughput,Throughput Units,Throughput Confidence Width (%),Confidence Iterations Run,Stddev Latency Microseconds,50th Percentile Latency Microseconds,90th Percentile Latency Microseconds,99th Percentile Latency Microseconds",
+    "1973.37,10^6bits/s,4.995,7,694.10,2,4,20"
+  ],
+  [
+    "MIGRATED UDP REQUEST/RESPONSE TEST from 0.0.0.0 (0.0.0.0) port 20001 AF_INET to 104.154.50.86 () port 20001 AF_INET : +/-2.500% @ 99% conf.  : first burst 0",
+    "Throughput,Throughput Units,Throughput Confidence Width (%),Confidence Iterations Run,Stddev Latency Microseconds,50th Percentile Latency Microseconds,90th Percentile Latency Microseconds,99th Percentile Latency Microseconds",
+    "1359.71,Trans/s,4.911,13,808.44,700,757,891"
+  ],
+  [
+    "MIGRATED UDP REQUEST/RESPONSE TEST from 0.0.0.0 (0.0.0.0) port 20001 AF_INET to 10.240.31.117 () port 20001 AF_INET : +/-2.500% @ 99% conf.  : first burst 0",
+    "Throughput,Throughput Units,Throughput Confidence Width (%),Confidence Iterations Run,Stddev Latency Microseconds,50th Percentile Latency Microseconds,90th Percentile Latency Microseconds,99th Percentile Latency Microseconds",
+    "3313.49,Trans/s,7.546,20,214.64,295,330,406"
+  ]
+]


### PR DESCRIPTION
* Use and parse CSV output format in place of free text + regex parsing.
* Report p50, p90, and p99 from netperf TPS metrics.

This is a subset of the changes originally in #29. The benchmark running time
and results don't change in my tests, this just adds tail latencies for
TCP_RR, TCP_CRR, and UDP_RR.

Example output for internal IP:

     TCP_RR_Transaction_Rate   3649.72   transactions_per_second
     TCP_RR_Latency_p50        265       us
     TCP_RR_Latency_p90        308       us
     TCP_RR_Latency_p99        371       us
     TCP_CRR_Transaction_Rate  1094.74   transactions_per_second
     TCP_CRR_Latency_p50       868       us
     TCP_CRR_Latency_p90       983       us
     TCP_CRR_Latency_p99       1546      us
     TCP_STREAM_Throughput     1904.1    Mbits/sec
     UDP_RR_Transaction_Rate   3577.23   transactions_per_second
     UDP_RR_Latency_p50        262       us
     UDP_RR_Latency_p90        306       us
     UDP_RR_Latency_p99        370       us