### PR TITLE
Fix 'no attribute pkb_thread_log_context' error for sub-thread logs

### DIFF
--- a/perfkitbenchmarker/log_util.py
+++ b/perfkitbenchmarker/log_util.py
@@ -32,9 +32,6 @@ LOG_LEVELS = {
 }
 
 
-thread_local = threading.local()
-
-
 class ThreadLogContext(object):
   """Per-thread context for log message prefix labels."""
   def __init__(self, thread_log_context=None):
@@ -77,6 +74,13 @@ class ThreadLogContext(object):
     yield
     self._label_list.pop()
     self._RecalculateLabel()
+
+
+class _ThreadData(threading.local):
+  def __init__(self):
+    self.pkb_thread_log_context = ThreadLogContext()
+
+thread_local = _ThreadData()
 
 
 def SetThreadLogContext(thread_log_context):


### PR DESCRIPTION
The logging filter assumes that log_util.SetThreadLogContext was called
in the current thread, but this is not the case for ad-hoc threads
created by threading.Thread() or similar. This broke timeout handling
since it tried to log a message before killing subprocesses.

Includes a test to ensure logging works for plain threads.