### PR TITLE
Pre-split YCSB table for Cloud Bigtable benchmark.

### DIFF
--- a/perfkitbenchmarker/benchmarks/cloud_bigtable_ycsb_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/cloud_bigtable_ycsb_benchmark.py
@@ -38,6 +38,7 @@ import subprocess
 from perfkitbenchmarker import data
 from perfkitbenchmarker import flags
 from perfkitbenchmarker import vm_util
+from perfkitbenchmarker.benchmarks import hbase_ycsb_benchmark as hbase_ycsb
 from perfkitbenchmarker.packages import hbase
 from perfkitbenchmarker.packages import ycsb
 
@@ -227,9 +228,8 @@ def Prepare(benchmark_spec):
   vm_util.RunThreaded(_Install, vms)
 
   # Create table
-  command = """echo 'create "{0}", "{1}"; exit' | {2}/hbase shell""".format(
-      _GetTableName(), COLUMN_FAMILY, hbase.HBASE_BIN)
-  vms[0].RemoteCommand(command, should_log=True)
+  hbase_ycsb.CreateYCSBTable(vms[0], table_name=_GetTableName(),
+                             use_snappy=False, limit_filesize=False)
 
 
 def Run(benchmark_spec):

--- a/perfkitbenchmarker/data/hbase/create-ycsb-table.hbaseshell.j2
+++ b/perfkitbenchmarker/data/hbase/create-ycsb-table.hbaseshell.j2
@@ -15,7 +15,7 @@
 # See: https://issues.apache.org/jira/browse/HBASE-4163
 # Creates 4GB files.
 create "{{ table_name }}", {NAME => "{{ family }}"{% if use_snappy %}, COMPRESSION => 'snappy'{% endif %} },
-       {SPLITS => (1..{{ n_splits }}).map {|i| "user#{1000+i*(9999-1000)/{{n_splits}}}"},
-        MAX_FILESIZE => 4*1024**3};
+       {SPLITS => (1..{{ n_splits }}).map {|i| "user#{1000+i*(9999-1000)/{{n_splits}}}"}{%if limit_filesize %},
+        MAX_FILESIZE => 4*1024**3{% endif %}};
 
 exit;


### PR DESCRIPTION
This is recommended, and is now supported by the Bigtable client.