### PR TITLE
Web search: update flag names, minor tweaks.

### DIFF
--- a/perfkitbenchmarker/benchmarks/cloudsuite_websearch_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/cloudsuite_websearch_benchmark.py
@@ -140,8 +140,8 @@ def _BuildIndex(solr_nodes, fw):
   def DownloadIndex(vm):
     solr_core_dir = posixpath.join(vm.GetScratchDir(), 'solr_cores')
     vm.RobustRemoteCommand('cd {0} && '
-                           'wget {1} && '
-                           'tar zxvf index -C {2}'.format(
+                           'curl -L {1} | '
+                           'tar zxvf - -C {2}'.format(
                                solr_core_dir, INDEX_URL,
                                'cloudsuite_web_search*'))
 


### PR DESCRIPTION
For the CloudSuite Web Search benchmark:

* Adds a `cs_websearch_` prefix to all flag names, to prevent confusion
  with other benchmarks that use a JVM.
* Adds a validation function for heap sizes.
* Renames cloudsuite_web_search_benchmark to cloudsuite_websearch_benchmark