### PR TITLE
pkb: Add DigitalOcean cloud support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Before you can run the PerfKit Benchmaker on Cloud providers you need accounts a
 * Get a GCE account to run tests on GCE. Our site is https://cloud.google.com
 * Get an AWS account to run tests on AWS. Their site is http://aws.amazon.com/
 * Get an Azure account to run tests on Azure. Their site is http://azure.microsoft.com/
+* Get a DigitalOcean account to run tests on DigitalOcean. Their site is https://www.digitalocean.com/
 
 You also need the software dependencies, which are mostly command line tools and credentials to access your
 accounts without a password.  The following steps should help you get the CLI tool auth in place.
@@ -175,6 +176,40 @@ Test that azure is installed correctly
 ```
 $ azure vm list
 ```
+
+## DigitalOcean configuration and credentials
+
+PerfKitBenchmarker uses the *curl* tool to interact with
+DigitalOcean's REST API. This API uses oauth for authentication.
+Please set this up as follows:
+
+Log in to your DigitalOcean account and create a Personal Access Token
+for use by PerfKitBenchmarker with read/write access in Settings /
+API: https://cloud.digitalocean.com/settings/applications
+
+Save a copy of the authentication token it shows, this is a
+64-character hex string.
+
+Create a curl configuration file containing the needed authorization
+header. The double quotes are required. Example:
+
+```
+$ cat > ~/.config/digitalocean-oauth.curl
+header = "Authorization: Bearer 9876543210fedc...ba98765432"
+^D
+```
+
+Confirm that the authentication works:
+
+```
+$ curl --config ~/.config/digitalocean-oauth.curl https://api.digitalocean.com/v2/sizes
+{"sizes":[{"slug":"512mb","memory":512,"vcpus":1,...
+```
+
+PerfKitBenchmarker uses the file location `~/.config/digitalocean-oauth.curl`
+by default, you can use the `--digitalocean_curl_config` flag to
+override the path.
+
 ## Create and Configure a `.boto` file for object storage benchmarks
 
 In order to run object storage benchmark tests, you need to have a properly configured ~/.boto file.
@@ -215,7 +250,8 @@ $ sudo pip install -r requirements.txt
 
 RUNNING A SINGLE BENCHMARK
 ==========================
-PerfKitBenchmarks can run benchmarks both on Cloud Providers (GCP, AWS, Azure) as well as any "machine" you can SSH into.
+PerfKitBenchmarks can run benchmarks both on Cloud Providers (GCP,
+AWS, Azure, DigitalOcean) as well as any "machine" you can SSH into.
 
 ## Example run on GCP
 ```
@@ -233,6 +269,11 @@ $ ./pkb.py --cloud=AWS --benchmarks=iperf --machine_type=t1.micro
 $ ./pkb.py --cloud=Azure --machine_type=ExtraSmall --benchmarks=iperf
 ```
 
+## Example run on DigitalOcean
+```
+$ ./pkb.py --cloud=DigitalOcean --machine_type=16gb --benchmarks=iperf
+```
+
 HOW TO RUN ALL STANDARD BENCHMARKS
 ==================
 Run without the --benchmarks parameter and every benchmark in the standard set will run serially which can take a couple of hours (alternatively run with --benchmarks="standard_set").  Additionally if you dont specify --cloud=... all benchmarks will run on the Google Cloud Platform.
@@ -246,13 +287,28 @@ To run all benchmarks in a named set, specify the set name in the benchmarks par
 
 USEFUL GLOBAL FLAGS
 ==================
-```
-The following are some common flags used when configuring PerfKitBenchmaker.
---help           : see all flags
---cloud          : Check where the bechmarks are run.  Choices are GCP, AWS, or AZURE
---zone           : This flag always you to override the default zone.  It is thats the same value that the Cloud CLI's take such as --zone=us-central1-a is use for GCP, --zone=us-east-1a is used for AWS, and --zone='East US' is used by AZURE.
---benchmarks     : A comman separted list of benchmarks to run such as --benchmarks=iperf,ping . To see the full list just run ./pkd.py --help
-```
+
+The following are some common flags used when configuring
+PerfKitBenchmaker.
+
+Flag | Notes
+-----|------
+`--help`       | see all flags
+`--cloud`      | Check where the bechmarks are run.  Choices are `GCP`, `AWS`, `Azure`, or `DigitalOcean`
+`--zone`       | This flag allows you to override the default zone. See below.
+`--benchmarks` | A comma separated list of benchmarks or benchmark sets to run such as `--benchmarks=iperf,ping` . To see the full list, run `./pkb.py --help`
+
+The zone (region) as specified with the --zone flag uses the same
+value that the Cloud CLIs take:
+
+Cloud | Default | Notes
+-------|---------|-------
+GCP | us-central1-a | |
+AWS | us-east-1a | |
+Azure | East US | |
+DigitalOcean | sfo1 | You must use a zone that supports the features 'metadata' (for cloud config) and 'private_networking'.
+
+
 ADVANCED: HOW TO RUN BENCHMARKS WITHOUT CLOUD PROVISIONING (eg: local workstation)
 ==================
 It is possible to run PerfKitBenchmarker without running the Cloud provioning steps.  This is useful if you want to run on a local machine, or have a benchmark like iperf run from an external point to a Cloud VM.

--- a/perfkitbenchmarker/benchmark_spec.py
+++ b/perfkitbenchmarker/benchmark_spec.py
@@ -28,12 +28,15 @@ from perfkitbenchmarker.azure import azure_network
 from perfkitbenchmarker.azure import azure_virtual_machine
 from perfkitbenchmarker.deployment.config import config_reader
 import perfkitbenchmarker.deployment.shared.ini_constants as ini_constants
+from perfkitbenchmarker.digitalocean import digitalocean_network
+from perfkitbenchmarker.digitalocean import digitalocean_virtual_machine
 from perfkitbenchmarker.gcp import gce_network
 from perfkitbenchmarker.gcp import gce_virtual_machine
 
 GCP = 'GCP'
 AZURE = 'Azure'
 AWS = 'AWS'
+DIGITALOCEAN = 'DigitalOcean'
 DEBIAN = 'debian'
 RHEL = 'rhel'
 IMAGE = 'image'
@@ -58,6 +61,11 @@ DEFAULTS = {
         IMAGE: None,
         MACHINE_TYPE: 'm3.medium',
         ZONE: 'us-east-1a'
+    },
+    DIGITALOCEAN: {
+        IMAGE: 'ubuntu-14-04-x64',
+        MACHINE_TYPE: '2gb',
+        ZONE: 'sfo1'
     }
 }
 CLASSES = {
@@ -84,12 +92,23 @@ CLASSES = {
         },
         NETWORK: aws_network.AwsNetwork,
         FIREWALL: aws_network.AwsFirewall
-    }
+    },
+    DIGITALOCEAN: {
+        VIRTUAL_MACHINE: {
+            DEBIAN:
+            digitalocean_virtual_machine.DebianBasedDigitalOceanVirtualMachine,
+            RHEL:
+            digitalocean_virtual_machine.RhelBasedDigitalOceanVirtualMachine,
+        },
+        NETWORK: digitalocean_network.DigitalOceanNetwork,
+        FIREWALL: digitalocean_network.DigitalOceanFirewall
+    },
 }
 
 FLAGS = flags.FLAGS
 
-flags.DEFINE_enum('cloud', GCP, [GCP, AZURE, AWS], 'Name of the cloud to use.')
+flags.DEFINE_enum('cloud', GCP, [GCP, AZURE, AWS, DIGITALOCEAN],
+                  'Name of the cloud to use.')
 
 
 class BenchmarkSpec(object):

--- a/perfkitbenchmarker/digitalocean/__init__.py
+++ b/perfkitbenchmarker/digitalocean/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""DigitalOcean cloud provider implementation."""

--- a/perfkitbenchmarker/digitalocean/digitalocean_disk.py
+++ b/perfkitbenchmarker/digitalocean/digitalocean_disk.py
@@ -1,0 +1,46 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Module containing classes related to DigitalOcean disks.
+
+At this time, DigitalOcean does not implement any standalone disk objects,
+the instances come with directly integrated storage.
+"""
+
+from perfkitbenchmarker import disk
+from perfkitbenchmarker import errors
+
+
+class DigitalOceanDisk(disk.BaseDisk):
+  """Dummy Object representing a DigitalOcean Disk."""
+
+  def __init__(self, disk_spec):
+    super(DigitalOceanDisk, self).__init__(disk_spec)
+
+  def Attach(self, vm):
+    pass
+
+  def Detach(self):
+    pass
+
+  def GetDevicePath(self):
+    # DigitalOcean VMs only have a single disk block device which is
+    # in use for the live filesystem, so it's not usable as a scratch
+    # disk device.
+    raise errors.Error('GetDevicePath not supported for DigitalOcean.')
+
+  def _Create(self):
+    pass
+
+  def _Delete(self):
+    pass

--- a/perfkitbenchmarker/digitalocean/digitalocean_network.py
+++ b/perfkitbenchmarker/digitalocean/digitalocean_network.py
@@ -1,0 +1,33 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Module containing classes related to DigitalOcean VM networking."""
+
+from perfkitbenchmarker import network
+
+
+class DigitalOceanFirewall(network.BaseFirewall):
+  """A dummy firewall for DigitalOcean, this does nothing."""
+  pass
+
+
+class DigitalOceanNetwork(network.BaseNetwork):
+  """Object representing a DigitalOcean Network."""
+
+  def Create(self):
+    """Creates the actual network."""
+    pass
+
+  def Delete(self):
+    """Deletes the actual network."""
+    pass

--- a/perfkitbenchmarker/digitalocean/digitalocean_virtual_machine.py
+++ b/perfkitbenchmarker/digitalocean/digitalocean_virtual_machine.py
@@ -1,0 +1,215 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Class to represent a DigitalOcean Virtual Machine object (Droplet).
+"""
+
+import json
+import logging
+import time
+
+from perfkitbenchmarker import disk
+from perfkitbenchmarker import errors
+from perfkitbenchmarker import flags
+from perfkitbenchmarker import package_managers
+from perfkitbenchmarker import virtual_machine
+from perfkitbenchmarker import vm_util
+from perfkitbenchmarker.digitalocean import digitalocean_disk
+from perfkitbenchmarker.digitalocean import util
+
+FLAGS = flags.FLAGS
+
+CLOUD_CONFIG_TEMPLATE = '''#cloud-config
+users:
+  - name: {0}
+    ssh-authorized-keys:
+      - {1}
+    sudo: ['ALL=(ALL) NOPASSWD:ALL']
+    groups: sudo
+    shell: /bin/bash
+'''
+
+# HTTP status codes for creation that should not be retried.
+FATAL_CREATION_ERRORS = set([
+    422,  # 'unprocessable_entity' such as invalid size or region.
+])
+
+# Default configuration for action status polling.
+DEFAULT_ACTION_WAIT_SECONDS = 10
+DEFAULT_ACTION_MAX_TRIES = 90
+
+
+def GetErrorMessage(stdout):
+  """Extract a message field from JSON output if present."""
+  try:
+    return json.loads(stdout)['message']
+  except (ValueError, KeyError):
+    return stdout
+
+
+class DigitalOceanVirtualMachine(virtual_machine.BaseVirtualMachine):
+  """Object representing a DigitalOcean Virtual Machine (Droplet)."""
+
+  def __init__(self, vm_spec):
+    """Initialize a DigitalOcean virtual machine.
+
+    Args:
+      vm_spec: virtual_machine.BaseVirtualMachineSpec object of the vm.
+    """
+    super(DigitalOceanVirtualMachine, self).__init__(vm_spec)
+    self.droplet_id = None
+    self.max_local_disks = 1
+    self.local_disk_counter = 0
+
+  def _Create(self):
+    """Create a DigitalOcean VM instance (droplet)."""
+    super(DigitalOceanVirtualMachine, self)._Create()
+    with open(self.ssh_public_key) as f:
+      public_key = f.read().rstrip('\n')
+
+    stdout, ret = util.RunCurlCommand(
+        'POST', 'droplets', {
+            'name': self.name,
+            'region': self.zone,
+            'size': self.machine_type,
+            'image': self.image,
+            'backups': False,
+            'ipv6': False,
+            'private_networking': True,
+            'ssh_keys': [],
+            'user_data': CLOUD_CONFIG_TEMPLATE.format(
+                self.user_name, public_key)
+        })
+    if ret != 0:
+      msg = GetErrorMessage(stdout)
+      if ret in FATAL_CREATION_ERRORS:
+        raise errors.Error('Creation request invalid, not retrying: %s' % msg)
+      raise errors.Resource.RetryableCreationError('Creation failed: %s' % msg)
+    response = json.loads(stdout)
+    self.droplet_id = response['droplet']['id']
+
+    # The freshly created droplet will be in a locked and unusable
+    # state for a while, and it cannot be deleted or modified in
+    # this state. Wait for the action to finish and check the
+    # reported result.
+    if not self._GetActionResult(response['links']['actions'][0]['id']):
+      raise errors.Resource.RetryableCreationError('Creation failed, see log.')
+
+  def _GetActionResult(
+      self, action_id, wait_seconds=DEFAULT_ACTION_WAIT_SECONDS,
+      max_tries=DEFAULT_ACTION_MAX_TRIES):
+    """Wait until a VM action completes."""
+    for _ in xrange(max_tries):
+      time.sleep(wait_seconds)
+      stdout, ret = util.RunCurlCommand('GET', 'actions/%s' % action_id)
+      if ret != 0:
+        logging.warn('Unexpected action lookup failure.')
+        return False
+      response = json.loads(stdout)
+      status = response['action']['status']
+      logging.debug('action %d: status is "%s".', action_id, status)
+      if status == 'completed':
+        return True
+      elif status == 'errored':
+        return False
+    # If we get here, waiting timed out. Treat as failure.
+    logging.debug('action %d: timed out waiting.', action_id)
+    return False
+
+  @vm_util.Retry()
+  def _PostCreate(self):
+    """Get the instance's data."""
+    stdout, _ = util.RunCurlCommand(
+        'GET', 'droplets/%s' % self.droplet_id)
+    response = json.loads(stdout)['droplet']
+    for interface in response['networks']['v4']:
+      if interface['type'] == 'public':
+        self.ip_address = interface['ip_address']
+      else:
+        self.internal_ip = interface['ip_address']
+
+  def _Delete(self):
+    """Delete a DigitalOcean VM instance."""
+    stdout, ret = util.RunCurlCommand(
+        'DELETE', 'droplets/%s' % self.droplet_id)
+    if ret != 0:
+      if ret == 404:
+        return  # Assume already deleted.
+      raise errors.Resource.RetryableDeletionError('Deletion failed: %s' %
+                                                   GetErrorMessage(stdout))
+
+    # Get the droplet's actions so that we can look up the
+    # ID for the deletion just issued.
+    stdout, ret = util.RunCurlCommand(
+        'GET', 'droplets/%s/actions' % self.droplet_id)
+    if ret != 0:
+      # There's a race condition here - if the lookup fails, assume it's
+      # due to deletion already being complete. Don't raise an error in
+      # that case,  the _Exists check should trigger retry if needed.
+      return
+    response = json.loads(stdout)['actions']
+
+    # Get the action ID for the 'destroy' action. This assumes there's only
+    # one of them, but AFAIK there can't be more since 'destroy' locks the VM.
+    destroy = [v for v in response if v['type'] == 'destroy'][0]
+
+    # Wait for completion. Actions are global objects, so the action
+    # status should still be retrievable after the VM got destroyed.
+    # We don't care about the result, let the _Exists check decide if we
+    # need to try again.
+    self._GetActionResult(destroy['id'])
+
+  def _Exists(self):
+    """Returns true if the VM exists."""
+    _, ret = util.RunCurlCommand(
+        'GET', 'droplets/%s' % self.droplet_id,
+        suppress_warning=True)
+    if ret == 0:
+      return True
+    if ret == 404:
+      # Definitely doesn't exist.
+      return False
+    # Unknown status - assume it doesn't exist. TODO(klausw): retry?
+    return False
+
+  def CreateScratchDisk(self, disk_spec):
+    """Create a VM's scratch disk.
+
+    Args:
+      disk_spec: virtual_machine.BaseDiskSpec object of the disk.
+    """
+    if disk_spec.disk_type != disk.STANDARD:
+      # TODO(klausw): support type BOOT_DISK once that's implemented.
+      raise errors.Error('DigitalOcean does not support disk type %s.' %
+                         disk_spec.disk_type)
+
+    if self.scratch_disks:
+      # We have a "disk" already, don't add more. TODO(klausw): permit
+      # multiple creation for type BOOT_DISK once that's implemented.
+      raise errors.Error('DigitalOcean does not support multiple disks.')
+
+    # Just create a local directory at the specified path, don't mount
+    # anything.
+    self.RemoteCommand('sudo mkdir -p {0} && sudo chown -R $USER:$USER {0}'
+                       .format(disk_spec.mount_point))
+    self.scratch_disks.append(digitalocean_disk.DigitalOceanDisk(disk_spec))
+
+
+class DebianBasedDigitalOceanVirtualMachine(DigitalOceanVirtualMachine,
+                                            package_managers.AptMixin):
+  pass
+
+
+class RhelBasedDigitalOceanVirtualMachine(DigitalOceanVirtualMachine,
+                                          package_managers.YumMixin):
+  pass

--- a/perfkitbenchmarker/digitalocean/util.py
+++ b/perfkitbenchmarker/digitalocean/util.py
@@ -1,0 +1,129 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utilities for working with DigitalOcean resources."""
+
+import json
+import logging
+import os
+
+from perfkitbenchmarker import flags
+from perfkitbenchmarker import vm_util
+
+DIGITALOCEAN_API = 'https://api.digitalocean.com/v2/'
+
+flags.DEFINE_string('digitalocean_curl_config',
+                    os.getenv('DIGITALOCEAN_CURL_CONFIG',
+                              '~/.config/digitalocean-oauth.curl'),
+                    ('Path to Curl config file containing oauth header, '
+                     'also settable via $DIGITALOCEAN_CURL_CONFIG env var.\n'
+                     '\n'
+                     'File format:\n'
+                     '  header = "Authorization: Bearer 9876...ba98"'))
+
+flags.DEFINE_string('curl_path',
+                    'curl',
+                    'The path for the curl utility.')
+
+flags.DEFINE_list('additional_curl_flags',
+                  [],
+                  'Additional flags to pass to curl such as proxy settings.')
+
+FLAGS = flags.FLAGS
+
+
+def GetDefaultDigitalOceanCurlFlags():
+  """Return common set of curl options for Digital Ocean.
+
+  Returns:
+    A common set of curl options.
+  """
+  options = [
+      '--config', os.path.expanduser(FLAGS.digitalocean_curl_config),
+  ]
+  options.extend(FLAGS.additional_curl_flags)
+
+  return options
+
+
+def GetCurlCommand(action, url, args=None):
+  """Returns a curl command line.
+
+  Args:
+    action: HTTP request type such as 'POST'
+    url: URL location such as 'account/keys'
+    args: key/value dict, used for JSON input
+  Returns:
+    Command as argv list.
+  """
+
+  cmd = [
+      FLAGS.curl_path,
+      '--request', action,
+      '--url', DIGITALOCEAN_API + url,
+      '--include',
+      '--silent',
+  ]
+
+  if action == 'GET':
+    # Disable pagination
+    cmd.extend(['--form', 'per_page=999999999'])
+
+  if args is not None:
+    cmd.extend([
+        '--header', 'Content-Type: application/json',
+        '--data', json.dumps(args, separators=(',', ':'))])
+
+  return cmd
+
+
+def RunCurlCommand(action, url, args=None, suppress_warning=False):
+  """Runs a curl command and processes the result.
+
+  Args:
+    action: HTTP request type such as 'POST'
+    url: URL location such as 'account/keys'
+    args: key/value dict, used for JSON input
+    suppress_warning: if true, failures aren't interesting
+  Returns:
+    (stdout, ret) tuple, where stdout is a JSON string and
+    ret is zero for success, the command exit code (1-255),
+    or the HTTP status code (300 and up).
+  """
+
+  cmd = GetCurlCommand(action, url, args)
+
+  cmd.extend(GetDefaultDigitalOceanCurlFlags())
+
+  stdout, _, curl_ret, = vm_util.IssueCommand(
+      cmd, suppress_warning=suppress_warning)
+  if curl_ret:
+    # Executing command failed - IssueCommand will have logged details.
+    return stdout, curl_ret
+
+  # Use last two \r\n separated blocks, there may be
+  # extra blocks for HTTP "100 Continue" responses.
+  meta, body = stdout.split('\r\n\r\n')[-2:]
+
+  response, unused_header = meta.split('\r\n', 1)
+  code = int(response.split()[1])
+  status = 0  # Success.
+  if code >= 300:
+    # For non-success responses, use the HTTP code as return value.
+    status = code
+
+  if status and not suppress_warning:
+    logging.info('Got HTTP status code (%s).\nRESPONSE: %s\n',
+                 code, body)
+
+  return body, status

--- a/perfkitbenchmarker/virtual_machine.py
+++ b/perfkitbenchmarker/virtual_machine.py
@@ -495,6 +495,10 @@ class BaseVirtualMachine(resource.BaseResource):
       The mounted disk directory.
 
     """
+    if disk_num >= len(self.scratch_disks):
+      raise errors.Error(
+          'GetScratchDir(disk_num=%s) is invalid, max disk_num is %s' % (
+              disk_num, len(self.scratch_disks)))
     return self.scratch_disks[disk_num].mount_point
 
   @property

--- a/tests/scratch_disk_test.py
+++ b/tests/scratch_disk_test.py
@@ -21,6 +21,7 @@ import mock
 
 from perfkitbenchmarker import pkb  # NOQA
 from perfkitbenchmarker import disk
+from perfkitbenchmarker import errors
 from perfkitbenchmarker import virtual_machine
 from perfkitbenchmarker.aws import aws_disk
 from perfkitbenchmarker.aws import aws_virtual_machine
@@ -99,6 +100,14 @@ class ScratchDiskTestMixin(object):
     vm.CreateScratchDisk(disk_spec)
 
     assert len(vm.scratch_disks) == 2, 'Disk not added to scratch disks.'
+
+    # Check that these execute without exceptions. The return value
+    # is a MagicMock, not a string, so we can't compare to expected results.
+    vm.GetScratchDir()
+    vm.GetScratchDir(0)
+    vm.GetScratchDir(1)
+    with self.assertRaises(errors.Error):
+      vm.GetScratchDir(2)
 
     scratch_disk = vm.scratch_disks[1]
 


### PR DESCRIPTION
Add initial support for DigitalOcean as a cloud provider.

This uses the `curl` tool to access the DigitalOcean v2 API. You must set
 up authentication before use, see README.md for instructions.

Since DigitalOcean does not provide add-on disks, droplets always use local
SSD storage as mounted on a single root partition, and AFAIK this cannot be
repartitioned. Benchmarks that request a data directory via vm.GetScratchDir()
will use a subdirectory of the root partition.

Benchmarks that need multiple scratch disks or raw devices are **NOT**
supported and will fail to run in such configurations. This includes
*copy_throughput* in disk-to-disk mode, or *aerospike* when using
non-memory storage modes.

Usage example:

```
./pkb.py --cloud=DigitalOcean --machine_type=16gb --benchmarks=iperf
```

Working benchmarks on a 16gb VM (droplet):

* aerospike, block_storage_workload, bonnie++, cassandra_stress,
  cluster_boot, coremark, fio, hpcc, iperf, mesh_network, mongodb, netperf,
  oldisim, ping, redis, scimark2, silo, sysbench_oltp, unixbench

Test in progress:

* speccpu2006

Not yet tested:

* hadoop_terasort, hbase_ycsb

Unsupported benchmarks:

* _copy_throughput:_ this needs multiple scratch disks.
* _object_storage_service:_ DigitalOcean doesn't offer an object store.
  It should work to run the benchmark using an external object store
  provider, I haven't tested that.