### PR TITLE
netperf/iperf: add firewall rules for external IP tests only.

### DIFF
--- a/perfkitbenchmarker/benchmarks/iperf_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/iperf_benchmark.py
@@ -62,7 +62,8 @@ def Prepare(benchmark_spec):
   vms = benchmark_spec.vms
   for vm in vms:
     vm.Install('iperf')
-    fw.AllowPort(vm, IPERF_PORT)
+    if vm_util.ShouldRunOnExternalIpAddress():
+      fw.AllowPort(vm, IPERF_PORT)
     vm.RemoteCommand('nohup iperf --server --port %s &> /dev/null &' %
                      IPERF_PORT)
 

--- a/perfkitbenchmarker/benchmarks/netperf_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/netperf_benchmark.py
@@ -78,10 +78,10 @@ def Prepare(benchmark_spec):
   vms = vms[:2]
   vm_util.RunThreaded(PrepareNetperf, vms)
 
-  fw = benchmark_spec.firewall
-
-  fw.AllowPort(vms[1], COMMAND_PORT)
-  fw.AllowPort(vms[1], DATA_PORT)
+  if vm_util.ShouldRunOnExternalIpAddress():
+    fw = benchmark_spec.firewall
+    fw.AllowPort(vms[1], COMMAND_PORT)
+    fw.AllowPort(vms[1], DATA_PORT)
 
   vms[1].RemoteCommand('%s -p %s' %
                        (netperf.NETSERVER_PATH, COMMAND_PORT))


### PR DESCRIPTION
Speeds up runs for internal IP tests.