### PR TITLE
Move VM name to BaseVirtualMachine.

### DIFF
--- a/perfkitbenchmarker/azure/azure_virtual_machine.py
+++ b/perfkitbenchmarker/azure/azure_virtual_machine.py
@@ -85,8 +85,6 @@ class AzureService(resource.BaseResource):
 class AzureVirtualMachine(virtual_machine.BaseVirtualMachine):
   """Object representing an Azure Virtual Machine."""
 
-  instance_counter = 0
-
   def __init__(self, vm_spec):
     """Initialize a Azure virtual machine.
 
@@ -94,8 +92,6 @@ class AzureVirtualMachine(virtual_machine.BaseVirtualMachine):
       vm_spec: virtual_machine.BaseVirtualMachineSpec object of the vm.
     """
     super(AzureVirtualMachine, self).__init__(vm_spec)
-    self.name = 'perfkit-%s-%s' % (FLAGS.run_uri, self.instance_counter)
-    AzureVirtualMachine.instance_counter += 1
     self.service = AzureService(self.name,
                                 self.network.affinity_group.name)
     disk_spec = disk.BaseDiskSpec(None, None, None)

--- a/perfkitbenchmarker/gcp/gce_virtual_machine.py
+++ b/perfkitbenchmarker/gcp/gce_virtual_machine.py
@@ -58,8 +58,6 @@ SCSI = 'SCSI'
 class GceVirtualMachine(virtual_machine.BaseVirtualMachine):
   """Object representing a Google Compute Engine Virtual Machine."""
 
-  instance_counter = 0
-
   def __init__(self, vm_spec):
     """Initialize a GCE virtual machine.
 
@@ -67,8 +65,6 @@ class GceVirtualMachine(virtual_machine.BaseVirtualMachine):
       vm_spec: virtual_machine.BaseVirtualMachineSpec object of the vm.
     """
     super(GceVirtualMachine, self).__init__(vm_spec)
-    self.name = 'perfkit-%s-%s' % (FLAGS.run_uri, self.instance_counter)
-    GceVirtualMachine.instance_counter += 1
     disk_spec = disk.BaseDiskSpec(BOOT_DISK_SIZE_GB, BOOT_DISK_TYPE, None)
     self.boot_disk = gce_disk.GceDisk(
         disk_spec, self.name, self.zone, self.project, self.image)

--- a/perfkitbenchmarker/virtual_machine.py
+++ b/perfkitbenchmarker/virtual_machine.py
@@ -96,6 +96,9 @@ class BaseVirtualMachine(resource.BaseResource):
   # Serializing calls to ssh with the -t option fixes the problem.
   pseudo_tty_lock = threading.Lock()
 
+  _instance_counter_lock = threading.Lock()
+  _instance_counter = 0
+
   def __init__(self, vm_spec):
     """Initialize BaseVirtualMachine class.
 
@@ -103,6 +106,9 @@ class BaseVirtualMachine(resource.BaseResource):
       vm_spec: virtual_machine.BaseVirtualMachineSpec object of the vm.
     """
     super(BaseVirtualMachine, self).__init__()
+    with self._instance_counter_lock:
+      self.name = 'perfkit-%s-%d' % (FLAGS.run_uri, self._instance_counter)
+      BaseVirtualMachine._instance_counter += 1
     self.create_time = None
     self.bootable_time = None
     self.project = vm_spec.project


### PR DESCRIPTION
* Adds _instance_counter and associated lock to BaseVirtualMachine.
* Removes (non-thread-safe) implementations from GCE VM, Azure VM (see
  #118)