### PR TITLE
Kubernetes provider.

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,57 @@ echo topsecretpassword > ~/.config/openstack-password.txt
 ./pkb.py --cloud=OpenStack --benchmarks=ping
 ```
 
+## Kubernetes configuration and credentials
+Perfkit uses `kubectl` binary in order to communicate with Kubernetes cluster - you need to pass the path to `kubectl` binary using `--kubectl` flag.  
+Authentication to Kubernetes cluster is done via `kubeconfig` file. Its path is passed using `--kubeconfig` flag.
+
+**Image prerequisites**  
+Docker instances by default doesn't allow to SSH into them. Thus it is important to configure your Docker image so that it has SSH server installed. You can rely on `https://quay.io/repository/mateusz_blaszkowski/pkb-k8s ` while creating your own image.
+
+**Kubernetes cluster configuration**  
+If your Kubernetes cluster is running on CoreOS:
+1. Fix `$PATH` environment variable so that the appropriate binaries can be found:
+   ```
+   sudo mkdir /etc/systemd/system/kubelet.service.d
+   sudo vim /etc/systemd/system/kubelet.service.d/10-env.conf
+   ```
+   Add the following line to `[Service]` section:
+   ```
+   Environment=PATH=/opt/bin:/usr/bin:/usr/sbin:$PATH
+   ```
+2. Reboot the node:
+   ```
+   sudo reboot
+   ```
+
+Note that some benchmark require to run within a privileged container. By default Kubernetes doesn't allow to schedule Dockers in privileged mode - you have to add `--allow-privileged=true` flag to `kube-apiserver` and each `kubelet` startup commands.
+
+**Ceph integration**  
+Currently only Ceph volumes are supported. Running benchmarks which require scratch volume is only permitted if you have Kubernetes cluster integrated with Ceph. There are some configuration steps you need to follow before you will be able to spawn Kubernetes PODs with Ceph volume. On each of Kubernetes-Nodes do the following:
+1. copy /etc/ceph directory from Ceph-host,
+2. install `ceph-common` package so that `rbd` command is available
+  * if your Kubernetes cluster is running on CoreOS, then you need to create a bash script called `rbd` which will run `rbd` command inside a Docker container:
+      ```
+      #!/usr/bin/bash
+      /usr/bin/docker run -v /etc/ceph:/etc/ceph -v /dev:/dev -v /sys:/sys  --net=host --privileged=true --rm=true ceph/rbd $@
+      ```
+      Save the file as 'rbd'. Then:
+      ```
+      chmod +x rbd
+      sudo mkdir /opt/bin
+      sudo cp rbd /opt/bin
+      ```
+      Install `rbdmap` (https://github.com/ceph/ceph-docker/tree/master/examples/coreos/rbdmap):
+      ```
+      git clone https://github.com/ceph/ceph-docker.git
+      cd ceph-docker/examples/coreos/rbdmap/
+      sudo mkdir /opt/sbin
+      sudo cp rbdmap /opt/sbin
+      sudo cp ceph-rbdnamer /opt/bin
+      sudo cp 50-rbd.rules /etc/udev/rules.d
+      sudo reboot
+      ```
+
 ## Install AWS CLI and setup authentication
 Make sure you have installed pip (see the section above).
 
@@ -341,6 +392,11 @@ $ ./pkb.py --cloud=DigitalOcean --machine_type=16gb --benchmarks=iperf
 $ ./pkb.py --cloud=OpenStack --benchmarks=iperf --os_auth_url=http://localhost:5000/v2.0/
 ```
 
+## Example run on Kubernetes
+```
+$ ./pkb.py --cloud=Kubernetes --benchmarks=iperf --kubectl=/path/to/kubectl --kubeconfig=/path/to/kubeconfig --image=image-with-ssh-server  --ceph_monitors=10.20.30.40:6789,10.20.30.41:6789 --kubernetes_nodes=10.20.30.42,10.20.30.43
+```
+
 ## Example run on Rackspace
 ```
 $ ./pkb.py --cloud=Rackspace --machine_type=general1-2 --benchmarks=iperf
@@ -399,6 +455,7 @@ Azure | East US | |
 DigitalOcean | sfo1 | You must use a zone that supports the features 'metadata' (for cloud config) and 'private_networking'.
 OpenStack | nova | |
 Rackspace | IAD | OnMetal machine-types are available only in IAD zone
+Kubernetes | k8s | |
 
 Example:
 

--- a/perfkitbenchmarker/benchmark_spec.py
+++ b/perfkitbenchmarker/benchmark_spec.py
@@ -37,6 +37,8 @@ from perfkitbenchmarker.digitalocean import digitalocean_network
 from perfkitbenchmarker.digitalocean import digitalocean_virtual_machine
 from perfkitbenchmarker.gcp import gce_network
 from perfkitbenchmarker.gcp import gce_virtual_machine as gce_vm
+from perfkitbenchmarker.kubernetes import kubernetes_virtual_machine
+from perfkitbenchmarker.kubernetes import kubernetes_network
 from perfkitbenchmarker.openstack import os_network as openstack_network
 from perfkitbenchmarker.openstack import os_virtual_machine as openstack_vm
 from perfkitbenchmarker.rackspace import rackspace_network as rax_net
@@ -60,6 +62,7 @@ copy_reg.pickle(thread.LockType, PickleLock)
 GCP = 'GCP'
 AZURE = 'Azure'
 AWS = 'AWS'
+KUBERNETES = 'Kubernetes'
 DIGITALOCEAN = 'DigitalOcean'
 OPENSTACK = 'OpenStack'
 RACKSPACE = 'Rackspace'
@@ -109,6 +112,14 @@ CLASSES = {
         },
         FIREWALL: digitalocean_network.DigitalOceanFirewall
     },
+    KUBERNETES: {
+        VIRTUAL_MACHINE: {
+            DEBIAN:
+                kubernetes_virtual_machine.DebianBasedKubernetesVirtualMachine,
+            RHEL: kubernetes_virtual_machine.KubernetesVirtualMachine
+        },
+        FIREWALL: kubernetes_network.KubernetesFirewall
+    },
     OPENSTACK: {
         VIRTUAL_MACHINE: {
             DEBIAN: openstack_vm.DebianBasedOpenStackVirtualMachine,
@@ -128,7 +139,8 @@ CLASSES = {
 FLAGS = flags.FLAGS
 
 flags.DEFINE_enum('cloud', GCP,
-                  [GCP, AZURE, AWS, DIGITALOCEAN, OPENSTACK, RACKSPACE],
+                  [GCP, AZURE, AWS, DIGITALOCEAN, KUBERNETES, OPENSTACK,
+                   RACKSPACE],
                   'Name of the cloud to use.')
 flags.DEFINE_enum(
     'os_type', DEBIAN, [DEBIAN, RHEL, UBUNTU_CONTAINER, WINDOWS],

--- a/perfkitbenchmarker/benchmarks/copy_throughput_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/copy_throughput_benchmark.py
@@ -105,7 +105,7 @@ def RunCp(vms):
   Returns:
     A list of sample.Sample objects.
   """
-  cmd = ('rm %s/*; sudo sync; sudo sysctl vm.drop_caches=3; '
+  cmd = ('rm -rf %s/*; sudo sync; sudo sysctl vm.drop_caches=3; '
          'time cp %s/data/* %s/; ' %
          (vms[0].GetScratchDir(1), vms[0].GetScratchDir(0),
           vms[0].GetScratchDir(1)))

--- a/perfkitbenchmarker/benchmarks/fio_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/fio_benchmark.py
@@ -298,7 +298,8 @@ def Prepare(benchmark_spec):
       fill_size = FLAGS.device_fill_size
     else:
       fill_path = posixpath.join(mount_point, DEFAULT_TEMP_FILE_NAME)
-      if FLAGS['disk_fill_size'].present:
+
+      if FLAGS.FlagValuesDict().get('disk_fill_size') is not None:
         fill_size = FLAGS.disk_fill_size
       else:
         # Default to 90% of capacity because the file system will add

--- a/perfkitbenchmarker/kubernetes/kubernetes_disk.py
+++ b/perfkitbenchmarker/kubernetes/kubernetes_disk.py
@@ -1,0 +1,116 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import re
+
+from perfkitbenchmarker import disk
+from perfkitbenchmarker import flags
+from perfkitbenchmarker import vm_util
+from perfkitbenchmarker.vm_util import OUTPUT_STDOUT as STDOUT,\
+    OUTPUT_STDERR as STDERR, OUTPUT_EXIT_CODE as EXIT_CODE
+
+FLAGS = flags.FLAGS
+
+
+flags.DEFINE_boolean('use_ceph_volumes', True,
+                     'Use Ceph volumes for scratch disks')
+
+flags.DEFINE_string('ceph_secret', None,
+                    'Name of the Ceph Secret which Kubernetes uses to '
+                    'authenticate with Ceph.')
+
+flags.DEFINE_list('ceph_monitors', [],
+                  'IP addresses and ports of Ceph Monitors. '
+                  'Must be provided when scratch disk is required. '
+                  'Example: "127.0.0.1:6789,192.168.1.1:6789"')
+
+
+class CephDisk(disk.BaseDisk):
+
+  def __init__(self, disk_num, disk_spec, name):
+    super(CephDisk, self).__init__(disk_spec)
+    self.disk_num = disk_num
+    self.image_name = 'rbd-%s-%s' % (name, self.disk_num)
+    self.ceph_secret = FLAGS.ceph_secret
+
+  def _Create(self):
+    """
+    Creates Rados Block Device volumes and installs filesystem on them.
+    """
+    cmd = ['rbd', 'create', self.image_name, '--size',
+           str(1024 * self.disk_size)]
+    output = vm_util.IssueCommand(cmd)
+    if output[EXIT_CODE] != 0:
+      raise Exception("Creating RBD image failed: %s" % output[STDERR])
+
+    cmd = ['rbd', 'map', self.image_name]
+    output = vm_util.IssueCommand(cmd)
+    if output[EXIT_CODE] != 0:
+      raise Exception("Mapping RBD image failed: %s" % output[STDERR])
+    rbd_device = output[STDOUT].rstrip()
+    if '/dev/rbd' not in rbd_device:
+      # Sometimes 'rbd map' command doesn't return any output.
+      # Trying to find device location another way.
+      cmd = ['rbd', 'showmapped']
+      output = vm_util.IssueCommand(cmd)
+      for image_device in output[STDOUT].split('\n'):
+        if self.image_name in image_device:
+          pattern = re.compile("/dev/rbd.*")
+          output = pattern.findall(image_device)
+          rbd_device = output[STDOUT].rstrip()
+          break
+
+    cmd = ['mkfs.ext4', rbd_device]
+    output = vm_util.IssueCommand(cmd)
+    if output[EXIT_CODE] != 0:
+      raise Exception("Formatting partition failed: %s" % output[STDERR])
+
+    cmd = ['rbd', 'unmap', rbd_device]
+    output = vm_util.IssueCommand(cmd)
+    if output[EXIT_CODE] != 0:
+      raise Exception("Unmapping block device failed: %s" % output[STDERR])
+
+  def _Delete(self):
+    cmd = ['rbd', 'rm', self.image_name]
+    output = vm_util.IssueCommand(cmd)
+    if output[EXIT_CODE] != 0:
+      msg = "Removing RBD image failed. Reattempting."
+      logging.warning(msg)
+      raise Exception(msg)
+
+  def BuildVolumeBody(self):
+    ceph_volume = {
+        "name": self.image_name,
+        "rbd": {
+            "monitors": FLAGS.ceph_monitors,
+            "pool": "rbd",
+            "image": self.image_name,
+            "secretRef": {
+                "name": FLAGS.ceph_secret
+            },
+            "fsType": "ext4",
+            "readOnly": False
+        }
+    }
+    return ceph_volume
+
+  def GetDevicePath(self):
+    return self.mount_point
+
+  def Attach(self):
+    pass
+
+  def Detach(self):
+    pass

--- a/perfkitbenchmarker/kubernetes/kubernetes_disk.py
+++ b/perfkitbenchmarker/kubernetes/kubernetes_disk.py
@@ -28,8 +28,11 @@ flags.DEFINE_boolean('use_ceph_volumes', True,
                      'Use Ceph volumes for scratch disks')
 
 flags.DEFINE_string('ceph_secret', None,
-                    'Name of the Ceph Secret which Kubernetes uses to '
+                    'Name of the Ceph Secret used by Kubernetes in order to '
                     'authenticate with Ceph.')
+
+flags.DEFINE_string('rbd_pool', 'rbd',
+                    'Name of RBD pool for Ceph volumes.')
 
 flags.DEFINE_list('ceph_monitors', [],
                   'IP addresses and ports of Ceph Monitors. '
@@ -95,7 +98,7 @@ class CephDisk(disk.BaseDisk):
         "name": self.image_name,
         "rbd": {
             "monitors": FLAGS.ceph_monitors,
-            "pool": "rbd",
+            "pool": FLAGS.rbd_pool,
             "image": self.image_name,
             "secretRef": {
                 "name": FLAGS.ceph_secret

--- a/perfkitbenchmarker/kubernetes/kubernetes_network.py
+++ b/perfkitbenchmarker/kubernetes/kubernetes_network.py
@@ -1,0 +1,19 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from perfkitbenchmarker import network
+
+
+class KubernetesFirewall(network.BaseFirewall):
+  pass

--- a/perfkitbenchmarker/kubernetes/kubernetes_virtual_machine.py
+++ b/perfkitbenchmarker/kubernetes/kubernetes_virtual_machine.py
@@ -116,7 +116,8 @@ class KubernetesVirtualMachine(virtual_machine.BaseVirtualMachine):
       raise NotImplementedError('Only Ceph volumes are supported right now. '
                                 'Exiting.')
     if self.disk_specs and not FLAGS.ceph_secret:
-      raise Exception('Please provide the name of Ceph Secret using '
+      raise Exception('Please provide the name of Ceph Secret used by '
+                      'Kubernetes in order to authenticate with Ceph.'
                       '--ceph_secret flag')
 
   def _CreatePod(self):

--- a/perfkitbenchmarker/kubernetes/kubernetes_virtual_machine.py
+++ b/perfkitbenchmarker/kubernetes/kubernetes_virtual_machine.py
@@ -1,0 +1,468 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import base64
+import json
+import logging
+import random
+import re
+
+from subprocess import Popen, PIPE, STDOUT
+
+from perfkitbenchmarker import flags
+from perfkitbenchmarker import virtual_machine, linux_virtual_machine
+from perfkitbenchmarker import vm_util
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_string('kubeconfig', '',
+                    'Path to kubeconfig to be used by kubectl')
+
+flags.DEFINE_string('kubectl', '/opt/bin/kubectl',
+                    'Path to kubectl tool')
+
+flags.DEFINE_string('username', 'root',
+                    'User name that Perfkit will attempt to use in order to '
+                    'SSH into Docker instance.')
+
+flags.DEFINE_boolean('docker_in_privileged_mode', True,
+                     'If set to True, will attempt to create Docker containers '
+                     'in a privileged mode. Note that some benchmarks execute '
+                     'commands which are only allowed in privileged mode.')
+
+flags.DEFINE_list('kubernetes_nodes', [],
+                  'IP addresses of Kubernetes Nodes. These need to be '
+                  'accessible from the machine running Perfkit '
+                  'benchmarker. Example: "10.20.30.40,10.20.30.41"')
+
+flags.DEFINE_boolean('use_ceph_volumes', True,
+                     'Use Ceph volumes for scratch disks')
+
+flags.DEFINE_list('ceph_monitors', [],
+                  'IP addresses and ports of Ceph Monitors. '
+                  'Must be provided when scratch disk is required. '
+                  'Example: "127.0.0.1:6789,192.168.1.1:6789"')
+
+DEFAULT_ZONE = 'k8s'
+SECRET_PREFIX = 'public-key-'
+UBUNTU_IMAGE = 'ubuntu-upstart'
+SELECTOR_PREFIX = 'pkb'
+OUTPUT_EXIT_CODE = 2
+
+
+class KubernetesVirtualMachine(virtual_machine.BaseVirtualMachine):
+  """
+  Object representing a Kubernetes POD.
+  """
+
+  def __init__(self, vm_spec):
+    super(KubernetesVirtualMachine, self).__init__(vm_spec)
+    self.num_scratch_disks = 0
+    self.name = self.name.replace('_', '-')
+    self.user_name = FLAGS.username
+
+  @classmethod
+  def SetVmSpecDefaults(cls, vm_spec):
+    """
+    Updates VM spec with cloud specific defaults.
+    """
+    if vm_spec.image is None:
+      vm_spec.image = UBUNTU_IMAGE
+    if vm_spec.zone is None:
+      # Although Kubernetes doesn't have zone mechanism,
+      # Perfkit requires zone to be set.
+      vm_spec.zone = DEFAULT_ZONE
+
+  def _CreateDependencies(self):
+    if self.disk_specs and not FLAGS.use_ceph_volumes:
+      raise NotImplementedError('Only Ceph volumes are supported right '
+                                'now. Exiting')
+    if not FLAGS.kubernetes_nodes:
+      raise Exception('Kubernetes Nodes IP addresses not found. Please specify'
+                      'them using --kubernetes_nodes flag. Exiting.')
+
+    self._CreateSecret()
+    self._CreateCephVolumes()
+
+  def _DeleteDependencies(self):
+    self._DeleteCephVolumes()
+    self._DeleteSecret()
+
+  def _Create(self):
+    self._CreatePod()
+    self._CreateService()
+    self._WaitForPodBootCompletion()
+    self._WaitForEndpoint()
+
+  @vm_util.Retry()
+  def _PostCreate(self):
+    self._SetSshDetails()
+    self._ConfigureProxy()
+
+  def _Delete(self):
+    self._DeletePod()
+    self._DeleteService()
+
+  def _CreatePod(self):
+    """
+    Creates a POD (Docker container with optional volumes).
+    """
+    create_cmd = [FLAGS.kubectl, '--kubeconfig=%s' % FLAGS.kubeconfig,
+                  'create', '-f', '-']
+    process = Popen(create_cmd, stdout=PIPE, stdin=PIPE, stderr=STDOUT)
+    create_rc_body = self._BuildPodBody()
+    output = process.communicate(input=create_rc_body)
+    logging.info(output[0].rstrip())
+
+  def _CreateService(self):
+    """
+    Creates a Service (POD accessor).
+    """
+    create_cmd = [FLAGS.kubectl, '--kubeconfig=%s' % FLAGS.kubeconfig,
+                  'create', '-f', '-']
+    create_svc_body = self._BuildServiceBody()
+    process = Popen(create_cmd, stdout=PIPE, stdin=PIPE, stderr=STDOUT)
+    output = process.communicate(input=create_svc_body)
+    logging.info(output[0].rstrip())
+
+  @vm_util.Retry(poll_interval=10, max_retries=100, log_errors=False)
+  def _WaitForPodBootCompletion(self):
+    """
+    Need to wait for the PODs to get up  - PODs are created with a little delay.
+    """
+    exists_cmd = [FLAGS.kubectl, '--kubeconfig=%s' % FLAGS.kubeconfig, 'get',
+                  'pod', '-o=json', '-l', '%s=%s' % (SELECTOR_PREFIX,
+                                                     self.name)]
+    pod_selector = (SELECTOR_PREFIX, self.name)
+    logging.info("Waiting for POD %s=%s" % pod_selector)
+    pod_info, _, _ = vm_util.IssueCommand(exists_cmd, suppress_warning=True)
+    pod_info = json.loads(pod_info)
+
+    if len(pod_info['items']) == 1:
+      containers = pod_info['items'][0]['spec']['containers']
+      if len(containers) == 1:
+        pod_status = pod_info['items'][0]['status']['phase']
+        if (containers[0]['name'].startswith(self.name)
+            and pod_status == "Running"):
+          logging.info("POD is up and running.")
+          return
+    raise Exception()
+
+  @vm_util.Retry(poll_interval=10, max_retries=20, log_errors=False)
+  def _WaitForEndpoint(self):
+    """
+    Waits till Service is matched with a POD. Only after this we will be able
+    to connect to container via SSH.
+    """
+    endpoint_selector = (SELECTOR_PREFIX, self.name)
+    logging.info("Waiting for endpoint %s=%s" % endpoint_selector)
+    exists_cmd = [FLAGS.kubectl, '--kubeconfig=%s' % FLAGS.kubeconfig, 'get',
+                  'endpoints', '-o=json', '-l', '%s=%s' % endpoint_selector]
+
+    endpoint, _, _ = vm_util.IssueCommand(exists_cmd, suppress_warning=True)
+    endpoint = json.loads(endpoint)
+
+    if len(endpoint['items']) == 1:
+      if len(endpoint['items'][0]['subsets']) > 0:
+        logging.info("Endpoint found. Service is successfully matched with "
+                     "POD.")
+        return
+    raise Exception()
+
+  def _DeletePod(self):
+    """
+    Deletes a POD.
+    """
+    delete_rc = [FLAGS.kubectl, '--kubeconfig=%s' % FLAGS.kubeconfig,
+                 'delete', 'pod', '-l', '%s=%s' % (SELECTOR_PREFIX, self.name)]
+    output = vm_util.IssueCommand(delete_rc)
+    logging.info(output[0].rstrip())
+
+  def _DeleteService(self):
+    """
+    Deletes a Service.
+    """
+    delete_service = [FLAGS.kubectl, '--kubeconfig=%s' % FLAGS.kubeconfig,
+                      'delete', 'service', '-l', '%s=%s' % (SELECTOR_PREFIX,
+                                                            self.name)]
+    output = vm_util.IssueCommand(delete_service)
+    logging.info(output[0].rstrip())
+
+  @vm_util.Retry(poll_interval=10, max_retries=20)
+  def _Exists(self):
+    """
+    POD should have been already created but this is a double check.
+    """
+    exists_cmd = [FLAGS.kubectl, '--kubeconfig=%s' % FLAGS.kubeconfig, 'get',
+                  'pod', '-o=json', '-l', '%s=%s' % (SELECTOR_PREFIX,
+                                                     self.name)]
+    pod_info, _, _ = vm_util.IssueCommand(exists_cmd, suppress_warning=True)
+    pod_info = json.loads(pod_info)
+
+    if len(pod_info['items']) == 0:
+      return False
+    return True
+
+  def _CreateCephVolumes(self):
+    """
+    Creates Rados Block Device volumes and installs filesystem on them.
+
+    These volumes have to be created BEFORE containers creation
+    because Kubernetes doesn't allow to attach volume to currently
+    running containers.
+    """
+    for disk_num, disk_spec in enumerate(self.disk_specs):
+      image_name = 'rbd_%s_%s' % (self.name, disk_num)
+      disk_spec.image_name = image_name
+      cmd = ['rbd', 'create', image_name, '--size',
+             str(1024 * disk_spec.disk_size)]
+      vm_util.IssueCommand(cmd)
+
+      cmd = ['rbd', 'map', image_name]
+      output = vm_util.IssueCommand(cmd)
+      rbd_device = output[0].rstrip()
+      if '/dev/rbd' not in rbd_device:
+        # Sometimes 'rbd map' command doesn't return any output.
+        # Trying to find device location another way.
+        cmd = ['rbd', 'showmapped']
+        output = vm_util.IssueCommand(cmd)
+        for image_device in output[0].split('\n'):
+          if image_name in image_device:
+            pattern = re.compile("/dev/rbd.*")
+            output = pattern.findall(image_device)
+            rbd_device = output[0].rstrip()
+            break
+
+      cmd = ['mkfs.ext4', rbd_device]
+      vm_util.IssueCommand(cmd)
+
+      cmd = ['rbd', 'unmap', rbd_device]
+      vm_util.IssueCommand(cmd)
+
+      self.scratch_disks.append(disk_spec)
+
+  @vm_util.Retry(poll_interval=10, max_retries=20, log_errors=False)
+  def _DeleteCephVolumes(self):
+    """
+    Deletes RBD volumes.
+    """
+    for disk_spec in self.scratch_disks[:]:
+      cmd = ['rbd', 'rm', disk_spec.image_name]
+      output = vm_util.IssueCommand(cmd)
+      if output[OUTPUT_EXIT_CODE] != 0:
+        msg = "Removing RBD image failed. Reattempting."
+        logging.warning(msg)
+        raise Exception(msg)
+      self.scratch_disks.remove(disk_spec)
+
+  def _CreateSecret(self):
+    """
+    Creates a Kubernetes secret which will store public key.
+    It will be used during during POD creation.
+    """
+    cat_cmd = ['cat', vm_util.GetPublicKeyPath()]
+    key_file, _ = vm_util.IssueRetryableCommand(cat_cmd)
+    encoded_public_key = base64.b64encode(key_file)
+    template = {
+        "kind": "Secret",
+        "apiVersion": "v1",
+        "metadata": {
+            "name": SECRET_PREFIX + self.name
+        },
+        "data": {
+            "authorizedkey": encoded_public_key
+        }
+    }
+    create_secret_body = json.dumps(template)
+    create_secret = [FLAGS.kubectl, '--kubeconfig=%s' % FLAGS.kubeconfig,
+                     'create', '-f', '-']
+    process = Popen(create_secret, stdout=PIPE, stdin=PIPE, stderr=STDOUT)
+    result = process.communicate(input=create_secret_body)
+    logging.info(result[0].rstrip())
+
+  def _DeleteSecret(self):
+    """
+    Deletes a secret.
+    """
+    delete_secret = [FLAGS.kubectl, '--kubeconfig=%s' % FLAGS.kubeconfig,
+                     'delete', 'secret', SECRET_PREFIX + self.name]
+    result = vm_util.IssueCommand(delete_secret)
+    logging.info(result[0].rstrip())
+
+  def DeleteScratchDisks(self):
+    pass
+
+  def _SetSshDetails(self):
+    """
+    SSH to containers is done through one of Kubernetes Nodes:
+    - SSH IP address is the address of one of the Nodes,
+    - SSH port is assigned to Kubernetes Service matched with this container.
+    """
+
+    get_port_cmd = [FLAGS.kubectl, '--kubeconfig=%s' % FLAGS.kubeconfig,
+                    'get', 'service', '-l', '%s=%s' %
+                    (SELECTOR_PREFIX, self.name), '-o', 'jsonpath',
+                    '--template', '"{.items[0].spec.ports[0].nodePort}"']
+
+    stdout, _, _ = vm_util.IssueCommand(get_port_cmd, suppress_warning=True)
+    if not stdout:
+      raise Exception("Port of service %s=%s not found. Exiting." %
+                      (SELECTOR_PREFIX, self.name))
+    port = stdout.replace('"', '')
+    self.ssh_port = port
+    self.ip_address = self.internal_ip = random.choice(FLAGS.kubernetes_nodes)
+
+  def _ConfigureProxy(self):
+    """
+    In Docker containers environment variables from /etc/environment
+    are not sourced - this results in connection problems when running
+    behind proxy. Prepending proxy environment variables to bashrc
+    solves the problem. Note: APPENDING to bashrc will not work because
+    the script exits when it is NOT executed in interactive shell.
+    """
+
+    if FLAGS.http_proxy:
+      http_proxy = "sed -i '1i export http_proxy=%s' /etc/bash.bashrc"
+      self.RemoteCommand(http_proxy % FLAGS.http_proxy)
+    if FLAGS.https_proxy:
+      https_proxy = "sed -i '1i export https_proxy=%s' /etc/bash.bashrc"
+      self.RemoteCommand(https_proxy % FLAGS.http_proxy)
+
+  def _BuildPodBody(self):
+    """
+    Builds a JSON which will be passed as a body of POST request
+    to Kuberneres API in order to create a POD.
+    """
+
+    container = self._BuildContainerBody()
+    volumes = self._BuildVolumesBody()
+
+    template = {
+        "kind": "Pod",
+        "apiVersion": "v1",
+        "metadata": {
+            "name": self.name,
+            "labels": {
+                SELECTOR_PREFIX: self.name
+            }
+        },
+        "spec": {
+            "volumes": volumes,
+            "containers": [container],
+            "dnsPolicy": "Default"
+        }
+    }
+    return json.dumps(template)
+
+  def _BuildVolumesBody(self):
+    """
+    Constructs volumes-related part of POST request to create POD.
+    """
+    volumes = []
+    secret_volume = {
+        "name": "ssh-details",
+        "secret": {
+            "secretName": SECRET_PREFIX + self.name
+        }
+    }
+    volumes.append(secret_volume)
+
+    disc_specs_count = len(self.disk_specs)
+    for disk_num in range(0, disc_specs_count):
+      image_name = 'rbd_%s_%s' % (self.name, disk_num)
+      ceph_volume = {
+          "name": "rbdpd-%s-%s" % (self.instance_number, disk_num),
+          "rbd": {
+              "monitors": FLAGS.ceph_monitors,
+              "pool": "rbd",
+              "image": image_name,
+              "secretRef": {
+                  "name": "ceph-secret"
+              },
+              "fsType": "ext4",
+              "readOnly": False
+          }
+      }
+      volumes.append(ceph_volume)
+    return volumes
+
+  def _BuildContainerBody(self):
+    """
+    Constructs containers-related part of POST request to create POD.
+    """
+
+    # Kubernetes 'secret' mechanism is used to pass public key.
+    # Unfortunately, Kubernetes doesn't allow to specify underline
+    # character in file name. Thus 'authorizedkey' is passed which
+    # is later properly moved to 'authorized_keys'.
+    public_key = "/bin/mkdir /root/.ssh\n" + \
+                 "mv /tmp/authorizedkey /root/.ssh/authorized_keys\n"
+    container_boot_commands = public_key + "/usr/sbin/sshd -D"
+
+    container = {
+        "command": [
+            "bash",
+            "-c",
+            container_boot_commands
+        ],
+        "image": self.image,
+        "name": self.name,
+        "securityContext": {
+            "privileged": FLAGS.docker_in_privileged_mode
+        },
+        "volumeMounts": [
+            {
+                "name": "ssh-details",
+                "mountPath": "/tmp"
+            }
+        ]
+    }
+    for disk_num, disk_spec in enumerate(self.disk_specs):
+      mount_point = disk_spec.mount_point
+      ceph_volume_mount = {
+          "mountPath": mount_point,
+          "name": "rbdpd-%s-%s" % (self.instance_number, disk_num)
+      }
+      container['volumeMounts'].append(ceph_volume_mount)
+
+    return container
+
+  def _BuildServiceBody(self):
+    service = {
+        "kind": "Service",
+        "apiVersion": "v1",
+        "metadata": {
+            "name": self.name,
+            "labels": {
+                SELECTOR_PREFIX: self.name
+            }
+        },
+        "spec": {
+            "ports": [
+                {
+                    "port": self.ssh_port
+                }
+            ],
+            "selector": {
+                SELECTOR_PREFIX: self.name
+            },
+            "type": "NodePort"
+        }
+    }
+    return json.dumps(service)
+
+
+class DebianBasedKubernetesVirtualMachine(KubernetesVirtualMachine,
+                                          linux_virtual_machine.DebianMixin):
+  DEFAULT_IMAGE = UBUNTU_IMAGE

--- a/perfkitbenchmarker/kubernetes/kubernetes_virtual_machine.py
+++ b/perfkitbenchmarker/kubernetes/kubernetes_virtual_machine.py
@@ -29,7 +29,7 @@ FLAGS = flags.FLAGS
 flags.DEFINE_string('kubeconfig', '',
                     'Path to kubeconfig to be used by kubectl')
 
-flags.DEFINE_string('kubectl', '/opt/bin/kubectl',
+flags.DEFINE_string('kubectl', 'kubectl',
                     'Path to kubectl tool')
 
 flags.DEFINE_string('username', 'root',
@@ -331,6 +331,9 @@ class KubernetesVirtualMachine(virtual_machine.BaseVirtualMachine):
     if FLAGS.https_proxy:
       https_proxy = "sed -i '1i export https_proxy=%s' /etc/bash.bashrc"
       self.RemoteCommand(https_proxy % FLAGS.http_proxy)
+    if FLAGS.ftp_proxy:
+      ftp_proxy = "sed -i '1i export ftp_proxy=%s' /etc/bash.bashrc"
+      self.RemoteCommand(ftp_proxy % FLAGS.ftp_proxy)
 
   def _BuildPodBody(self):
     """

--- a/perfkitbenchmarker/vm_util.py
+++ b/perfkitbenchmarker/vm_util.py
@@ -59,6 +59,10 @@ MAX_RETRIES = -1
 WINDOWS = 'nt'
 PASSWORD_LENGTH = 15
 
+OUTPUT_STDOUT = 0
+OUTPUT_STDERR = 1
+OUTPUT_EXIT_CODE = 2
+
 flags.DEFINE_integer('default_timeout', TIMEOUT, 'The default timeout for '
                      'retryable commands in seconds.')
 flags.DEFINE_integer('burn_cpu_seconds', 0,
@@ -345,7 +349,7 @@ def Retry(poll_interval=POLL_INTERVAL, max_retries=MAX_RETRIES,
 
 
 def IssueCommand(cmd, force_info_log=False, suppress_warning=False,
-                 env=None, timeout=DEFAULT_TIMEOUT):
+                 env=None, timeout=DEFAULT_TIMEOUT, input=None):
   """Tries running the provided command once.
 
   Args:
@@ -377,7 +381,7 @@ def IssueCommand(cmd, force_info_log=False, suppress_warning=False,
 
   shell_value = RunningOnWindows()
   process = subprocess.Popen(cmd, env=env, shell=shell_value,
-                             stdout=subprocess.PIPE,
+                             stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE)
 
   def _KillProcess():
@@ -389,7 +393,7 @@ def IssueCommand(cmd, force_info_log=False, suppress_warning=False,
   timer.start()
 
   try:
-    stdout, stderr = process.communicate()
+    stdout, stderr = process.communicate(input)
   finally:
     timer.cancel()
 


### PR DESCRIPTION
Instead of VMs in Kubernetes we have a concept of PODs. Create() method
creates a POD with a single container inside. Access to this container is
done through the Service. Authentication is done via Secret - SSH key is
base64 encoded and stored in a file which is later mounted as a volume.

Additionaly, Ceph support was added. You can specify IP addresses of Ceph
Monitors. When scratch disk is needed, RBD image will be created with ext4
filesystem. This volume has to be created _before_ the actual POD launch.
Ceph volume is currently the only option if the benchmark requires scratch
disk but I plan to add local disk support in the next check-ins.

Signed-off-by: Mateusz Blaszkowski <mateusz.blaszkowski@intel.com>