### PR TITLE
rackspace: Remove extra parameter in constructor for firewall implementation

### DIFF
--- a/perfkitbenchmarker/rackspace/rackspace_network.py
+++ b/perfkitbenchmarker/rackspace/rackspace_network.py
@@ -41,7 +41,7 @@ SSH_PORT = 22
 class RackspaceSecurityGroup(network.BaseFirewall):
     """An object representing the Rackspace Security Group."""
 
-    def __init__(self, project):
+    def __init__(self):
         """Initialize Rackspace security group class."""
         self._lock = threading.Lock()
         self.firewall_names = set()


### PR DESCRIPTION
Removes vestigial parameter on the constructor for Rackspace's Firewall
implementation, which made PKB exit with __init__ error.

This is a fix for the following error that seems to have sneaked in due to lack of testing on Rackspace.

```
    firewalls_dict[cls] = cls()
TypeError: __init__() takes exactly 2 arguments (1 given)
```