### PR TITLE
Add resource creation/deletion times

### DIFF
--- a/perfkitbenchmarker/aws/aws_virtual_machine.py
+++ b/perfkitbenchmarker/aws/aws_virtual_machine.py
@@ -209,8 +209,6 @@ class AwsVirtualMachine(virtual_machine.BaseVirtualMachine):
 
   def _Create(self):
     """Create a VM instance."""
-    super(AwsVirtualMachine, self)._Create()
-
     placement = 'AvailabilityZone=%s' % self.zone
     if IsPlacementGroupCompatible(self.machine_type):
       placement += ',GroupName=%s' % self.network.placement_group.name

--- a/perfkitbenchmarker/azure/azure_virtual_machine.py
+++ b/perfkitbenchmarker/azure/azure_virtual_machine.py
@@ -109,7 +109,6 @@ class AzureVirtualMachine(virtual_machine.BaseVirtualMachine):
     self.service.Delete()
 
   def _Create(self):
-    super(AzureVirtualMachine, self)._Create()
     create_cmd = [AZURE_PATH,
                   'vm',
                   'create',

--- a/perfkitbenchmarker/digitalocean/digitalocean_virtual_machine.py
+++ b/perfkitbenchmarker/digitalocean/digitalocean_virtual_machine.py
@@ -73,7 +73,6 @@ class DigitalOceanVirtualMachine(virtual_machine.BaseVirtualMachine):
 
   def _Create(self):
     """Create a DigitalOcean VM instance (droplet)."""
-    super(DigitalOceanVirtualMachine, self)._Create()
     with open(self.ssh_public_key) as f:
       public_key = f.read().rstrip('\n')
 

--- a/perfkitbenchmarker/gcp/gce_virtual_machine.py
+++ b/perfkitbenchmarker/gcp/gce_virtual_machine.py
@@ -79,7 +79,6 @@ class GceVirtualMachine(virtual_machine.BaseVirtualMachine):
 
   def _Create(self):
     """Create a GCE VM instance."""
-    super(GceVirtualMachine, self)._Create()
     with open(self.ssh_public_key) as f:
       public_key = f.read().rstrip('\n')
     with vm_util.NamedTemporaryFile(dir=vm_util.GetTempDir(),

--- a/perfkitbenchmarker/virtual_machine.py
+++ b/perfkitbenchmarker/virtual_machine.py
@@ -514,10 +514,10 @@ class BaseVirtualMachine(resource.BaseResource):
     """Gets the time it took to boot this VM.
 
     Returns:
-      Boot time (in seconds), or None if the boot is incomplete.
+      Boot time (in seconds).
     """
-    if not self.bootable_time or not self.create_start_time:
-      return None
+    assert self.bootable_time, 'VM must have booted to get boot time.'
+    assert self.create_start_time, 'VM must be created to get boot time.'
     assert self.bootable_time >= self.create_start_time
     return self.bootable_time - self.create_start_time
 

--- a/perfkitbenchmarker/virtual_machine.py
+++ b/perfkitbenchmarker/virtual_machine.py
@@ -110,7 +110,6 @@ class BaseVirtualMachine(resource.BaseResource):
     with self._instance_counter_lock:
       self.name = 'perfkit-%s-%d' % (FLAGS.run_uri, self._instance_counter)
       BaseVirtualMachine._instance_counter += 1
-    self.create_time = None
     self.bootable_time = None
     self.project = vm_spec.project
     self.zone = vm_spec.zone
@@ -137,9 +136,6 @@ class BaseVirtualMachine(resource.BaseResource):
     self._reachable = {}
     self._total_memory_kb = None
     self._num_cpus = None
-
-  def _Create(self):
-    self.create_time = time.time()
 
   def __repr__(self):
     return '<BaseVirtualMachine [ip={0}, internal_ip={1}]>'.format(
@@ -520,10 +516,10 @@ class BaseVirtualMachine(resource.BaseResource):
     Returns:
       Boot time (in seconds), or None if the boot is incomplete.
     """
-    if not self.bootable_time or not self.create_time:
+    if not self.bootable_time or not self.create_start_time:
       return None
-    assert self.bootable_time >= self.create_time
-    return self.bootable_time - self.create_time
+    assert self.bootable_time >= self.create_start_time
+    return self.bootable_time - self.create_start_time
 
   def IsReachable(self, target_vm):
     """Indicates whether the target VM can be reached from it's internal ip.


### PR DESCRIPTION
Instead of recording the creation time in the VM class record it in the resource class.
Also record some other time info about resources that we can use later if we decide to publish resource creation/deletion times.