### PR TITLE
Aerospike: Use vm.num_cpus where recommended.

### DIFF
--- a/perfkitbenchmarker/benchmarks/aerospike_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/aerospike_benchmark.py
@@ -108,10 +108,12 @@ def _PrepareServer(server):
     else:
       devices = [scratch_disk.GetDevicePath()
                  for scratch_disk in server.scratch_disks]
+  else:
+    devices = []
 
-    server.RenderTemplate(data.ResourcePath('aerospike.conf.j2'),
-                          aerospike_server.AEROSPIKE_CONF_PATH,
-                          {'devices': devices})
+  server.RenderTemplate(data.ResourcePath('aerospike.conf.j2'),
+                        aerospike_server.AEROSPIKE_CONF_PATH,
+                        {'devices': devices})
 
   for scratch_disk in server.scratch_disks:
     server.RemoteCommand('sudo umount %s' % scratch_disk.mount_point)

--- a/perfkitbenchmarker/data/aerospike.conf.j2
+++ b/perfkitbenchmarker/data/aerospike.conf.j2
@@ -63,16 +63,21 @@ network {
 }
 
 namespace test {
-        replication-factor 2
-        memory-size 4G
-        default-ttl 30d # 30 days, use 0 to never expire/evict.
-        storage-engine device { # Configure the storage-engine to use persistence
-        {% for device_path in devices %}
-        device {{ device_path }}
-        {% endfor %}
-        write-block-size 128K   # adjust block size to make it efficient for SSDs
-        disable-odirect true
-        }
+	replication-factor 2
+	memory-size 4G
+	default-ttl 30d # 30 days, use 0 to never expire/evict.
+	{# if storage devices are passed to the template, use them for storage; otherwise use memory. -#}
+	{% if devices %}
+	storage-engine device { # Configure the storage-engine to use persistence
+	{% for device_path in devices %}
+	device {{ device_path }}
+	{% endfor %}
+	write-block-size 128K   # adjust block size to make it efficient for SSDs
+	disable-odirect true
+	}
+	{% else %}
+	storage-engine memory
+	{% endif %}
 }
 
 namespace bar {

--- a/perfkitbenchmarker/data/aerospike.conf.j2
+++ b/perfkitbenchmarker/data/aerospike.conf.j2
@@ -4,8 +4,8 @@
 service {
 	run-as-daemon false
 	paxos-single-replica-limit 1 # Number of nodes where the replica count is automatically reduced to 1.
-	service-threads 4
-	transaction-queues 4
+	service-threads {{ vm.num_cpus }}
+	transaction-queues {{ vm.num_cpus }}
 	transaction-threads-per-queue 4
 	# Note:  The number of concurrent connections to the database is limited by "proto-fd-max",
 	#         which is in turn limited by the system's maximum number of open file descriptors.

--- a/perfkitbenchmarker/virtual_machine.py
+++ b/perfkitbenchmarker/virtual_machine.py
@@ -352,7 +352,8 @@ class BaseOsMixin(object):
     template = environment.from_string(template_contents)
     prefix = 'pkb-' + os.path.basename(template_path)
 
-    with vm_util.NamedTemporaryFile(prefix=prefix) as tf:
+    with vm_util.NamedTemporaryFile(prefix=prefix, dir=vm_util.GetTempDir(),
+                                    delete=False) as tf:
       tf.write(template.render(vm=self, **context))
       tf.close()
       self.RemoteCopy(tf.name, remote_path)

--- a/perfkitbenchmarker/vm_util.py
+++ b/perfkitbenchmarker/vm_util.py
@@ -522,7 +522,7 @@ def GetLastRunUri():
 
 
 @contextlib.contextmanager
-def NamedTemporaryFile(prefix='tmp', suffix='', dir=None):
+def NamedTemporaryFile(prefix='tmp', suffix='', dir=None, delete=True):
   """Behaves like tempfile.NamedTemporaryFile.
 
   The existing tempfile.NamedTemporaryFile has the annoying property on
@@ -539,7 +539,8 @@ def NamedTemporaryFile(prefix='tmp', suffix='', dir=None):
   finally:
     if not f.closed:
       f.close()
-    os.unlink(f.name)
+    if delete:
+      os.unlink(f.name)
 
 
 def GenerateSSHConfig(vms):


### PR DESCRIPTION
Use vm.num_cpus for Aerospike configurations service-threads, transaction-queues.
This is the recommended value per the documentation.

See #354.

Also modifies `vm_util.NamedTemporaryFile` to optionally delete the created
file (rather than always deleting it), so that rendered templates can be saved
to the run temp dir for debugging.  I can separate that out if preferred.