### PR TITLE
Added Iptables configuration

### DIFF
--- a/perfkitbenchmarker/gcp/gce_virtual_machine.py
+++ b/perfkitbenchmarker/gcp/gce_virtual_machine.py
@@ -152,6 +152,16 @@ class GceVirtualMachine(virtual_machine.BaseVirtualMachine):
     network_interface = response['networkInterfaces'][0]
     self.internal_ip = network_interface['networkIP']
     self.ip_address = network_interface['accessConfigs'][0]['natIP']
+    self.network_name = network_interface['network']
+
+    getinstance_cmd = [FLAGS.gcloud_path,
+                       'compute',
+                       'networks',
+                       'describe', self.network_name]
+    getinstance_cmd.extend(['--format', 'json'])
+    stdout, _, _ = vm_util.IssueCommand(getinstance_cmd)
+    response = json.loads(stdout)
+    self.allowed_ip_range = response['IPv4Range']
 
   def _Delete(self):
     """Delete a GCE VM instance."""

--- a/perfkitbenchmarker/gcp/gce_virtual_machine.py
+++ b/perfkitbenchmarker/gcp/gce_virtual_machine.py
@@ -153,7 +153,7 @@ class GceVirtualMachine(virtual_machine.BaseVirtualMachine):
     self.internal_ip = network_interface['networkIP']
     self.ip_address = network_interface['accessConfigs'][0]['natIP']
 
-    if FLAGS.setup_host_firewall:
+    if FLAGS.setup_remote_firewall:
       self.network_name = network_interface['network']
       getinstance_cmd = [FLAGS.gcloud_path,
                          'compute',

--- a/perfkitbenchmarker/gcp/gce_virtual_machine.py
+++ b/perfkitbenchmarker/gcp/gce_virtual_machine.py
@@ -153,17 +153,6 @@ class GceVirtualMachine(virtual_machine.BaseVirtualMachine):
     self.internal_ip = network_interface['networkIP']
     self.ip_address = network_interface['accessConfigs'][0]['natIP']
 
-    if FLAGS.setup_remote_firewall:
-      self.network_name = network_interface['network']
-      getinstance_cmd = [FLAGS.gcloud_path,
-                         'compute',
-                         'networks',
-                         'describe', self.network_name]
-      getinstance_cmd.extend(['--format', 'json'])
-      stdout, _, _ = vm_util.IssueCommand(getinstance_cmd)
-      response = json.loads(stdout)
-      self.allowed_ip_range = response['IPv4Range']
-
   def _Delete(self):
     """Delete a GCE VM instance."""
     delete_cmd = [FLAGS.gcloud_path,

--- a/perfkitbenchmarker/gcp/gce_virtual_machine.py
+++ b/perfkitbenchmarker/gcp/gce_virtual_machine.py
@@ -152,16 +152,17 @@ class GceVirtualMachine(virtual_machine.BaseVirtualMachine):
     network_interface = response['networkInterfaces'][0]
     self.internal_ip = network_interface['networkIP']
     self.ip_address = network_interface['accessConfigs'][0]['natIP']
-    self.network_name = network_interface['network']
 
-    getinstance_cmd = [FLAGS.gcloud_path,
-                       'compute',
-                       'networks',
-                       'describe', self.network_name]
-    getinstance_cmd.extend(['--format', 'json'])
-    stdout, _, _ = vm_util.IssueCommand(getinstance_cmd)
-    response = json.loads(stdout)
-    self.allowed_ip_range = response['IPv4Range']
+    if FLAGS.setup_host_firewall:
+      self.network_name = network_interface['network']
+      getinstance_cmd = [FLAGS.gcloud_path,
+                         'compute',
+                         'networks',
+                         'describe', self.network_name]
+      getinstance_cmd.extend(['--format', 'json'])
+      stdout, _, _ = vm_util.IssueCommand(getinstance_cmd)
+      response = json.loads(stdout)
+      self.allowed_ip_range = response['IPv4Range']
 
   def _Delete(self):
     """Delete a GCE VM instance."""

--- a/perfkitbenchmarker/linux_virtual_machine.py
+++ b/perfkitbenchmarker/linux_virtual_machine.py
@@ -801,7 +801,7 @@ class ContainerizedDebianMixin(DebianMixin):
   def RemoteCommand(self, command,
                     should_log=False, retries=SSH_RETRIES,
                     ignore_failure=False, login_shell=False,
-                    suppress_warning=False):
+                    suppress_warning=False, timeout=None):
     """Runs a command inside the container.
 
     Args:

--- a/perfkitbenchmarker/linux_virtual_machine.py
+++ b/perfkitbenchmarker/linux_virtual_machine.py
@@ -69,6 +69,10 @@ EXECUTE_COMMAND = 'execute_command.py'
 # by EXECUTE_COMMAND.
 WAIT_FOR_COMMAND = 'wait_for_command.py'
 
+flags.DEFINE_bool('setup_host_firewall', False,
+                  'Whether PKB should configure the firewall of each remote'
+                  'host VM to make sure it accepts all internal connections.')
+
 
 class BaseLinuxMixin(virtual_machine.BaseOsMixin):
   """Class that holds Linux related VM methods and attributes."""
@@ -196,7 +200,8 @@ class BaseLinuxMixin(virtual_machine.BaseOsMixin):
   def PrepareVMEnvironment(self):
     self.SetupProxy()
     self.RemoteCommand('mkdir -p %s' % vm_util.VM_TMP_DIR)
-    self.SetupHostFirewall()
+    if FLAGS.setup_host_firewall:
+      self.SetupHostFirewall()
     if self.is_static and self.install_packages:
       self.SnapshotPackages()
     self.BurnCpu()

--- a/perfkitbenchmarker/linux_virtual_machine.py
+++ b/perfkitbenchmarker/linux_virtual_machine.py
@@ -69,9 +69,9 @@ EXECUTE_COMMAND = 'execute_command.py'
 # by EXECUTE_COMMAND.
 WAIT_FOR_COMMAND = 'wait_for_command.py'
 
-flags.DEFINE_bool('setup_host_firewall', False,
+flags.DEFINE_bool('setup_remote_firewall', False,
                   'Whether PKB should configure the firewall of each remote'
-                  'host VM to make sure it accepts all internal connections.')
+                  'VM to make sure it accepts all internal connections.')
 
 
 class BaseLinuxMixin(virtual_machine.BaseOsMixin):
@@ -161,10 +161,10 @@ class BaseLinuxMixin(virtual_machine.BaseOsMixin):
                     '--delete']
     return self.RemoteCommand(' '.join(wait_command), should_log=False)
 
-  def SetupHostFirewall(self):
+  def SetupRemoteFirewall(self):
     """Sets up IP table configurations on the VM."""
     if hasattr(self, 'allowed_ip_range') and self.allowed_ip_range:
-      self.RemoteHostCommand('sudo iptables -A --source %s '
+      self.RemoteHostCommand('sudo iptables -A INPUT --source %s '
                              '-p tcp -j ACCEPT' % self.allowed_ip_range)
       self.RemoteHostCommand('sudo iptables -A INPUT --source %s '
                              '-p udp -j ACCEPT' % self.allowed_ip_range)
@@ -200,8 +200,8 @@ class BaseLinuxMixin(virtual_machine.BaseOsMixin):
   def PrepareVMEnvironment(self):
     self.SetupProxy()
     self.RemoteCommand('mkdir -p %s' % vm_util.VM_TMP_DIR)
-    if FLAGS.setup_host_firewall:
-      self.SetupHostFirewall()
+    if FLAGS.setup_remote_firewall:
+      self.SetupRemoteFirewall()
     if self.is_static and self.install_packages:
       self.SnapshotPackages()
     self.BurnCpu()

--- a/perfkitbenchmarker/linux_virtual_machine.py
+++ b/perfkitbenchmarker/linux_virtual_machine.py
@@ -163,15 +163,8 @@ class BaseLinuxMixin(virtual_machine.BaseOsMixin):
 
   def SetupRemoteFirewall(self):
     """Sets up IP table configurations on the VM."""
-    if hasattr(self, 'allowed_ip_range') and self.allowed_ip_range:
-      self.RemoteHostCommand('sudo iptables -A INPUT --source %s '
-                             '-p tcp -j ACCEPT' % self.allowed_ip_range)
-      self.RemoteHostCommand('sudo iptables -A INPUT --source %s '
-                             '-p udp -j ACCEPT' % self.allowed_ip_range)
-      self.RemoteHostCommand('sudo iptables -A OUTPUT --destination %s '
-                             '-p udp -j ACCEPT' % self.allowed_ip_range)
-      self.RemoteHostCommand('sudo iptables -A OUTPUT --destination %s '
-                             '-p tcp -j ACCEPT' % self.allowed_ip_range)
+    self.RemoteHostCommand('sudo iptables -A INPUT -j ACCEPT')
+    self.RemoteHostCommand('sudo iptables -A OUTPUT -j ACCEPT')
 
   def SetupProxy(self):
     """Sets up proxy configuration variables for the cloud environment."""


### PR DESCRIPTION
This allows PKB to ensure that UDP and TCP internal connections on a GCP project are always allowed. Some distros have a DROP all iptables policy by default, so we need this for those.