### PR TITLE
Containerized refactor to add Rhel support

### DIFF
--- a/perfkitbenchmarker/benchmark_spec.py
+++ b/perfkitbenchmarker/benchmark_spec.py
@@ -48,6 +48,7 @@ RACKSPACE = 'Rackspace'
 DEBIAN = 'debian'
 RHEL = 'rhel'
 WINDOWS = 'windows'
+CENTOS_CONTAINER = 'centos_container'
 UBUNTU_CONTAINER = 'ubuntu_container'
 IMAGE = 'image'
 WINDOWS_IMAGE = 'windows_image'
@@ -61,8 +62,9 @@ CLASSES = {
         VIRTUAL_MACHINE: {
             DEBIAN: gce_vm.DebianBasedGceVirtualMachine,
             RHEL: gce_vm.RhelBasedGceVirtualMachine,
-            UBUNTU_CONTAINER: gce_vm.ContainerizedGceVirtualMachine,
-            WINDOWS: gce_vm.WindowsGceVirtualMachine
+            WINDOWS: gce_vm.WindowsGceVirtualMachine,
+            CENTOS_CONTAINER: gce_vm.RhelContainerizedGceVirtualMachine,
+            UBUNTU_CONTAINER: gce_vm.DebianContainerizedGceVirtualMachine
         },
         FIREWALL: gce_network.GceFirewall
     },
@@ -113,7 +115,8 @@ flags.DEFINE_enum('cloud', GCP,
                   [GCP, AZURE, AWS, DIGITALOCEAN, OPENSTACK, RACKSPACE],
                   'Name of the cloud to use.')
 flags.DEFINE_enum(
-    'os_type', DEBIAN, [DEBIAN, RHEL, UBUNTU_CONTAINER, WINDOWS],
+    'os_type', DEBIAN, [DEBIAN, RHEL, WINDOWS,
+                        CENTOS_CONTAINER, UBUNTU_CONTAINER],
     'The VM\'s OS type. Ubuntu\'s os_type is "debian" because it is largely '
     'built on Debian and uses the same package manager. Likewise, CentOS\'s '
     'os_type is "rhel". In general if two OS\'s use the same package manager, '

--- a/perfkitbenchmarker/gcp/gce_virtual_machine.py
+++ b/perfkitbenchmarker/gcp/gce_virtual_machine.py
@@ -55,6 +55,8 @@ SCSI = 'SCSI'
 UBUNTU_IMAGE = 'ubuntu-14-04'
 RHEL_IMAGE = 'rhel-7'
 WINDOWS_IMAGE = 'windows-2012-r2'
+CONTAINER_UBUNTU_IMAGE = 'ubuntu:14.04'
+CONTAINER_CENTOS_IMAGE = 'centos:7'
 
 
 class GceVirtualMachine(virtual_machine.BaseVirtualMachine):
@@ -64,6 +66,7 @@ class GceVirtualMachine(virtual_machine.BaseVirtualMachine):
   DEFAULT_MACHINE_TYPE = 'n1-standard-1'
   # Subclasses should override the default image.
   DEFAULT_IMAGE = None
+  CONTAINER_IMAGE = None
   BOOT_DISK_SIZE_GB = 10
   BOOT_DISK_TYPE = disk.STANDARD
 
@@ -227,9 +230,18 @@ class GceVirtualMachine(virtual_machine.BaseVirtualMachine):
     vm_util.IssueCommand(cmd)
 
 
-class ContainerizedGceVirtualMachine(GceVirtualMachine,
-                                     linux_vm.ContainerizedDebianMixin):
+class DebianContainerizedGceVirtualMachine(GceVirtualMachine,
+                                           linux_vm.ContainerizedMixin,
+                                           linux_vm.DebianMixin):
   DEFAULT_IMAGE = UBUNTU_IMAGE
+  CONTAINER_IMAGE = CONTAINER_UBUNTU_IMAGE
+
+
+class RhelContainerizedGceVirtualMachine(GceVirtualMachine,
+                                         linux_vm.ContainerizedMixin,
+                                         linux_vm.RhelMixin):
+  DEFAULT_IMAGE = RHEL_IMAGE
+  CONTAINER_IMAGE = CONTAINER_CENTOS_IMAGE
 
 
 class DebianBasedGceVirtualMachine(GceVirtualMachine,

--- a/perfkitbenchmarker/linux_virtual_machine.py
+++ b/perfkitbenchmarker/linux_virtual_machine.py
@@ -734,7 +734,7 @@ class DebianMixin(BaseLinuxMixin):
       self.RemoteCommand(";".join(commands))
 
 
-class ContainerizedDebianMixin(DebianMixin):
+class ContainerizedMixin(BaseLinuxMixin):
   """Class representing a Containerized Virtual Machine.
 
   A Containerized Virtual Machine is a VM that runs remote commands
@@ -757,11 +757,10 @@ class ContainerizedDebianMixin(DebianMixin):
     if not self._CheckDockerExists():
       self.Install('docker')
     self.InitDocker()
-    super(ContainerizedDebianMixin, self).PrepareVMEnvironment()
+    super(ContainerizedMixin, self).PrepareVMEnvironment()
 
   def InitDocker(self):
     """Initializes the docker container daemon."""
-    self.CONTAINER_IMAGE = 'ubuntu:latest'
     init_docker_cmd = ['sudo docker run -d '
                        '--net=host '
                        '--workdir=%s '


### PR DESCRIPTION
Slight refactor that abstracts ContainerizedMixin away from a specific Linux type. Without this, containers only work on Debian systems (Debian image running Ubuntu container). With this, containers work on both Rhel and Debian systems (as well as any linux flavor).