### PR TITLE
Adding Container support to Rhel

### DIFF
--- a/perfkitbenchmarker/benchmark_spec.py
+++ b/perfkitbenchmarker/benchmark_spec.py
@@ -42,6 +42,7 @@ DIGITALOCEAN = 'DigitalOcean'
 DEBIAN = 'debian'
 RHEL = 'rhel'
 WINDOWS = 'windows'
+CENTOS_CONTAINER = 'centos_container'
 UBUNTU_CONTAINER = 'ubuntu_container'
 IMAGE = 'image'
 WINDOWS_IMAGE = 'windows_image'
@@ -55,8 +56,9 @@ CLASSES = {
         VIRTUAL_MACHINE: {
             DEBIAN: gce_vm.DebianBasedGceVirtualMachine,
             RHEL: gce_vm.RhelBasedGceVirtualMachine,
-            UBUNTU_CONTAINER: gce_vm.ContainerizedGceVirtualMachine,
-            WINDOWS: gce_vm.WindowsGceVirtualMachine
+            WINDOWS: gce_vm.WindowsGceVirtualMachine,
+            CENTOS_CONTAINER: gce_vm.RhelContainerizedGceVirtualMachine,
+            UBUNTU_CONTAINER: gce_vm.DebianContainerizedGceVirtualMachine
         },
         FIREWALL: gce_network.GceFirewall
     },
@@ -91,7 +93,8 @@ FLAGS = flags.FLAGS
 flags.DEFINE_enum('cloud', GCP, [GCP, AZURE, AWS, DIGITALOCEAN],
                   'Name of the cloud to use.')
 flags.DEFINE_enum(
-    'os_type', DEBIAN, [DEBIAN, RHEL, UBUNTU_CONTAINER, WINDOWS],
+    'os_type', DEBIAN, [DEBIAN, RHEL, WINDOWS,
+                        CENTOS_CONTAINER, UBUNTU_CONTAINER],
     'The VM\'s OS type. Ubuntu\'s os_type is "debian" because it is largely '
     'built on Debian and uses the same package manager. Likewise, CentOS\'s '
     'os_type is "rhel". In general if two OS\'s use the same package manager, '

--- a/perfkitbenchmarker/gcp/gce_virtual_machine.py
+++ b/perfkitbenchmarker/gcp/gce_virtual_machine.py
@@ -55,6 +55,8 @@ SCSI = 'SCSI'
 UBUNTU_IMAGE = 'ubuntu-14-04'
 RHEL_IMAGE = 'rhel-7'
 WINDOWS_IMAGE = 'windows-2012-r2'
+CONTAINER_UBUNTU_IMAGE = 'ubuntu:14.04'
+CONTAINER_CENTOS_IMAGE = 'centos:7'
 
 
 class GceVirtualMachine(virtual_machine.BaseVirtualMachine):
@@ -64,6 +66,7 @@ class GceVirtualMachine(virtual_machine.BaseVirtualMachine):
   DEFAULT_MACHINE_TYPE = 'n1-standard-1'
   # Subclasses should override the default image.
   DEFAULT_IMAGE = None
+  CONTAINER_IMAGE = None
   BOOT_DISK_SIZE_GB = 10
   BOOT_DISK_TYPE = disk.STANDARD
 
@@ -227,9 +230,18 @@ class GceVirtualMachine(virtual_machine.BaseVirtualMachine):
     vm_util.IssueCommand(cmd)
 
 
-class ContainerizedGceVirtualMachine(GceVirtualMachine,
-                                     linux_vm.ContainerizedDebianMixin):
+class DebianContainerizedGceVirtualMachine(GceVirtualMachine,
+                                           linux_vm.ContainerizedMixin,
+                                           linux_vm.DebianMixin):
   DEFAULT_IMAGE = UBUNTU_IMAGE
+  CONTAINER_IMAGE = CONTAINER_UBUNTU_IMAGE
+
+
+class RhelContainerizedGceVirtualMachine(GceVirtualMachine,
+                                         linux_vm.ContainerizedMixin,
+                                         linux_vm.RhelMixin):
+  DEFAULT_IMAGE = RHEL_IMAGE
+  CONTAINER_IMAGE = CONTAINER_CENTOS_IMAGE
 
 
 class DebianBasedGceVirtualMachine(GceVirtualMachine,

--- a/perfkitbenchmarker/linux_virtual_machine.py
+++ b/perfkitbenchmarker/linux_virtual_machine.py
@@ -177,10 +177,6 @@ class BaseLinuxMixin(virtual_machine.BaseOsMixin):
     if commands:
       self.RemoteCommand(";".join(commands))
 
-  def SetupPackageManager(self):
-    """Performs initial setup specific to the package manager."""
-    pass
-
   def PrepareVMEnvironment(self):
     self.SetupProxy()
     if self.is_static and self.install_packages:
@@ -746,7 +742,7 @@ class ContainerizedMixin(BaseLinuxMixin):
   whereas any call to RemoteHostCommand() will be run in the VM itself.
   """
 
-  def CheckDockerExists(self):
+  def _CheckDockerExists(self):
     """Returns whether docker is installed or not."""
     resp, _ = self.RemoteHostCommand('command -v docker', ignore_failure=True,
                                      suppress_warning=True)
@@ -757,7 +753,7 @@ class ContainerizedMixin(BaseLinuxMixin):
   def PrepareVMEnvironment(self):
     """Initializes docker before proceeding with preparation."""
     self.RemoteHostCommand('mkdir -p %s' % vm_util.VM_TMP_DIR)
-    if not self.CheckDockerExists():
+    if not self._CheckDockerExists():
       self.Install('docker')
     self.InitDocker()
     super(ContainerizedMixin, self).PrepareVMEnvironment()

--- a/perfkitbenchmarker/packages/docker.py
+++ b/perfkitbenchmarker/packages/docker.py
@@ -13,19 +13,28 @@
 # limitations under the License.
 
 
-"""Module containing docker installation and cleanup functions."""
+"""Module containing docker installation and cleanup functions.
 
+This is probably the only package that should use RemoteHostCommand instead
+of RemoteCommand, since Docker has to be installed directly on the remote VM
+and not within a container running on that VM.
+"""
 
-def _Install(vm):
-  """Installs the docker package on the VM."""
-  vm.RemoteHostCommand('wget -qO- https://get.docker.com/ | sh')
+from perfkitbenchmarker import vm_util
+
+DOCKER_RPM_URL = ('https://get.docker.com/rpm/1.7.0/centos-6/'
+                  'RPMS/x86_64/docker-engine-1.7.0-1.el6.x86_64.rpm')
 
 
 def YumInstall(vm):
   """Installs the docker package on the VM."""
-  _Install(vm)
+  vm.RemoteHostCommand('curl -o %s/docker.rpm -sSL %s'
+                       % (vm_util.VM_TMP_DIR, DOCKER_RPM_URL))
+  vm.RemoteHostCommand('sudo yum localinstall '
+                       '--nogpgcheck %s/docker.rpm -y' % vm_util.VM_TMP_DIR)
+  vm.RemoteHostCommand('sudo service docker start')
 
 
 def AptInstall(vm):
   """Installs the docker package on the VM."""
-  _Install(vm)
+  vm.RemoteHostCommand('curl -sSL https://get.docker.com/ | sh')


### PR DESCRIPTION
Slight refactor that abstracts ContainerizedMixin away from a specific Linux type. Now ContainerizedMixin works both with CentOS and with Ubuntu.