### PR TITLE
Collect fio data over time

### DIFF
--- a/perfkitbenchmarker/benchmarks/fio_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/fio_benchmark.py
@@ -18,6 +18,7 @@ Man: http://manpages.ubuntu.com/manpages/natty/man1/fio.1.html
 Quick howto: http://www.bluestop.org/fio/HOWTO.txt
 """
 
+import datetime
 import json
 import logging
 import posixpath
@@ -90,11 +91,15 @@ flags.DEFINE_integer('working_set_size', None,
                      'The size of the working set, in GB. If not given, use '
                      'the full size of the device.',
                      lower_bound=0)
+flags.DEFINE_integer('run_for_minutes', 10,
+                     'Repeat the job scenario(s) for the given number of '
+                     'minutes. Only valid when using --generate_scenarios.',
+                     lower_bound=0)
 
 
 
 FLAGS_IGNORED_FOR_CUSTOM_JOBFILE = {
-    'generate_scenarios', 'io_depths'}
+    'generate_scenarios', 'io_depths', 'run_for_minutes'}
 
 
 IODEPTHS_REGEXP = re.compile(r'(\d+)(-(\d+))?$')
@@ -159,6 +164,9 @@ size={{size}}
 {% endfor %}
 {% endfor %}
 """
+
+MINUTES_PER_JOB = 10  # Must match the JOB_FILE_TEMPLATE above.
+SECONDS_PER_MINUTE = 60
 
 
 def GetIODepths(io_depths):
@@ -280,6 +288,10 @@ def Prepare(benchmark_spec):
       logging.warning('Fio job file specified. Ignoring options "%s"',
                       ', '.join(ignored_flags))
 
+  if FLAGS.run_for_minutes % MINUTES_PER_JOB != 0:
+    logging.warning('Runtime %s will be rounded up to the next multiple of %s '
+                    'minutes.' % (MINUTES_PER_JOB,))
+
   vm = benchmark_spec.vms[0]
   logging.info('FIO prepare on %s', vm)
   vm.Install('fio')
@@ -340,21 +352,46 @@ def Run(benchmark_spec):
 
   fio_command = 'sudo %s --output-format=json %s' % (fio.FIO_PATH,
                                                      REMOTE_JOB_FILE_PATH)
+
+  run_reps = FLAGS.run_for_minutes // MINUTES_PER_JOB
+  if FLAGS.run_for_minutes % MINUTES_PER_JOB != 0:
+    run_reps += 1
+    # We already warned the user about rounding during the prepare
+    # phase. No need to warn them again here.
+
+  disk = vm.scratch_disks[0]
+
   # TODO(user): This only gives results at the end of a job run
   #      so the program pauses here with no feedback to the user.
   #      This is a pretty lousy experience.
   logging.info('FIO Results:')
-  stdout, stderr = vm.RemoteCommand(fio_command, should_log=True)
 
-  disk = vm.scratch_disks[0]
-  return fio.ParseResults(
-      GetOrGenerateJobFileString(FLAGS.fio_jobfile,
-                                 disk,
-                                 FLAGS.against_device,
-                                 FLAGS.generate_scenarios,
-                                 GetIODepths(FLAGS.io_depths),
-                                 FLAGS.working_set_size),
-      json.loads(stdout))
+  samples = []
+  start_time = datetime.datetime.now()
+  for rep_num in xrange(run_reps):
+    logging.info('**** Repetition number %s of %s ****' % (rep_num, run_reps))
+    run_start = datetime.datetime.now()
+    stdout, stderr = vm.RemoteCommand(fio_command, should_log=True)
+
+    seconds_since_start = int(round((run_start - start_time).total_seconds()))
+    minutes_since_start = seconds_since_start // SECONDS_PER_MINUTE
+    if seconds_since_start % SECONDS_PER_MINUTE > (SECONDS_PER_MINUTE // 2):
+      minutes_since_start += 1
+    base_metadata = {
+        'repeat_number': rep_num,
+        'minutes_since_start': minutes_since_start
+    }
+    samples.extend(fio.ParseResults(
+        GetOrGenerateJobFileString(FLAGS.fio_jobfile,
+                                   disk,
+                                   FLAGS.against_device,
+                                   FLAGS.generate_scenarios,
+                                   GetIODepths(FLAGS.io_depths),
+                                   FLAGS.working_set_size),
+        json.loads(stdout),
+        base_metadata=base_metadata))
+
+  return samples
 
 
 def Cleanup(benchmark_spec):

--- a/perfkitbenchmarker/benchmarks/fio_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/fio_benchmark.py
@@ -298,9 +298,8 @@ def Prepare(benchmark_spec):
       fill_size = FLAGS.device_fill_size
     else:
       fill_path = posixpath.join(mount_point, DEFAULT_TEMP_FILE_NAME)
-
-      if FLAGS.FlagValuesDict().get('disk_fill_size') is not None:
-        fill_size = FLAGS.disk_fill_size
+      if FLAGS['device_fill_size'].present:
+        fill_size = FLAGS.device_fill_size
       else:
         # Default to 90% of capacity because the file system will add
         # some overhead.

--- a/perfkitbenchmarker/benchmarks/fio_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/fio_benchmark.py
@@ -303,8 +303,8 @@ def Prepare(benchmark_spec):
       else:
         # Default to 90% of capacity because the file system will add
         # some overhead.
-        fill_size = str(DISK_USABLE_SPACE_FRACTION *
-                        1000 * disk.disk_size) + 'M'
+        fill_size = str(int(DISK_USABLE_SPACE_FRACTION *
+                            1000 * disk.disk_size)) + 'M'
 
     logging.info('Fill file %s on %s', fill_path, vm)
     command = GenerateFillCommand(fio.FIO_PATH,

--- a/perfkitbenchmarker/packages/fio.py
+++ b/perfkitbenchmarker/packages/fio.py
@@ -115,12 +115,13 @@ def FioParametersToJob(fio_parameters):
                                 JOB_STONEWALL_PARAMETER)
 
 
-def ParseResults(job_file, fio_json_result):
+def ParseResults(job_file, fio_json_result, base_metadata={}):
   """Parse fio json output into samples.
 
   Args:
     job_file: The contents of the fio job file.
     fio_json_result: Fio results in json format.
+    base_metadata: Extra metadata to annotate the samples with.
 
   Returns:
     A list of sample.Sample objects.
@@ -137,6 +138,7 @@ def ParseResults(job_file, fio_json_result):
       if job[mode]['io_bytes']:
         metric_name = '%s:%s' % (job_name, mode)
         parameters = parameter_metadata[job_name]
+        parameters.update(base_metadata)
         parameters['fio_job'] = job_name
         bw_metadata = {
             'bw_min': job[mode]['bw_min'],

--- a/perfkitbenchmarker/packages/fio.py
+++ b/perfkitbenchmarker/packages/fio.py
@@ -115,7 +115,7 @@ def FioParametersToJob(fio_parameters):
                                 JOB_STONEWALL_PARAMETER)
 
 
-def ParseResults(job_file, fio_json_result, base_metadata={}):
+def ParseResults(job_file, fio_json_result, base_metadata=None):
   """Parse fio json output into samples.
 
   Args:
@@ -138,7 +138,8 @@ def ParseResults(job_file, fio_json_result, base_metadata={}):
       if job[mode]['io_bytes']:
         metric_name = '%s:%s' % (job_name, mode)
         parameters = parameter_metadata[job_name]
-        parameters.update(base_metadata)
+        if base_metadata:
+          parameters.update(base_metadata)
         parameters['fio_job'] = job_name
         bw_metadata = {
             'bw_min': job[mode]['bw_min'],

--- a/tests/packages/fio_test.py
+++ b/tests/packages/fio_test.py
@@ -15,7 +15,6 @@
 
 import json
 import os
-import time
 import unittest
 
 import mock
@@ -81,10 +80,7 @@ class FioTestCase(unittest.TestCase, test_util.SamplesTestMixin):
             'sequential_read': {},
             'random_write_test': {},
             'random_read_test': {},
-            'random_read_test_parallel': {}}), \
-        mock.patch(
-            time.__name__ + '.time',
-            return_value=1.0):
+            'random_read_test_parallel': {}}):
       result = fio.ParseResults('', self.result_contents)
       expected_result = [
           ['sequential_write:write:bandwidth', 68118, 'KB/s',

--- a/tests/packages/fio_test.py
+++ b/tests/packages/fio_test.py
@@ -362,6 +362,23 @@ class FioTestCase(unittest.TestCase, test_util.SamplesTestMixin):
                          for sample_tuple in expected_result]
       self.assertSampleListsEqualUpToTimestamp(result, expected_result)
 
+  def testParseResultsBaseMetadata(self):
+    BASE_METADATA = {'foo': 'bar'}
+
+    with mock.patch(
+        fio.__name__ + '.ParseJobFile',
+        return_value={
+            'sequential_write': {},
+            'sequential_read': {},
+            'random_write_test': {},
+            'random_read_test': {},
+            'random_read_test_parallel': {}}):
+      results = fio.ParseResults('', self.result_contents,
+                                 base_metadata=BASE_METADATA)
+
+      for result in results:
+        self.assertDictContainsSubset(BASE_METADATA, result.metadata)
+
   def testFioCommandToJob(self):
     fio_parameters = (
         '--filesize=10g --directory=/scratch0 --ioengine=libaio '


### PR DESCRIPTION
This PR adds a flag --run_for_minutes to the fio benchmark. When supplied, the user can specify a length of time (in minutes) to run for. Fio will then do repeated 10-minute jobs until it hits the user's requested time, reporting statistics for each job individually, and annotating each job's data with its job number and how many minutes into the overall run it started.

This PR also includes a bug fix in the case where fio is run against a formatted disk using a non-default device_fill_size parameter.