### PR TITLE
Execute long running commands via a remote agent.

### DIFF
--- a/perfkitbenchmarker/benchmarks/cassandra_stress_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/cassandra_stress_benchmark.py
@@ -129,7 +129,7 @@ def RunTestOnLoader(vm, data_node_ips):
     vm: The target vm.
     data_node_ips: List of IP addresses for all data nodes.
   """
-  vm.RemoteCommand(
+  vm.RobustRemoteCommand(
       '%s '
       '--file "%s" --nodes %s '
       '--replication-factor %s --consistency-level %s '

--- a/perfkitbenchmarker/benchmarks/hadoop_terasort_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/hadoop_terasort_benchmark.py
@@ -97,15 +97,17 @@ def Run(benchmark_spec):
   hadoop_cmd = '{0} jar {1}'.format(
       posixpath.join(hadoop.HADOOP_BIN, 'yarn'),
       mapreduce_example_jar)
-  master.RemoteCommand('{0} teragen {1} /teragen'.format(
+  master.RobustRemoteCommand('{0} teragen {1} /teragen'.format(
       hadoop_cmd, FLAGS.terasort_num_rows))
   num_cpus = sum(vm.num_cpus for vm in vms[1:])
   start_time = time.time()
-  stdout, _ = master.RemoteCommand(hadoop_cmd + ' terasort /teragen /terasort')
+  stdout, _ = master.RobustRemoteCommand(
+      hadoop_cmd + ' terasort /teragen /terasort')
   logging.info('Terasort output: %s', stdout)
   time_elapsed = time.time() - start_time
   data_processed_in_mbytes = FLAGS.terasort_num_rows * NUM_MB_PER_ROW
-  master.RemoteCommand(hadoop_cmd + ' teravalidate /terasort /teravalidate')
+  master.RobustRemoteCommand(
+      hadoop_cmd + ' teravalidate /terasort /teravalidate')
 
   # Clean up
   master.RemoteCommand(

--- a/perfkitbenchmarker/benchmarks/hpcc_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/hpcc_benchmark.py
@@ -213,7 +213,7 @@ def Run(benchmark_spec):
   mpi_cmd = ('mpirun -np %s -machinefile %s --mca orte_rsh_agent '
              '"ssh -o StrictHostKeyChecking=no" ./hpcc' %
              (num_processes, MACHINEFILE))
-  master_vm.LongRunningRemoteCommand(mpi_cmd)
+  master_vm.RobustRemoteCommand(mpi_cmd)
   logging.info('HPCC Results:')
   stdout, _ = master_vm.RemoteCommand('cat hpccoutf.txt', should_log=True)
 

--- a/perfkitbenchmarker/benchmarks/speccpu2006_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/speccpu2006_benchmark.py
@@ -246,11 +246,12 @@ def Run(benchmark_spec):
                FLAGS.runspec_iterations != 3 else ''
   defines = ' --define ' + ' --define '.join(FLAGS.runspec_define.split(','))\
             if FLAGS.runspec_define != '' else ''
-  vm.RemoteCommand('cd %s; . ./shrc; ./bin/relocate; . ./shrc; rm -rf result; '
-                   'runspec --config=%s --tune=base '
-                   '--size=ref --noreportable --rate %s%s%s %s'
-                   % (vm.spec_dir, FLAGS.runspec_config, num_cpus, iterations,
-                      defines, FLAGS.benchmark_subset))
+  cmd = ('cd %s; . ./shrc; ./bin/relocate; . ./shrc; rm -rf result; '
+         'runspec --config=%s --tune=base '
+         '--size=ref --noreportable --rate %s%s%s %s'
+         % (vm.spec_dir, FLAGS.runspec_config, num_cpus, iterations,
+            defines, FLAGS.benchmark_subset))
+  vm.RobustRemoteCommand(cmd)
   logging.info('SpecCPU2006 Results:')
   return ParseOutput(vm)
 

--- a/perfkitbenchmarker/packages/openmpi.py
+++ b/perfkitbenchmarker/packages/openmpi.py
@@ -31,8 +31,9 @@ def _Install(vm):
   make_jobs = vm.num_cpus
   config_cmd = ('./configure --enable-static --disable-shared --disable-dlopen '
                 '--prefix=/usr')
-  vm.RemoteCommand('cd %s && %s && make -j %s && sudo make install' %
-                   (MPI_DIR, config_cmd, make_jobs))
+  vm.RobustRemoteCommand(
+      'cd %s && %s && make -j %s && sudo make install' %
+      (MPI_DIR, config_cmd, make_jobs))
 
 
 def YumInstall(vm):

--- a/perfkitbenchmarker/packages/ycsb.py
+++ b/perfkitbenchmarker/packages/ycsb.py
@@ -508,7 +508,7 @@ class YCSBExecutor(object):
       param, value = pv.split('=', 1)
       kwargs[param] = value
     command = self._BuildCommand('load', **kwargs)
-    stdout, _ = vm.RemoteCommand(command)
+    stdout, _ = vm.RobustRemoteCommand(command)
     return ParseResults(str(stdout))
 
   def _LoadThreaded(self, vms, workload_file, **kwargs):
@@ -584,7 +584,7 @@ class YCSBExecutor(object):
       param, value = pv.split('=', 1)
       kwargs[param] = value
     command = self._BuildCommand('run', **kwargs)
-    stdout, _ = vm.RemoteCommand(command)
+    stdout, _ = vm.RobustRemoteCommand(command)
     return ParseResults(str(stdout))
 
   def _RunThreaded(self, vms, **kwargs):

--- a/perfkitbenchmarker/scripts/__init__.py
+++ b/perfkitbenchmarker/scripts/__init__.py
@@ -11,3 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Files to run *on the guest VM*.
+
+Nothing in this package should be imported.
+"""

--- a/perfkitbenchmarker/scripts/execute_command.py
+++ b/perfkitbenchmarker/scripts/execute_command.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -*- coding: utf-8 -*-
+"""Runs a command, saving stdout, stderr, and the return code in files.
+
+Simplifies executing long-running commands on a remote host.
+The status file (as specified by --status) is exclusively locked until the
+child process running the user-specified command exits.
+This command will fail if the status file cannot be successfully locked.
+
+To await completion, "wait_for_command.py" acquires a shared lock on the
+status file, which blocks until the process completes.
+
+*Runs on the guest VM. Supports Python 2.6, 2.7, and 3.x.*
+"""
+import fcntl
+import logging
+import optparse
+import sys
+import subprocess
+
+
+def main():
+  parser = optparse.OptionParser()
+  parser.add_option('-o', '--stdout', dest='stdout', metavar='FILE',
+                    help="""Write stdout to FILE. Required.""")
+  parser.add_option('-e', '--stderr', dest='stderr', metavar='FILE',
+                    help="""Write stderr to FILE. Required.""")
+  parser.add_option('-p', '--pid', dest='pid', help="""Write PID to FILE.""",
+                    metavar='FILE')
+  parser.add_option('-s', '--status', dest='status', help="""Write process exit
+                    status to FILE. An exclusive lock will be placed on FILE
+                    until this process exits. Required.""", metavar='FILE')
+  parser.add_option('-c', '--command', dest='command', help="""Shell command to
+                    execute. Required.""")
+  options, args = parser.parse_args()
+  if args:
+    sys.stderr.write('Unexpected arguments: {0}\n'.format(args))
+    return 1
+
+  missing = []
+  for option in ('stdout', 'stderr', 'status', 'command'):
+    if getattr(options, option) is None:
+      missing.append(option)
+
+  if missing:
+    parser.print_usage()
+    msg = 'Missing required flag(s): {0}\n'.format(
+        ', '.join('--' + i for i in missing))
+    sys.stderr.write(msg)
+    return 1
+
+  with open(options.status, 'w+') as status:
+    with open(options.stdout, 'w') as stdout:
+      with open(options.stderr, 'w') as stderr:
+        logging.info('Acquiring lock on %s', options.status)
+        # Non-blocking exclusive lock acquisition; will raise an IOError if
+        # acquisition fails, which is desirable here.
+        fcntl.lockf(status, fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+        # Initialize the status to -1; will be filled with the exit status
+        # on subprocess completion.
+        status.write('-1')
+        status.flush()
+        status.seek(0)
+
+        p = subprocess.Popen(options.command, stdout=stdout, stderr=stderr,
+                             shell=True)
+        logging.info('Started pid %d: %s', p.pid, options.command)
+
+        if options.pid:
+          with open(options.pid, 'w') as pid:
+            pid.write(str(p.pid))
+
+        logging.info('Waiting on PID %s', p.pid)
+        return_code = p.wait()
+        logging.info('Return code: %s', return_code)
+        status.truncate()
+        status.write(str(return_code))
+
+        # File lock will be released when the status file is closed.
+        return return_code
+
+if __name__ == '__main__':
+  logging.basicConfig(level=logging.INFO)
+  sys.exit(main())

--- a/perfkitbenchmarker/scripts/wait_for_command.py
+++ b/perfkitbenchmarker/scripts/wait_for_command.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python2
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -*- coding: utf-8 -*-
+"""Waits for a command started by execute_command.py to complete.
+
+Blocks until a command wrapped by "execute_command.py" completes, then mimics
+the wrapped command, copying the wrapped command's stdout/stderr to this
+process' stdout/stderr, and exiting with the wrapped command's status.
+
+*Runs on the guest VM. Supports Python 2.6, 2.7, and 3.x.*
+"""
+
+import fcntl
+import optparse
+import os
+import shutil
+import sys
+import threading
+
+
+def main():
+  p = optparse.OptionParser()
+  p.add_option('-o', '--stdout', dest='stdout',
+               help="""Read stdout from FILE.""", metavar='FILE')
+  p.add_option('-e', '--stderr', dest='stderr',
+               help="""Read stderr from FILE.""", metavar='FILE')
+  p.add_option('-s', '--status', dest='status', metavar='FILE',
+               help='Get process exit status from FILE. '
+               'Will block until a shared lock is acquired on FILE.')
+  p.add_option('-d', '--delete', dest='delete', action='store_true',
+               help='Delete stdout, stderr, and status files when finished.')
+  options, args = p.parse_args()
+  if args:
+    sys.stderr.write('Unexpected arguments: {0}\n'.format(args))
+    return 1
+
+  missing = []
+  for option in ('stdout', 'stderr', 'status'):
+    if getattr(options, option) is None:
+      missing.append(option)
+
+  if missing:
+    p.print_usage()
+    msg = 'Missing required flag(s): {0}\n'.format(
+        ', '.join('--' + i for i in missing))
+    sys.stderr.write(msg)
+    return 1
+
+  with open(options.stdout, 'r') as stdout:
+    with open(options.stderr, 'r') as stderr:
+      with open(options.status, 'r') as status:
+        fcntl.lockf(status, fcntl.LOCK_SH)
+        return_code = int(status.read())
+        status.close()
+
+        stderr_copier = threading.Thread(target=shutil.copyfileobj,
+                                         args=[stderr, sys.stderr],
+                                         name='stderr-copier')
+        stderr_copier.daemon = True
+        stderr_copier.start()
+        try:
+          shutil.copyfileobj(stdout, sys.stdout)
+        finally:
+          stderr_copier.join()
+
+  if options.delete:
+    for f in [options.stdout, options.stderr, options.status]:
+      os.unlink(f)
+
+  return return_code
+
+if __name__ == '__main__':
+  sys.exit(main())


### PR DESCRIPTION
This makes `LongRunningRemoteCommand` a little more robust via two scripts run on the guest VM:
* `remote_command.py`: executed via `nohup`, runs a command, holding a lock on a status file until the command exits.
* `wait_for_command.py`: waits for the long running command to finish by waiting on the lock held by `remote_command.py`, then returns the long-running command's `stdout` and `stderr`, exiting with the command's exit status.  This can be safely retried on SSH failure.

We gain a bit of resilience on SSH flakiness, will catch non-zero exits from the long running command, and avoid parsing the command name to find the PID.

Ran HPCC against CentOS 6 and Ubuntu 14.04 to test.