### PR TITLE
Remove the temporary status written by execute_command.py

### DIFF
--- a/perfkitbenchmarker/scripts/execute_command.py
+++ b/perfkitbenchmarker/scripts/execute_command.py
@@ -74,9 +74,9 @@ def main():
         # acquisition fails, which is desirable here.
         fcntl.lockf(status, fcntl.LOCK_EX | fcntl.LOCK_NB)
 
-        # Initialize the status to -1; will be filled with the exit status
+        # Initialize the status to 99; will be filled with the exit status
         # on subprocess completion.
-        status.write('-1')
+        status.write('')
         status.flush()
         status.seek(0)
 


### PR DESCRIPTION
execute_command.py has been writing `-1` to the status file until the
command completes. If `execute_command.py` itself exits / is killed,
this has been the return code of wait_for_command. Since bash exit codes
are in the range `[0,255]`, -1 overflows to 255, is interpreted as a
temporary SSH failure, and the command retried. On the second try, the
process stdout / stderr files have been removed.

This also adds some logging for the wrapper script itself, which is
logged when RobustRemoteCommand has an exception.