### PR TITLE
Ensure the _KillProcess task is always cancelled.

### DIFF
--- a/perfkitbenchmarker/vm_util.py
+++ b/perfkitbenchmarker/vm_util.py
@@ -391,9 +391,10 @@ def IssueCommand(cmd, force_info_log=False, suppress_warning=False,
   timer = threading.Timer(timeout, _KillProcess)
   timer.start()
 
-  stdout, stderr = process.communicate()
-
-  timer.cancel()
+  try:
+    stdout, stderr = process.communicate()
+  finally:
+    timer.cancel()
 
   stdout = stdout.decode('ascii', 'ignore')
   stderr = stderr.decode('ascii', 'ignore')

--- a/tests/vm_util_test.py
+++ b/tests/vm_util_test.py
@@ -14,6 +14,7 @@
 
 """Tests for perfkitbenchmarker.vm_util."""
 
+import subprocess
 import unittest
 
 import mock
@@ -80,6 +81,12 @@ class IssueCommandTestCase(unittest.TestCase):
   def testNoTimeout(self):
     _, _, retcode = vm_util.IssueCommand(['sleep', '2s'], timeout=None)
     self.assertEqual(retcode, 0)
+
+  def testNoTimeout_ExceptionRaised(self):
+    with mock.patch('subprocess.Popen', spec=subprocess.Popen) as mock_popen:
+      mock_popen.return_value.communicate.side_effect = KeyboardInterrupt()
+      with self.assertRaises(KeyboardInterrupt):
+        vm_util.IssueCommand(['sleep', '2s'], timeout=None)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Errors raised in [`subprocess.Popen.communicate`](https://github.com/GoogleCloudPlatform/PerfKitBenchmarker/blob/651c7558321db1d5dc6b641453a376467cc1b2a1/perfkitbenchmarker/vm_util.py#L394) (e.g. `KeyboardInterrupt`) cause the process to hang without exiting, since the `Timer` thread does not exit.

When a timeout is set, this will exit after the timer elapses. Without a timeout, the process hangs indefinitely.

Newly-added test hangs prior to making this change.