### PR TITLE
Add Rackspace cloud provider support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,42 @@ PerfKitBenchmarker uses the file location `~/.config/digitalocean-oauth.curl`
 by default, you can use the `--digitalocean_curl_config` flag to
 override the path.
 
+
+## Installing CLIs and credentials for Rackspace
+
+In order to interact with the Rackspace Public Cloud, PerfKitBenchmarker makes
+use of the Nova, and the Neutron CLI clients with the Rackspace extensions.
+
+To run PerfKitBenchmarker against Rackspace is very easy. First, install the
+CLI clients as follows:
+```bash
+pip install -U rackspace-neutronclient
+pip install -U rackspace-novaclient
+```
+
+Once these are installed, all we need to do is to set 3 environment variables,
+```bash
+export OS_USERNAME=<your_rackspace_username>
+export OS_PASSWORD=<your_rackspace_API_key>
+export OS_TENANT_NAME=<your_rackspace_account_number>
+```
+
+For a Rackspace UK Public Cloud account, an extra environment variable has to
+be set, please remember that only the LON region is available under
+a Rackspace UK Public Cloud account.
+```bash
+export OS_AUTH_URL=https://lon.identity.api.rackspacecloud.com/v2.0/
+
+export OS_USERNAME=<your_rackspace_uk_username>
+export OS_PASSWORD=<your_rackspace_uk_API_key>
+export OS_TENANT_NAME=<your_rackspace_uk_account_number>
+```
+*Tip*: Put these variables in a file, and simple source them to your shell with
+`source <filename>` 
+
+**Note:** Not all flavors are supported on every region. Always check first
+if the flavor is supported in the region.
+
 ## Create and Configure a `.boto` file for object storage benchmarks
 
 In order to run object storage benchmark tests, you need to have a properly configured `~/.boto` file.
@@ -304,6 +340,11 @@ $ ./pkb.py --cloud=DigitalOcean --machine_type=16gb --benchmarks=iperf
 $ ./pkb.py --cloud=OpenStack --benchmarks=iperf --os_auth_url=http://localhost:5000/v2.0/
 ```
 
+## Example run on Rackspace
+```
+$ ./pkb.py --cloud=Rackspace --machine_type=general1-2 --benchmarks=iperf
+```
+
 HOW TO RUN WINDOWS BENCHMARKS
 ==================
 You must be running on a Windows machine in order to run Windows benchmarks.
@@ -356,6 +397,7 @@ AWS | us-east-1a | |
 Azure | East US | |
 DigitalOcean | sfo1 | You must use a zone that supports the features 'metadata' (for cloud config) and 'private_networking'.
 OpenStack | nova | |
+Rackspace | IAD | OnMetal machine-types are available only in IAD zone
 
 Example:
 

--- a/perfkitbenchmarker/benchmark_sets.py
+++ b/perfkitbenchmarker/benchmark_sets.py
@@ -95,7 +95,11 @@ BENCHMARK_SETS = {
     },
     'rackspace_set': {
         MESSAGE: 'Rackspace benchmark set.',
-        BENCHMARK_LIST: [STANDARD_SET]
+        BENCHMARK_LIST: ['aerospike', 'cassandra_stress', 'cluster_boot',
+                         'copy_throughput', 'fio', 'hpcc', 'iperf',
+                         'mesh_network', 'mongodb_ycsb', 'netperf', 'ping',
+                         'redis', 'block_storage_workload', 'sysbench_oltp',
+                         'unixbench', 'oldisim', 'silo']
     },
     'red_hat_set': {
         MESSAGE: 'Red Hat benchmark set.',

--- a/perfkitbenchmarker/benchmark_spec.py
+++ b/perfkitbenchmarker/benchmark_spec.py
@@ -36,12 +36,15 @@ from perfkitbenchmarker.gcp import gce_network
 from perfkitbenchmarker.gcp import gce_virtual_machine as gce_vm
 from perfkitbenchmarker.openstack import os_network as openstack_network
 from perfkitbenchmarker.openstack import os_virtual_machine as openstack_vm
+from perfkitbenchmarker.rackspace import rackspace_network as rax_net
+from perfkitbenchmarker.rackspace import rackspace_virtual_machine as rax_vm
 
 GCP = 'GCP'
 AZURE = 'Azure'
 AWS = 'AWS'
 DIGITALOCEAN = 'DigitalOcean'
 OPENSTACK = 'OpenStack'
+RACKSPACE = 'Rackspace'
 DEBIAN = 'debian'
 RHEL = 'rhel'
 WINDOWS = 'windows'
@@ -94,12 +97,20 @@ CLASSES = {
             RHEL: openstack_vm.OpenStackVirtualMachine
         },
         FIREWALL: openstack_network.OpenStackFirewall
+    },
+    RACKSPACE: {
+        VIRTUAL_MACHINE: {
+            DEBIAN: rax_vm.DebianBasedRackspaceVirtualMachine,
+            RHEL: rax_vm.RhelBasedRackspaceVirtualMachine
+        },
+        FIREWALL: rax_net.RackspaceSecurityGroup
     }
 }
 
 FLAGS = flags.FLAGS
 
-flags.DEFINE_enum('cloud', GCP, [GCP, AZURE, AWS, DIGITALOCEAN, OPENSTACK],
+flags.DEFINE_enum('cloud', GCP,
+                  [GCP, AZURE, AWS, DIGITALOCEAN, OPENSTACK, RACKSPACE],
                   'Name of the cloud to use.')
 flags.DEFINE_enum(
     'os_type', DEBIAN, [DEBIAN, RHEL, UBUNTU_CONTAINER, WINDOWS],

--- a/perfkitbenchmarker/rackspace/__init__.py
+++ b/perfkitbenchmarker/rackspace/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/perfkitbenchmarker/rackspace/rackspace_disk.py
+++ b/perfkitbenchmarker/rackspace/rackspace_disk.py
@@ -1,0 +1,209 @@
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Module containing classes related to Rackspace volumes.
+
+Volumes can be created, deleted, *attached to VMs, and *detached from VMs. Also
+disks could be either remote, or ephemeral. Remote disks are storage volumes
+provided by Rackspace Cloud Block Storage, and supports two disk types, SATA,
+and SSD. Ephemeral disks can be local data disks if they are provided by the
+flavor, otherwise it will default to the system's boot disk.
+"""
+
+import json
+import os
+import time
+
+from perfkitbenchmarker import disk
+from perfkitbenchmarker import errors
+from perfkitbenchmarker import flags
+from perfkitbenchmarker import vm_util
+from perfkitbenchmarker.rackspace import util
+
+FLAGS = flags.FLAGS
+flags.DEFINE_string(
+    'image_id', None, 'The ID of the image from which you want to'
+    ' create the volume.')
+
+DISK_TYPE = {
+    disk.STANDARD: 'SATA',
+    disk.REMOTE_SSD: 'SSD'
+}
+
+
+class RackspaceEphemeralDisk(disk.BaseDisk):
+  def __init__(self, disk_spec, device_name, is_root_disk=False):
+    super(RackspaceEphemeralDisk, self).__init__(disk_spec)
+    self.device_name = device_name
+    self.is_root_disk = is_root_disk
+
+    if self.is_root_disk:
+      self.mount_point = ''
+
+    self.exists = False
+
+  def __str__(self):
+    return ("%s(device_path=%s, is_root_disk=%s)"
+            % (self.__class__.__name__,
+               self.GetDevicePath(), self.is_root_disk))
+
+  def __repr__(self):
+    return self.__str__()
+
+  def _Create(self):
+    """Boot disk must exists, so pass."""
+    self.exists = True
+
+  def _Delete(self):
+    """Boot disk cannot be deleted"""
+    self.exists = False
+
+  def _Exists(self):
+    """Boot disk always exists"""
+    return self.exists
+
+  def Attach(self, vm):
+    """Boot disk is always attached."""
+    pass
+
+  def Detach(self):
+    """No need to detach boot disk."""
+    pass
+
+  def GetDevicePath(self):
+    return '/dev/%s' % self.device_name
+
+
+class RackspaceRemoteDisk(disk.BaseDisk):
+  """Object representing a Rackspace Volume."""
+
+  def __init__(self, disk_spec, name, zone, image=None):
+      super(RackspaceRemoteDisk, self).__init__(disk_spec)
+      self.attached_vm_name = None
+      self.image = image
+      self.name = name
+      self.zone = zone
+      self.id = ''
+
+  def __str__(self):
+    return ("%s(device_path=%s, id=%s, attached_vm=%s, disk_type=%s)"
+            % (self.__class__.__name__, self.GetDevicePath(),
+               self.id, self.attached_vm_name, self.disk_type))
+
+  def __repr__(self):
+    return self.__str__()
+
+  def _Create(self):
+    """Creates the volume."""
+    nova_env = os.environ.copy()
+    nova_env.update(util.GetDefaultRackspaceNovaEnv(self.zone))
+    create_cmd = [
+        FLAGS.nova_path,
+        'volume-create',
+        '--display-name', self.name,
+        '--volume-type', DISK_TYPE[self.disk_type],
+        str(self.disk_size)]
+    stdout, _, _ = vm_util.IssueCommand(create_cmd, env=nova_env)
+    volume = util.ParseNovaTable(stdout)
+    if 'id' in volume and volume['id']:
+      self.id = volume['id']
+    else:
+      raise errors.Error('There was a problem when creating a volume.')
+
+  def _Delete(self):
+    """Deletes the volume."""
+    nova_env = os.environ.copy()
+    nova_env.update(util.GetDefaultRackspaceNovaEnv(self.zone))
+    delete_cmd = [FLAGS.nova_path, 'volume-delete', self.name]
+    vm_util.IssueCommand(delete_cmd, env=nova_env)
+
+  def _Exists(self):
+    """Returns true if the volume exists."""
+    nova_env = os.environ.copy()
+    nova_env.update(util.GetDefaultRackspaceNovaEnv(self.zone))
+    getdisk_cmd = [FLAGS.nova_path, 'volume-show', self.name]
+    stdout, _, _ = vm_util.IssueCommand(getdisk_cmd, env=nova_env)
+    if stdout.strip() == '':
+      return False
+    volume = util.ParseNovaTable(stdout)
+    return 'status' in volume and volume['status'] == 'available'
+
+  def Attach(self, vm):
+    """Attaches the volume to a VM.
+
+    Args:
+      vm: The RackspaceVirtualMachine instance to which the volume will be
+          attached.
+    """
+    self.attached_vm_name = vm.name
+    nova_env = os.environ.copy()
+    nova_env.update(util.GetDefaultRackspaceNovaEnv(self.zone))
+    attach_cmd = [
+        FLAGS.nova_path,
+        'volume-attach',
+        self.attached_vm_name,
+        self.id, ""]
+    vm_util.IssueRetryableCommand(attach_cmd, env=nova_env)
+
+    if not self._WaitForDiskUntilAttached(vm):
+      raise errors.Resource.RetryableCreationError(
+          'Failed to attach all scratch disks to vms. Exiting...')
+
+  def _WaitForDiskUntilAttached(self, vm, max_retries=30, poll_interval_secs=5):
+    """Wait until volume is attached to the instance."""
+    env = os.environ.copy()
+    env.update(util.GetDefaultRackspaceNovaEnv(self.zone))
+    volume_show_cmd = [FLAGS.nova_path, 'volume-show', self.id]
+
+    for _ in xrange(max_retries):
+      stdout, _, _ = vm_util.IssueCommand(volume_show_cmd, env=env)
+      volume = util.ParseNovaTable(stdout)
+      if 'attachments' in volume and vm.id in volume['attachments']:
+        return True
+      time.sleep(poll_interval_secs)
+
+    return False
+
+  def Detach(self):
+      """Detaches the disk from a VM."""
+      nova_env = os.environ.copy()
+      nova_env.update(util.GetDefaultRackspaceNovaEnv(self.zone))
+      detach_cmd = [
+          FLAGS.nova_path,
+          'volume-detach',
+          self.attached_vm_name,
+          self.id]
+      vm_util.IssueRetryableCommand(detach_cmd, env=nova_env)
+      self.attached_vm_name = None
+
+  def GetDevicePath(self):
+    """Returns the path to the device inside the VM."""
+    nova_env = os.environ.copy()
+    nova_env.update(util.GetDefaultRackspaceNovaEnv(self.zone))
+    getdisk_cmd = [FLAGS.nova_path, 'volume-show', self.name]
+    stdout, _, _ = vm_util.IssueCommand(getdisk_cmd, env=nova_env)
+    volume = util.ParseNovaTable(stdout)
+
+    attachment_list = []
+    if 'attachments' in volume and volume['attachments']:
+      attachment_list = json.loads(volume['attachments'])
+
+    if not attachment_list:
+      raise errors.Error('Cannot determine volume %s attachments' % self.name)
+
+    for attachment in attachment_list:
+      if 'volume_id' in attachment and attachment['volume_id'] == self.id:
+        return attachment['device']
+    else:
+      raise errors.Error(
+          'Could not find device path in the volume %s attachments')

--- a/perfkitbenchmarker/rackspace/rackspace_machine_types.py
+++ b/perfkitbenchmarker/rackspace/rackspace_machine_types.py
@@ -1,0 +1,97 @@
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Module contains constants, baked-in assumptions and utility functions related
+ to Rackspace flavors, aka. machine types."""
+
+from perfkitbenchmarker import disk
+
+STANDARD1_CLASS = 'standard1'
+GENERAL1_CLASS = 'general1'
+COMPUTE1_CLASS = 'compute1'
+MEMORY1_CLASS = 'memory1'
+IO1_CLASS = 'io1'
+PERFORMANCE1_CLASS = 'performance1'
+PERFORMANCE2_CLASS = 'performance2'
+ONMETAL_CLASS = 'onmetal'
+
+ROOT_DISK = 'root_disk'
+LOCAL = 'local'
+REMOTE = 'remote'
+
+RACKSPACE_DISK_TYPES = {
+    (disk.STANDARD, STANDARD1_CLASS): ROOT_DISK,
+    (disk.STANDARD, GENERAL1_CLASS): REMOTE,
+    (disk.STANDARD, COMPUTE1_CLASS): REMOTE,
+    (disk.STANDARD, MEMORY1_CLASS): REMOTE,
+    (disk.STANDARD, IO1_CLASS): REMOTE,
+    (disk.STANDARD, PERFORMANCE1_CLASS): REMOTE,
+    (disk.STANDARD, PERFORMANCE2_CLASS): REMOTE,
+    (disk.STANDARD, ONMETAL_CLASS): ROOT_DISK,
+    (disk.LOCAL, STANDARD1_CLASS): ROOT_DISK,
+    (disk.LOCAL, GENERAL1_CLASS): ROOT_DISK,
+    (disk.LOCAL, COMPUTE1_CLASS): ROOT_DISK,
+    (disk.LOCAL, MEMORY1_CLASS): ROOT_DISK,
+    (disk.LOCAL, IO1_CLASS): LOCAL,
+    (disk.LOCAL, PERFORMANCE1_CLASS): ROOT_DISK,
+    (disk.LOCAL, PERFORMANCE2_CLASS): LOCAL,
+    (disk.LOCAL, ONMETAL_CLASS): ROOT_DISK,
+    (disk.REMOTE_SSD, GENERAL1_CLASS): REMOTE,
+    (disk.REMOTE_SSD, COMPUTE1_CLASS): REMOTE,
+    (disk.REMOTE_SSD, MEMORY1_CLASS): REMOTE,
+    (disk.REMOTE_SSD, IO1_CLASS): REMOTE,
+    (disk.REMOTE_SSD, PERFORMANCE1_CLASS): REMOTE,
+    (disk.REMOTE_SSD, PERFORMANCE2_CLASS): REMOTE,
+}
+
+REMOTE_BOOT_DISK_SIZE_GB = 50
+ONMETAL_IO_LOCAL_DISKS_NUM = 2
+ONMETAL_DISK_MODEL = 'NWD-BLP4-1600'
+
+
+def GetRackspaceDiskSpecs(machine_type, flavor_specs):
+  """Returns a dict with data about the disk assumptions based on the given
+  machine type.
+
+  Returns
+    A dict with key a strings for each disk property
+  """
+  flavor_class = flavor_specs.get('class')
+  disk_specs = {}
+
+  if flavor_class in (IO1_CLASS, PERFORMANCE2_CLASS,):
+    data_disks = int(flavor_specs.get('number_of_data_disks', 0))
+    disk_specs['max_local_disks'] = data_disks
+  elif machine_type == 'onmetal-io1':
+    disk_specs['max_local_disks'] = ONMETAL_IO_LOCAL_DISKS_NUM
+  else:
+    disk_specs['max_local_disks'] = 1  # Boot disk
+
+  disk_specs['remote_disk_support'] = flavor_class not in (ONMETAL_CLASS,
+                                                           STANDARD1_CLASS,)
+  return disk_specs
+
+
+def GetRackspaceDiskType(machine_type, flavor_class, scratch_disk_type):
+  """Returns the type of disk to use for the machine_type and scratch_disk_type
+  combination.
+
+  Returns
+    A string from (ROOT_DISK, REMOTE, LOCAL)
+  """
+  key = (scratch_disk_type, flavor_class,)
+  rackspace_disk_type = RACKSPACE_DISK_TYPES.get(key)
+  if machine_type == 'onmetal-io1' and rackspace_disk_type == ROOT_DISK:
+    return LOCAL
+
+  return rackspace_disk_type

--- a/perfkitbenchmarker/rackspace/rackspace_network.py
+++ b/perfkitbenchmarker/rackspace/rackspace_network.py
@@ -1,0 +1,169 @@
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Module containing classes related to Rackspace VM networking.
+
+The SecurityGroup class provides a way of opening VM ports. The Network class
+allows VMs to communicate via internal IPs.
+"""
+import json
+import os
+import threading
+
+from perfkitbenchmarker import flags
+from perfkitbenchmarker import network
+from perfkitbenchmarker import vm_util
+from perfkitbenchmarker.rackspace import util
+
+
+FLAGS = flags.FLAGS
+flags.DEFINE_boolean(
+    'use_security_group', False,
+    'A boolean indicating if whether or not to create a security group for the'
+    ' new instance. Applies default security group rules'
+    ' (e.g. allow ingress TCP, and UDP traffic through port 22). If no security'
+    ' group is used, all incoming and outgoing traffic through TCP, UDP and'
+    ' ICMP is allowed, this is the default.')
+
+SSH_PORT = 22
+
+
+class RackspaceSecurityGroup(network.BaseFirewall):
+    """An object representing the Rackspace Security Group."""
+
+    def __init__(self, project):
+        """Initialize Rackspace security group class."""
+        self._lock = threading.Lock()
+        self.firewall_names = set()
+        self.sg_counter = 0
+
+    def __getstate__(self):
+        """Implements getstate to allow pickling (since locks can't be
+         pickled)."""
+        d = self.__dict__.copy()
+        del d['_lock']
+        return d
+
+    def __setstate__(self, state):
+        """Restores the lock after the object is unpickled."""
+        self.__dict__ = state
+        self._lock = threading.Lock()
+
+    def AllowPort(self, vm, port):
+        """Opens a port on the firewall.
+
+        Args:
+          vm: The BaseVirtualMachine object to open the port for.
+          port: The local port to open.
+        """
+        if vm.is_static or not FLAGS.use_security_group or port == SSH_PORT:
+            return
+        with self._lock:
+            firewall_name = ('perfkit-firewall-%s-%d-%d' %
+                             (FLAGS.run_uri, port, self.sg_counter))
+            self.sg_counter += 1
+            if firewall_name in self.firewall_names:
+                return
+
+            firewall_env = dict(os.environ.copy(),
+                                **util.GetDefaultRackspaceNeutronEnv(self))
+
+            firewall_cmd = [FLAGS.neutron_path]
+            firewall_cmd.extend(['security-group-create'])
+            firewall_cmd.append(firewall_name)
+
+            vm_util.IssueRetryableCommand(firewall_cmd, env=firewall_env)
+
+            self.firewall_names.add(firewall_name)
+
+            for protocol in ['tcp', 'udp']:
+                rule_cmd = []
+                rule_cmd.extend([FLAGS.neutron_path,
+                                 'security-group-rule-create',
+                                 '--direction', 'ingress',
+                                 '--ethertype', 'IPv4',
+                                 '--protocol', protocol,
+                                 '--port-range-min', str(port),
+                                 '--port-range-max', str(port)])
+                rule_cmd.append(firewall_name)
+
+                vm_util.IssueRetryableCommand(rule_cmd, env=firewall_env)
+
+            rule_cmd = []
+            rule_cmd.extend([FLAGS.neutron_path,
+                             'security-group-rule-create',
+                             '--direction', 'ingress',
+                             '--ethertype', 'IPv4',
+                             '--protocol', 'tcp',
+                             '--port-range-min', str(SSH_PORT),
+                             '--port-range-max', str(SSH_PORT)])
+            rule_cmd.append(firewall_name)
+
+            vm_util.IssueRetryableCommand(rule_cmd, env=firewall_env)
+
+            getport_cmd = []
+            getport_cmd.extend([FLAGS.neutron_path, 'port-list',
+                                '--format', 'table'])
+
+            stdout, _ = vm_util.IssueRetryableCommand(getport_cmd,
+                                                      env=firewall_env)
+            attrs = stdout.split('\n')
+            for attr in attrs:
+                if vm.ip_address in attr or vm.ip_address6 in attr:
+                    port_id = [v.strip() for v in attr.split('|') if v != ''][0]
+                    if port_id != '':
+                        break
+
+            if not port_id:
+              raise ValueError('Could not find port_id from response.')
+
+            updateport_cmd = []
+            updateport_cmd.extend([FLAGS.neutron_path, 'port-update'])
+            for firewall in self.firewall_names:
+                updateport_cmd.extend(['--security-group', firewall])
+            updateport_cmd.append(port_id)
+
+            vm_util.IssueRetryableCommand(updateport_cmd, env=firewall_env)
+
+    def DisallowAllPorts(self):
+        """Closes all ports on the firewall."""
+        firewall_env = dict(os.environ.copy(),
+                            **util.GetDefaultRackspaceNeutronEnv(self))
+
+        for firewall in self.firewall_names:
+            firewall_cmd = []
+            firewall_cmd.extend([FLAGS.neutron_path,
+                                 'security-group-show',
+                                 '--format', 'value'])
+            firewall_cmd.append(firewall)
+
+            stdout, _ = vm_util.IssueRetryableCommand(firewall_cmd,
+                                                      env=firewall_env)
+
+            rules = [v for v in stdout.split('\n') if v != ''][2:-1]
+            for rule in rules:
+                rule_id = str(json.loads(rule)['id'])
+                rule_cmd = []
+                rule_cmd.extend([FLAGS.neutron_path,
+                                 'security-group-rule-delete'])
+                rule_cmd.append(rule_id)
+
+                vm_util.IssueRetryableCommand(rule_cmd, env=firewall_env)
+
+            firewall_cmd = [FLAGS.neutron_path]
+            firewall_cmd.extend(['security-group-delete'])
+            firewall_cmd.append(firewall)
+
+            vm_util.IssueRetryableCommand(firewall_cmd, env=firewall_env)
+
+            self.firewall_names.remove(firewall)

--- a/perfkitbenchmarker/rackspace/rackspace_virtual_machine.py
+++ b/perfkitbenchmarker/rackspace/rackspace_virtual_machine.py
@@ -1,0 +1,459 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Class to represent a Rackspace Virtual Machine object.
+
+Zones:
+    DFW (Dallas-Fort Worth)
+    IAD (Northern Virginia)
+    ORD (Chicago)
+    LON (London)
+    SYD (Sydney)
+    HKG (Hong Kong)
+Machine Types:
+run 'nova flavor-list'
+Images:
+run 'nova image-list'
+
+All VM specifics are self-contained and the class provides methods to
+operate on the VM: boot, shutdown, etc.
+"""
+import json
+import logging
+import os
+import re
+import tempfile
+import threading
+import time
+
+from perfkitbenchmarker import disk
+from perfkitbenchmarker import errors
+from perfkitbenchmarker import flags
+from perfkitbenchmarker import linux_virtual_machine
+from perfkitbenchmarker import virtual_machine
+from perfkitbenchmarker import vm_util
+from perfkitbenchmarker.rackspace import rackspace_disk
+from perfkitbenchmarker.rackspace import rackspace_machine_types as rax
+from perfkitbenchmarker.rackspace import util
+
+FLAGS = flags.FLAGS
+flags.DEFINE_boolean(
+    'rackspace_apply_onmetal_ssd_tuning', default=False,
+    help='Apply Rackspace recommended tuning to PCIe-based flash storage '
+         'included with OnMetal IO instances. See: '
+         'http://www.rackspace.com/knowledge_center/article/'
+         'configure-flash-drives-in-high-io-instances-as-data-drives')
+
+CLOUD_CONFIG_TEMPLATE = '''#cloud-config
+users:
+  - name: {0}
+    ssh-authorized-keys:
+      - {1}
+    sudo: ['ALL=(ALL) NOPASSWD:ALL']
+    groups: sudo
+    shell: /bin/bash
+
+'''
+
+BLOCK_DEVICE_TEMPLATE = '''
+source=image,id={0},dest=volume,size={1},shutdown=remove,bootindex=0
+'''
+
+LSBLK_REGEX = (r'NAME="(.*)"\s+MODEL="(.*)"\s+SIZE="(.*)"'
+               r'\s+TYPE="(.*)"\s+MOUNTPOINT="(.*)"\s+LABEL="(.*)"')
+LSBLK_PATTERN = re.compile(LSBLK_REGEX)
+
+UBUNTU_IMAGE = '28153eac-1bae-4039-8d9f-f8b513241efe'
+RHEL_IMAGE = 'c07409c8-0931-40e4-a3bc-4869ecb5931e'
+
+
+class RackspaceVirtualMachine(virtual_machine.BaseVirtualMachine):
+
+  DEFAULT_ZONE = 'IAD'
+  DEFAULT_MACHINE_TYPE = 'general1-4'
+  # Subclasses should override the default image.
+  DEFAULT_IMAGE = None
+
+  count = 1
+  _lock = threading.Lock()
+  has_keypair = False
+
+  "Object representing a Rackspace Virtual Machine"
+  def __init__(self, vm_spec):
+    """Initialize Rackspace virtual machine
+
+    Args:
+      vm_spec: virtual_machine.BaseVirtualMachineSpec object of the vm.
+    """
+
+    super(RackspaceVirtualMachine, self).__init__(vm_spec)
+    with RackspaceVirtualMachine._lock:
+      self.name = 'perfkit-%s-%s' % (FLAGS.run_uri,
+                                     RackspaceVirtualMachine.count)
+      self.device_id = RackspaceVirtualMachine.count
+      RackspaceVirtualMachine.count += 1
+
+    self.id = ''
+    self.ip_address6 = ''
+    self.mounted_disks = set()
+    self.key_name = 'perfkit-%s' % FLAGS.run_uri
+    self.max_local_disks = 0
+    self.flavor = self._GetFlavorDetails()
+    self.flavor_class = None
+    self.boot_device_path = ''
+    if 'extra_specs' in self.flavor and self.flavor['extra_specs']:
+      flavor_specs = json.loads(self.flavor['extra_specs'])
+      self.flavor_class = flavor_specs.get('class', None)
+      disk_specs = rax.GetRackspaceDiskSpecs(self.machine_type, flavor_specs)
+      self.max_local_disks = disk_specs['max_local_disks']
+      self.remote_disk_support = disk_specs['remote_disk_support']
+    else:
+      raise errors.Error(
+          'There was a problem while retrieving machine_type'
+          ' information from the cloud provider.')
+
+  @classmethod
+  def SetVmSpecDefaults(cls, vm_spec):
+    """Updates the VM spec with cloud specific defaults."""
+    if vm_spec.machine_type is None:
+      vm_spec.machine_type = cls.DEFAULT_MACHINE_TYPE
+    if vm_spec.zone is None:
+      vm_spec.zone = cls.DEFAULT_ZONE
+    if vm_spec.image is None:
+      vm_spec.image = cls.DEFAULT_IMAGE
+
+  def CreateKeyPair(self):
+    """Imports the public keyfile to Rackspace."""
+    with open(self.ssh_public_key) as f:
+      public_key = f.read().rstrip('\n')
+
+    with tempfile.NamedTemporaryFile(dir=vm_util.GetTempDir(),
+                                     prefix='key-metadata') as tf:
+      tf.write('%s\n' % public_key)
+      tf.flush()
+      env = os.environ.copy()
+      env.update(util.GetDefaultRackspaceNovaEnv(self.zone))
+      key_cmd = [
+          FLAGS.nova_path, 'keypair-add',
+          '--pub-key', tf.name, self.key_name]
+
+      vm_util.IssueRetryableCommand(key_cmd, env=env)
+
+  def DeleteKeyPair(self):
+    """Deletes the imported keyfile for an account."""
+    env = os.environ.copy()
+    env.update(util.GetDefaultRackspaceNovaEnv(self.zone))
+    key_cmd = [FLAGS.nova_path, 'keypair-delete', self.key_name]
+    vm_util.IssueCommand(key_cmd, env=env)
+
+  def _CreateDependencies(self):
+    """Create VM dependencies."""
+    with RackspaceVirtualMachine._lock:
+        if not RackspaceVirtualMachine.has_keypair:
+            self.CreateKeyPair()
+            RackspaceVirtualMachine.has_keypair = True
+
+  def _DeleteDependencies(self):
+    """Delete VM dependencies."""
+    with RackspaceVirtualMachine._lock:
+        if RackspaceVirtualMachine.has_keypair:
+            self.DeleteKeyPair()
+            RackspaceVirtualMachine.has_keypair = False
+
+  def _Create(self):
+    """Create a Rackspace instance."""
+    with tempfile.NamedTemporaryFile(dir=vm_util.GetTempDir(),
+                                     prefix='user-data') as tf:
+      with open(self.ssh_public_key) as f:
+        public_key = f.read().rstrip('\n')
+
+      script = CLOUD_CONFIG_TEMPLATE.format(self.user_name, public_key)
+      tf.write(script)
+      tf.flush()
+
+      env = os.environ.copy()
+      env.update(util.GetDefaultRackspaceNovaEnv(self.zone))
+      create_cmd = self._GetCreateCommand()
+      create_cmd.extend([
+          '--config-drive', 'true',
+          '--user-data', tf.name,
+          self.name])
+      stdout, _, _ = vm_util.IssueCommand(create_cmd, env=env)
+      instance = util.ParseNovaTable(stdout)
+      if 'id' in instance:
+        self.id = instance['id']
+      else:
+        raise errors.Resource.RetryableCreationError(
+            'There was a problem trying to create instance %s' % self.name)
+
+    if not self._WaitForInstanceUntilActive():
+      raise errors.Resource.RetryableCreationError(
+          'Failed to create instance')
+
+  def _WaitForInstanceUntilActive(self, max_retries=720, poll_interval_secs=5):
+    """Wait until instance achieves non-transient state."""
+    env = os.environ.copy()
+    env.update(util.GetDefaultRackspaceNovaEnv(self.zone))
+    getinstance_cmd = [FLAGS.nova_path, 'show', self.id]
+
+    for _ in xrange(max_retries):
+      time.sleep(poll_interval_secs)
+      stdout, _, _ = vm_util.IssueCommand(getinstance_cmd, env=env)
+      instance = util.ParseNovaTable(stdout)
+      if 'status' in instance and instance['status'] != 'BUILD':
+        return instance['status'] == 'ACTIVE'
+
+    return False
+
+  def _GetCreateCommand(self):
+    create_cmd = [
+        FLAGS.nova_path, 'boot',
+        '--flavor', self.machine_type,
+        '--key-name', self.key_name]
+
+    boot_from_cbs = (
+        self.flavor_class in (rax.COMPUTE1_CLASS, rax.MEMORY1_CLASS,) or
+        util.FLAGS.boot_from_cbs_volume)
+
+    if self.remote_disk_support and boot_from_cbs:
+        blk_params = BLOCK_DEVICE_TEMPLATE.strip('\n').format(
+            self.image, str(rax.REMOTE_BOOT_DISK_SIZE_GB))
+        create_cmd.extend(['--block-device', blk_params])
+    else:
+      create_cmd.extend(['--image', self.image])
+
+    return create_cmd
+
+  @vm_util.Retry()
+  def _PostCreate(self):
+    """Get the instance's data."""
+    env = os.environ.copy()
+    env.update(util.GetDefaultRackspaceNovaEnv(self.zone))
+    getinstance_cmd = [FLAGS.nova_path, 'show', self.id]
+    stdout, _, _ = vm_util.IssueCommand(getinstance_cmd, env=env)
+    instance = util.ParseNovaTable(stdout)
+    if 'status' in instance and instance['status'] == 'ACTIVE':
+      self.ip_address = instance['accessIPv4']
+      self.ip_address6 = instance['accessIPv6']
+      self.internal_ip = instance['private network']
+    else:
+      raise errors.Error('Unexpected failure.')
+
+  def _Delete(self):
+    """Delete a Rackspace VM instance."""
+    env = os.environ.copy()
+    env.update(util.GetDefaultRackspaceNovaEnv(self.zone))
+    delete_cmd = [FLAGS.nova_path, 'delete', self.id]
+    vm_util.IssueCommand(delete_cmd, env=env)
+
+  def _Exists(self):
+    """Returns true if the VM exists."""
+    env = os.environ.copy()
+    env.update(util.GetDefaultRackspaceNovaEnv(self.zone))
+    getinstance_cmd = [FLAGS.nova_path, 'show', self.id]
+    stdout, stderr, _ = vm_util.IssueCommand(getinstance_cmd, env=env)
+    if stdout.strip() == '':
+        return False
+    instance = util.ParseNovaTable(stdout)
+    return (instance.get('OS-EXT-STS:task_state') == 'deleting' or
+            instance.get('status') == 'ACTIVE')
+
+  def _GetFlavorDetails(self):
+    """Retrieves details about the flavor used to build the instance.
+
+    Returns:
+      A dict of properties of the flavor used to build the instance.
+    """
+    env = os.environ.copy()
+    env.update(util.GetDefaultRackspaceNovaEnv(self.zone))
+    flavor_show_cmd = [FLAGS.nova_path, 'flavor-show', self.machine_type]
+    stdout, _, _ = vm_util.IssueCommand(flavor_show_cmd, env=env)
+    flavor_properties = util.ParseNovaTable(stdout)
+    return flavor_properties
+
+  def _GetBlockDevices(self):
+    stdout, _ = self.RemoteCommand(
+        'sudo lsblk -o NAME,MODEL,SIZE,TYPE,MOUNTPOINT,LABEL -n -b -P')
+    lines = stdout.splitlines()
+    groups = [LSBLK_PATTERN.match(line) for line in lines]
+    tuples = [g.groups() for g in groups if g]
+    colnames = ('name', 'model', 'size_bytes', 'type', 'mountpoint', 'label',)
+    blk_devices = [dict(zip(colnames, t)) for t in tuples]
+    for d in blk_devices:
+      d['model'] = d['model'].rstrip()
+      d['label'] = d['label'].rstrip()
+      d['size_bytes'] = int(d['size_bytes'])
+    return blk_devices
+
+  def _GetBootDevice(self):
+    blk_devices = self._GetBlockDevices()
+    boot_blk_device = None
+    for dev in blk_devices:
+      if dev['mountpoint'] == '/':
+        boot_blk_device = dev
+        break
+
+    if boot_blk_device is None:  # Unlikely
+      raise errors.Error('Could not find disk with "/" root mount point.')
+
+    if boot_blk_device['type'] == 'part':
+      blk_device_name = boot_blk_device['name'].rstrip('0123456789')
+      for dev in blk_devices:
+        if dev['type'] == 'disk' and dev['name'] == blk_device_name:
+          boot_blk_device = dev
+          break
+      else:  # Also, unlikely
+        raise errors.Error('Could not find disk containing boot partition.')
+
+    return boot_blk_device
+
+  def _ApplyOnMetalDiskTuning(self, disks):
+    """Applies recommended I/O scheduler and queue tuning for OnMetal IO
+    PCIe SSD drives.
+    """
+    for d in disks:
+      name = d['name']
+      cmd = [
+          'echo noop | sudo tee /sys/block/%s/queue/scheduler' % name,
+          'echo 4096 | sudo tee /sys/block/%s/queue/nr_requests' % name,
+          'echo 1024 | sudo tee /sys/block/%s/queue/max_sectors_kb' % name,
+          'echo 1 | sudo tee /sys/block/%s/queue/nomerges' % name,
+          'echo 512 | sudo tee /sys/block/%s/device/queue_depth' % name]
+      self.RemoteCommand('; '.join(cmd))
+
+  def SetupLocalDisks(self):
+    """Set up any local drives that exist."""
+    if (self.flavor_class == rax.ONMETAL_CLASS and
+        FLAGS.rackspace_apply_onmetal_ssd_tuning):
+      onmetal_disks = [d for d in self._GetBlockDevices()
+                       if d['type'] == 'disk'
+                       and rax.ONMETAL_DISK_MODEL in d['model']]
+      self._ApplyOnMetalDiskTuning(onmetal_disks)
+
+  def CreateScratchDisk(self, disk_spec):
+    """Create a VM's scratch disk.
+
+    Args:
+      disk_spec: virtual_machine.BaseDiskSpec object of the disk.
+    """
+    logging.info('Create scratch disk(s) for instance %s.', self.id)
+    boot_device = self._GetBootDevice()
+    self.boot_device_path = '/dev/%s' % boot_device['name']
+
+    rackspace_disk_type = rax.GetRackspaceDiskType(
+        self.machine_type, self.flavor_class, disk_spec.disk_type)
+
+    if rackspace_disk_type == rax.REMOTE:
+      disks = self._CreateRemoteDisks(disk_spec)
+    elif rackspace_disk_type == rax.LOCAL:  # local
+      if disk_spec.disk_type == disk.STANDARD:
+        self.SetupLocalDisks()
+      disks = self._CreateLocalDisks(disk_spec)
+    elif rackspace_disk_type == rax.ROOT_DISK:  # boot
+      boot_disk = rackspace_disk.RackspaceEphemeralDisk(
+          disk_spec, boot_device['name'], is_root_disk=True)
+      disks = [boot_disk]
+    else:
+      # not supported
+      raise errors.Error(
+          'Combination of machine_type=%s and scratch_disk_type=%s'
+          ' is not supported.' % (self.machine_type, disk_spec.disk_type))
+
+    self._CreateScratchDiskFromDisks(disk_spec, disks)
+    logging.info('Created %d scratch disks. Disks=%s' % (len(disks), disks))
+
+  def _CreateRemoteDisks(self, disk_spec):
+    disks_names = ['%s-data-%s-%d-%d'
+                   % (self.name, rackspace_disk.DISK_TYPE[disk_spec.disk_type],
+                      len(self.scratch_disks), i)
+                   for i in range(disk_spec.num_striped_disks)]
+    disks = [rackspace_disk.RackspaceRemoteDisk(disk_spec, name,
+                                                self.zone, self.image)
+             for name in disks_names]
+    return disks
+
+  def _CreateLocalDisks(self, disk_spec):
+    boot_device = self._GetBootDevice()
+    blk_devices = self._GetBlockDevices()
+    extra_blk_devices = []
+    for dev in blk_devices:
+      if (dev['type'] != 'part' and dev['name'] != boot_device['name'] and
+          'config' not in dev['label'] and
+          dev['name'] not in self.mounted_disks):
+        extra_blk_devices.append(dev)
+
+    if len(extra_blk_devices) == 0:
+      raise errors.Error(
+          ('Machine type %s does not include' % self.machine_type,
+           ' local disks. Please use a different disk_type,',
+           ' or a machine_type that provides local disks.'))
+    elif len(extra_blk_devices) < disk_spec.num_striped_disks:
+      raise errors.Error(
+          'Not enough local data disks.'
+          ' Requesting %d disk, but only %d available.'
+          % (disk_spec.num_striped_disks, len(extra_blk_devices)))
+
+    disks = []
+    for i in range(disk_spec.num_striped_disks):
+      local_device = extra_blk_devices[i]
+      local_disk = rackspace_disk.RackspaceEphemeralDisk(
+          disk_spec, local_device['name'])
+      self.mounted_disks.add(local_device['name'])
+      disks.append(local_disk)
+    return disks
+
+  def GetScratchDir(self, disk_num=0):
+    if self.scratch_disks[disk_num].mount_point == '':
+      return '/scratch%s' % disk_num
+
+    return super(RackspaceVirtualMachine, self).GetScratchDir(disk_num)
+
+  def MountDisk(self, device_path, mount_path):
+    if device_path == self.boot_device_path:
+      mk_cmd = ('sudo mkdir -p {0};'
+                'sudo chown -R $USER:$USER {0};').format(mount_path)
+      self.RemoteCommand(mk_cmd)
+    else:
+      super(RackspaceVirtualMachine, self).MountDisk(device_path, mount_path)
+
+  def FormatDisk(self, device_path):
+    """Formats a disk attached to the VM."""
+    if device_path != self.boot_device_path:
+      fmt_cmd = ('sudo mke2fs -F -E lazy_itable_init=0 -O '
+                 '^has_journal -t ext4 -b 4096 %s' % device_path)
+      self.RemoteCommand(fmt_cmd)
+
+  def GetName(self):
+    """Get a Rackspace VM's unique name."""
+    return self.name
+
+  def AddMetadata(self, **kwargs):
+    """Adds metadata to the Rackspace VM"""
+    if not kwargs:
+        return
+    env = os.environ.copy()
+    env.update(util.GetDefaultRackspaceNovaEnv(self.zone))
+    cmd = [FLAGS.nova_path, 'meta', self.id, 'set']
+    for key, value in kwargs.iteritems():
+        cmd.append('{0}={1}'.format(key, value))
+    vm_util.IssueCommand(cmd, env=env)
+
+
+class DebianBasedRackspaceVirtualMachine(RackspaceVirtualMachine,
+                                         linux_virtual_machine.DebianMixin):
+  DEFAULT_IMAGE = UBUNTU_IMAGE
+
+
+class RhelBasedRackspaceVirtualMachine(RackspaceVirtualMachine,
+                                       linux_virtual_machine.RhelMixin):
+  DEFAULT_IMAGE = RHEL_IMAGE

--- a/perfkitbenchmarker/rackspace/util.py
+++ b/perfkitbenchmarker/rackspace/util.py
@@ -1,0 +1,126 @@
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utilities for working with Rackspace Cloud Platform resources."""
+
+import os
+import re
+
+from perfkitbenchmarker import errors
+from perfkitbenchmarker import flags
+
+flags.DEFINE_boolean('boot_from_cbs_volume', 'False',
+                     'When flag is included the instance will use a remote disk'
+                     'as its boot disk, if machine_type supports it.')
+
+flags.DEFINE_string('nova_path',
+                    'nova',
+                    'The path for the rackspace-novaclient tool.')
+
+flags.DEFINE_string('neutron_path',
+                    'neutron',
+                    'The path for the rackspace-neutronclient tool.')
+
+
+flags.DEFINE_list('additional_rackspace_flags',
+                  [],
+                  'Additional flags to pass to Rackspace.')
+
+FLAGS = flags.FLAGS
+
+PROPERTY_VALUE_ROW_REGEX = r'\|\s+(:?\S+\s\S+|\S+)\s+\|\s+(.*?)\s+\|'
+PROP_VAL_PATTERN = re.compile(PROPERTY_VALUE_ROW_REGEX)
+
+
+def ParseNovaTable(output):
+  """Returns a dict with key/values returned from a Nova CLI formatted table.
+
+  Returns:
+  dict with key/values of the resource requested.
+  """
+  stdout_lines = output.split('\n')
+  groups = (PROP_VAL_PATTERN.match(line) for line in stdout_lines)
+  tuples = (g.groups() for g in groups if g)
+  filtered_tuples = ((key, val) for (key, val) in tuples
+                     if key and key not in ('', 'Property',))
+  return dict(filtered_tuples)
+
+
+def GetDefaultRackspaceCommonEnv(zone='IAD'):
+  """Return common set of environment variables for using any OpenStack client
+  against the Rackspace Public Cloud.
+
+  Args:
+  zone: string specifying Rackspace region to use.
+
+  Returns:
+  dict of environment variables
+  """
+  env = {
+      'OS_AUTH_URL': os.getenv('OS_AUTH_URL',
+                               'https://identity.api.rackspacecloud.com/v2.0/'),
+      'OS_AUTH_SYSTEM': os.getenv('OS_AUTH_SYSTEM', 'rackspace'),
+      'OS_SERVICE_NAME': os.getenv('OS_SERVICE_NAME', 'cloudServersOpenStack'),
+      'OS_REGION_NAME': zone,
+      'OS_USERNAME': os.getenv('OS_USERNAME'),
+      'OS_PASSWORD': os.getenv('OS_PASSWORD'),
+      'OS_TENANT_NAME': os.getenv('OS_TENANT_NAME'),
+      'OS_NO_CACHE': os.getenv('OS_NO_CACHE', '1'),
+  }
+
+  environment_vars_missing = []
+  for key, val in env.items():
+    if val is None:
+      environment_vars_missing.append(key)
+
+  if len(environment_vars_missing) != 0:
+    msg = ('The following required environment variables were not found:\n',
+           '\n'.join(environment_vars_missing),
+           '\n\nPlease make sure to source them into your environment, and try',
+           ' again.',)
+    raise errors.Error(''.join(msg))
+
+  return env
+
+
+def GetDefaultRackspaceNovaEnv(zone):
+  """Return common set of environment variables for using the Nova client
+  against the Rackspace Public Cloud.
+
+  Args:
+  zone: string specifying Rackspace region to use.
+
+  Returns:
+  dict of environment variables for Nova
+  """
+  env = GetDefaultRackspaceCommonEnv(zone)
+  env.update({
+      'NOVA_RAX_AUTH': os.getenv('NOVA_RAX_AUTH', '1'),
+  })
+
+  return env
+
+
+def GetDefaultRackspaceNeutronEnv(zone):
+  """Return common set of environment variables for using the Neutron client
+  against the Rackspace Public Cloud.
+
+  Args:
+  zone: string specifying Rackspace region to use.
+
+  Returns:
+  dict of environment variables for Neutron
+  """
+  env = GetDefaultRackspaceCommonEnv(zone)
+
+  return env


### PR DESCRIPTION
See the toplevel README.md for usage information and prerequisites.

This is a combined commit, comments from the original component
commits include:

- Add rackspace_set to benchmark sets

- Add --use_security_group flag to Rackspace provider

  Rackspace instances by default does not apply any firewall rules,
  or security group rules, to its instances. As of this commit, a
  beta version of Rackspace Network API is available that allows to
  use security groups, since this is not available to all customers
  yet, this commit disables the usage of security groups by default. For
  those users interested, can set this flag to true.

- Handle machine types that support certain disk types

  Machine types, or flavors, that do not support remote or local
  storage will default to use their boot disk iff 'STANDARD' or 'LOCAL'
  is specify for the scratch_disk_type flag. Those machine types
  with local disks will use those instead.

  To support boot from volume as recommended by Rackspace,
  this commit changes the method to create, show, and delete volumes
  to use the Nova CLI instead of Cinder CLI. This also simplifies
  the installation, and reduces the dependencies.

  Mock disk creation, attachment, and deletion of boot disks by
  providing new BaseDisk implementation.

  Refactor CLI commands to use environment variables instead of
  flags.

- Add support for OnMetal flavors.

- Set default for compute1, memory1 flavors to boot from CBS volumes

- Make OnMetal IO drive tuning opt-in through flag
  --rackspace_apply_onmetal_ssd_tuning, off by default.