### PR TITLE
Comma-delimit multiple args passed to gcloud flags.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@
 
 # Don't let git change end of line characters in the data directory.
 perfkitbenchmarker/data/* -text
+tests/data/* -text

--- a/perfkitbenchmarker/gcp/gce_virtual_machine.py
+++ b/perfkitbenchmarker/gcp/gce_virtual_machine.py
@@ -91,9 +91,7 @@ class GceVirtualMachine(virtual_machine.BaseVirtualMachine):
                     'instances',
                     'create', self.name,
                     '--disk',
-                    'name=%s' % self.boot_disk.name,
-                    'boot=yes',
-                    'mode=rw',
+                    'name=%s,boot=yes,mode=rw' % self.boot_disk.name,
                     '--machine-type', self.machine_type,
                     '--tags=perfkitbenchmarker',
                     '--maintenance-policy', 'TERMINATE',
@@ -108,7 +106,7 @@ class GceVirtualMachine(virtual_machine.BaseVirtualMachine):
         create_cmd.append('interface=%s' % ssd_interface_option)
       if FLAGS.gcloud_scopes:
         create_cmd.extend(['--scopes'] +
-                          re.split(r'[,; ]', FLAGS.gcloud_scopes))
+                          ','.join(re.split(r'[,; ]', FLAGS.gcloud_scopes)))
       create_cmd.extend(util.GetDefaultGcloudFlags(self))
       vm_util.IssueCommand(create_cmd)
 


### PR DESCRIPTION
The current configuration is giving warnings like:

       WARNING: Lists should be separated by commas, try "--disk=name=perfkit-NNNNNN-0,boot=yes,mode=rw".
       If you intend to use boot=yes, mode=rw for positional arguments, put them before the flag.

This may turn into an error in the future.