### PR TITLE
Removing singleton pattern for Openstack Novaclient.

### DIFF
--- a/perfkitbenchmarker/openstack/utils.py
+++ b/perfkitbenchmarker/openstack/utils.py
@@ -92,12 +92,6 @@ class KeystoneAuth(object):
 
 
 class NovaClient(object):
-    instance = None
-
-    def __new__(cls, *args):
-        if not NovaClient.instance:
-            cls.instance = object.__new__(cls, *args)
-        return cls.instance
 
     def __getattribute__(self, item):
         try:


### PR DESCRIPTION
Novaclient lib is not designed to be used by multiple threads.
In particular, it may cause race conditions when connecting to different
Openstack services (like Nova and Cinder).

Signed-off-by: Mateusz Blaszkowski <mateusz.blaszkowski@intel.com>