### PR TITLE
GCE: do not restart on host failure.

### DIFF
--- a/perfkitbenchmarker/gcp/gce_virtual_machine.py
+++ b/perfkitbenchmarker/gcp/gce_virtual_machine.py
@@ -98,6 +98,7 @@ class GceVirtualMachine(virtual_machine.BaseVirtualMachine):
                     '--machine-type', self.machine_type,
                     '--tags=perfkitbenchmarker',
                     '--maintenance-policy', 'TERMINATE',
+                    '--no-restart-on-failure',
                     '--metadata-from-file',
                     'sshKeys=%s' % tf.name,
                     '--metadata',


### PR DESCRIPTION
Setting `--maintenance-policy TERMINATE` *without* `--no-restart-on-failure`
will cause the VM to be rebooted on host failure.