### PR TITLE
Fix Hash Sum mismatch errors

### DIFF
--- a/perfkitbenchmarker/package_managers.py
+++ b/perfkitbenchmarker/package_managers.py
@@ -43,6 +43,8 @@ EPEL6_RPM = ('http://dl.fedoraproject.org/pub/epel/'
 EPEL7_RPM = ('http://dl.fedoraproject.org/pub/epel/'
              '7/x86_64/e/epel-release-7-5.noarch.rpm')
 
+UPDATE_RETRIES = 5
+
 FLAGS = flags.FLAGS
 
 flags.DEFINE_enum('os_type', DEBIAN,
@@ -211,11 +213,19 @@ class AptMixin(BasePackageMixin):
     self.AptUpdate()
     self.RemoteCommand('mkdir -p %s' % vm_util.VM_TMP_DIR)
 
+  @vm_util.Retry(max_retries=UPDATE_RETRIES)
   def AptUpdate(self):
     """Updates the package lists on VMs using apt."""
-    # We don't want to fail if updating fails. The '--ignore-missing'
-    # option lets us continue even when we can't locate an archive.
-    self.RemoteCommand('sudo apt-get update --ignore-missing')
+    try:
+      # We don't want to fail if updating fails. The '--ignore-missing'
+      # option lets us continue even when we can't locate an archive.
+      self.RemoteCommand('sudo apt-get update --ignore-missing')
+    except errors.VmUtil.SshConnectionError as e:
+      # If there is a problem, remove the lists in order to get rid of
+      # "Hash Sum mismatch" errors (the files will be restored when
+      # apt-get update is run again).
+      self.RemoteCommand('sudo rm -r /var/lib/apt/lists/*')
+      raise e
 
   def SnapshotPackages(self):
     """Grabs a snapshot of the currently installed packages."""

--- a/perfkitbenchmarker/package_managers.py
+++ b/perfkitbenchmarker/package_managers.py
@@ -217,9 +217,7 @@ class AptMixin(BasePackageMixin):
   def AptUpdate(self):
     """Updates the package lists on VMs using apt."""
     try:
-      # We don't want to fail if updating fails. The '--ignore-missing'
-      # option lets us continue even when we can't locate an archive.
-      self.RemoteCommand('sudo apt-get update --ignore-missing')
+      self.RemoteCommand('sudo apt-get update')
     except errors.VmUtil.SshConnectionError as e:
       # If there is a problem, remove the lists in order to get rid of
       # "Hash Sum mismatch" errors (the files will be restored when


### PR DESCRIPTION
Apparently running with --ignore-missing was not sufficient to
get around the errors - see
http://askubuntu.com/questions/41605/trouble-downloading-packages-list-due-to-a-hash-sum-mismatch-error
for an explanation of the fix