### PR TITLE
Include coremark and speccpu2006 tarballs in gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /build
+/perfkitbenchmarker/data/coremark*.tgz
+/perfkitbenchmarker/data/cpu2006*.tgz
 /setuptools-*.egg
 /setuptools*.zip
 *.py[co]


### PR DESCRIPTION
These files require separate download for licensing reasons,
and they must not be republished. Adding them to the ignore list
to help avoid accidentally uploading them into the repository.