### PR TITLE
Work around annoying API difference across psutil versions.

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -16,4 +16,4 @@ nose>=1.3
 nose-progressive>=1.5
 flake8>=2.1.0
 futures>=2.1.0
-psutil==3.0.0
+psutil>=2.0.0

--- a/tests/requirements_test.py
+++ b/tests/requirements_test.py
@@ -1,0 +1,51 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Verifies that test requirements are satisfied."""
+
+import os
+import pkg_resources
+import psutil
+import sys
+import unittest
+
+class CheckResourcesTestCase(unittest.TestCase):
+  def testRequirements(self):
+    testreq_file = os.path.join(
+        os.path.dirname(__file__), os.pardir, 'test-requirements.txt')
+    expected_modules = set(['psutil'])
+    checked_modules = set()
+    with open(testreq_file) as requirements:
+      for line in requirements:
+        try:
+          req = pkg_resources.Requirement.parse(line)
+          # There's no obvious mapping from project name as used in
+          # requirements to importable package names. For now, just
+          # manually import packages to check above.
+          module = sys.modules.get(req.project_name)
+          if not module:
+            continue
+          # Version strings aren't standardized, may need more variants.
+          actual_version = getattr(module, '__version__', None)
+          if actual_version and actual_version not in req:
+            raise Exception('Module mismatch: Expected %s, got %s.' % (
+               req, actual_version))
+          checked_modules.add(req.project_name)
+        except ValueError:
+          # Empty or unparseable line
+          pass
+    missing_modules = expected_modules - checked_modules
+    if missing_modules:
+      raise Exception('Checks not done for modules: %s' % (
+        missing_modules))

--- a/tests/vm_util_test.py
+++ b/tests/vm_util_test.py
@@ -122,6 +122,15 @@ class WaitUntilSleepTimer(threading.Thread):
 
 class IssueCommandTestCase(unittest.TestCase):
 
+  def setUp(self):
+    # psutil changed its API in v2.0, and we ask for a current one
+    # in test-requirements.txt. Unfortunately we may still get an old
+    # version if there's a system package already installed.
+    # Catch this and show a diagnostic to avoid obscure errors.
+    if psutil.version_info < (2, 0):
+      raise Exception('Wrong psutil version, found %s. Use virtualenv?' % (
+          psutil.__version__))
+
   def testTimeoutNotReached(self):
     _, _, retcode = vm_util.IssueCommand(['sleep', '0s'])
     self.assertEqual(retcode, 0)


### PR DESCRIPTION
We ask for v3.0.0 in test-requirements.txt, but the system
may have an older version installed which would get used
instead of that.