### PR TITLE
Rackspace: change default machine type to single-core.

### DIFF
--- a/perfkitbenchmarker/rackspace/rackspace_virtual_machine.py
+++ b/perfkitbenchmarker/rackspace/rackspace_virtual_machine.py
@@ -80,7 +80,7 @@ RHEL_IMAGE = 'c07409c8-0931-40e4-a3bc-4869ecb5931e'
 class RackspaceVirtualMachine(virtual_machine.BaseVirtualMachine):
 
   DEFAULT_ZONE = 'IAD'
-  DEFAULT_MACHINE_TYPE = 'general1-4'
+  DEFAULT_MACHINE_TYPE = 'general1-1'
   # Subclasses should override the default image.
   DEFAULT_IMAGE = None
 


### PR DESCRIPTION
Other cloud providers have been using single-core machines as the
default machine type, so this keeps things more consistent if run
without explicit machine type. Users can (and should) explicitly
set `--machine_type=...` if they want to test other combinations.