### PR TITLE
Style fix in fio_benchmark.py

### DIFF
--- a/perfkitbenchmarker/benchmarks/fio_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/fio_benchmark.py
@@ -98,9 +98,8 @@ flags.DEFINE_integer('run_for_minutes', 10,
                      'minutes. Only valid when using --generate_scenarios. '
                      'When using multiple scenarios, each one is run for the '
                      'given number of minutes. Time will be rounded up to the '
-                     'next multiple of %s minutes.' % (MINUTES_PER_JOB,),
+                     'next multiple of %s minutes.' % MINUTES_PER_JOB,
                      lower_bound=0)
-
 
 
 FLAGS_IGNORED_FOR_CUSTOM_JOBFILE = {


### PR DESCRIPTION
This should have been in my fio-run-for-minutes merge yesterday, but I
accidentally left it out.