### PR TITLE
Clean up _GenerateBenchmarkDocumentation

### DIFF
--- a/perfkitbenchmarker/pkb.py
+++ b/perfkitbenchmarker/pkb.py
@@ -400,15 +400,14 @@ def RunBenchmarks(publish=True):
         'To run again with this setup, please use --run_uri=%s', FLAGS.run_uri)
 
 
-
 def _GenerateBenchmarkDocumentation():
   """Generates benchmark documentation to show in --help."""
   benchmark_docs = []
   for benchmark_module in benchmarks.BENCHMARKS:
-    benchmark_info = benchmark_module.GetInfo()
-    vm_count = benchmark_info['num_machines']
+    benchmark_info = benchmark_module.BENCHMARK_INFO
+    vm_count = benchmark_info.get('num_machines') or 'variable'
     scratch_disk_str = ''
-    if benchmark_info['scratch_disk']:
+    if benchmark_info.get('scratch_disk'):
       scratch_disk_str = ' with scratch volume'
 
     benchmark_docs.append('%s: %s (%s VMs%s)' %


### PR DESCRIPTION
Removes the use of FLAG values in _GenerateBenchmarkDocumentation

New help text:

```
Benchmarks (default requirements):
	aerospike: Runs Aerospike (2 VMs)
	block_storage_workload: Runs FIO in sequential, random, read and write modes to simulate various scenarios. (1 VMs with scratch volume)
	bonnie++: Runs Bonnie++. (1 VMs with scratch volume)
	cassandra_stress: Benchmark Cassandra using cassandra-stress (4 VMs)
	cluster_boot: Create a cluster, record all times to boot. Specify the cluster size with --num_vms. (variable VMs)
	copy_throughput: Get cp and scp performance between vms. (variable VMs with scratch volume)
	coremark: Run Coremark a simple processor benchmark (1 VMs)
	fio: Runs fio in sequential, random, read and write modes. (1 VMs with scratch volume)
	hadoop_terasort: Runs Terasort. Control the number of VMs with --num_vms. (9 VMs with scratch volume)
	hbase_ycsb: Run YCSB against HBase. Specify the HBase cluster size with --num_vms. Specify the number of YCSB VMs with --ycsb_client_vms. (variable VMs with scratch volume)
	hpcc: Runs HPCC. Specify the number of VMs with --num_vms (variable VMs)
	iperf: Run iperf (2 VMs)
	mesh_network: Measures VM to VM cross section bandwidth in a mesh network. Specify the number of VMs in the network with --num_vms. (variable VMs)
	mongodb: Run YCSB against MongoDB. (2 VMs)
	netperf: Run TCP_RR, TCP_CRR, UDP_RR and TCP_STREAM Netperf benchmarks (2 VMs)
	object_storage_service: Object/blob storage service benchmarks. Specify --object_storage_scenario to select a set of sub-benchmarks to run. default is all. (1 VMs with scratch volume)
	oldisim: Run oldisim. Specify the number of leaf nodes with --oldisim_num_leaves (variable VMs)
	ping: Benchmarks ping latency over internal IP addresses (2 VMs)
	redis: Run memtier_benchmark against Redis. Specify the number of client VMs with --redis_clients. (variable VMs)
	silo: Runs Silo (1 VMs)
	speccpu2006: Run Spec CPU2006 (1 VMs with scratch volume)
	sysbench_oltp: Runs Sysbench OLTP (1 VMs with scratch volume)
	unixbench: Runs UnixBench. (1 VMs with scratch volume)
```