### PR TITLE
Add event support

### DIFF
--- a/perfkitbenchmarker/events.py
+++ b/perfkitbenchmarker/events.py
@@ -16,6 +16,9 @@
 
 All events are passed keyword arguments, and possibly a sender. See event
 definitions below.
+
+Event handlers are run synchronously in an unspecified order; any exceptions
+raised will be propagated.
 """
 
 from blinker import Namespace

--- a/perfkitbenchmarker/events.py
+++ b/perfkitbenchmarker/events.py
@@ -45,3 +45,11 @@ successful.
 
 Sender: the phase. Currently only RUN_PHASE.
 Payload: benchmark_spec.""")
+
+sample_created = _events.signal('sample-created', doc="""
+Called with sample object and benchmark spec.
+
+Signal sent immediately after a sample is created by a publisher.
+
+Sender: None
+Payload: benchmark_spec (BenchmarkSpec), sample (dict).""")

--- a/perfkitbenchmarker/events.py
+++ b/perfkitbenchmarker/events.py
@@ -1,0 +1,47 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Defines observable events in PerfKitBenchmarker.
+
+All events are passed keyword arguments, and possibly a sender. See event
+definitions below.
+"""
+
+from blinker import Namespace
+
+_events = Namespace()
+
+
+initialization_complete = _events.signal('system-ready', doc="""
+Signal sent once after the system is initialized (command-line flags
+parsed, temporary directory initialized, run_uri set).
+
+Sender: None
+Payload: parsed_flags, the parsed FLAGS object.""")
+
+
+RUN_PHASE = 'run'
+
+before_phase = _events.signal('before-phase', doc="""
+Signal sent immediately before a phase runs.
+
+Sender: the phase. Currently only RUN_PHASE.
+Payload: benchmark_spec.""")
+
+after_phase = _events.signal('after-phase', doc="""
+Signal sent immediately after a phase runs, regardless of whether it was
+successful.
+
+Sender: the phase. Currently only RUN_PHASE.
+Payload: benchmark_spec.""")

--- a/perfkitbenchmarker/events.py
+++ b/perfkitbenchmarker/events.py
@@ -53,6 +53,7 @@ sample_created = _events.signal('sample-created', doc="""
 Called with sample object and benchmark spec.
 
 Signal sent immediately after a sample is created by a publisher.
+The sample's metadata is mutable, and may be updated by the subscriber.
 
 Sender: None
 Payload: benchmark_spec (BenchmarkSpec), sample (dict).""")

--- a/perfkitbenchmarker/publisher.py
+++ b/perfkitbenchmarker/publisher.py
@@ -25,6 +25,7 @@ import time
 import uuid
 
 from perfkitbenchmarker import disk
+from perfkitbenchmarker import events
 from perfkitbenchmarker import flags
 from perfkitbenchmarker import version
 from perfkitbenchmarker import vm_util
@@ -551,6 +552,8 @@ class SampleCollector(object):
       sample['timestamp'] = time.time()
       sample['run_uri'] = self.run_uri
       sample['sample_uri'] = str(uuid.uuid4())
+      events.sample_created.send(benchmark_spec=benchmark_spec,
+                                 sample=sample)
       self.samples.append(sample)
 
   def PublishSamples(self):

--- a/perfkitbenchmarker/vm_util.py
+++ b/perfkitbenchmarker/vm_util.py
@@ -27,6 +27,7 @@ import tempfile
 import threading
 import time
 import traceback
+import uuid
 
 import jinja2
 
@@ -657,7 +658,8 @@ class _DStatCollector(object):
 
   def Start(self, sender, benchmark_spec):
     """Install and start dstat on all VMs in 'benchmark_spec'."""
-    suffix = '-{0}-dstat'.format(benchmark_spec.benchmark_name)
+    suffix = '-{0}-{1}-dstat'.format(benchmark_spec.benchmark_name,
+                                     str(uuid.uuid4())[:8])
     start_on_vm = functools.partial(self._StartOnVm, suffix=suffix)
     RunThreaded(start_on_vm, benchmark_spec.vms)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ python-gflags==2.0
 jinja2>=2.7
 setuptools
 colorlog[windows]==2.6.0
+blinker>=1.3


### PR DESCRIPTION
* Add a dependency on [`blinker`](https://pythonhosted.org/blinker/) to provide signal support.
* Add `perfkitbenchmarker.events` module, which defines a set of events
  for subscription.
* Switch `dstat` collector to use `{before,after}_phase` events to
  start/stop dstat.

See #205.