### PR TITLE
Fix file headers that don't match expected boilerplate.

### DIFF
--- a/perfkitbenchmarker/benchmarks/silo_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/silo_benchmark.py
@@ -1,3 +1,5 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/perfkitbenchmarker/scripts/execute_command.py
+++ b/perfkitbenchmarker/scripts/execute_command.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+#
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +13,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 # -*- coding: utf-8 -*-
+
 """Runs a command, saving stdout, stderr, and the return code in files.
 
 Simplifies executing long-running commands on a remote host.
@@ -25,6 +28,7 @@ status file, which blocks until the process completes.
 
 *Runs on the guest VM. Supports Python 2.6, 2.7, and 3.x.*
 """
+
 import fcntl
 import logging
 import optparse

--- a/perfkitbenchmarker/scripts/wait_for_command.py
+++ b/perfkitbenchmarker/scripts/wait_for_command.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python2
+#
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +13,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 # -*- coding: utf-8 -*-
+
 """Waits for a command started by execute_command.py to complete.
 
 Blocks until a command wrapped by "execute_command.py" completes, then mimics


### PR DESCRIPTION
Running the new `hooks/check-everything` script complains about these
pre-existing files. Fix them to get clean output by default.