### PR TITLE
Add ability to inject environment variables to IssueCommand

### DIFF
--- a/perfkitbenchmarker/vm_util.py
+++ b/perfkitbenchmarker/vm_util.py
@@ -324,7 +324,7 @@ def Retry(poll_interval=POLL_INTERVAL, max_retries=MAX_RETRIES,
   return Wrap
 
 
-def IssueCommand(cmd, force_info_log=False, suppress_warning=False):
+def IssueCommand(cmd, force_info_log=False, suppress_warning=False, env=None):
   """Tries running the provided command once.
 
   Args:
@@ -337,13 +337,24 @@ def IssueCommand(cmd, force_info_log=False, suppress_warning=False):
         not be logged at the info level in the event of a non-zero
         return code. When force_info_log is True, the output is logged
         regardless of suppress_warning's value.
+    env: A dict of key/value strings, such as is given to the subprocess.Popen()
+        constructor, that contains environment variables to be injected.
 
   Returns:
     A tuple of stdout, stderr, and retcode from running the provided command.
   """
+
+  if env is not None:
+    cmd_env = env
+  else:
+    cmd_env = os.environ.copy()
+
+  logging.debug('Environment variables: %s' % cmd_env)
+
   full_cmd = ' '.join(cmd)
   logging.info('Running: %s', full_cmd)
-  process = subprocess.Popen(cmd,
+
+  process = subprocess.Popen(cmd, env=cmd_env,
                              stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE)
   stdout, stderr = process.communicate()
@@ -361,23 +372,33 @@ def IssueCommand(cmd, force_info_log=False, suppress_warning=False):
   return stdout, stderr, process.returncode
 
 
-def IssueBackgroundCommand(cmd, stdout_path, stderr_path):
+def IssueBackgroundCommand(cmd, stdout_path, stderr_path, env=None):
   """Run the provided command once in the background.
 
   Args:
     cmd: Command to be run, as expected by subprocess.Popen.
     stdout_path: Redirect stdout here. Overwritten.
     stderr_path: Redirect stderr here. Overwritten.
+    env: A dict of key/value strings, such as is given to the subprocess.Popen()
+        constructor, that contains environment variables to be injected.
   """
+  if env is not None:
+    cmd_env = env
+  else:
+    cmd_env = os.environ.copy()
+
+  logging.debug('Environment variables: %s' % cmd_env)
+
   full_cmd = ' '.join(cmd)
   logging.info('Spawning: %s', full_cmd)
   outfile = open(stdout_path, 'w')
   errfile = open(stderr_path, 'w')
-  subprocess.Popen(cmd, stdout=outfile, stderr=errfile, close_fds=True)
+  subprocess.Popen(cmd, env=cmd_env,
+                   stdout=outfile, stderr=errfile, close_fds=True)
 
 
 @Retry()
-def IssueRetryableCommand(cmd):
+def IssueRetryableCommand(cmd, env=None):
   """Tries running the provided command until it succeeds or times out.
 
   Args:
@@ -387,7 +408,7 @@ def IssueRetryableCommand(cmd):
   Returns:
     A tuple of stdout and stderr from running the provided command.
   """
-  stdout, stderr, retcode = IssueCommand(cmd)
+  stdout, stderr, retcode = IssueCommand(cmd, env=env)
   if retcode:
     raise errors.VmUtil.CalledProcessException(
         'Command returned a non-zero exit code.\n')

--- a/perfkitbenchmarker/vm_util.py
+++ b/perfkitbenchmarker/vm_util.py
@@ -343,18 +343,12 @@ def IssueCommand(cmd, force_info_log=False, suppress_warning=False, env=None):
   Returns:
     A tuple of stdout, stderr, and retcode from running the provided command.
   """
-
-  if env is not None:
-    cmd_env = env
-  else:
-    cmd_env = os.environ.copy()
-
-  logging.debug('Environment variables: %s' % cmd_env)
+  logging.debug('Environment variables: %s' % env)
 
   full_cmd = ' '.join(cmd)
   logging.info('Running: %s', full_cmd)
 
-  process = subprocess.Popen(cmd, env=cmd_env,
+  process = subprocess.Popen(cmd, env=env,
                              stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE)
   stdout, stderr = process.communicate()
@@ -382,18 +376,13 @@ def IssueBackgroundCommand(cmd, stdout_path, stderr_path, env=None):
     env: A dict of key/value strings, such as is given to the subprocess.Popen()
         constructor, that contains environment variables to be injected.
   """
-  if env is not None:
-    cmd_env = env
-  else:
-    cmd_env = os.environ.copy()
-
-  logging.debug('Environment variables: %s' % cmd_env)
+  logging.debug('Environment variables: %s' % env)
 
   full_cmd = ' '.join(cmd)
   logging.info('Spawning: %s', full_cmd)
   outfile = open(stdout_path, 'w')
   errfile = open(stderr_path, 'w')
-  subprocess.Popen(cmd, env=cmd_env,
+  subprocess.Popen(cmd, env=env,
                    stdout=outfile, stderr=errfile, close_fds=True)
 
 

--- a/tests/vm_util_test.py
+++ b/tests/vm_util_test.py
@@ -17,54 +17,8 @@
 import unittest
 
 import mock
-import os
 
 from perfkitbenchmarker import vm_util
-
-
-if os.name is 'posix':
-  class IssueCommandsWithEnvironmentVariablesTestCase(unittest.TestCase):
-
-    def testNoEnvArgument(self):
-      with mock.patch.dict('perfkitbenchmarker.vm_util.os.environ',
-                           {'perfkit': 'benchmarker'}, clear=True):
-
-        (stdout, stderr, retcode) = vm_util.IssueCommand(['/usr/bin/env'])
-
-        self.assertTrue('perfkit=benchmarker' in stdout)
-        self.assertEqual(0, retcode)
-
-    def testOverwriteEnvArgument(self):
-      with mock.patch.dict('perfkitbenchmarker.vm_util.os.environ',
-                           {'perfkit': 'old'}, clear=True):
-
-        env = {'perfkit': 'new'}
-        (stdout, stderr, retcode) = vm_util.IssueCommand(['/usr/bin/env'],
-                                                         env=env)
-        self.assertTrue('perfkit=new' in stdout)
-        self.assertTrue('perfkit=old' not in stdout)
-        self.assertEqual(0, retcode)
-
-    def testAppendEnvArgument(self):
-      with mock.patch.dict('perfkitbenchmarker.vm_util.os.environ',
-                           {'perfkit': 'old'}, clear=True):
-
-        env = {'perfkit': 'old', 'newkey': 'newvalue'}
-        (stdout, stderr, retcode) = vm_util.IssueCommand(['/usr/bin/env'],
-                                                         env=env)
-        self.assertTrue('perfkit=old' in stdout)
-        self.assertTrue('newkey=newvalue' in stdout)
-        self.assertEqual(0, retcode)
-
-    def testUnsetEnvArgument(self):
-      with mock.patch.dict('perfkitbenchmarker.vm_util.os.environ',
-                           {'perfkit': 'old'}, clear=True):
-        env = {}
-        (stdout, stderr, retcode) = vm_util.IssueCommand(['/usr/bin/env'],
-                                                         env=env)
-
-        self.assertTrue('perfkit=old' not in stdout)
-        self.assertEqual(0, retcode)
 
 
 class ShouldRunOnInternalIpAddressTestCase(unittest.TestCase):


### PR DESCRIPTION
Adds an optional parameter to the functions Issue*Command() that  allows a user to set append/overwrite/unset environment variables  before the command is issued. Included tests demonstrate usage.

Background:
For some providers like Rackspace, and OpenStack, the command line utilities provided by these need certain environments variables to be set to pass configuration data such as credentials, endpoints, regions, etc. Before this patch, PerfKitBenchmarker ran with the same environment variables which the process was started with, and did not provide a way to extend, overwrite, or unset environment variables.