### PR TITLE
Generate Fio Job Files Automatically

### DIFF
--- a/perfkitbenchmarker/benchmarks/fio_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/fio_benchmark.py
@@ -32,6 +32,8 @@ from perfkitbenchmarker.packages import fio
 LOCAL_JOB_FILE_NAME = 'fio.job'  # used with vm_util.PrependTempDir()
 REMOTE_JOB_FILE_PATH = posixpath.join(vm_util.VM_TMP_DIR, 'fio.job')
 DEFAULT_TEMP_FILE_NAME = 'fio-temp-file'
+MAX_FILE_SIZE_GB = 100
+DISK_USABLE_SPACE_FRACTION = 0.9
 
 
 FLAGS = flags.FLAGS
@@ -40,9 +42,7 @@ flags.DEFINE_string('fio_jobfile', None,
                     'Job file that fio will use. Giving a custom job file '
                     'overrides the other fio options.')
 flags.DEFINE_boolean('against_device', False,
-                     'Test direct against scratch disk. If set True, will '
-                     'create a modified job file in temp directory, '
-                     'which ignores directory and filename parameter.')
+                     'If true, test directly against the scratch disk.')
 flags.DEFINE_string('device_fill_size', '100%',
                     'The amount of device to fill in prepare stage. '
                     'This flag is only valid when against_device=True. '
@@ -53,6 +53,10 @@ flags.DEFINE_string('device_fill_size', '100%',
 flags.DEFINE_string('io_depths', '1',
                     'IO queue depths to run on. Can specify a single number, '
                     'like --io_depths=1, or a range, like --io_depths=1-4')
+
+
+FLAGS_IGNORED_FOR_CUSTOM_JOBFILE = {
+    'against_device', 'device_fill_size', 'io_depth'}
 
 
 IODEPTHS_REGEXP = re.compile(r'(\d+)(-(\d+))?')
@@ -123,44 +127,60 @@ def GetIODepths(io_depths):
     return range(int(match.group(1)), int(match.group(3)) + 1)
 
 
-def GenerateJobFileString(mount_point):
+def GenerateJobFileString(mount_point, against_device,
+                          device_fill_size, io_depths, device_size):
   """Write a fio job file.
 
   Args:
     mount_point: the mount point of the disk we're testing against.
+    against_device: bool. True if we're using a raw disk.
+    device_fill_size: string. The amount of the disk to pre-fill.
+    io_depths: string. The contents of the io_depths flag.
+    device_size: int. The size of the device, in gigabytes.
 
   Returns:
     The contents of a fio job file, as a string.
   """
 
-  if FLAGS.against_device:
+  if against_device:
     filename = mount_point
-    size = FLAGS.device_fill_size
+    size = device_fill_size
   else:
     filename = posixpath.join(mount_point, DEFAULT_TEMP_FILE_NAME)
-    size = '100G'
+    size = str(min(MAX_FILE_SIZE_GB,
+                   int(DISK_USABLE_SPACE_FRACTION * device_size))) + 'G'
 
-  return jinja2.Template(JOB_FILE_TEMPLATE).render(
+  return str(jinja2.Template(JOB_FILE_TEMPLATE,
+                             undefined=jinja2.StrictUndefined).render(
       filename=filename,
       size=size,
-      iodepths=GetIODepths(FLAGS.io_depths))
+      iodepths=GetIODepths(io_depths)))
 
 
-def JobFileString(vm):
+def JobFileString(fio_jobfile, mount_point, against_device,
+                  device_fill_size, io_depths, device_size):
   """Get the contents of our job file.
 
   Args:
+    fio_jobfile: string or False. The path to the user's jobfile, if provided.
+    mount_point: the mount point of the disk we're testing against.
+    against_device: bool. True if we're using a raw disk.
+    device_fill_size: string. The amount of the disk to pre-fill.
+    io_depths: string. The contents of the io_depths flag.
+    device_size: int. The size of the device, in gigabytes.
+
     vm: the virtual_machine.BaseVirtualMachine that we will run on.
 
   Returns:
     A string containing the user's job file.
   """
 
-  if FLAGS.fio_jobfile:
-    with open(FLAGS.fio_jobfile, 'r') as jobfile:
+  if fio_jobfile:
+    with open(fio_jobfile, 'r') as jobfile:
       return jobfile.read()
   else:
-    return GenerateJobFileString(vm.scratch_disks[0].mount_point)
+    return GenerateJobFileString(mount_point, against_device,
+                                 device_fill_size, io_depths, device_size)
 
 
 def GetInfo():
@@ -181,33 +201,44 @@ def Prepare(benchmark_spec):
 
   """
 
+
   if FLAGS.fio_jobfile:
-    ignored_flags = []
-    if FLAGS.against_device:
-      ignored_flags.append('--against_device')
-    if FLAGS.device_fill_size != '100%':
-      ignored_flags.append('--device_fill_size')
-    if FLAGS.io_depths != '1':
-      ignored_flags.append('--io_depths')
+    ignored_flags = {flag_name for flag_name in FLAGS_IGNORED_FOR_CUSTOM_JOBFILE
+                     if FLAGS[flag_name].present}
 
     if ignored_flags:
       logging.warning('Fio job file specified. Ignoring options "%s"',
                       ', '.join(ignored_flags))
-  if FLAGS.device_fill_size != '100%' and not FLAGS.against_device:
+  if FLAGS['device_fill_size'].present and not FLAGS['against_device'].present:
     logging.warning('--device_fill_size has no effect without --against_device')
 
   vm = benchmark_spec.vms[0]
   logging.info('FIO prepare on %s', vm)
   vm.Install('fio')
 
+  disk = vm.scratch_disks[0]
   if FLAGS.against_device and not FLAGS.fio_jobfile:
-    mount_point = vm.scratch_disks[0].mount_point
+    mount_point = disk.mount_point
     logging.info('Umount scratch disk on %s at %s', vm, mount_point)
     vm.RemoteCommand('sudo umount %s' % mount_point)
 
+    device_path = disk.GetDevicePath()
+    logging.info('Fill scratch disk on %s at %s', vm, device_path)
+    command = (
+        ('sudo %s --filename=%s --ioengine=libaio '
+         '--name=fill-device --blocksize=512k --iodepth=64 '
+         '--rw=write --direct=1 --size=%s') %
+        (fio.FIO_PATH, device_path, FLAGS.device_fill_size))
+    vm.RemoteCommand(command)
+
   job_file_path = vm_util.PrependTempDir(LOCAL_JOB_FILE_NAME)
   with open(job_file_path, 'w') as job_file:
-    job_file.write(JobFileString(vm))
+    job_file.write(JobFileString(FLAGS.fio_jobfile,
+                                 disk.mount_point,
+                                 FLAGS.against_device,
+                                 FLAGS.device_fill_size,
+                                 FLAGS.io_depths,
+                                 disk.disk_size))
     logging.info('Wrote fio job file at %s', job_file_path)
 
   vm.PushFile(job_file_path, REMOTE_JOB_FILE_PATH)
@@ -237,7 +268,14 @@ def Run(benchmark_spec):
   logging.info('FIO Results:')
   stdout, stderr = vm.RemoteCommand(fio_command, should_log=True)
 
-  return fio.ParseResults(JobFileString(vm), json.loads(stdout))
+  disk = vm.scratch_disks[0]
+  return fio.ParseResults(JobFileString(FLAGS.fio_jobfile,
+                                        disk.mount_point,
+                                        FLAGS.against_device,
+                                        FLAGS.device_fill_size,
+                                        FLAGS.io_depths,
+                                        disk.disk_size),
+                          json.loads(stdout))
 
 
 def Cleanup(benchmark_spec):

--- a/perfkitbenchmarker/benchmarks/fio_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/fio_benchmark.py
@@ -81,7 +81,8 @@ flags.DEFINE_string('device_fill_size', '100%',
                     'The valid value can either be an integer, which '
                     'represents the number of bytes to fill or a '
                     'percentage, which represents the percentage '
-                    'of the device.')
+                    'of the device. Default to filling 100% of a raw device or '
+                    '90% of a filesystem.')
 flags.DEFINE_string('io_depths', '1',
                     'IO queue depths to run on. Can specify a single number, '
                     'like --io_depths=1, or a range, like --io_depths=1-4')
@@ -183,7 +184,7 @@ def GetIODepths(io_depths):
 
 def GenerateJobFileString(disk, against_device,
                           scenarios, io_depths, working_set_size):
-  """Write a fio job file.
+  """Make a string with our fio job file.
 
   Args:
     disk: the disk.BaseDisk object we're benchmarking with.
@@ -221,7 +222,10 @@ def GenerateJobFileString(disk, against_device,
 
 def JobFileString(fio_jobfile, disk, against_device,
                   scenario_strings, io_depths, working_set_size):
-  """Get the contents of our job file.
+  """Get the contents of the fio job file we're working with.
+
+  This will either read the user's job file, if given, or generate a
+  new one.
 
   Args:
     fio_jobfile: string or None. The path to the user's jobfile, if provided.
@@ -231,10 +235,9 @@ def JobFileString(fio_jobfile, disk, against_device,
       generate.
     io_depths: iterable. The IO queue depths to test.
     working_set_size: int or None. If int, the size of the working set in GB.
-    vm: the virtual_machine.BaseVirtualMachine that we will run on.
 
   Returns:
-    A string containing the user's job file.
+    A string containing a fio job file.
   """
 
   # The default behavior is to run with the standard fio job file.
@@ -336,10 +339,7 @@ def Run(benchmark_spec):
         required to run the benchmark.
 
   Returns:
-    A list of samples in the form of 3 or 4 tuples. The tuples contain
-        the sample metric (string), value (float), and unit (string).
-        If a 4th element is included, it is a dictionary of sample
-        metadata.
+    A list of sample.Sample objects.
   """
   vm = benchmark_spec.vms[0]
   logging.info('FIO running on %s', vm)

--- a/perfkitbenchmarker/benchmarks/fio_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/fio_benchmark.py
@@ -176,9 +176,9 @@ def Prepare(benchmark_spec):
   logging.info('FIO prepare on %s', vm)
   vm.Install('fio')
 
-  device_path = vm.scratch_disks[0].GetDevicePath()
-  logging.info('Umount scratch disk on %s at %s', vm, device_path)
-  vm.RemoteCommand('sudo umount %s' % vm.GetScratchDir())
+  mount_point = vm.scratch_disks[0].mount_point
+  logging.info('Umount scratch disk on %s at %s', vm, mount_point)
+  vm.RemoteCommand('sudo umount %s' % mount_point)
 
   job_file_path = vm_util.PrependTempDir(LOCAL_JOB_FILE_NAME)
   with open(job_file_path, 'w') as job_file:

--- a/perfkitbenchmarker/benchmarks/fio_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/fio_benchmark.py
@@ -123,7 +123,7 @@ def GetIODepths(io_depths):
     return range(int(match.group(1)), int(match.group(3)) + 1)
 
 
-def WriteJobFile(mount_point):
+def GenerateJobFileString(mount_point):
   """Write a fio job file.
 
   Args:
@@ -160,7 +160,7 @@ def JobFileString(vm):
     with open(FLAGS.fio_jobfile, 'r') as jobfile:
       return jobfile.read()
   else:
-    return WriteJobFile(vm.scratch_disks[0].mount_point)
+    return GenerateJobFileString(vm.scratch_disks[0].mount_point)
 
 
 def GetInfo():

--- a/perfkitbenchmarker/benchmarks/fio_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/fio_benchmark.py
@@ -135,7 +135,7 @@ def GenerateJobFileString(mount_point, against_device,
     mount_point: the mount point of the disk we're testing against.
     against_device: bool. True if we're using a raw disk.
     device_fill_size: string. The amount of the disk to pre-fill.
-    io_depths: string. The contents of the io_depths flag.
+    io_depths: iterable. The IO queue depths to test.
     device_size: int. The size of the device, in gigabytes.
 
   Returns:
@@ -154,7 +154,7 @@ def GenerateJobFileString(mount_point, against_device,
                              undefined=jinja2.StrictUndefined).render(
       filename=filename,
       size=size,
-      iodepths=GetIODepths(io_depths)))
+      iodepths=io_depths))
 
 
 def JobFileString(fio_jobfile, mount_point, against_device,
@@ -166,7 +166,7 @@ def JobFileString(fio_jobfile, mount_point, against_device,
     mount_point: the mount point of the disk we're testing against.
     against_device: bool. True if we're using a raw disk.
     device_fill_size: string. The amount of the disk to pre-fill.
-    io_depths: string. The contents of the io_depths flag.
+    io_depths: iterable. The IO queue depths to test.
     device_size: int. The size of the device, in gigabytes.
 
     vm: the virtual_machine.BaseVirtualMachine that we will run on.
@@ -203,7 +203,8 @@ def Prepare(benchmark_spec):
 
 
   if FLAGS.fio_jobfile:
-    ignored_flags = {flag_name for flag_name in FLAGS_IGNORED_FOR_CUSTOM_JOBFILE
+    ignored_flags = {'--' + flag_name
+                     for flag_name in FLAGS_IGNORED_FOR_CUSTOM_JOBFILE
                      if FLAGS[flag_name].present}
 
     if ignored_flags:
@@ -237,7 +238,7 @@ def Prepare(benchmark_spec):
                                  disk.mount_point,
                                  FLAGS.against_device,
                                  FLAGS.device_fill_size,
-                                 FLAGS.io_depths,
+                                 GetIODepths(FLAGS.io_depths),
                                  disk.disk_size))
     logging.info('Wrote fio job file at %s', job_file_path)
 
@@ -273,7 +274,7 @@ def Run(benchmark_spec):
                                         disk.mount_point,
                                         FLAGS.against_device,
                                         FLAGS.device_fill_size,
-                                        FLAGS.io_depths,
+                                        GetIODepths(FLAGS.io_depths),
                                         disk.disk_size),
                           json.loads(stdout))
 

--- a/perfkitbenchmarker/benchmarks/fio_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/fio_benchmark.py
@@ -98,13 +98,12 @@ def GetIODepths(io_depths):
   try:
     return [int(io_depths)]
   except ValueError:
-    pass
+    bounds = io_depths.split('-', 1)
 
-  bounds = io_depths.split('-', 1)
-  if len(bounds) != 2:
-    raise ValueError
+    if len(bounds) != 2:
+      raise ValueError
 
-  return range(int(bounds[0]), int(bounds[1]) + 1)
+    return range(int(bounds[0]), int(bounds[1]) + 1)
 
 
 def WriteJobFile(mount_point):

--- a/perfkitbenchmarker/benchmarks/fio_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/fio_benchmark.py
@@ -97,12 +97,12 @@ FLAGS_IGNORED_FOR_CUSTOM_JOBFILE = {
     'generate_scenarios', 'io_depths'}
 
 
-IODEPTHS_REGEXP = re.compile(r'(\d+)(-(\d+))?')
+IODEPTHS_REGEXP = re.compile(r'(\d+)(-(\d+))?$')
 
 
 def IODepthsValidator(string):
   match = IODEPTHS_REGEXP.match(string)
-  return match and match.end() == len(string) and int(match.group(1)) > 0
+  return match and int(match.group(1)) > 0
 
 
 flags.RegisterValidator('io_depths',

--- a/tests/benchmarks/fio_benchmark_test.py
+++ b/tests/benchmarks/fio_benchmark_test.py
@@ -14,9 +14,10 @@
 
 """Tests for fio_benchmark."""
 
-import mock
 import unittest
 
+from perfkitbenchmarker import disk
+from perfkitbenchmarker.gcp import gce_disk
 from perfkitbenchmarker.benchmarks import fio_benchmark
 
 
@@ -30,15 +31,26 @@ class TestGetIODepths(unittest.TestCase):
 
 class TestGenerateJobFileString(unittest.TestCase):
   def setUp(self):
-    self.disk = mock.Mock(mount_point='/foo', disk_size=100)
-    self.disk.GetDevicePath = mock.MagicMock(return_value='/bar')
+    # self.disk = mock.Mock(mount_point='/foo', disk_size=100)
+    # self.disk.GetDevicePath = mock.MagicMock(return_value='/bar')
+
+    self.disk_spec = disk.BaseDiskSpec(100, 'remote_ssd', '/scratch0')
+    self.disk = gce_disk.GceDisk(self.disk_spec, 'foo', 'us-central1-a', 'proj')
 
   def testAgainstDevice(self):
     # This just checks that the template renders.
-    fio_benchmark.GenerateJobFileString(self.disk, True, '100G', range(1, 5))
+    fio_benchmark.GenerateJobFileString(
+        self.disk,
+        True,
+        [fio_benchmark.SCENARIOS['sequential_read']],
+        range(1, 5))
 
   def testAgainstFile(self):
-    fio_benchmark.GenerateJobFileString(self.disk, False, '100G', range(1, 5))
+    fio_benchmark.GenerateJobFileString(
+        self.disk,
+        False,
+        [fio_benchmark.SCENARIOS['sequential_read']],
+        range(1, 5))
 
 
 if __name__ == '__main__':

--- a/tests/benchmarks/fio_benchmark_test.py
+++ b/tests/benchmarks/fio_benchmark_test.py
@@ -27,5 +27,14 @@ class TestGetIODepths(unittest.TestCase):
     self.assertEqual(list(fio_benchmark.GetIODepths('3-5')), [3, 4, 5])
 
 
+class TestGenerateJobFileString(unittest.TestCase):
+  def testAgainstDevice(self):
+    # This just checks that the template renders.
+    fio_benchmark.GenerateJobFileString('/foo', True, '100G', '1-4', 100)
+
+  def testAgainstFile(self):
+    fio_benchmark.GenerateJobFileString('/foo', False, '100G', '1-4', 100)
+
+
 if __name__ == '__main__':
   unittest.main()

--- a/tests/benchmarks/fio_benchmark_test.py
+++ b/tests/benchmarks/fio_benchmark_test.py
@@ -14,7 +14,6 @@
 
 """Tests for fio_benchmark."""
 
-import os
 import unittest
 
 from perfkitbenchmarker.benchmarks import fio_benchmark
@@ -22,12 +21,10 @@ from perfkitbenchmarker.benchmarks import fio_benchmark
 
 class TestGetIODepths(unittest.TestCase):
   def testOneInteger(self):
-    self.assertEqual(list(fio_benchmark.GetIODepths('3')),
-                      [3])
+    self.assertEqual(list(fio_benchmark.GetIODepths('3')), [3])
 
   def testIntegerRange(self):
-    self.assertEqual(list(fio_benchmark.GetIODepths('3-5')),
-                      [3, 4, 5])
+    self.assertEqual(list(fio_benchmark.GetIODepths('3-5')), [3, 4, 5])
 
   def testBadValue(self):
     with self.assertRaises(ValueError):

--- a/tests/benchmarks/fio_benchmark_test.py
+++ b/tests/benchmarks/fio_benchmark_test.py
@@ -26,14 +26,6 @@ class TestGetIODepths(unittest.TestCase):
   def testIntegerRange(self):
     self.assertEqual(list(fio_benchmark.GetIODepths('3-5')), [3, 4, 5])
 
-  def testBadValue(self):
-    with self.assertRaises(ValueError):
-      fio_benchmark.GetIODepths('foo')
-
-  def testBadRange(self):
-    with self.assertRaises(ValueError):
-      fio_benchmark.GetIODepths('3-foo')
-
 
 if __name__ == '__main__':
   unittest.main()

--- a/tests/benchmarks/fio_benchmark_test.py
+++ b/tests/benchmarks/fio_benchmark_test.py
@@ -1,0 +1,42 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for fio_benchmark."""
+
+import os
+import unittest
+
+from perfkitbenchmarker.benchmarks import fio_benchmark
+
+
+class TestGetIODepths(unittest.TestCase):
+  def testOneInteger(self):
+    self.assertEqual(list(fio_benchmark.GetIODepths('3')),
+                      [3])
+
+  def testIntegerRange(self):
+    self.assertEqual(list(fio_benchmark.GetIODepths('3-5')),
+                      [3, 4, 5])
+
+  def testBadValue(self):
+    with self.assertRaises(ValueError):
+      fio_benchmark.GetIODepths('foo')
+
+  def testBadRange(self):
+    with self.assertRaises(ValueError):
+      fio_benchmark.GetIODepths('3-foo')
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tests/benchmarks/fio_benchmark_test.py
+++ b/tests/benchmarks/fio_benchmark_test.py
@@ -114,6 +114,49 @@ size=100%
             None),
         expected_jobfile)
 
+  def testMultipleScenarios(self):
+    expected_jobfile = """
+[global]
+ioengine=libaio
+invalidate=1
+direct=1
+runtime=10m
+time_based
+filename=/scratch0/fio-temp-file
+do_verify=0
+verify_fatal=0
+randrepeat=0
+
+
+
+[sequential_read-io-depth-1]
+stonewall
+rw=read
+blocksize=512k
+iodepth=1
+size=100%
+
+
+
+[sequential_write-io-depth-1]
+stonewall
+rw=write
+blocksize=512k
+iodepth=1
+size=100%
+
+"""
+
+    self.assertEqual(
+        fio_benchmark.GenerateJobFileString(
+            self.disk,
+            False,
+            [fio_benchmark.SCENARIOS['sequential_read'],
+             fio_benchmark.SCENARIOS['sequential_write']],
+            [1],
+            None),
+        expected_jobfile)
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/tests/benchmarks/fio_benchmark_test.py
+++ b/tests/benchmarks/fio_benchmark_test.py
@@ -14,6 +14,7 @@
 
 """Tests for fio_benchmark."""
 
+import mock
 import unittest
 
 from perfkitbenchmarker.benchmarks import fio_benchmark
@@ -28,12 +29,16 @@ class TestGetIODepths(unittest.TestCase):
 
 
 class TestGenerateJobFileString(unittest.TestCase):
+  def setUp(self):
+    self.disk = mock.Mock(mount_point='/foo', disk_size=100)
+    self.disk.GetDevicePath = mock.MagicMock(return_value='/bar')
+
   def testAgainstDevice(self):
     # This just checks that the template renders.
-    fio_benchmark.GenerateJobFileString('/foo', True, '100G', '1-4', 100)
+    fio_benchmark.GenerateJobFileString(self.disk, True, '100G', range(1, 5))
 
   def testAgainstFile(self):
-    fio_benchmark.GenerateJobFileString('/foo', False, '100G', '1-4', 100)
+    fio_benchmark.GenerateJobFileString(self.disk, False, '100G', range(1, 5))
 
 
 if __name__ == '__main__':

--- a/tests/benchmarks/fio_benchmark_test.py
+++ b/tests/benchmarks/fio_benchmark_test.py
@@ -43,14 +43,16 @@ class TestGenerateJobFileString(unittest.TestCase):
         self.disk,
         True,
         [fio_benchmark.SCENARIOS['sequential_read']],
-        range(1, 5))
+        range(1, 5),
+        None)
 
   def testAgainstFile(self):
     fio_benchmark.GenerateJobFileString(
         self.disk,
         False,
         [fio_benchmark.SCENARIOS['sequential_read']],
-        range(1, 5))
+        range(1, 5),
+        None)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Make the fio benchmark generate job files automatically based on
user-specified parameters. Can still be overridden with a
user-supplied job file.