### PR TITLE
Fix aws on windows

### DIFF
--- a/perfkitbenchmarker/aws/aws_disk.py
+++ b/perfkitbenchmarker/aws/aws_disk.py
@@ -88,7 +88,8 @@ class AwsDisk(disk.BaseDisk):
         'describe-volumes',
         '--region=%s' % self.region,
         '--filter=Name=volume-id,Values=%s' % self.id]
-    stdout, _ = vm_util.IssueRetryableCommand(describe_cmd)
+    stdout, _ = vm_util.IssueRetryableCommand(describe_cmd,
+                                              retry_on_stderr=True)
     response = json.loads(stdout)
     volumes = response['Volumes']
     assert len(volumes) < 2, 'Too many volumes.'
@@ -121,7 +122,7 @@ class AwsDisk(disk.BaseDisk):
         '--device=%s' % self.GetDevicePath()]
     logging.info('Attaching AWS volume %s. This may fail if the disk is not '
                  'ready, but will be retried.', self.id)
-    vm_util.IssueRetryableCommand(attach_cmd)
+    vm_util.IssueRetryableCommand(attach_cmd, retry_on_stderr=True)
 
   def Detach(self):
     """Detaches the disk from a VM."""
@@ -131,7 +132,7 @@ class AwsDisk(disk.BaseDisk):
         '--region=%s' % self.region,
         '--instance-id=%s' % self.attached_vm_id,
         '--volume-id=%s' % self.id]
-    vm_util.IssueRetryableCommand(detach_cmd)
+    vm_util.IssueRetryableCommand(detach_cmd, retry_on_stderr=True)
 
     with self._lock:
       assert self.attached_vm_id in AwsDisk.vm_devices

--- a/perfkitbenchmarker/aws/aws_disk.py
+++ b/perfkitbenchmarker/aws/aws_disk.py
@@ -88,8 +88,7 @@ class AwsDisk(disk.BaseDisk):
         'describe-volumes',
         '--region=%s' % self.region,
         '--filter=Name=volume-id,Values=%s' % self.id]
-    stdout, _ = vm_util.IssueRetryableCommand(describe_cmd,
-                                              retry_on_stderr=True)
+    stdout, _ = util.IssueRetryableCommand(describe_cmd)
     response = json.loads(stdout)
     volumes = response['Volumes']
     assert len(volumes) < 2, 'Too many volumes.'
@@ -122,7 +121,7 @@ class AwsDisk(disk.BaseDisk):
         '--device=%s' % self.GetDevicePath()]
     logging.info('Attaching AWS volume %s. This may fail if the disk is not '
                  'ready, but will be retried.', self.id)
-    vm_util.IssueRetryableCommand(attach_cmd, retry_on_stderr=True)
+    util.IssueRetryableCommand(attach_cmd)
 
   def Detach(self):
     """Detaches the disk from a VM."""
@@ -132,7 +131,7 @@ class AwsDisk(disk.BaseDisk):
         '--region=%s' % self.region,
         '--instance-id=%s' % self.attached_vm_id,
         '--volume-id=%s' % self.id]
-    vm_util.IssueRetryableCommand(detach_cmd, retry_on_stderr=True)
+    util.IssueRetryableCommand(detach_cmd)
 
     with self._lock:
       assert self.attached_vm_id in AwsDisk.vm_devices

--- a/perfkitbenchmarker/aws/aws_network.py
+++ b/perfkitbenchmarker/aws/aws_network.py
@@ -76,9 +76,9 @@ class AwsFirewall(network.BaseFirewall):
           '--port=%s' % port,
           '--cidr=0.0.0.0/0']
       vm_util.IssueRetryableCommand(
-          authorize_cmd + ['--protocol=tcp'])
+          authorize_cmd + ['--protocol=tcp'], retry_on_stderr=True)
       vm_util.IssueRetryableCommand(
-          authorize_cmd + ['--protocol=udp'])
+          authorize_cmd + ['--protocol=udp'], retry_on_stderr=True)
       self.firewall_set.add(entry)
 
   def DisallowAllPorts(self):
@@ -114,7 +114,8 @@ class AwsVpc(resource.BaseResource):
         'describe-vpcs',
         '--region=%s' % self.region,
         '--filter=Name=vpc-id,Values=%s' % self.id]
-    stdout, _ = vm_util.IssueRetryableCommand(describe_cmd)
+    stdout, _ = vm_util.IssueRetryableCommand(describe_cmd,
+                                              retry_on_stderr=True)
     response = json.loads(stdout)
     vpcs = response['Vpcs']
     assert len(vpcs) < 2, 'Too many VPCs.'
@@ -136,7 +137,8 @@ class AwsVpc(resource.BaseResource):
         '--enable-dns-hostnames',
         '{ "Value": true }']
 
-    vm_util.IssueRetryableCommand(enable_hostnames_command)
+    vm_util.IssueRetryableCommand(enable_hostnames_command,
+                                  retry_on_stderr=True)
 
   def _Delete(self):
     """Delete's the VPC."""
@@ -191,7 +193,8 @@ class AwsSubnet(resource.BaseResource):
         'describe-subnets',
         '--region=%s' % self.region,
         '--filter=Name=subnet-id,Values=%s' % self.id]
-    stdout, _ = vm_util.IssueRetryableCommand(describe_cmd)
+    stdout, _ = vm_util.IssueRetryableCommand(describe_cmd,
+                                              retry_on_stderr=True)
     response = json.loads(stdout)
     subnets = response['Subnets']
     assert len(subnets) < 2, 'Too many subnets.'
@@ -235,7 +238,8 @@ class AwsInternetGateway(resource.BaseResource):
         'describe-internet-gateways',
         '--region=%s' % self.region,
         '--filter=Name=internet-gateway-id,Values=%s' % self.id]
-    stdout, _ = vm_util.IssueRetryableCommand(describe_cmd)
+    stdout, _ = vm_util.IssueRetryableCommand(describe_cmd,
+                                              retry_on_stderr=True)
     response = json.loads(stdout)
     internet_gateways = response['InternetGateways']
     assert len(internet_gateways) < 2, 'Too many internet gateways.'
@@ -251,7 +255,7 @@ class AwsInternetGateway(resource.BaseResource):
           '--region=%s' % self.region,
           '--internet-gateway-id=%s' % self.id,
           '--vpc-id=%s' % self.vpc_id]
-      vm_util.IssueRetryableCommand(attach_cmd)
+      vm_util.IssueRetryableCommand(attach_cmd, retry_on_stderr=True)
       self.attached = True
 
   def Detach(self):
@@ -263,7 +267,7 @@ class AwsInternetGateway(resource.BaseResource):
           '--region=%s' % self.region,
           '--internet-gateway-id=%s' % self.id,
           '--vpc-id=%s' % self.vpc_id]
-      vm_util.IssueRetryableCommand(detach_cmd)
+      vm_util.IssueRetryableCommand(detach_cmd, retry_on_stderr=True)
       self.attached = False
 
 
@@ -297,7 +301,8 @@ class AwsRouteTable(resource.BaseResource):
         'describe-route-tables',
         '--region=%s' % self.region,
         '--filters=Name=vpc-id,Values=%s' % self.vpc_id]
-    stdout, _ = vm_util.IssueRetryableCommand(describe_cmd)
+    stdout, _ = vm_util.IssueRetryableCommand(describe_cmd,
+                                              retry_on_stderr=True)
     response = json.loads(stdout)
     self.id = response['RouteTables'][0]['RouteTableId']
 
@@ -310,7 +315,8 @@ class AwsRouteTable(resource.BaseResource):
         '--route-table-id=%s' % self.id,
         '--gateway-id=%s' % internet_gateway_id,
         '--destination-cidr-block=0.0.0.0/0']
-    vm_util.IssueRetryableCommand(create_cmd)
+    vm_util.IssueRetryableCommand(create_cmd,
+                                  retry_on_stderr=True)
 
 
 class AwsPlacementGroup(resource.BaseResource):
@@ -358,7 +364,8 @@ class AwsPlacementGroup(resource.BaseResource):
         'describe-placement-groups',
         '--region=%s' % self.region,
         '--filter=Name=group-name,Values=%s' % self.name]
-    stdout, _ = vm_util.IssueRetryableCommand(describe_cmd)
+    stdout, _ = vm_util.IssueRetryableCommand(describe_cmd,
+                                              retry_on_stderr=True)
     response = json.loads(stdout)
     placement_groups = response['PlacementGroups']
     assert len(placement_groups) < 2, 'Too many placement groups.'

--- a/perfkitbenchmarker/aws/aws_network.py
+++ b/perfkitbenchmarker/aws/aws_network.py
@@ -75,10 +75,10 @@ class AwsFirewall(network.BaseFirewall):
           '--group-id=%s' % vm.group_id,
           '--port=%s' % port,
           '--cidr=0.0.0.0/0']
-      vm_util.IssueRetryableCommand(
-          authorize_cmd + ['--protocol=tcp'], retry_on_stderr=True)
-      vm_util.IssueRetryableCommand(
-          authorize_cmd + ['--protocol=udp'], retry_on_stderr=True)
+      util.IssueRetryableCommand(
+          authorize_cmd + ['--protocol=tcp'])
+      util.IssueRetryableCommand(
+          authorize_cmd + ['--protocol=udp'])
       self.firewall_set.add(entry)
 
   def DisallowAllPorts(self):
@@ -114,8 +114,7 @@ class AwsVpc(resource.BaseResource):
         'describe-vpcs',
         '--region=%s' % self.region,
         '--filter=Name=vpc-id,Values=%s' % self.id]
-    stdout, _ = vm_util.IssueRetryableCommand(describe_cmd,
-                                              retry_on_stderr=True)
+    stdout, _ = util.IssueRetryableCommand(describe_cmd)
     response = json.loads(stdout)
     vpcs = response['Vpcs']
     assert len(vpcs) < 2, 'Too many VPCs.'
@@ -137,8 +136,7 @@ class AwsVpc(resource.BaseResource):
         '--enable-dns-hostnames',
         '{ "Value": true }']
 
-    vm_util.IssueRetryableCommand(enable_hostnames_command,
-                                  retry_on_stderr=True)
+    util.IssueRetryableCommand(enable_hostnames_command)
 
   def _Delete(self):
     """Delete's the VPC."""
@@ -193,8 +191,7 @@ class AwsSubnet(resource.BaseResource):
         'describe-subnets',
         '--region=%s' % self.region,
         '--filter=Name=subnet-id,Values=%s' % self.id]
-    stdout, _ = vm_util.IssueRetryableCommand(describe_cmd,
-                                              retry_on_stderr=True)
+    stdout, _ = util.IssueRetryableCommand(describe_cmd)
     response = json.loads(stdout)
     subnets = response['Subnets']
     assert len(subnets) < 2, 'Too many subnets.'
@@ -238,8 +235,7 @@ class AwsInternetGateway(resource.BaseResource):
         'describe-internet-gateways',
         '--region=%s' % self.region,
         '--filter=Name=internet-gateway-id,Values=%s' % self.id]
-    stdout, _ = vm_util.IssueRetryableCommand(describe_cmd,
-                                              retry_on_stderr=True)
+    stdout, _ = util.IssueRetryableCommand(describe_cmd)
     response = json.loads(stdout)
     internet_gateways = response['InternetGateways']
     assert len(internet_gateways) < 2, 'Too many internet gateways.'
@@ -255,7 +251,7 @@ class AwsInternetGateway(resource.BaseResource):
           '--region=%s' % self.region,
           '--internet-gateway-id=%s' % self.id,
           '--vpc-id=%s' % self.vpc_id]
-      vm_util.IssueRetryableCommand(attach_cmd, retry_on_stderr=True)
+      util.IssueRetryableCommand(attach_cmd)
       self.attached = True
 
   def Detach(self):
@@ -267,7 +263,7 @@ class AwsInternetGateway(resource.BaseResource):
           '--region=%s' % self.region,
           '--internet-gateway-id=%s' % self.id,
           '--vpc-id=%s' % self.vpc_id]
-      vm_util.IssueRetryableCommand(detach_cmd, retry_on_stderr=True)
+      util.IssueRetryableCommand(detach_cmd)
       self.attached = False
 
 
@@ -301,8 +297,7 @@ class AwsRouteTable(resource.BaseResource):
         'describe-route-tables',
         '--region=%s' % self.region,
         '--filters=Name=vpc-id,Values=%s' % self.vpc_id]
-    stdout, _ = vm_util.IssueRetryableCommand(describe_cmd,
-                                              retry_on_stderr=True)
+    stdout, _ = util.IssueRetryableCommand(describe_cmd)
     response = json.loads(stdout)
     self.id = response['RouteTables'][0]['RouteTableId']
 
@@ -315,8 +310,7 @@ class AwsRouteTable(resource.BaseResource):
         '--route-table-id=%s' % self.id,
         '--gateway-id=%s' % internet_gateway_id,
         '--destination-cidr-block=0.0.0.0/0']
-    vm_util.IssueRetryableCommand(create_cmd,
-                                  retry_on_stderr=True)
+    util.IssueRetryableCommand(create_cmd)
 
 
 class AwsPlacementGroup(resource.BaseResource):
@@ -364,8 +358,7 @@ class AwsPlacementGroup(resource.BaseResource):
         'describe-placement-groups',
         '--region=%s' % self.region,
         '--filter=Name=group-name,Values=%s' % self.name]
-    stdout, _ = vm_util.IssueRetryableCommand(describe_cmd,
-                                              retry_on_stderr=True)
+    stdout, _ = util.IssueRetryableCommand(describe_cmd)
     response = json.loads(stdout)
     placement_groups = response['PlacementGroups']
     assert len(placement_groups) < 2, 'Too many placement groups.'

--- a/perfkitbenchmarker/aws/aws_virtual_machine.py
+++ b/perfkitbenchmarker/aws/aws_virtual_machine.py
@@ -162,7 +162,7 @@ class AwsVirtualMachine(virtual_machine.BaseVirtualMachine):
           'import-key-pair',
           '--key-name=%s' % 'perfkit-key-%s' % FLAGS.run_uri,
           '--public-key-material=%s' % keyfile]
-      vm_util.IssueRetryableCommand(import_cmd)
+      vm_util.IssueRetryableCommand(import_cmd, retry_on_stderr=True)
       self.imported_keyfile_set.add(self.region)
       if self.region in self.deleted_keyfile_set:
         self.deleted_keyfile_set.remove(self.region)
@@ -176,7 +176,7 @@ class AwsVirtualMachine(virtual_machine.BaseVirtualMachine):
           'ec2', '--region=%s' % self.region,
           'delete-key-pair',
           '--key-name=%s' % 'perfkit-key-%s' % FLAGS.run_uri]
-      vm_util.IssueRetryableCommand(delete_cmd)
+      vm_util.IssueRetryableCommand(delete_cmd, retry_on_stderr=True)
       self.deleted_keyfile_set.add(self.region)
       if self.region in self.imported_keyfile_set:
         self.imported_keyfile_set.remove(self.region)
@@ -191,7 +191,8 @@ class AwsVirtualMachine(virtual_machine.BaseVirtualMachine):
         '--instance-ids=%s' % self.id]
     logging.info('Getting instance %s public IP. This will fail until '
                  'a public IP is available, but will be retried.', self.id)
-    stdout, _ = vm_util.IssueRetryableCommand(describe_cmd)
+    stdout, _ = vm_util.IssueRetryableCommand(describe_cmd,
+                                              retry_on_stderr=True)
     response = json.loads(stdout)
     instance = response['Reservations'][0]['Instances'][0]
     self.ip_address = instance['PublicIpAddress']
@@ -248,7 +249,8 @@ class AwsVirtualMachine(virtual_machine.BaseVirtualMachine):
         'describe-instances',
         '--region=%s' % self.region,
         '--filter=Name=instance-id,Values=%s' % self.id]
-    stdout, _ = vm_util.IssueRetryableCommand(describe_cmd)
+    stdout, _ = vm_util.IssueRetryableCommand(describe_cmd,
+                                              retry_on_stderr=True)
     response = json.loads(stdout)
     reservations = response['Reservations']
     assert len(reservations) < 2, 'Too many reservations.'

--- a/perfkitbenchmarker/aws/aws_virtual_machine.py
+++ b/perfkitbenchmarker/aws/aws_virtual_machine.py
@@ -162,7 +162,7 @@ class AwsVirtualMachine(virtual_machine.BaseVirtualMachine):
           'import-key-pair',
           '--key-name=%s' % 'perfkit-key-%s' % FLAGS.run_uri,
           '--public-key-material=%s' % keyfile]
-      vm_util.IssueRetryableCommand(import_cmd, retry_on_stderr=True)
+      util.IssueRetryableCommand(import_cmd)
       self.imported_keyfile_set.add(self.region)
       if self.region in self.deleted_keyfile_set:
         self.deleted_keyfile_set.remove(self.region)
@@ -176,7 +176,7 @@ class AwsVirtualMachine(virtual_machine.BaseVirtualMachine):
           'ec2', '--region=%s' % self.region,
           'delete-key-pair',
           '--key-name=%s' % 'perfkit-key-%s' % FLAGS.run_uri]
-      vm_util.IssueRetryableCommand(delete_cmd, retry_on_stderr=True)
+      util.IssueRetryableCommand(delete_cmd)
       self.deleted_keyfile_set.add(self.region)
       if self.region in self.imported_keyfile_set:
         self.imported_keyfile_set.remove(self.region)
@@ -191,8 +191,7 @@ class AwsVirtualMachine(virtual_machine.BaseVirtualMachine):
         '--instance-ids=%s' % self.id]
     logging.info('Getting instance %s public IP. This will fail until '
                  'a public IP is available, but will be retried.', self.id)
-    stdout, _ = vm_util.IssueRetryableCommand(describe_cmd,
-                                              retry_on_stderr=True)
+    stdout, _ = util.IssueRetryableCommand(describe_cmd)
     response = json.loads(stdout)
     instance = response['Reservations'][0]['Instances'][0]
     self.ip_address = instance['PublicIpAddress']
@@ -249,8 +248,7 @@ class AwsVirtualMachine(virtual_machine.BaseVirtualMachine):
         'describe-instances',
         '--region=%s' % self.region,
         '--filter=Name=instance-id,Values=%s' % self.id]
-    stdout, _ = vm_util.IssueRetryableCommand(describe_cmd,
-                                              retry_on_stderr=True)
+    stdout, _ = util.IssueRetryableCommand(describe_cmd)
     response = json.loads(stdout)
     reservations = response['Reservations']
     assert len(reservations) < 2, 'Too many reservations.'

--- a/perfkitbenchmarker/aws/util.py
+++ b/perfkitbenchmarker/aws/util.py
@@ -41,7 +41,7 @@ def AddTags(resource_id, region, **kwargs):
       '--tags']
   for key, value in kwargs.iteritems():
     tag_cmd.append('Key={0},Value={1}'.format(key, value))
-  vm_util.IssueRetryableCommand(tag_cmd)
+  vm_util.IssueRetryableCommand(tag_cmd, retry_on_stderr=True)
 
 
 def AddDefaultTags(resource_id, region):

--- a/perfkitbenchmarker/vm_util.py
+++ b/perfkitbenchmarker/vm_util.py
@@ -433,15 +433,13 @@ def IssueBackgroundCommand(cmd, stdout_path, stderr_path, env=None):
 
 
 @Retry()
-def IssueRetryableCommand(cmd, env=None, retry_on_stderr=False):
+def IssueRetryableCommand(cmd, env=None):
   """Tries running the provided command until it succeeds or times out.
 
   Args:
     cmd: A list of strings such as is given to the subprocess.Popen()
         constructor.
     env: An alternate environment to pass to the Popen command.
-    retry_on_stderr: If True, getting any output on stderr will be treated
-        like a non-zero return code (i.e. the command will be retried).
 
   Returns:
     A tuple of stdout and stderr from running the provided command.
@@ -450,10 +448,6 @@ def IssueRetryableCommand(cmd, env=None, retry_on_stderr=False):
   if retcode:
     raise errors.VmUtil.CalledProcessException(
         'Command returned a non-zero exit code.\n')
-  if retry_on_stderr and stderr:
-    raise errors.VmUtil.CalledProcessException(
-        'The "retry_on_stderr" option was set and the command '
-        'had output on stderr:\n%s' % stderr)
   return stdout, stderr
 
 

--- a/perfkitbenchmarker/vm_util.py
+++ b/perfkitbenchmarker/vm_util.py
@@ -433,12 +433,15 @@ def IssueBackgroundCommand(cmd, stdout_path, stderr_path, env=None):
 
 
 @Retry()
-def IssueRetryableCommand(cmd, env=None):
+def IssueRetryableCommand(cmd, env=None, retry_on_stderr=False):
   """Tries running the provided command until it succeeds or times out.
 
   Args:
     cmd: A list of strings such as is given to the subprocess.Popen()
         constructor.
+    env: An alternate environment to pass to the Popen command.
+    retry_on_stderr: If True, getting any output on stderr will be treated
+        like a non-zero return code (i.e. the command will be retried).
 
   Returns:
     A tuple of stdout and stderr from running the provided command.
@@ -447,6 +450,10 @@ def IssueRetryableCommand(cmd, env=None):
   if retcode:
     raise errors.VmUtil.CalledProcessException(
         'Command returned a non-zero exit code.\n')
+  if retry_on_stderr and stderr:
+    raise errors.VmUtil.CalledProcessException(
+        'The "retry_on_stderr" option was set and the command '
+        'had output on stderr:\n%s' % stderr)
   return stdout, stderr
 
 

--- a/tests/aws_test.py
+++ b/tests/aws_test.py
@@ -22,16 +22,16 @@ import mock
 
 from perfkitbenchmarker import disk
 from perfkitbenchmarker import virtual_machine
-from perfkitbenchmarker import vm_util
 from perfkitbenchmarker.aws import aws_disk
 from perfkitbenchmarker.aws import aws_network
 from perfkitbenchmarker.aws import aws_virtual_machine
+from perfkitbenchmarker.aws import util
 
 
 class AwsVolumeExistsTestCase(unittest.TestCase):
 
   def setUp(self):
-    self.p = mock.patch('perfkitbenchmarker.vm_util.IssueRetryableCommand')
+    self.p = mock.patch('perfkitbenchmarker.aws.util.IssueRetryableCommand')
     self.p.start()
     self.disk = aws_disk.AwsDisk(disk.BaseDiskSpec(None, None, None), 'zone-a')
     self.disk.id = 'vol-foo'
@@ -44,7 +44,7 @@ class AwsVolumeExistsTestCase(unittest.TestCase):
                 '"CreateTime": "2015-05-04T23:47:31.726Z","VolumeId":'
                 '"vol-5859691f","AvailabilityZone":"us-east-1a","VolumeType":'
                 '"standard","State":"creating"}]}')
-    vm_util.IssueRetryableCommand.side_effect = [(response, None)]
+    util.IssueRetryableCommand.side_effect = [(response, None)]
     self.assertTrue(self.disk._Exists())
 
   def testVolumeDeleted(self):
@@ -52,14 +52,14 @@ class AwsVolumeExistsTestCase(unittest.TestCase):
                 '"AvailabilityZone": "us-east-1a","CreateTime":'
                 '"2015-05-04T23:53:42.952Z","Attachments":[],"State":'
                 '"deleting","SnapshotId":null,"VolumeType": "standard"}]}')
-    vm_util.IssueRetryableCommand.side_effect = [(response, None)]
+    util.IssueRetryableCommand.side_effect = [(response, None)]
     self.assertFalse(self.disk._Exists())
 
 
 class AwsVpcExistsTestCase(unittest.TestCase):
 
   def setUp(self):
-    self.p = mock.patch('perfkitbenchmarker.vm_util.IssueRetryableCommand')
+    self.p = mock.patch('perfkitbenchmarker.aws.util.IssueRetryableCommand')
     self.p.start()
     self.vpc = aws_network.AwsVpc('region')
     self.vpc.id = 'vpc-foo'
@@ -69,7 +69,7 @@ class AwsVpcExistsTestCase(unittest.TestCase):
 
   def testVpcDeleted(self):
     response = '{"Vpcs": [] }'
-    vm_util.IssueRetryableCommand.side_effect = [(response, None)]
+    util.IssueRetryableCommand.side_effect = [(response, None)]
     self.assertFalse(self.vpc._Exists())
 
   def testVpcPresent(self):
@@ -77,7 +77,7 @@ class AwsVpcExistsTestCase(unittest.TestCase):
                 '"10.0.0.0/16","IsDefault":false,"DhcpOptionsId":'
                 '"dopt-59b12f38","State":"available","VpcId":"vpc-2289a647"'
                 '}]}')
-    vm_util.IssueRetryableCommand.side_effect = [(response, None)]
+    util.IssueRetryableCommand.side_effect = [(response, None)]
     self.assertTrue(self.vpc._Exists())
 
 
@@ -85,7 +85,7 @@ class AwsVpcExistsTestCase(unittest.TestCase):
 class AwsVirtualMachineExistsTestCase(unittest.TestCase):
 
   def setUp(self):
-    self.p = mock.patch('perfkitbenchmarker.vm_util.IssueRetryableCommand')
+    self.p = mock.patch('perfkitbenchmarker.aws.util.IssueRetryableCommand')
     self.p.start()
     self.vm = aws_virtual_machine.AwsVirtualMachine(
         virtual_machine.BaseVirtualMachineSpec(
@@ -100,14 +100,14 @@ class AwsVirtualMachineExistsTestCase(unittest.TestCase):
     self.p.stop()
 
   def testInstancePresent(self):
-    vm_util.IssueRetryableCommand.side_effect = [(self.response, None)]
+    util.IssueRetryableCommand.side_effect = [(self.response, None)]
     self.assertTrue(self.vm._Exists())
 
   def testInstanceDeleted(self):
     response = json.loads(self.response)
     state = response['Reservations'][0]['Instances'][0]['State']
     state['Name'] = 'shutting-down'
-    vm_util.IssueRetryableCommand.side_effect = [(json.dumps(response), None)]
+    util.IssueRetryableCommand.side_effect = [(json.dumps(response), None)]
     self.assertFalse(self.vm._Exists())
 
 if __name__ == '__main__':


### PR DESCRIPTION
The AWS CLI does not correctly set either $LastExitCode or $? when it
fails (at least with version 1.7.28 which was what I was running with on Windows). 
This leads to us thinking a command succeeded when it didn't.
By adding the option to retry the command in IssueRetryableCommand when
there is output on stderr, we can work around this.