### PR TITLE
Enables easy use of local disks

### DIFF
--- a/perfkitbenchmarker/aws/aws_disk.py
+++ b/perfkitbenchmarker/aws/aws_disk.py
@@ -137,4 +137,7 @@ class AwsDisk(disk.BaseDisk):
 
   def GetDevicePath(self):
     """Returns the path to the device inside the VM."""
-    return '/dev/xvdb%s' % self.device_letter
+    if self.disk_type == disk.LOCAL:
+      return '/dev/xvd%s' % self.device_letter
+    else:
+      return '/dev/xvdb%s' % self.device_letter

--- a/perfkitbenchmarker/aws/aws_disk.py
+++ b/perfkitbenchmarker/aws/aws_disk.py
@@ -33,7 +33,7 @@ from perfkitbenchmarker.aws import util
 VOLUME_EXISTS_STATUSES = frozenset(['creating', 'available', 'in-use', 'error'])
 VOLUME_DELETED_STATUSES = frozenset(['deleting', 'deleted'])
 VOLUME_KNOWN_STATUSES = VOLUME_EXISTS_STATUSES | VOLUME_DELETED_STATUSES
-DISK_TYPE = {disk.STANDARD: 'standard', disk.SSD: 'gp2', disk.IOPS: 'io1'}
+DISK_TYPE = {disk.STANDARD: 'standard', disk.SSD: 'gp2', disk.PIOPS: 'io1'}
 
 
 class AwsDisk(disk.BaseDisk):

--- a/perfkitbenchmarker/aws/aws_disk.py
+++ b/perfkitbenchmarker/aws/aws_disk.py
@@ -33,6 +33,7 @@ from perfkitbenchmarker.aws import util
 VOLUME_EXISTS_STATUSES = frozenset(['creating', 'available', 'in-use', 'error'])
 VOLUME_DELETED_STATUSES = frozenset(['deleting', 'deleted'])
 VOLUME_KNOWN_STATUSES = VOLUME_EXISTS_STATUSES | VOLUME_DELETED_STATUSES
+DISK_TYPE = {disk.STANDARD: 'standard', disk.SSD: 'gp2', disk.IOPS: 'io1'}
 
 
 class AwsDisk(disk.BaseDisk):
@@ -57,7 +58,7 @@ class AwsDisk(disk.BaseDisk):
         '--region=%s' % self.region,
         '--size=%s' % self.disk_size,
         '--availability-zone=%s' % self.zone,
-        '--volume-type=%s' % self.disk_type]
+        '--volume-type=%s' % DISK_TYPE[self.disk_type]]
     if self.disk_type == 'io1':
       create_cmd.append('--iops=%s' % self.iops)
     stdout, _, _ = vm_util.IssueCommand(create_cmd)

--- a/perfkitbenchmarker/aws/aws_disk.py
+++ b/perfkitbenchmarker/aws/aws_disk.py
@@ -33,7 +33,11 @@ from perfkitbenchmarker.aws import util
 VOLUME_EXISTS_STATUSES = frozenset(['creating', 'available', 'in-use', 'error'])
 VOLUME_DELETED_STATUSES = frozenset(['deleting', 'deleted'])
 VOLUME_KNOWN_STATUSES = VOLUME_EXISTS_STATUSES | VOLUME_DELETED_STATUSES
-DISK_TYPE = {disk.STANDARD: 'standard', disk.SSD: 'gp2', disk.PIOPS: 'io1'}
+DISK_TYPE = {
+    disk.STANDARD: 'standard',
+    disk.REMOTE_SSD: 'gp2',
+    disk.PIOPS: 'io1'
+}
 
 
 class AwsDisk(disk.BaseDisk):

--- a/perfkitbenchmarker/azure/azure_disk.py
+++ b/perfkitbenchmarker/azure/azure_disk.py
@@ -31,6 +31,7 @@ from perfkitbenchmarker import vm_util
 AZURE_PATH = 'azure'
 
 DRIVE_START_LETTER = 'c'
+DISK_TYPE = {disk.STANDARD: None}  # Azure doesn't have a disk type option yet.
 
 
 class AzureDisk(disk.BaseDisk):
@@ -47,6 +48,7 @@ class AzureDisk(disk.BaseDisk):
 
   def _Create(self):
     """Creates the disk."""
+    assert self.disk_type in DISK_TYPE, self.disk_type
     with self._lock:
       create_cmd = [AZURE_PATH,
                     'vm',

--- a/perfkitbenchmarker/azure/azure_disk.py
+++ b/perfkitbenchmarker/azure/azure_disk.py
@@ -125,4 +125,7 @@ class AzureDisk(disk.BaseDisk):
 
   def GetDevicePath(self):
     """Returns the path to the device inside the VM."""
-    return '/dev/sd%s' % chr(ord(DRIVE_START_LETTER) + self.lun)
+    if self.disk_type == disk.LOCAL:
+      return '/dev/sdb'
+    else:
+      return '/dev/sd%s' % chr(ord(DRIVE_START_LETTER) + self.lun)

--- a/perfkitbenchmarker/benchmark_spec.py
+++ b/perfkitbenchmarker/benchmark_spec.py
@@ -86,28 +86,10 @@ CLASSES = {
         FIREWALL: aws_network.AwsFirewall
     }
 }
-STANDARD = 'standard'
-SSD = 'ssd'
-IOPS = 'iops'  # Provisioned IOPS (ssd) in AWS
-DISK_TYPE = {
-    GCP: {
-        STANDARD: 'pd-standard',
-        SSD: 'pd-ssd',
-    },
-    AWS: {
-        STANDARD: 'standard',
-        SSD: 'gp2',
-        IOPS: 'io1',
-    },
-    AZURE: {
-        STANDARD: None,  # Azure doesn't have a disk type option yet.
-    }
-}
 
 FLAGS = flags.FLAGS
 
 flags.DEFINE_enum('cloud', GCP, [GCP, AZURE, AWS], 'Name of the cloud to use.')
-
 
 
 class BenchmarkSpec(object):
@@ -168,8 +150,7 @@ class BenchmarkSpec(object):
       self.vm_dict['default'] = self.vms
       for i in range(benchmark_info['scratch_disk']):
         disk_spec = disk.BaseDiskSpec(
-            self.scratch_disk_size,
-            DISK_TYPE[self.cloud][self.scratch_disk_type],
+            self.scratch_disk_size, self.scratch_disk_type,
             '/scratch%d' % i, self.scratch_disk_iops)
         for vm in self.vms:
           vm.disk_specs.append(disk_spec)
@@ -273,7 +254,7 @@ class BenchmarkSpec(object):
         disk_size, disk_type, mnt_point = node_section[option].split(':')
         disk_size = int(disk_size)
         disk_spec = disk.BaseDiskSpec(
-            disk_size, DISK_TYPE[self.cloud][disk_type], mnt_point)
+            disk_size, disk_type, mnt_point)
         for vm in vms:
           vm.disk_specs.append(disk_spec)
 

--- a/perfkitbenchmarker/benchmark_spec.py
+++ b/perfkitbenchmarker/benchmark_spec.py
@@ -272,6 +272,8 @@ class BenchmarkSpec(object):
     vm.AddMetadata(benchmark=self.benchmark_name)
     vm.WaitForBootCompletion()
     vm.Startup()
+    if FLAGS.scratch_disk_type == disk.LOCAL:
+      vm.SetupLocalDrives()
     for disk_spec in vm.disk_specs:
       vm.CreateScratchDisk(disk_spec)
     vm_util.BurnCpu(vm)

--- a/perfkitbenchmarker/benchmarks/aerospike_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/aerospike_benchmark.py
@@ -27,6 +27,7 @@ import re
 import time
 
 from perfkitbenchmarker import data
+from perfkitbenchmarker import disk
 from perfkitbenchmarker import flags
 from perfkitbenchmarker import sample
 from perfkitbenchmarker import vm_util
@@ -56,11 +57,13 @@ THREAD_STEP = 8
 
 
 def GetInfo():
-  if FLAGS.aerospike_storage_type == DISK and not FLAGS.use_local_disk:
-    BENCHMARK_INFO['scratch_disk'] = True
+  info = BENCHMARK_INFO.copy()
+  if (FLAGS.aerospike_storage_type == DISK and
+      FLAGS.scratch_disk_type != disk.LOCAL):
+    info['scratch_disk'] = True
   else:
-    BENCHMARK_INFO['scratch_disk'] = False
-  return BENCHMARK_INFO
+    info['scratch_disk'] = False
+  return info
 
 
 def CheckPrerequisites():
@@ -100,17 +103,18 @@ def _PrepareServer(server):
   server.Install('aerospike_server')
 
   if FLAGS.aerospike_storage_type == DISK:
-    if FLAGS.use_local_disk:
+    if FLAGS.scratch_disk_type == disk.LOCAL:
       devices = server.GetLocalDrives()
     else:
-      devices = [disk.GetDevicePath() for disk in server.scratch_disks]
+      devices = [scratch_disk.GetDevicePath()
+                 for scratch_disk in server.scratch_disks]
 
     server.RenderTemplate(data.ResourcePath('aerospike.conf.j2'),
                           aerospike_server.AEROSPIKE_CONF_PATH,
                           {'devices': devices})
 
-  for disk in server.scratch_disks:
-    server.RemoteCommand('sudo umount %s' % disk.mount_point)
+  for scratch_disk in server.scratch_disks:
+    server.RemoteCommand('sudo umount %s' % scratch_disk.mount_point)
 
   server.RemoteCommand('cd %s && make init' % aerospike_server.AEROSPIKE_DIR)
   server.RemoteCommand('cd %s; nohup sudo make start &> /dev/null &' %

--- a/perfkitbenchmarker/benchmarks/cassandra_stress_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/cassandra_stress_benchmark.py
@@ -24,7 +24,6 @@ import re
 import time
 
 
-from perfkitbenchmarker import benchmark_spec as bs
 from perfkitbenchmarker import data
 from perfkitbenchmarker import disk
 from perfkitbenchmarker import errors
@@ -132,7 +131,7 @@ def Prepare(benchmark_spec):
     vm_dict[DATA_NODE] = vm_dict['default'][:3]
     disk_spec = disk.BaseDiskSpec(
         FLAGS.scratch_disk_size,
-        bs.DISK_TYPE[benchmark_spec.cloud][FLAGS.scratch_disk_type],
+        FLAGS.scratch_disk_type,
         '/cassandra_data')
     for vm in vm_dict[DATA_NODE]:
       vm.CreateScratchDisk(disk_spec)

--- a/perfkitbenchmarker/disk.py
+++ b/perfkitbenchmarker/disk.py
@@ -23,7 +23,7 @@ from perfkitbenchmarker import resource
 
 STANDARD = 'standard'
 REMOTE_SSD = 'remote_ssd'
-PIOPS = 'piops'  # Provisioned IOPS (ssd) in AWS
+PIOPS = 'piops'  # Provisioned IOPS (SSD) in AWS
 LOCAL = 'local'
 
 

--- a/perfkitbenchmarker/disk.py
+++ b/perfkitbenchmarker/disk.py
@@ -21,6 +21,11 @@ import abc
 
 from perfkitbenchmarker import resource
 
+STANDARD = 'standard'
+SSD = 'ssd'
+IOPS = 'iops'  # Provisioned IOPS (ssd) in AWS
+LOCAL = 'local'
+
 
 class BaseDiskSpec(object):
   """Storing type and size about a disk."""

--- a/perfkitbenchmarker/disk.py
+++ b/perfkitbenchmarker/disk.py
@@ -22,7 +22,7 @@ import abc
 from perfkitbenchmarker import resource
 
 STANDARD = 'standard'
-SSD = 'ssd'
+REMOTE_SSD = 'remote_ssd'
 PIOPS = 'piops'  # Provisioned IOPS (ssd) in AWS
 LOCAL = 'local'
 

--- a/perfkitbenchmarker/disk.py
+++ b/perfkitbenchmarker/disk.py
@@ -23,7 +23,7 @@ from perfkitbenchmarker import resource
 
 STANDARD = 'standard'
 SSD = 'ssd'
-IOPS = 'iops'  # Provisioned IOPS (ssd) in AWS
+PIOPS = 'piops'  # Provisioned IOPS (ssd) in AWS
 LOCAL = 'local'
 
 

--- a/perfkitbenchmarker/gcp/gce_disk.py
+++ b/perfkitbenchmarker/gcp/gce_disk.py
@@ -30,7 +30,7 @@ flags.DEFINE_string(
     ' be resolved. See: '
     'https://cloud.google.com/sdk/gcloud/reference/compute/disks/create')
 
-DISK_TYPE = {disk.STANDARD: 'pd-standard', disk.SSD: 'pd-ssd'}
+DISK_TYPE = {disk.STANDARD: 'pd-standard', disk.REMOTE_SSD: 'pd-ssd'}
 
 
 class GceDisk(disk.BaseDisk):

--- a/perfkitbenchmarker/gcp/gce_disk.py
+++ b/perfkitbenchmarker/gcp/gce_disk.py
@@ -30,6 +30,8 @@ flags.DEFINE_string(
     ' be resolved. See: '
     'https://cloud.google.com/sdk/gcloud/reference/compute/disks/create')
 
+DISK_TYPE = {disk.STANDARD: 'pd-standard', disk.SSD: 'pd-ssd'}
+
 
 class GceDisk(disk.BaseDisk):
   """Object representing an GCE Disk."""
@@ -49,7 +51,7 @@ class GceDisk(disk.BaseDisk):
                   'disks',
                   'create', self.name,
                   '--size', str(self.disk_size),
-                  '--type', self.disk_type]
+                  '--type', DISK_TYPE[self.disk_type]]
     create_cmd.extend(util.GetDefaultGcloudFlags(self))
     if self.image:
       create_cmd.extend(['--image', self.image])

--- a/perfkitbenchmarker/gcp/gce_virtual_machine.py
+++ b/perfkitbenchmarker/gcp/gce_virtual_machine.py
@@ -48,7 +48,7 @@ FLAGS = flags.FLAGS
 
 SET_INTERRUPTS_SH = 'set-interrupts.sh'
 BOOT_DISK_SIZE_GB = 10
-BOOT_DISK_TYPE = 'pd-standard'
+BOOT_DISK_TYPE = disk.STANDARD
 DRIVE_START_LETTER = 'b'
 NVME = 'nvme'
 SCSI = 'SCSI'

--- a/perfkitbenchmarker/pkb.py
+++ b/perfkitbenchmarker/pkb.py
@@ -61,6 +61,7 @@ import uuid
 from perfkitbenchmarker import benchmarks
 from perfkitbenchmarker import benchmark_sets
 from perfkitbenchmarker import benchmark_spec
+from perfkitbenchmarker import disk
 from perfkitbenchmarker import flags
 from perfkitbenchmarker import log_util
 from perfkitbenchmarker import static_virtual_machine
@@ -132,8 +133,8 @@ flags.DEFINE_string('static_vm_file', None,
                     'static_virtual_machine.py for a description of this file.')
 flags.DEFINE_boolean('version', False, 'Display the version and exit.')
 flags.DEFINE_enum(
-    'scratch_disk_type', benchmark_spec.STANDARD,
-    [benchmark_spec.STANDARD, benchmark_spec.SSD, benchmark_spec.IOPS],
+    'scratch_disk_type', disk.STANDARD,
+    [disk.STANDARD, disk.SSD, disk.IOPS, disk.LOCAL],
     'Type for all scratch disks. The default is standard')
 flags.DEFINE_boolean('use_local_disk', False, 'For benchmarks that use disks, '
                      'this indicates that they should run against '

--- a/perfkitbenchmarker/pkb.py
+++ b/perfkitbenchmarker/pkb.py
@@ -136,9 +136,6 @@ flags.DEFINE_enum(
     'scratch_disk_type', disk.STANDARD,
     [disk.STANDARD, disk.SSD, disk.IOPS, disk.LOCAL],
     'Type for all scratch disks. The default is standard')
-flags.DEFINE_boolean('use_local_disk', False, 'For benchmarks that use disks, '
-                     'this indicates that they should run against '
-                     'the local disk(s) instead of remote storage.')
 flags.DEFINE_integer('scratch_disk_iops', 1500,
                      'IOPS for Provisioned IOPS (SSD) volumes in AWS.')
 

--- a/perfkitbenchmarker/pkb.py
+++ b/perfkitbenchmarker/pkb.py
@@ -134,7 +134,7 @@ flags.DEFINE_string('static_vm_file', None,
 flags.DEFINE_boolean('version', False, 'Display the version and exit.')
 flags.DEFINE_enum(
     'scratch_disk_type', disk.STANDARD,
-    [disk.STANDARD, disk.SSD, disk.IOPS, disk.LOCAL],
+    [disk.STANDARD, disk.SSD, disk.PIOPS, disk.LOCAL],
     'Type for all scratch disks. The default is standard')
 flags.DEFINE_integer('scratch_disk_iops', 1500,
                      'IOPS for Provisioned IOPS (SSD) volumes in AWS.')

--- a/perfkitbenchmarker/pkb.py
+++ b/perfkitbenchmarker/pkb.py
@@ -134,7 +134,7 @@ flags.DEFINE_string('static_vm_file', None,
 flags.DEFINE_boolean('version', False, 'Display the version and exit.')
 flags.DEFINE_enum(
     'scratch_disk_type', disk.STANDARD,
-    [disk.STANDARD, disk.SSD, disk.PIOPS, disk.LOCAL],
+    [disk.STANDARD, disk.REMOTE_SSD, disk.PIOPS, disk.LOCAL],
     'Type for all scratch disks. The default is standard')
 flags.DEFINE_integer('scratch_disk_iops', 1500,
                      'IOPS for Provisioned IOPS (SSD) volumes in AWS.')

--- a/perfkitbenchmarker/virtual_machine.py
+++ b/perfkitbenchmarker/virtual_machine.py
@@ -85,6 +85,8 @@ class BaseVirtualMachine(resource.BaseResource):
     disk_specs: list of BaseDiskSpec objects. Specifications for disks attached
       to the VM.
     scratch_disks: list of BaseDisk objects. Scratch disks attached to the VM.
+    max_local_drives: The number of local drives on the VM that can be used as
+      scratch disks or that can be striped together.
   """
 
   is_static = False

--- a/perfkitbenchmarker/virtual_machine.py
+++ b/perfkitbenchmarker/virtual_machine.py
@@ -122,6 +122,7 @@ class BaseVirtualMachine(resource.BaseResource):
     self.disk_specs = []
     self.scratch_disks = []
     self.hostname = None
+    self.max_local_drives = 0
 
     # Cached values
     self._reachable = {}
@@ -495,35 +496,9 @@ class BaseVirtualMachine(resource.BaseResource):
     """Returns a list of local drives on the VM."""
     return []
 
-  def SetupLocalDrives(self, mount_path=LOCAL_MOUNT_PATH):
-    """Set up any local drives that exist.
-
-    Gets all local drives, stripes them together (if possible), formats,
-    and mounts them at 'mount_path'. If there are no local drives to set up,
-    this method will return False. If this method does set up local drives,
-    then it will return True.
-
-    Args:
-      mount_path: The path where the local drives should be mounted. If this
-          is None, then the device won't be formatted or mounted.
-
-    Returns:
-      A boolean indicating whether the setup occured.
-    """
-    devices = self.GetLocalDrives()
-    if not devices:
-      return False
-
-    if len(devices) > 1:
-      device_path = STRIPED_DEVICE
-      self.StripeDrives(devices, device_path)
-    else:
-      device_path = devices[0]
-
-    if mount_path:
-      self.FormatDisk(device_path)
-      self.MountDisk(device_path, mount_path)
-    return True
+  def SetupLocalDrives(self):
+    """Perform cloud specific setup on any local drives that exist."""
+    pass
 
   def AddMetadata(self, **kwargs):
     """Add key/value metadata to the instance.


### PR DESCRIPTION
Any benchmark that uses a scratch disk can now use a local disk by specifying --scratch_disk_type=local