### PR TITLE
Adding support to ContainerizedVM

### DIFF
--- a/perfkitbenchmarker/benchmark_spec.py
+++ b/perfkitbenchmarker/benchmark_spec.py
@@ -15,7 +15,6 @@
 """Container for all data required for a benchmark to run."""
 
 import logging
-import os
 import pickle
 
 from perfkitbenchmarker import disk
@@ -97,8 +96,10 @@ flags.DEFINE_enum(
     'os_type is "rhel". In general if two OS\'s use the same package manager, '
     'and are otherwise very similar, the same os_type should work on both of '
     'them.')
-flags.DEFINE_string('scratch_dir', '/',
-                    'Directory in the VM where scratch disks will be mounted.')
+flags.DEFINE_string('scratch_dir', '/scratch',
+                    'Base name for all scratch disk directories in the VM.'
+                    'Upon creation, these directories will have numbers'
+                    'appended to them (for example /scratch0, /scratch1, etc).')
 
 
 class BenchmarkSpec(object):
@@ -165,7 +166,7 @@ class BenchmarkSpec(object):
         else:
           num_striped_disks = FLAGS.num_striped_disks
         for i in range(benchmark_info['scratch_disk']):
-          mount_point = os.path.join(FLAGS.scratch_dir, 'scratch%d' % i)
+          mount_point = '%s%d' % (FLAGS.scratch_dir, i)
           disk_spec = disk.BaseDiskSpec(
               self.scratch_disk_size, self.scratch_disk_type,
               mount_point, self.scratch_disk_iops,

--- a/perfkitbenchmarker/benchmark_spec.py
+++ b/perfkitbenchmarker/benchmark_spec.py
@@ -294,6 +294,7 @@ class BenchmarkSpec(object):
       firewall.AllowPort(vm, port)
     vm.AddMetadata(benchmark=self.benchmark_name)
     vm.WaitForBootCompletion()
+    vm.OnStartup()
     if FLAGS.scratch_disk_type == disk.LOCAL:
       vm.SetupLocalDisks()
     for disk_spec in vm.disk_specs:
@@ -301,7 +302,7 @@ class BenchmarkSpec(object):
 
     # This must come after Scratch Disk creation to support the
     # Containerized VM case
-    vm.OnStartup()
+    vm.PrepareVMEnvironment()
 
   def DeleteVm(self, vm):
     """Deletes a single vm and scratch disk if required.

--- a/perfkitbenchmarker/benchmark_spec.py
+++ b/perfkitbenchmarker/benchmark_spec.py
@@ -33,7 +33,7 @@ import perfkitbenchmarker.deployment.shared.ini_constants as ini_constants
 from perfkitbenchmarker.digitalocean import digitalocean_network
 from perfkitbenchmarker.digitalocean import digitalocean_virtual_machine
 from perfkitbenchmarker.gcp import gce_network
-from perfkitbenchmarker.gcp import gce_virtual_machine
+from perfkitbenchmarker.gcp import gce_virtual_machine as gce_vm
 
 GCP = 'GCP'
 AZURE = 'Azure'
@@ -53,10 +53,10 @@ FIREWALL = 'firewall'
 CLASSES = {
     GCP: {
         VIRTUAL_MACHINE: {
-            DEBIAN: gce_virtual_machine.DebianBasedGceVirtualMachine,
-            RHEL: gce_virtual_machine.RhelBasedGceVirtualMachine,
-            UBUNTU_CONTAINER: gce_virtual_machine.ContainerizedGceVirtualMachine,
-            WINDOWS: gce_virtual_machine.WindowsGceVirtualMachine
+            DEBIAN: gce_vm.DebianBasedGceVirtualMachine,
+            RHEL: gce_vm.RhelBasedGceVirtualMachine,
+            UBUNTU_CONTAINER: gce_vm.ContainerizedGceVirtualMachine,
+            WINDOWS: gce_vm.WindowsGceVirtualMachine
         },
         FIREWALL: gce_network.GceFirewall
     },

--- a/perfkitbenchmarker/benchmarks/bonnie_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/bonnie_benchmark.py
@@ -23,7 +23,10 @@ from perfkitbenchmarker import sample
 FLAGS = flags.FLAGS
 
 BENCHMARK_INFO = {'name': 'bonnie++',
-                  'description': 'Runs Bonnie++.',
+                  'description': 'Runs Bonnie++. Running this benchmark inside '
+                                 'a container is currently not supported, '
+                                 'since Docker tries to run it as root, which '
+                                 'is not recommended.',
                   'scratch_disk': True,
                   'num_machines': 1}
 

--- a/perfkitbenchmarker/benchmarks/cassandra_stress_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/cassandra_stress_benchmark.py
@@ -99,10 +99,11 @@ def Prepare(benchmark_spec):
                  '1 loader node, 3 data nodes')
     vm_dict[LOADER_NODE] = [vm_dict['default'][-1]]
     vm_dict[DATA_NODE] = vm_dict['default'][:3]
+    mount_point = os.path.join(vm_util.GetTempDir(), 'cassandra_data')
     disk_spec = disk.BaseDiskSpec(
         FLAGS.scratch_disk_size,
         FLAGS.scratch_disk_type,
-        '/cassandra_data')
+        mount_point)
     for vm in vm_dict[DATA_NODE]:
       vm.CreateScratchDisk(disk_spec)
 

--- a/perfkitbenchmarker/benchmarks/cassandra_stress_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/cassandra_stress_benchmark.py
@@ -99,7 +99,7 @@ def Prepare(benchmark_spec):
                  '1 loader node, 3 data nodes')
     vm_dict[LOADER_NODE] = [vm_dict['default'][-1]]
     vm_dict[DATA_NODE] = vm_dict['default'][:3]
-    mount_point = os.path.join(vm_util.GetTempDir(), 'cassandra_data')
+    mount_point = os.path.join(vm_util.VM_TMP_DIR, 'cassandra_data')
     disk_spec = disk.BaseDiskSpec(
         FLAGS.scratch_disk_size,
         FLAGS.scratch_disk_type,

--- a/perfkitbenchmarker/gcp/gce_virtual_machine.py
+++ b/perfkitbenchmarker/gcp/gce_virtual_machine.py
@@ -30,7 +30,7 @@ import re
 from perfkitbenchmarker import disk
 from perfkitbenchmarker import errors
 from perfkitbenchmarker import flags
-from perfkitbenchmarker import linux_virtual_machine
+from perfkitbenchmarker import linux_virtual_machine as linux_vm
 from perfkitbenchmarker import virtual_machine
 from perfkitbenchmarker import vm_util
 from perfkitbenchmarker import windows_virtual_machine
@@ -223,13 +223,18 @@ class GceVirtualMachine(virtual_machine.BaseVirtualMachine):
     vm_util.IssueCommand(cmd)
 
 
+class ContainerizedGceVirtualMachine(GceVirtualMachine,
+                                     linux_vm.ContainerizedDebianMixin):
+  pass
+
+
 class DebianBasedGceVirtualMachine(GceVirtualMachine,
-                                   linux_virtual_machine.DebianMixin):
+                                   linux_vm.DebianMixin):
   DEFAULT_IMAGE = UBUNTU_IMAGE
 
 
 class RhelBasedGceVirtualMachine(GceVirtualMachine,
-                                 linux_virtual_machine.RhelMixin):
+                                 linux_vm.RhelMixin):
   DEFAULT_IMAGE = RHEL_IMAGE
 
 

--- a/perfkitbenchmarker/gcp/gce_virtual_machine.py
+++ b/perfkitbenchmarker/gcp/gce_virtual_machine.py
@@ -225,7 +225,7 @@ class GceVirtualMachine(virtual_machine.BaseVirtualMachine):
 
 class ContainerizedGceVirtualMachine(GceVirtualMachine,
                                      linux_vm.ContainerizedDebianMixin):
-  pass
+  DEFAULT_IMAGE = UBUNTU_IMAGE
 
 
 class DebianBasedGceVirtualMachine(GceVirtualMachine,

--- a/perfkitbenchmarker/linux_virtual_machine.py
+++ b/perfkitbenchmarker/linux_virtual_machine.py
@@ -29,6 +29,7 @@ for you.
 import logging
 import os
 import pipes
+import posixpath
 import re
 import threading
 import time
@@ -788,7 +789,7 @@ class ContainerizedDebianMixin(DebianMixin):
       A tuple of stdout and stderr from running the command.
     """
     # Escapes bash sequences
-    command = command.replace("\'", "\'\\\'\'")
+    command = command.replace("'", r"'\''")
 
     logging.info('Docker running: %s' % command)
     command = "sudo docker exec %s bash -c '%s'" % (self.docker_id, command)
@@ -811,14 +812,14 @@ class ContainerizedDebianMixin(DebianMixin):
 
       # Everything in vm_util.VM_TMP_DIR is directly accessible
       # both in the host and in the container
-      source_path = os.path.join(CONTAINER_MOUNT_DIR, file_name)
+      source_path = posixpath.join(CONTAINER_MOUNT_DIR, file_name)
       command = 'cp %s %s' % (source_path, container_path)
       self.RemoteCommand(command)
     else:
       if container_path == '':
         raise errors.VirtualMachine.RemoteExceptionError('Cannot copy '
                                                          'from blank target')
-      destination_path = os.path.join(CONTAINER_MOUNT_DIR, file_name)
+      destination_path = posixpath.join(CONTAINER_MOUNT_DIR, file_name)
       command = 'cp %s %s' % (container_path, destination_path)
       self.RemoteCommand(command)
 
@@ -832,12 +833,12 @@ class ContainerizedDebianMixin(DebianMixin):
     """
     if copy_to:
       file_name = os.path.basename(file_path)
-      tmp_path = os.path.join(vm_util.VM_TMP_DIR, file_name)
+      tmp_path = posixpath.join(vm_util.VM_TMP_DIR, file_name)
       self.RemoteHostCopy(file_path, tmp_path, copy_to)
       self.ContainerCopy(file_name, remote_path, copy_to)
     else:
-      file_name = os.path.basename(remote_path)
-      tmp_path = os.path.join(vm_util.VM_TMP_DIR, file_name)
+      file_name = posixpath.basename(remote_path)
+      tmp_path = posixpath.join(vm_util.VM_TMP_DIR, file_name)
       self.ContainerCopy(file_name, remote_path, copy_to)
       self.RemoteHostCopy(file_path, tmp_path, copy_to)
 
@@ -853,13 +854,13 @@ class ContainerizedDebianMixin(DebianMixin):
       remote_path: The destination of the file on the TARGET machine, default
           is the root directory.
     """
-    file_name = os.path.basename(source_path)
+    file_name = posixpath.basename(source_path)
 
     # Copies the file to vm_util.VM_TMP_DIR in source
     self.ContainerCopy(file_name, source_path, copy_to=False)
 
     # Moves the file to vm_util.VM_TMP_DIR in target
-    source_host_path = os.path.join(vm_util.VM_TMP_DIR, file_name)
+    source_host_path = posixpath.join(vm_util.VM_TMP_DIR, file_name)
     target_host_dir = vm_util.VM_TMP_DIR
     self.MoveHostFile(target, source_host_path, target_host_dir)
 

--- a/perfkitbenchmarker/packages/cassandra.py
+++ b/perfkitbenchmarker/packages/cassandra.py
@@ -63,6 +63,7 @@ def CheckPrerequisites():
 def _Install(vm):
   """Installs Cassandra from a tarball."""
   vm.Install('openjdk7')
+  vm.Install('curl')
   vm.RemoteCommand('mkdir {0} && curl -L {1} | '
                    'tar -C {0} -xzf - --strip-components=1'.format(
                        CASSANDRA_DIR, CASSANDRA_TAR_URL))

--- a/perfkitbenchmarker/packages/docker.py
+++ b/perfkitbenchmarker/packages/docker.py
@@ -13,19 +13,19 @@
 # limitations under the License.
 
 
-"""Module containing curl installation and cleanup functions."""
+"""Module containing docker installation and cleanup functions."""
 
 
 def _Install(vm):
-  """Installs the curl package on the VM."""
-  vm.InstallPackages('curl')
+  """Installs the docker package on the VM."""
+  vm.RemoteHostCommand('wget -qO- https://get.docker.com/ | sh')
 
 
 def YumInstall(vm):
-  """Installs the curl package on the VM."""
+  """Installs the docker package on the VM."""
   _Install(vm)
 
 
 def AptInstall(vm):
-  """Installs the curl package on the VM."""
+  """Installs the docker package on the VM."""
   _Install(vm)

--- a/perfkitbenchmarker/packages/hadoop.py
+++ b/perfkitbenchmarker/packages/hadoop.py
@@ -59,6 +59,7 @@ def CheckPrerequisites():
 
 def _Install(vm):
   vm.Install('openjdk7')
+  vm.Install('curl')
   vm.RemoteCommand(('mkdir {0} && curl -L {1} | '
                     'tar -C {0} --strip-components=1 -xzf -').format(
                         HADOOP_DIR, HADOOP_URL))

--- a/perfkitbenchmarker/packages/hbase.py
+++ b/perfkitbenchmarker/packages/hbase.py
@@ -52,6 +52,7 @@ def CheckPrerequisites():
 
 def _Install(vm):
   vm.Install('hadoop')
+  vm.Install('curl')
   vm.RemoteCommand(('mkdir {0} && curl -L {1} | '
                     'tar -C {0} --strip-components=1 -xzf -').format(
                         HBASE_DIR, HBASE_URL))

--- a/perfkitbenchmarker/packages/ycsb.py
+++ b/perfkitbenchmarker/packages/ycsb.py
@@ -159,6 +159,7 @@ def _Install(vm):
   """Installs the YCSB package on the VM."""
   vm.Install('maven')
   vm.Install('openjdk7')
+  vm.Install('curl')
   vm.RemoteCommand(('mkdir -p {0} && curl -L {1} | '
                     'tar -C {0} --strip-components=1 -xzf -').format(
                         YCSB_BUILD_DIR, YCSB_TAR_URL))

--- a/perfkitbenchmarker/virtual_machine.py
+++ b/perfkitbenchmarker/virtual_machine.py
@@ -272,7 +272,6 @@ class BaseOsMixin(object):
     """
     pass
 
-
   @abc.abstractmethod
   def Install(self, package_name):
     """Installs a PerfKit package on the VM."""

--- a/perfkitbenchmarker/virtual_machine.py
+++ b/perfkitbenchmarker/virtual_machine.py
@@ -261,9 +261,17 @@ class BaseOsMixin(object):
   def OnStartup(self):
     """Performs any necessary setup on the VM specific to the OS.
 
-    This will be called once after the VM has booted.
+    This will be called once immediately after the VM has booted.
     """
     pass
+
+  def PrepareVMEnvironment(self):
+    """Performs any necessary setup on the VM specific to the OS.
+
+    This will be called once after setting up scratch disks.
+    """
+    pass
+
 
   @abc.abstractmethod
   def Install(self, package_name):


### PR DESCRIPTION
This PR adds the ContainerizedDebian class, which allows anyone to run benchmarks within a Ubuntu docker container. Every call to RemoteCommand runs within the Docker container via docker exec, whereas any call to RemoteHostCommand is guaranteed to run the command in the VM, outside the container.

This was only tested in GCE so far.