### PR TITLE
Fix String Comparison in Object Storage Benchmark

### DIFF
--- a/perfkitbenchmarker/benchmarks/object_storage_service_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/object_storage_service_benchmark.py
@@ -891,7 +891,7 @@ def Prepare(benchmark_spec):
   FLAGS.boto_file_location = os.path.expanduser(FLAGS.boto_file_location)
 
   if not os.path.isfile(FLAGS.boto_file_location):
-    if FLAGS.storage is not benchmark_spec_class.AZURE:
+    if FLAGS.storage != benchmark_spec_class.AZURE:
       raise errors.Benchmarks.MissingObjectCredentialException(
           'Boto file cannot be found in %s but it is required for gcs or s3.',
           FLAGS.boto_file_location)


### PR DESCRIPTION
The benchmark is meant to give an error when the user wants to store
data in GCS or S3 but does not have a boto file. This commit fixes a
bug where it would also throw an error if the user wants to store data
in the Azure Blob Service but does not have a boto file.