### PR TITLE
Switch MongoDB to use common YCSB code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ In its current release these are the benchmarks that are executed:
   - `iperf`: BSD license(http://iperf.sourceforge.net/)
   - `memtier_benchmark`: GPL v2 (https://github.com/RedisLabs/memtier_benchmark)
   - `mesh_network`: HP license (http://www.calculate-linux.org/packages/licenses/netperf)
-  - `mongodb`: GNU AGPL v3.0 (http://www.mongodb.org/about/licensing/)
+  - `mongodb`: **Deprecated**. GNU AGPL v3.0 (http://www.mongodb.org/about/licensing/)
+  - `mongodb_ycsb`: GNU AGPL v3.0 (http://www.mongodb.org/about/licensing/)
   - `netperf`: HP license (http://www.calculate-linux.org/packages/licenses/netperf)
   - `oldisim`: Apache v2.
   - `object_storage_service`: Apache v2.

--- a/perfkitbenchmarker/benchmark_sets.py
+++ b/perfkitbenchmarker/benchmark_sets.py
@@ -71,7 +71,7 @@ BENCHMARK_SETS = {
     'google_set': {
         MESSAGE: ('This benchmark set is maintained by Google Cloud Platform '
                   'Performance Team.'),
-        BENCHMARK_LIST: [STANDARD_SET, 'oldisim']
+        BENCHMARK_LIST: [STANDARD_SET, 'oldisim', 'mongodb_ycsb']
     },
     'intel_set': {
         MESSAGE: 'Intel benchmark set.',

--- a/perfkitbenchmarker/benchmarks/mongodb_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/mongodb_benchmark.py
@@ -19,6 +19,9 @@ database.
 
 MongoDB homepage: http://www.mongodb.org/
 YCSB homepage: https://github.com/brianfrankcooper/YCSB/wiki
+
+DEPRECATED: This performs a very short test against a VM without a scratch disk.
+Please use mongodb_ycsb_benchmark in place of this benchmark.
 """
 
 import logging
@@ -32,12 +35,16 @@ YCSB_CMD = ('cd %s; ./bin/ycsb %s mongodb -s -P workloads/workloada '
             '-p mongodb.writeConcern=normal')
 
 BENCHMARK_INFO = {'name': 'mongodb',
-                  'description': 'Run YCSB against MongoDB.',
+                  'description': 'Run YCSB against MongoDB. DEPRECATED.',
                   'scratch_disk': False,
                   'num_machines': 2}
 
 RESULT_REGEX = r'\[(\w+)\], (\w+)\(([\w/]+)\), ([-+]?[0-9]*\.?[0-9]+)'
 OPERATIONS_REGEX = r'\[(\w+)\], Operations, ([-+]?[0-9]*\.?[0-9]+)'
+
+DEPRECATION_MESSAGE = """DEPRECATED: This performs a very short test against a
+VM without a scratch disk. Please use 'mongodb_ycsb' in place of this
+benchmark. 'mongodb' will be removed in a future release."""
 
 
 def GetInfo():
@@ -51,6 +58,7 @@ def Prepare(benchmark_spec):
     benchmark_spec: The benchmark specification. Contains all data that is
         required to run the benchmark.
   """
+  logging.warn(DEPRECATION_MESSAGE)
   vms = benchmark_spec.vms
   assert len(vms) == BENCHMARK_INFO['num_machines']
   vm = vms[0]

--- a/perfkitbenchmarker/benchmarks/mongodb_ycsb_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/mongodb_ycsb_benchmark.py
@@ -1,0 +1,112 @@
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Run YCSB against MongoDB.
+
+YCSB is a load generator for many 'cloud' databases. MongoDB is a NoSQL
+database.
+
+MongoDB homepage: http://www.mongodb.org/
+YCSB homepage: https://github.com/brianfrankcooper/YCSB/wiki
+"""
+
+import os
+
+from perfkitbenchmarker import flags
+from perfkitbenchmarker.packages import ycsb
+
+FLAGS = flags.FLAGS
+
+
+BENCHMARK_INFO = {'name': 'mongodb_ycsb',
+                  'description': 'Run YCSB against MongoDB.',
+                  'scratch_disk': True,
+                  'num_machines': 2}
+
+RESULT_REGEX = r'\[(\w+)\], (\w+)\(([\w/]+)\), ([-+]?[0-9]*\.?[0-9]+)'
+OPERATIONS_REGEX = r'\[(\w+)\], Operations, ([-+]?[0-9]*\.?[0-9]+)'
+
+
+def GetInfo():
+  return BENCHMARK_INFO
+
+
+def _GetDataDir(vm):
+  return os.path.join(vm.GetScratchDir(), 'mongodb-data')
+
+
+def Prepare(benchmark_spec):
+  """Install MongoDB on one VM and YCSB on another.
+
+  Args:
+    benchmark_spec: The benchmark specification. Contains all data that is
+        required to run the benchmark.
+  """
+  vms = benchmark_spec.vms
+  assert len(vms) == BENCHMARK_INFO['num_machines']
+  mongo_vm = vms[0]
+
+  # Install mongodb on the 1st machine.
+  mongo_vm.Install('mongodb_server')
+  data_dir = _GetDataDir(mongo_vm)
+  mongo_vm.RemoteCommand('mkdir {0} && chmod a+rwx {0}'.format(data_dir))
+  mongo_vm.RemoteCommand(
+      "sudo sed -i -e '/bind_ip/ s/^/#/; s,^dbpath=.*,dbpath=%s,' %s" %
+      (data_dir,
+       mongo_vm.GetPathToConfig('mongodb_server')))
+  mongo_vm.RemoteCommand('sudo service %s restart' %
+                         mongo_vm.GetServiceName('mongodb_server'))
+
+  # Setup YCSB load generator on the 2nd machine.
+  ycsb_vm = vms[1]
+  ycsb_vm.Install('ycsb')
+
+
+def Run(benchmark_spec):
+  """Run run YCSB with workloada against MongoDB.
+
+  Args:
+    benchmark_spec: The benchmark specification. Contains all data that is
+        required to run the benchmark.
+
+  Returns:
+    A list of samples in the form of 3 or 4 tuples. The tuples contain
+        the sample metric (string), value (float), and unit (string).
+        If a 4th element is included, it is a dictionary of sample
+        metadata.
+  """
+  vms = benchmark_spec.vms
+  vm = vms[1]
+
+  executor = ycsb.YCSBExecutor('mongodb')
+  kwargs = {
+      'mongodb.url': 'mongodb://%s:27017' % vms[0].internal_ip,
+      'mongodb.writeConcern': 'normal'}
+  samples = list(executor.LoadAndRun([vm], load_kwargs=kwargs,
+                                     run_kwargs=kwargs))
+  return samples
+
+
+def Cleanup(benchmark_spec):
+  """Remove MongoDB and YCSB.
+
+  Args:
+    benchmark_spec: The benchmark specification. Contains all data that is
+        required to run the benchmark.
+  """
+  vms = benchmark_spec.vms
+  mongo_vm = vms[0]
+  mongo_vm.RemoteCommand('sudo service %s stop' %
+                         mongo_vm.GetServiceName('mongodb_server'))
+  mongo_vm.RemoteCommand('rm -rf %s' % _GetDataDir(mongo_vm))

--- a/perfkitbenchmarker/benchmarks/mongodb_ycsb_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/mongodb_ycsb_benchmark.py
@@ -38,9 +38,6 @@ BENCHMARK_INFO = {'name': 'mongodb_ycsb',
                   'scratch_disk': True,
                   'num_machines': 2}
 
-RESULT_REGEX = r'\[(\w+)\], (\w+)\(([\w/]+)\), ([-+]?[0-9]*\.?[0-9]+)'
-OPERATIONS_REGEX = r'\[(\w+)\], Operations, ([-+]?[0-9]*\.?[0-9]+)'
-
 
 def GetInfo():
   return BENCHMARK_INFO

--- a/perfkitbenchmarker/benchmarks/mongodb_ycsb_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/mongodb_ycsb_benchmark.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,6 +25,10 @@ import os
 
 from perfkitbenchmarker import flags
 from perfkitbenchmarker.packages import ycsb
+
+# See http://api.mongodb.org/java/2.13/com/mongodb/WriteConcern.html
+flags.DEFINE_string('mongodb_writeconcern', 'safe',
+                    'MongoDB write concern.')
 
 FLAGS = flags.FLAGS
 
@@ -92,7 +96,7 @@ def Run(benchmark_spec):
   executor = ycsb.YCSBExecutor('mongodb')
   kwargs = {
       'mongodb.url': 'mongodb://%s:27017' % vms[0].internal_ip,
-      'mongodb.writeConcern': 'normal'}
+      'mongodb.writeConcern': FLAGS.mongodb_writeconcern}
   samples = list(executor.LoadAndRun([vm], load_kwargs=kwargs,
                                      run_kwargs=kwargs))
   return samples

--- a/perfkitbenchmarker/benchmarks/mongodb_ycsb_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/mongodb_ycsb_benchmark.py
@@ -75,17 +75,14 @@ def Prepare(benchmark_spec):
 
 
 def Run(benchmark_spec):
-  """Run run YCSB with workloada against MongoDB.
+  """Run YCSB with against MongoDB.
 
   Args:
     benchmark_spec: The benchmark specification. Contains all data that is
         required to run the benchmark.
 
   Returns:
-    A list of samples in the form of 3 or 4 tuples. The tuples contain
-        the sample metric (string), value (float), and unit (string).
-        If a 4th element is included, it is a dictionary of sample
-        metadata.
+    A list of sample.Sample objects.
   """
   vms = benchmark_spec.vms
   vm = vms[1]


### PR DESCRIPTION
This PR adds a new benchmark: `mongodb_ycsb`, using the code common to `perfkitbenchmarker/packages/ycsb.py`. Differences from the current YCSB benchmark:
* Uses YCSB Executor, to report additional details.
* Stores data on scratch disks.
* Allows a user-configurable number of YCSB client vms, operations, initial database sizes.
* Allows a user-specifiable write concern, defaulting to `safe`.

This better matches other YCSB-based benchmarks, but is still slightly less
stringent than others:

* HBase flushes to 3 replicas by default before acking a write.
* Cassandra is configured in QUORUM write mode.

MongoDB write concern `JOURNALED` would better match these configurations,
but writes are committed in batches, so latency will be quite high.

Also deprecates the `mongodb` benchmark.