### PR TITLE
Move Vm SSH authentication away from copy_throughput benchmark

### DIFF
--- a/perfkitbenchmarker/benchmarks/copy_throughput_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/copy_throughput_benchmark.py
@@ -81,10 +81,7 @@ def PrepareDataFile(vm):
 
 
 def PreparePrivateKey(vm):
-  if not vm.has_private_key:
-    vm.PushFile(vm_util.GetPrivateKeyPath(),
-                linux_virtual_machine.REMOTE_KEY_PATH)
-    vm.has_private_key = True
+  vm.AuthenticateVm()
 
 
 def Prepare(benchmark_spec):

--- a/perfkitbenchmarker/linux_virtual_machine.py
+++ b/perfkitbenchmarker/linux_virtual_machine.py
@@ -400,6 +400,7 @@ class BaseLinuxMixin(virtual_machine.BaseOsMixin):
     """Authenticate a remote machine to access all peers."""
     self.RemoteHostCopy(vm_util.GetPrivateKeyPath(),
                         REMOTE_KEY_PATH)
+    self.has_private_key = True
 
   def CheckJavaVersion(self):
     """Check the version of java on remote machine.


### PR DESCRIPTION
For Private Keys, we must call vm.PushHostFile instead of vm.PushFile. AuthenticateVM in linux_virtual_machine already has that, so it's better to keep that functionality there.