### PR TITLE
Expose VM count and scratch disk requirements in help.

### DIFF
--- a/perfkitbenchmarker/benchmarks/cluster_boot_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/cluster_boot_benchmark.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Runs a cluster boot benchmark."""
+"""Records the time required to boot a cluster of VMs."""
 
 import logging
 
@@ -22,7 +22,8 @@ from perfkitbenchmarker import sample
 
 FLAGS = flags.FLAGS
 BENCHMARK_INFO = {'name': 'cluster_boot',
-                  'description': 'Create a cluster, record all times to boot',
+                  'description': 'Create a cluster, record all times to boot. '
+                  'Specify the cluster size with --num_vms.',
                   'scratch_disk': False,
                   'num_machines': None}  # Set in GetInfo()
 

--- a/perfkitbenchmarker/benchmarks/copy_throughput_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/copy_throughput_benchmark.py
@@ -35,7 +35,7 @@ FLAGS = flags.FLAGS
 BENCHMARK_INFO = {'name': 'copy_throughput',
                   'description': 'Get cp and scp performance between vms.',
                   'scratch_disk': True,
-                  'num_machines': 0}
+                  'num_machines': None}
 
 CIPHER = 'aes128-cbc'
 

--- a/perfkitbenchmarker/benchmarks/hpcc_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/hpcc_benchmark.py
@@ -55,7 +55,8 @@ BLOCK_SIZE = 192
 STREAM_METRICS = ['Copy', 'Scale', 'Add', 'Triad']
 
 BENCHMARK_INFO = {'name': 'hpcc',
-                  'description': 'Runs HPCC.',
+                  'description': 'Runs HPCC. Specify the number of VMs with '
+                  '--num_vms',
                   'scratch_disk': False}
 
 flags.DEFINE_integer('memory_size_mb',

--- a/perfkitbenchmarker/benchmarks/mesh_network_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/mesh_network_benchmark.py
@@ -41,7 +41,8 @@ FLAGS = flags.FLAGS
 
 BENCHMARK_INFO = {'name': 'mesh_network',
                   'description': 'Measures VM to VM cross section bandwidth in '
-                  'a mesh network.',
+                  'a mesh network. Specify the number of VMs in the network '
+                  'with --num_vms.',
                   'scratch_disk': False,
                   'num_machines': None}  # Set in GetInfo()
 

--- a/perfkitbenchmarker/benchmarks/oldisim_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/oldisim_benchmark.py
@@ -67,7 +67,8 @@ OLDISIM_DIR = 'oldisim'
 OLDISIM_VERSION = 'v0.1'
 BINARY_BASE = 'release/workloads/search'
 BENCHMARK_INFO = {'name': 'oldisim',
-                  'description': 'Run oldisim',
+                  'description': 'Run oldisim. Specify the number of leaf '
+                  'nodes with --oldisim_num_leaves',
                   'scratch_disk': False,
                   'num_machines': None}  # Set in GetInfo below
 

--- a/perfkitbenchmarker/benchmarks/redis_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/redis_benchmark.py
@@ -39,7 +39,8 @@ MEMTIER_COMMIT = '1.2.0'
 FIRST_PORT = 6379
 FLAGS = flags.FLAGS
 BENCHMARK_INFO = {'name': 'redis',
-                  'description': 'Run memtier_benchmark against Redis.',
+                  'description': 'Run memtier_benchmark against Redis. '
+                  'Specify the number of client VMs with --redis_clients.',
                   'scratch_disk': False,
                   'num_machines': None}  # Set in GetInfo below
 

--- a/perfkitbenchmarker/pkb.py
+++ b/perfkitbenchmarker/pkb.py
@@ -377,6 +377,26 @@ def RunBenchmarks(publish=True):
         'To run again with this setup, please use --run_uri=%s', FLAGS.run_uri)
 
 
+def _GenerateBenchmarkDocumentation():
+  """Generates benchmark documentation to show in --help."""
+  benchmark_docs = []
+  for benchmark_module in benchmarks.BENCHMARKS:
+    benchmark_info = benchmark_module.GetInfo()
+    vm_count = benchmark_info['num_machines']
+    if vm_count is None:
+      vm_count = "'--num_vms'"
+    scratch_disk_str = ''
+    if benchmark_info['scratch_disk']:
+      scratch_disk_str = ' with scratch volume'
+
+    benchmark_docs.append('%s: %s (%s VMs%s)' %
+                          (benchmark_info['name'],
+                           benchmark_info['description'],
+                           vm_count,
+                           scratch_disk_str))
+  return '\n\t'.join(benchmark_docs)
+
+
 def Main(argv=sys.argv):
   logging.basicConfig(level=logging.INFO)
   # TODO: Verify if there is other way of appending additional help
@@ -384,15 +404,12 @@ def Main(argv=sys.argv):
   # Inject more help documentation
   # The following appends descriptions of the benchmarks and descriptions of
   # the benchmark sets to the help text.
-  benchmark_list = ['%s:  %s' % (benchmark_module.GetInfo()['name'],
-                                 benchmark_module.GetInfo()['description'])
-                    for benchmark_module in benchmarks.BENCHMARKS]
   benchmark_sets_list = [
       '%s:  %s' %
       (set_name, benchmark_sets.BENCHMARK_SETS[set_name]['message'])
       for set_name in benchmark_sets.BENCHMARK_SETS]
   sys.modules['__main__'].__doc__ = __doc__ + (
-      '\nBenchmarks:\n\t%s') % '\n\t'.join(benchmark_list)
+      '\nBenchmarks:\n\t%s') % _GenerateBenchmarkDocumentation()
   sys.modules['__main__'].__doc__ += ('\n\nBenchmark Sets:\n\t%s'
                                       % '\n\t'.join(benchmark_sets_list))
   try:

--- a/perfkitbenchmarker/pkb.py
+++ b/perfkitbenchmarker/pkb.py
@@ -383,8 +383,6 @@ def _GenerateBenchmarkDocumentation():
   for benchmark_module in benchmarks.BENCHMARKS:
     benchmark_info = benchmark_module.GetInfo()
     vm_count = benchmark_info['num_machines']
-    if vm_count is None:
-      vm_count = "'--num_vms'"
     scratch_disk_str = ''
     if benchmark_info['scratch_disk']:
       scratch_disk_str = ' with scratch volume'
@@ -409,7 +407,8 @@ def Main(argv=sys.argv):
       (set_name, benchmark_sets.BENCHMARK_SETS[set_name]['message'])
       for set_name in benchmark_sets.BENCHMARK_SETS]
   sys.modules['__main__'].__doc__ = __doc__ + (
-      '\nBenchmarks:\n\t%s') % _GenerateBenchmarkDocumentation()
+      '\nBenchmarks (default requirements):\n\t%s' %
+      _GenerateBenchmarkDocumentation())
   sys.modules['__main__'].__doc__ += ('\n\nBenchmark Sets:\n\t%s'
                                       % '\n\t'.join(benchmark_sets_list))
   try:


### PR DESCRIPTION
```
Benchmarks:
	aerospike: Runs Aerospike (2 VMs)
	block_storage_workload: Runs FIO in sequential, random, read and write modes to simulate various scenarios. (1 VMs with scratch volume)
	bonnie++: Runs Bonnie++. (1 VMs with scratch volume)
	cassandra_stress: Benchmark Cassandra using cassandra-stress (4 VMs)
	cluster_boot: Create a cluster, record all times to boot (1 VMs)
	copy_throughput: Get cp and scp performance between vms. (1 VMs with scratch volume)
	coremark: Run Coremark a simple processor benchmark (1 VMs)
	fio: Runs fio in sequential, random, read and write modes. (1 VMs with scratch volume)
	hadoop_terasort: Runs Terasort (9 VMs with scratch volume)
	hpcc: Runs HPCC. (1 VMs)
	iperf: Run iperf (2 VMs)
	mesh_network: Measures VM to VM cross section bandwidth in a mesh network. (2 VMs)
	mongodb: Run YCSB against MongoDB. (2 VMs)
	netperf: Run TCP_RR, TCP_CRR, UDP_RR and TCP_STREAM Netperf benchmarks (2 VMs)
	object_storage_service: Object/blob storage service benchmarks. Specify --object_storage_scenario to select a set of sub-benchmarks to run. default is all. (1 VMs with scratch volume)
	oldisim: Run oldisim (6 VMs)
	ping: Benchmarks ping latency over internal IP addresses (2 VMs)
	redis: Run memtier_benchmark against Redis. (6 VMs)
	silo: Runs Silo (1 VMs)
	speccpu2006: Run Spec CPU2006 (1 VMs with scratch volume)
	sysbench_oltp: Runs Sysbench OLTP (1 VMs with scratch volume)
	unixbench: Runs UnixBench. (1 VMs with scratch volume)
```