### PR TITLE
Add a note on dependencies when tox tests fail.

### DIFF
--- a/hooks/lib/check-unittest.sh
+++ b/hooks/lib/check-unittest.sh
@@ -24,4 +24,8 @@ fi
 # Unit test failures can't easily be mapped to specific input files.
 # Always run all tests, and report a failure via nonzero exit code if
 # any test fails.
-tox -e py27 >&2
+if ! tox -e py27 >&2; then
+  >&2 echo "*** tox failed. Note: If dependencies have changed, try "\
+    "running 'tox -r' to update the tox environment"
+  exit 1
+fi


### PR DESCRIPTION
Fixes #484.