### PR TITLE
Add a timeout to iperf parallel benchmark runs to handle iperf hangs

### DIFF
--- a/perfkitbenchmarker/benchmarks/iperf_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/iperf_benchmark.py
@@ -83,7 +83,12 @@ def _RunIperf(sending_vm, receiving_vm, receiving_ip_address, ip_type):
                (receiving_ip_address, IPERF_PORT,
                 FLAGS.iperf_runtime_in_seconds,
                 FLAGS.iperf_sending_thread_count))
-  stdout, _ = sending_vm.RemoteCommand(iperf_cmd, should_log=True)
+  # the additional time on top of the iperf runtime is to account for the
+  # time it takes for the iperf process to start and exit
+  timeout_buffer = 30 + FLAGS.iperf_sending_thread_count
+  stdout, _ = sending_vm.RemoteCommand(iperf_cmd, should_log=True,
+                                       timeout=FLAGS.iperf_runtime_in_seconds +
+                                       timeout_buffer)
 
   # Example output from iperf that needs to be parsed
   # STDOUT: ------------------------------------------------------------

--- a/perfkitbenchmarker/linux_virtual_machine.py
+++ b/perfkitbenchmarker/linux_virtual_machine.py
@@ -286,15 +286,15 @@ class BaseLinuxMixin(virtual_machine.BaseOsMixin):
   def RemoteCommand(self, command,
                     should_log=False, retries=SSH_RETRIES,
                     ignore_failure=False, login_shell=False,
-                    suppress_warning=False):
+                    suppress_warning=False, timeout=None):
     return self.RemoteHostCommand(command, should_log, retries,
                                   ignore_failure, login_shell,
-                                  suppress_warning)
+                                  suppress_warning, timeout)
 
   def RemoteHostCommand(self, command,
                         should_log=False, retries=SSH_RETRIES,
                         ignore_failure=False, login_shell=False,
-                        suppress_warning=False):
+                        suppress_warning=False, timeout=None):
     """Runs a command on the VM.
 
     This is guaranteed to run on the host VM, whereas RemoteCommand might run
@@ -337,7 +337,7 @@ class BaseLinuxMixin(virtual_machine.BaseOsMixin):
         stdout, stderr, retcode = vm_util.IssueCommand(
             ssh_cmd, force_info_log=should_log,
             suppress_warning=suppress_warning,
-            timeout=None)
+            timeout=timeout)
         if retcode != 255:  # Retry on 255 because this indicates an SSH failure
           break
     finally:

--- a/perfkitbenchmarker/virtual_machine.py
+++ b/perfkitbenchmarker/virtual_machine.py
@@ -213,7 +213,7 @@ class BaseOsMixin(object):
 
   @abc.abstractmethod
   def RemoteCommand(self, command, should_log=False, ignore_failure=False,
-                    suppress_warning=False, **kwargs):
+                    suppress_warning=False, timeout=None, **kwargs):
     """Runs a command on the VM.
 
     Derived classes may add additional kwargs if necessary, but they should not
@@ -227,6 +227,8 @@ class BaseOsMixin(object):
       ignore_failure: Ignore any failure if set to true.
       suppress_warning: Suppress the result logging from IssueCommand when the
           return code is non-zero.
+      timeout is the time to wait in seconds for the command before exiting.
+          None means no timeout.
 
     Returns:
       A tuple of stdout and stderr from running the command.

--- a/perfkitbenchmarker/windows_virtual_machine.py
+++ b/perfkitbenchmarker/windows_virtual_machine.py
@@ -44,7 +44,7 @@ class WindowsMixin(virtual_machine.BaseOsMixin):
     self.temp_dir = None
 
   def RemoteCommand(self, command, should_log=False, ignore_failure=False,
-                    suppress_warning=False):
+                    suppress_warning=False, timeout=None):
     """Runs a command on the VM.
 
     Args:
@@ -83,7 +83,7 @@ class WindowsMixin(virtual_machine.BaseOsMixin):
                     create_session, invoke_command])
 
     stdout, stderr, retcode = vm_util.IssueCommand(
-        ['powershell', '-Command', cmd], timeout=None,
+        ['powershell', '-Command', cmd], timeout=timeout,
         suppress_warning=suppress_warning, force_info_log=should_log)
 
     if retcode and not ignore_failure:


### PR DESCRIPTION
This commit adds the ability to set RemoteCommand timeouts to fix an issue where iperf can hang indefinitely.  For iperf we know the length of each benchmark and so here a timeout really makes sense.