### PR TITLE
[OpenStack] use zone from flags

### DIFF
--- a/perfkitbenchmarker/openstack/os_virtual_machine.py
+++ b/perfkitbenchmarker/openstack/os_virtual_machine.py
@@ -112,7 +112,7 @@ class OpenStackVirtualMachine(virtual_machine.BaseVirtualMachine):
             key_name=self.key_name,
             security_groups=['perfkit_sc_group'],
             nics=nics,
-            availability_zone='nova',
+            availability_zone=self.zone,
             block_device_mapping_v2=boot_from_vol,
             scheduler_hints=scheduler_hints,
             config_drive=FLAGS.openstack_config_drive)


### PR DESCRIPTION
make possible to specify custom zone in parameter instead of using 'nova' zone