### PR TITLE
Add tests/data directory to gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@
 
 # Don't let git change end of line characters in the data directory.
 perfkitbenchmarker/data/* -text
+tests/data/* -text


### PR DESCRIPTION
This is to prevent a fresh checkout to show that test data file `tests/data/mongodb-sample-result.txt` (which has a single CRLF line break among other normal line breaks) is showed as modified from a fresh `git clone` checkout.

Tested by pushing this commit to my forked repository, checking it out with `git clone` and confirming it would not show any conflicts right away.

(A more proper solution would be to just remove the `.gitattributes` file since there's really no reason for it... If you want to support Windows clients, then just have them properly configured instead, have their editors generate files with proper normal newlines using only LF.)

@dyema @ehankland @gablg1