### PR TITLE
Remove Legacy Sample Representation

### DIFF
--- a/perfkitbenchmarker/publisher.py
+++ b/perfkitbenchmarker/publisher.py
@@ -29,7 +29,6 @@ from perfkitbenchmarker import events
 from perfkitbenchmarker import flags
 from perfkitbenchmarker import version
 from perfkitbenchmarker import vm_util
-from perfkitbenchmarker.sample import Sample
 
 FLAGS = flags.FLAGS
 
@@ -528,22 +527,11 @@ class SampleCollector(object):
     """Adds data samples to the publisher.
 
     Args:
-      samples: Either a list of Sample objects (preferred) or a list of 3, 4, or
-        5-tuples (deprecated). The tuples contain the metric name (string), the
-        value (float), and unit (string) of each sample. If a 4th element is
-        included, it is a dictionary of metadata associated with the sample. If
-        a 5th element is included, it is the sample's timestamp.
+      samples: A list of Sample objects.
       benchmark: string. The name of the benchmark.
       benchmark_spec: BenchmarkSpec. Benchmark specification.
     """
     for s in samples:
-      # Convert input in deprecated format to Sample objects.
-      if isinstance(s, (list, tuple)):
-        if len(s) not in (3, 4, 5):
-          raise ValueError(
-              'Invalid sample "{0}": should be 3-, 4-, or 5-tuple.'.format(s))
-        s = Sample(*s)
-
       # Annotate the sample.
       sample = dict(s.asdict())
       sample['test'] = benchmark

--- a/tests/publisher_test.py
+++ b/tests/publisher_test.py
@@ -224,16 +224,6 @@ class SampleCollectorTestCase(unittest.TestCase):
         },
         self.instance.samples[0])
 
-  def testAddSamples_3Tuple(self):
-    samples = [tuple(self.sample[:3])]
-    self.instance.AddSamples(samples, self.benchmark, self.benchmark_spec)
-    self._VerifyResult(False)
-
-  def testAddSamples_4Tuple(self):
-    samples = [tuple(self.sample[:4])]
-    self.instance.AddSamples(samples, self.benchmark, self.benchmark_spec)
-    self._VerifyResult()
-
 
 class DefaultMetadataProviderTestCase(unittest.TestCase):
 


### PR DESCRIPTION
Remove ability to represent samples as tuples; they must now be
sample.Sample objects. The tuples code is currently unused anyway.