### PR TITLE
Add a --dstat flag

### DIFF
--- a/perfkitbenchmarker/packages/dstat.py
+++ b/perfkitbenchmarker/packages/dstat.py
@@ -1,0 +1,31 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Module containing dstat installation and cleanup functions."""
+
+
+def _Install(vm):
+  """Installs the dstat package on the VM."""
+  vm.InstallPackages('dstat')
+
+
+def YumInstall(vm):
+  """Installs the dstat package on the VM."""
+  _Install(vm)
+
+
+def AptInstall(vm):
+  """Installs the dstat package on the VM."""
+  _Install(vm)

--- a/perfkitbenchmarker/pkb.py
+++ b/perfkitbenchmarker/pkb.py
@@ -206,8 +206,10 @@ def DoRunPhase(benchmark, name, spec, collector, timer):
   logging.info('Running benchmark %s', name)
   for before_run_hook in BEFORE_RUN_HOOKS:
     before_run_hook(benchmark=benchmark, benchmark_spec=spec)
-  with timer.Measure('Benchmark Run'):
-    samples = benchmark.Run(spec)
+
+  with vm_util.RunDStatIfConfigured(spec.vms, suffix='-{0}-dstat'.format(name)):
+    with timer.Measure('Benchmark Run'):
+      samples = benchmark.Run(spec)
   collector.AddSamples(samples, name, spec)
 
 

--- a/perfkitbenchmarker/vm_util.py
+++ b/perfkitbenchmarker/vm_util.py
@@ -14,8 +14,10 @@
 
 """Set of utility functions for working with virtual machines."""
 
+import contextlib
 import logging
 import os
+import posixpath
 import random
 import re
 import socket
@@ -56,6 +58,13 @@ flags.DEFINE_integer('default_timeout', TIMEOUT, 'The default timeout for '
 flags.DEFINE_integer('burn_cpu_seconds', 0,
                      'Amount of time in seconds to burn cpu on vm.')
 flags.DEFINE_integer('burn_cpu_threads', 1, 'Number of threads to burn cpu.')
+flags.DEFINE_boolean('dstat', False,
+                     'Run dstat (http://dag.wiee.rs/home-made/dstat/) '
+                     'on each VM to collect system performance metrics during '
+                     'each benchmark run.')
+flags.DEFINE_integer('dstat_interval', None,
+                     'dstat sample collection frequency, in seconds. Only '
+                     'applicable when --dstat is specified.')
 
 
 class IpAddressSubset(object):
@@ -501,3 +510,68 @@ def GenerateSSHConfig(vms):
     ofp.write(template.render({'vms': vms}))
   logging.info('ssh to VMs in this benchmark by name with: '
                'ssh -F {0} <vm name>'.format(target_file))
+
+
+@contextlib.contextmanager
+def RunDStatIfConfigured(vms, suffix='-dstat'):
+  """Installs and runs dstat on 'vms' if FLAGS.dstat is set.
+
+  On exiting the context manager, the results are copied to the run temp dir.
+
+  Args:
+    vms: List of virtual machines.
+    suffix: str. Suffix to add to each dstat result file.
+
+  Yields:
+    None
+  """
+  if not FLAGS.dstat:
+    yield
+    return
+
+  lock = threading.Lock()
+  pids = {}
+  file_names = {}
+
+  def StartDStat(vm):
+    vm.Install('dstat')
+
+    num_cpus = vm.num_cpus
+
+    # List block devices so that I/O to each block device can be recorded.
+    block_devices, _ = vm.RemoteCommand(
+        'lsblk --nodeps --output NAME --noheadings')
+    block_devices = block_devices.splitlines()
+    dstat_file = posixpath.join(
+        VM_TMP_DIR, '{0}{1}.csv'.format(vm.name, suffix))
+    cmd = ('dstat --epoch -C total,0-{max_cpu} '
+           '-D total,{block_devices} '
+           '-clrdngyi -pms --fs --ipc --tcp '
+           '--udp --raw --socket --unix --vm --rpc '
+           '--noheaders --output {output} {dstat_interval} > /dev/null 2>&1 & '
+           'echo $!').format(
+               max_cpu=num_cpus - 1,
+               block_devices=','.join(block_devices),
+               output=dstat_file,
+               dstat_interval=FLAGS.dstat_interval or '')
+    stdout, _ = vm.RemoteCommand(cmd)
+    with lock:
+      pids[vm.name] = stdout.strip()
+      file_names[vm.name] = dstat_file
+
+  def StopDStat(vm):
+    if vm.name not in pids:
+      logging.warn('No dstat PID for %s', vm.name)
+      return
+    cmd = 'kill {0} || true'.format(pids[vm.name])
+    vm.RemoteCommand(cmd)
+    try:
+      vm.PullFile(GetTempDir(), file_names[vm.name])
+    except:
+      logging.exception('Failed fetching dstat result.')
+
+  RunThreaded(StartDStat, vms)
+  try:
+    yield
+  finally:
+    RunThreaded(StopDStat, vms)


### PR DESCRIPTION
When set, runs 'dstat' during the benchmark run, copies the results to
the run temp dir once the benchmark run completes.