### PR TITLE
Add templating in fio jobfiles

### DIFF
--- a/perfkitbenchmarker/benchmarks/fio_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/fio_benchmark.py
@@ -67,9 +67,7 @@ FLAGS = flags.FLAGS
 
 flags.DEFINE_string('fio_jobfile', None,
                     'Job file that fio will use. If not given, use a job file '
-                    'bundled with PKB. {{filename}} in the job file will be '
-                    'replaced by the path of the disk or file we pre-filled, '
-                    'if requested. Cannot use with --generate_scenarios.')
+                    'bundled with PKB. Cannot use with --generate_scenarios.')
 flags.DEFINE_list('generate_scenarios', None,
                   'Generate a job file with the given scenarios. Special '
                   'scenario \'all\' generates all scenarios. Available '

--- a/perfkitbenchmarker/benchmarks/fio_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/fio_benchmark.py
@@ -490,7 +490,7 @@ def Run(benchmark_spec):
   #      This is a pretty lousy experience.
   logging.info('FIO Results:')
 
-  if not FLAGS.run_for_minutes:
+  if not FLAGS['run_for_minutes'].present:
     RunIt()
   else:
     RunForMinutes(RunIt, FLAGS.run_for_minutes, MINUTES_PER_JOB)

--- a/perfkitbenchmarker/benchmarks/fio_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/fio_benchmark.py
@@ -27,6 +27,7 @@ import re
 import jinja2
 
 from perfkitbenchmarker import data
+from perfkitbenchmarker import errors
 from perfkitbenchmarker import flags
 from perfkitbenchmarker import vm_util
 from perfkitbenchmarker.packages import fio
@@ -353,7 +354,7 @@ def WarnOnBadFlags():
       not FLAGS.working_set_size and
       not FLAGS.against_device):
     logging.error(NEED_SIZE_MESSAGE)
-    raise AssertionError(NEED_SIZE_MESSAGE)
+    raise errors.Benchmarks.PrepareException(NEED_SIZE_MESSAGE)
 
 
 def RunForMinutes(proc, mins_to_run, mins_per_call):
@@ -458,10 +459,17 @@ def Run(benchmark_spec):
     fio_command = 'sudo %s --output-format=json --directory=%s %s' % (
         fio.FIO_PATH, mount_point, REMOTE_JOB_FILE_PATH)
 
-
   samples = []
 
   def RunIt(repeat_number=None, minutes_since_start=None, total_repeats=None):
+    """Run the actual fio command on the VM and save the results.
+
+    Args:
+      repeat_number: if given, our number in a sequence of repetitions.
+      minutes_since_start: if given, minutes since the start of repetition.
+      total_repeats: if given, the total number of repetitions to do.
+    """
+
     if repeat_number:
       logging.info('**** Repetition number %s of %s ****',
                    repeat_number, total_repeats)

--- a/perfkitbenchmarker/benchmarks/fio_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/fio_benchmark.py
@@ -23,6 +23,7 @@ import json
 import logging
 import posixpath
 import re
+import sys
 
 import jinja2
 
@@ -90,7 +91,9 @@ flags.DEFINE_string('io_depths', '1',
                     'list, like --io_depths=1-4,6-8')
 flags.DEFINE_integer('working_set_size', None,
                      'The size of the working set, in GB. If not given, use '
-                     'the full size of the device.',
+                     'the full size of the device. If using '
+                     '--generate_scenarios and not --against_device, you must '
+                     'pass --working_set_size.',
                      lower_bound=0)
 flags.DEFINE_integer('run_for_minutes', 10,
                      'Repeat the job scenario(s) for the given number of '
@@ -342,6 +345,13 @@ def WarnOnBadFlags():
   if FLAGS.run_for_minutes % MINUTES_PER_JOB != 0:
     logging.warning('Runtime %s will be rounded up to the next multiple of %s '
                     'minutes.', FLAGS.run_for_minutes, MINUTES_PER_JOB)
+
+  if (FLAGS.fio_jobfile is None and
+      FLAGS.generate_scenarios and
+      not FLAGS.working_set_size):
+    logging.error('You must specify the working set size when using generated '
+                  'scenarios against a filesystem.')
+    sys.exit(1)
 
 
 def RunForMinutes(proc, mins_to_run, mins_per_call):

--- a/perfkitbenchmarker/benchmarks/fio_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/fio_benchmark.py
@@ -316,6 +316,23 @@ def GetOrGenerateJobFileString(fio_jobfile, remove_filename,
                                  io_depths, working_set_size)
 
 
+def WarnOnBadFlags():
+  """Warn the user if they pass bad flag combinations."""
+
+  if FLAGS.fio_jobfile:
+    ignored_flags = {'--' + flag_name
+                     for flag_name in FLAGS_IGNORED_FOR_CUSTOM_JOBFILE
+                     if FLAGS[flag_name].present}
+
+    if ignored_flags:
+      logging.warning('Fio job file specified. Ignoring options "%s"',
+                      ', '.join(ignored_flags))
+
+  if FLAGS.run_for_minutes % MINUTES_PER_JOB != 0:
+    logging.warning('Runtime %s will be rounded up to the next multiple of %s '
+                    'minutes.', FLAGS.run_for_minutes, MINUTES_PER_JOB)
+
+
 def GetInfo():
   return BENCHMARK_INFO
 
@@ -333,18 +350,7 @@ def Prepare(benchmark_spec):
 
   """
 
-  if FLAGS.fio_jobfile:
-    ignored_flags = {'--' + flag_name
-                     for flag_name in FLAGS_IGNORED_FOR_CUSTOM_JOBFILE
-                     if FLAGS[flag_name].present}
-
-    if ignored_flags:
-      logging.warning('Fio job file specified. Ignoring options "%s"',
-                      ', '.join(ignored_flags))
-
-  if FLAGS.run_for_minutes % MINUTES_PER_JOB != 0:
-    logging.warning('Runtime %s will be rounded up to the next multiple of %s '
-                    'minutes.', FLAGS.run_for_minutes, MINUTES_PER_JOB)
+  WarnOnBadFlags()
 
   vm = benchmark_spec.vms[0]
   logging.info('FIO prepare on %s', vm)

--- a/perfkitbenchmarker/data/fio.job
+++ b/perfkitbenchmarker/data/fio.job
@@ -14,7 +14,7 @@
 
 [global]
 filesize=10*10*1000*$mb_memory
-filename=fio_test_file
+filename={{ filename }}
 ioengine=libaio
 
 [sequential_write]

--- a/perfkitbenchmarker/data/fio.job
+++ b/perfkitbenchmarker/data/fio.job
@@ -14,7 +14,7 @@
 
 [global]
 filesize=10*10*1000*$mb_memory
-filename={{ filename }}
+filename=fio_test_file
 ioengine=libaio
 
 [sequential_write]

--- a/tests/benchmarks/fio_benchmark_test.py
+++ b/tests/benchmarks/fio_benchmark_test.py
@@ -19,7 +19,6 @@ import unittest
 import mock
 
 from perfkitbenchmarker.benchmarks import fio_benchmark
-from perfkitbenchmarker.packages import fio
 
 
 class TestGetIODepths(unittest.TestCase):
@@ -161,26 +160,25 @@ blocksize = 8k
 
 
 class TestRunForMinutes(unittest.TestCase):
-  def testRunForMinutes(self):
-    vm = mock.Mock()
-    vm.RemoteCommand = mock.MagicMock()
-    vm.scratch_disks = [mock.Mock()]
-    benchmark_spec = mock.Mock()
-    benchmark_spec.vms = [vm]
+  def testBasicRun(self):
+    proc = mock.Mock()
+    fio_benchmark.RunForMinutes(proc, 20, 10)
+    self.assertEquals(proc.call_count, 2)
 
-    bench_module = fio_benchmark.__name__
-    with mock.patch(bench_module + '.FLAGS') as fb_flags, \
-            mock.patch(bench_module + '.GetOrGenerateJobFileString'), \
-            mock.patch(fio.__name__ + '.ParseResults') as parse_results:
-      # Pick a length of time that forces rounding
-      fb_flags.run_for_minutes = int(round(fio_benchmark.MINUTES_PER_JOB * 2.5))
-      fb_flags.io_depths = '1'
-      fb_flags.generate_scenarios = ['random_read']
-      parse_results.return_value = ['spam']
-      vm.RemoteCommand.return_value = '{"foo": "bar"}', ''
-      self.assertEquals(fio_benchmark.Run(benchmark_spec),
-                        ['spam', 'spam', 'spam'])
-      self.assertEquals(vm.RemoteCommand.call_count, 3)
+  def TestRounding(self):
+    proc = mock.Mock()
+    fio_benchmark.RunForMinutes(proc, 18, 10)
+    self.assertEquals(proc.call_count, 2)
+
+  def TestRoundsUp(self):
+    proc = mock.Mock()
+    fio_benchmark.RunForMinutes(proc, 12, 10)
+    self.assertEquals(proc.call_count, 2)
+
+  def TestZeroMinutes(self):
+    proc = mock.Mock()
+    fio_benchmark.RunForMinutes(proc, 0, 10)
+    self.assertEquals(proc.call_count, 0)
 
 
 if __name__ == '__main__':

--- a/tests/benchmarks/fio_benchmark_test.py
+++ b/tests/benchmarks/fio_benchmark_test.py
@@ -88,8 +88,8 @@ size=100%
     self.assertEqual(
         fio_benchmark.GenerateJobFileString(
             self.filename,
-            [fio_benchmark.SCENARIOS['sequential_read']],
-            [1, 2],
+            ['sequential_read'],
+            '1,2',
             None),
         expected_jobfile)
 
@@ -129,14 +129,13 @@ size=100%
     self.assertEqual(
         fio_benchmark.GenerateJobFileString(
             self.filename,
-            [fio_benchmark.SCENARIOS['sequential_read'],
-             fio_benchmark.SCENARIOS['sequential_write']],
-            [1],
+            ['sequential_read', 'sequential_write'],
+            '1',
             None),
         expected_jobfile)
 
 
-class TestProcessUserJobFile(unittest.TestCase):
+class TestProcessedJobFileString(unittest.TestCase):
   def testReplaceFilenames(self):
     file_contents = """
 [global]
@@ -155,7 +154,7 @@ blocksize = 8k
     manager.__exit__.return_value = mock.Mock()
 
     with mock.patch('__builtin__.open', open_mock):
-      jobfile = fio_benchmark.ProcessUserJobFile('filename', True)
+      jobfile = fio_benchmark.ProcessedJobFileString('filename', True)
       self.assertNotIn('filename', jobfile)
       self.assertNotIn('zanzibar', jobfile)
       self.assertNotIn('asdf', jobfile)

--- a/tests/benchmarks/fio_benchmark_test.py
+++ b/tests/benchmarks/fio_benchmark_test.py
@@ -136,13 +136,29 @@ size=100%
         expected_jobfile)
 
 
-class TestGetOrGenerateJobFileString(unittest.TestCase):
-  def testFilenameSubstitution(self):
-    filename = '1234567890'
-    jobfile = str(fio_benchmark.GetOrGenerateJobFileString(
-        None, filename, None, '1', None))
+class TestProcessUserJobFile(unittest.TestCase):
+  def testReplaceFilenames(self):
+    file_contents = """
+[global]
+blocksize = 4k
+filename = zanzibar
+ioengine=libaio
 
-    self.assertIn(filename, jobfile)
+[job1]
+filename = asdf
+blocksize = 8k
+"""
+
+    open_mock = mock.MagicMock()
+    manager = open_mock.return_value.__enter__.return_value
+    manager.read.return_value = file_contents
+    manager.__exit__.return_value = mock.Mock()
+
+    with mock.patch('__builtin__.open', open_mock):
+      jobfile = fio_benchmark.ProcessUserJobFile('filename', True)
+      self.assertNotIn('filename', jobfile)
+      self.assertNotIn('zanzibar', jobfile)
+      self.assertNotIn('asdf', jobfile)
 
 
 class TestRunForMinutes(unittest.TestCase):


### PR DESCRIPTION
When fio_benchmark.py gets a user-supplied job file, replace the
string {{filename}} with the path to the file it pre-filled. Use this
ability to fix a bug introduced recently where the built-in fio.job
file no longer used the pre-filled disk or file.