### PR TITLE
Making sure Containerized VMs install Python within the container

### DIFF
--- a/perfkitbenchmarker/linux_virtual_machine.py
+++ b/perfkitbenchmarker/linux_virtual_machine.py
@@ -771,6 +771,9 @@ class ContainerizedDebianMixin(DebianMixin):
     if not self._CheckDockerExists():
       self.Install('docker')
     self.InitDocker()
+
+    # Python is needed for RobustRemoteCommands
+    self.Install('python')
     super(ContainerizedDebianMixin, self).PrepareVMEnvironment()
 
   def InitDocker(self):

--- a/perfkitbenchmarker/packages/python.py
+++ b/perfkitbenchmarker/packages/python.py
@@ -16,16 +16,11 @@
 """Module containing wget installation and cleanup functions."""
 
 
-def _Install(vm):
-  """Installs the python package on the VM."""
-  vm.InstallPackages('python')
-
-
 def YumInstall(vm):
   """Installs the package on the VM."""
-  _Install(vm)
+  vm.InstallPackages('python-2.7.5')
 
 
 def AptInstall(vm):
   """Installs the package on the VM."""
-  _Install(vm)
+  vm.InstallPackages('python2.7')

--- a/perfkitbenchmarker/packages/python.py
+++ b/perfkitbenchmarker/packages/python.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-"""Module containing wget installation and cleanup functions."""
+"""Module containing python 2.7 installation and cleanup functions."""
 
 
 def YumInstall(vm):

--- a/perfkitbenchmarker/packages/python.py
+++ b/perfkitbenchmarker/packages/python.py
@@ -1,0 +1,31 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Module containing wget installation and cleanup functions."""
+
+
+def _Install(vm):
+  """Installs the python package on the VM."""
+  vm.InstallPackages('python')
+
+
+def YumInstall(vm):
+  """Installs the package on the VM."""
+  _Install(vm)
+
+
+def AptInstall(vm):
+  """Installs the package on the VM."""
+  _Install(vm)


### PR DESCRIPTION
RobustRemoteCommand now uses python, which isn't in a Ubuntu container by default. This makes sure python is installed before proceeding.