### PR TITLE
Add tox.ini

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /setuptools-*.egg
 /setuptools*.zip
 *.py[co]
+/perfkitbenchmarker.egg-info
+/.tox

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ $ [sudo] pip install -r requirements.txt
 ```
 - Install PerfKitBenchmarker's test dependencies:
 ```
-$ [sudo] pip install -r test-requirements.txt
+$ [sudo] pip install tox
 ```
 - Install git pre-commit hooks, to enable linting and copyright checks:
 ```

--- a/hooks/prepare-commit-msg
+++ b/hooks/prepare-commit-msg
@@ -74,11 +74,11 @@ if [[ "${#files_with_lint_errors[@]}" -ne 0 ]]; then
   ) >> $1
 fi
 
-if [[ -z $(command -v nosetests) ]]; then
-  >&2 echo "Missing nose. Install it via 'pip' to enable unit testing."
+if [[ -z $(command -v tox) ]]; then
+  >&2 echo "Missing tox. Install it via 'pip' to enable unit testing."
   exit 1
 else
-  UNITTEST_RESULT=$(nosetests -v || echo "FAILED")
+  UNITTEST_RESULT=$(tox -e py27 || echo "FAILED")
   if [[ "$UNITTEST_RESULT" == *"FAILED"* ]]; then
     (
       echo

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,4 +22,3 @@ exclude = ez_setup.py,.git,build,dist
 detailed-errors = 1
 logging-clear-handlers = 1
 verbosity = 1
-with-progressive = 1

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ from setuptools import setup, find_packages
 setup(
     name='perfkitbenchmarker',
     url='https://github.com/GoogleCloudPlatform/PerfKitBenchmarker',
-    version='0.6.0',
     license='Apache 2.0',
     packages=find_packages(exclude=['tests']),
     scripts=['pkb.py'],

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -13,7 +13,6 @@
 # limitations under the License.
 mock>=1.0.1
 nose>=1.3
-nose-progressive>=1.5
 flake8>=2.1.0
 futures>=2.1.0
 psutil==3.0.0

--- a/tools/pre-commit/run-precommit.sh
+++ b/tools/pre-commit/run-precommit.sh
@@ -26,7 +26,7 @@ pushd $GIT_DIR > /dev/null
 >&2 echo "-------------------"
 
 find tests -name '*.pyc' | xargs --no-run-if-empty rm -f
-nosetests
+tox
 
 >&2 echo
 >&2 echo "Running linter."

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,28 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py27,flake8
+
+[testenv]
+usedevelop = True
+skip_install = True
+commands = nosetests {toxinidir}/tests []
+deps =
+    -rrequirements.txt
+    mock==1.0.1
+    nose==1.3.7
+    psutil==3.0.1
+
+[testenv:flake8]
+skip_install = True
+usedevelop = True
+commands = flake8 perfkitbenchmarker tests pkb.py
+deps =
+    flake8==2.4.1
+
+[flake8]
+ignore = E111,E129,E303
+max-line-length = 80


### PR DESCRIPTION
Adds support for executing tests via [tox](https://tox.readthedocs.org/en/latest/), for isolated consistent environments.
Not complete yet, the following are still required:

* [x] Update pre-submit hooks.
* [x] Update unit testing instructions.

To test:

```{bash}
$ [sudo] pip install tox
$ tox
```

For me, this yields the following:

```
GLOB sdist-make: /usr/local/google/home/connormccoy/git/PerfKitBenchmarker/setup.py
py27 recreate: /usr/local/google/home/connormccoy/git/PerfKitBenchmarker/.tox/py27
py27 installdeps: -rrequirements.txt, nose>=1.3, mock>=1.0.1, psutil==3.0.0
py27 inst: /usr/local/google/home/connormccoy/git/PerfKitBenchmarker/.tox/dist/perfkitbenchmarker-0.17.0.zip
py27 installed: colorama==0.3.3,colorlog==2.6.0,Jinja2==2.7.3,MarkupSafe==0.23,mock==1.0.1,nose==1.3.7,perfkitbenchmarker==0.17.0,psutil==3.0.0,python-gflags==2.0,wheel==0.24.0
py27 runtests: PYTHONHASHSEED='3809360237'
py27 runtests: commands[0] | nosetests /usr/local/google/home/connormccoy/git/PerfKitBenchmarker/tests
..........................................................................................................................
----------------------------------------------------------------------
Ran 122 tests in 0.451s

OK
__________________________________________________________________________ summary ___________________________________________________________________________
  py27: commands succeeded
  congratulations :)
```