### PR TITLE
Fix a bad SSH options in hadoop_terasort.

### DIFF
--- a/perfkitbenchmarker/data/hadoop/hadoop-env.sh.j2
+++ b/perfkitbenchmarker/data/hadoop/hadoop-env.sh.j2
@@ -19,4 +19,4 @@ export HADOOP_SSH_OPTS="-o IdentitiesOnly=yes \
   -o StrictHostKeyChecking=no \
   -o UserKnownHostsFile=/dev/null \
   -o IdentityFile={{ hadoop_private_key }} \
-  -o BatchMode=Yes"
+  -o BatchMode=yes"


### PR DESCRIPTION
The version of `ssh` on CentOS 6 is case sensitive. Not an issue on Ubuntu / CentOS 7.