### PR TITLE
More SPEC CPU 2006 execution flexibility

### DIFF
--- a/perfkitbenchmarker/benchmarks/speccpu2006_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/speccpu2006_benchmark.py
@@ -34,20 +34,20 @@ FLAGS = flags.FLAGS
 
 flags.DEFINE_enum('benchmark_subset', 'int', ['int', 'fp', 'all'],
                   'specify a subset of benchmarks to run: int, fp, all')
-                  
-flags.DEFINE_string('runspec_config', 'linux64-x64-gcc47.cfg', 
+
+flags.DEFINE_string('runspec_config', 'linux64-x64-gcc47.cfg',
                     'name of the cpu2006 configuration to use (runspec --config'
                     ' argument)')
-                    
-flags.DEFINE_integer('runspec_iterations', 3, 
-                    'number of benchmark iterations to execute - default 3 '
-                    '(runspec --iterations argument)')
-                    
-flags.DEFINE_string('runspec_define', '', 
+
+flags.DEFINE_integer('runspec_iterations', 3,
+                     'number of benchmark iterations to execute - default 3 '
+                     '(runspec --iterations argument)')
+
+flags.DEFINE_string('runspec_define', '',
                     'optional comma separated list of preprocessor macros: '
                     'SYMBOL[=VALUE] - e.g. numa,smt,sse=SSE4.2 (runspec '
                     '--define arguments)')
-                    
+
 flags.DEFINE_boolean('runspec_enable_32bit', default=False,
                      help='setting this flag will result in installation of '
                      'multilib packages to enable use of 32-bit cpu2006 '
@@ -242,13 +242,15 @@ def Run(benchmark_spec):
   vm = vms[0]
   logging.info('SpecCPU2006 running on %s', vm)
   num_cpus = vm.num_cpus
+  iterations = ' --iterations=' + repr(FLAGS.runspec_iterations) if \
+               FLAGS.runspec_iterations != 3 else ''
+  defines = ' --define ' + ' --define '.join(FLAGS.runspec_define.split(','))\
+            if FLAGS.runspec_define != '' else ''
   vm.RemoteCommand('cd %s; . ./shrc; ./bin/relocate; . ./shrc; rm -rf result; '
                    'runspec --config=%s --tune=base '
                    '--size=ref --noreportable --rate %s%s%s %s'
-                   % (vm.spec_dir, FLAGS.runspec_config, num_cpus, 
-                   ' --iterations=' + `FLAGS.runspec_iterations` if FLAGS.runspec_iterations != 3 else '',
-                   ' --define ' + ' --define '.join(FLAGS.runspec_define.split(',')) if FLAGS.runspec_define != '' else '',
-                   FLAGS.benchmark_subset))
+                   % (vm.spec_dir, FLAGS.runspec_config, num_cpus, iterations,
+                      defines, FLAGS.benchmark_subset))
   logging.info('SpecCPU2006 Results:')
   return ParseOutput(vm)
 

--- a/perfkitbenchmarker/benchmarks/speccpu2006_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/speccpu2006_benchmark.py
@@ -34,6 +34,26 @@ FLAGS = flags.FLAGS
 
 flags.DEFINE_enum('benchmark_subset', 'int', ['int', 'fp', 'all'],
                   'specify a subset of benchmarks to run: int, fp, all')
+                  
+flags.DEFINE_string('runspec_config', 'linux64-x64-gcc47.cfg', 
+                    'name of the cpu2006 configuration to use (runspec --config'
+                    ' argument)')
+                    
+flags.DEFINE_integer('runspec_iterations', 3, 
+                    'number of benchmark iterations to execute - default 3 '
+                    '(runspec --iterations argument)')
+                    
+flags.DEFINE_string('runspec_define', '', 
+                    'optional comma separated list of preprocessor macros: '
+                    'SYMBOL[=VALUE] - e.g. numa,smt,sse=SSE4.2 (runspec '
+                    '--define arguments)')
+                    
+flags.DEFINE_boolean('runspec_enable_32bit', default=False,
+                     help='setting this flag will result in installation of '
+                     'multilib packages to enable use of 32-bit cpu2006 '
+                     'binaries (useful when running on memory constrained '
+                     'instance types where 64-bit execution may be problematic '
+                     ' - i.e. < 1.5-2GB/core)')
 
 BENCHMARK_INFO = {'name': 'speccpu2006',
                   'description': 'Run Spec CPU2006',
@@ -70,6 +90,9 @@ def Prepare(benchmark_spec):
   vm.Install('wget')
   vm.Install('build_tools')
   vm.Install('fortran')
+  if (FLAGS.runspec_enable_32bit):
+    vm.Install('multilib')
+  vm.Install('numactl')
   try:
     local_tar_file_path = data.ResourcePath(SPECCPU2006_TAR)
   except data.ResourceNotFound as e:
@@ -220,9 +243,12 @@ def Run(benchmark_spec):
   logging.info('SpecCPU2006 running on %s', vm)
   num_cpus = vm.num_cpus
   vm.RemoteCommand('cd %s; . ./shrc; ./bin/relocate; . ./shrc; rm -rf result; '
-                   'runspec --config=linux64-x64-gcc47.cfg --tune=base '
-                   '--size=ref --noreportable -rate %s %s '
-                   % (vm.spec_dir, num_cpus, FLAGS.benchmark_subset))
+                   'runspec --config=%s --tune=base '
+                   '--size=ref --noreportable --rate %s%s%s %s'
+                   % (vm.spec_dir, FLAGS.runspec_config, num_cpus, 
+                   ' --iterations=' + `FLAGS.runspec_iterations` if FLAGS.runspec_iterations != 3 else '',
+                   ' --define ' + ' --define '.join(FLAGS.runspec_define.split(',')) if FLAGS.runspec_define != '' else '',
+                   FLAGS.benchmark_subset))
   logging.info('SpecCPU2006 Results:')
   return ParseOutput(vm)
 

--- a/perfkitbenchmarker/packages/multilib.py
+++ b/perfkitbenchmarker/packages/multilib.py
@@ -1,0 +1,23 @@
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module containing multilib installation and cleanup functions."""
+
+def YumInstall(vm):
+  """Installs multilib packages on the VM."""
+  vm.InstallPackages('glibc-devel.i686 libstdc++-devel.i686')
+
+def AptInstall(vm):
+  """Installs multilib packages on the VM."""
+  vm.InstallPackages('gcc-multilib g++-multilib')

--- a/perfkitbenchmarker/packages/multilib.py
+++ b/perfkitbenchmarker/packages/multilib.py
@@ -14,9 +14,11 @@
 
 """Module containing multilib installation and cleanup functions."""
 
+
 def YumInstall(vm):
   """Installs multilib packages on the VM."""
   vm.InstallPackages('glibc-devel.i686 libstdc++-devel.i686')
+
 
 def AptInstall(vm):
   """Installs multilib packages on the VM."""

--- a/perfkitbenchmarker/packages/numactl.py
+++ b/perfkitbenchmarker/packages/numactl.py
@@ -14,13 +14,16 @@
 
 """Module containing numactl installation and cleanup functions."""
 
+
 def _Install(vm):
   """Installs the numactl package on the VM."""
   vm.InstallPackages('numactl')
 
+
 def YumInstall(vm):
   """Installs the numactl package on the VM."""
   _Install(vm)
+
 
 def AptInstall(vm):
   """Installs the numactl package on the VM."""

--- a/perfkitbenchmarker/packages/numactl.py
+++ b/perfkitbenchmarker/packages/numactl.py
@@ -1,0 +1,27 @@
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module containing numactl installation and cleanup functions."""
+
+def _Install(vm):
+  """Installs the numactl package on the VM."""
+  vm.InstallPackages('numactl')
+
+def YumInstall(vm):
+  """Installs the numactl package on the VM."""
+  _Install(vm)
+
+def AptInstall(vm):
+  """Installs the numactl package on the VM."""
+  _Install(vm)


### PR DESCRIPTION
I use Intel compiled binaries and custom config/macros for 32 and 64 bit execution, and different SSE flags. Currently the SPEC CPU benchmark is hardcoded for a GCC 4.7 config and does not allow setting of any macros or runtime settings. This pull request consists of the following changes:

1. Added --runspec_config argument to allow override of default
   configuration linux64-x64-gcc47.cfg

2. Added --runspec_iterations argument to allow test execution using
   custom iteration count (default is 3)

3. Added --runspec_define argument to enable proprocessor macros

4. Added --runspec_enable_32bit to enable 32-bit execution on 64-bit
   images - useful when CPU cores to GB memory ratio is less than 2GB
   Setting this flag will install multilib packages
   (packages/multilib.py)

5. Added numactl package to enable NUMA scheduling