### PR TITLE
Write an SSH config file to the run temp directory

### DIFF
--- a/perfkitbenchmarker/benchmark_spec.py
+++ b/perfkitbenchmarker/benchmark_spec.py
@@ -179,6 +179,7 @@ class BenchmarkSpec(object):
     if self.vms:
       prepare_args = [((vm, self.firewall), {}) for vm in self.vms]
       vm_util.RunThreaded(self.PrepareVm, prepare_args)
+      vm_util.GenerateSSHConfig(self.vms)
 
   def Delete(self):
     if FLAGS.run_stage not in ['all', 'cleanup'] or self.deleted:

--- a/perfkitbenchmarker/data/ssh_config.j2
+++ b/perfkitbenchmarker/data/ssh_config.j2
@@ -1,0 +1,33 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+Host *
+  Protocol=2
+  UserKnownHostsFile=/dev/null
+  StrictHostKeyChecking=no
+  IdentitiesOnly=yes
+  PreferredAuthentications=publickey
+  PasswordAuthentication=no
+  ConnectTimeout=5
+  GSSAPIAuthentication=no
+  ServerAliveInterval=30
+  ServerAliveCountMax=10
+  BatchMode=yes
+
+{% for vm in vms %}
+Host {{ vm.name }} vm{{ loop.index0 }}
+  HostName={{ vm.ip_address }}
+  User={{ vm.user_name }}
+  Port={{ vm.ssh_port }}
+  IdentityFile={{ vm.ssh_private_key }}
+{% endfor %}


### PR DESCRIPTION
All VMs have names as of #265.

This change makes it simpler to SSH into VMs by name, to aid debugging.
Two aliases are provided for each VM: the VM name, and vm<index>, where
<index> is a unique number for each VM. The config file sets the same
SSH options used on the command line.

Example usage:

    ssh -F /tmp/perfkitbenchmarker/run_ea2f81a3/ssh_config perfkit-ea2f81a3-0

or (equivalent):

    ssh -F /tmp/perfkitbenchmarker/run_ea2f81a3/ssh_config vm0