### PR TITLE
Fio robustremotecommand

### DIFF
--- a/perfkitbenchmarker/benchmarks/fio_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/fio_benchmark.py
@@ -188,7 +188,7 @@ def FillDevice(vm, disk, fill_size):
   """Fill the given disk on the given vm up to fill_size.
 
   Args:
-    vm: a virtual_machine.VirtualMachine object.
+    vm: a linux_virtual_machine.BaseLinuxMixin object.
     disk: a disk.BaseDisk attached to the given vm.
     fill_size: amount of device to fill, in fio format.
   """
@@ -198,7 +198,7 @@ def FillDevice(vm, disk, fill_size):
               '--rw=write --direct=1 --size=%s') %
              (fio.FIO_PATH, disk.GetDevicePath(), fill_size))
 
-  vm.RemoteCommand(command)
+  vm.RobustRemoteCommand(command)
 
 
 BENCHMARK_INFO = {'name': 'fio',
@@ -481,7 +481,7 @@ def Run(benchmark_spec):
       logging.info('**** Repetition number %s of %s ****',
                    repeat_number, total_repeats)
 
-    stdout, stderr = vm.RemoteCommand(fio_command, should_log=True)
+    stdout, stderr = vm.RobustRemoteCommand(fio_command, should_log=True)
 
     if repeat_number:
       base_metadata = {

--- a/perfkitbenchmarker/linux_virtual_machine.py
+++ b/perfkitbenchmarker/linux_virtual_machine.py
@@ -103,7 +103,7 @@ class BaseLinuxMixin(virtual_machine.BaseOsMixin):
                                             os.path.basename(f)))
         self._has_remote_command_script = True
 
-  def RobustRemoteCommand(self, command):
+  def RobustRemoteCommand(self, command, should_log=False):
     """Runs a command on the VM in a more robust way than RemoteCommand.
 
     Executes a command via a pair of scripts on the VM:
@@ -115,6 +115,9 @@ class BaseLinuxMixin(virtual_machine.BaseOsMixin):
 
     Temporary SSH failures (where ssh returns a 255) while waiting for the
     command to complete will be tolerated and safely retried.
+
+    If should_log is True, log the command's output at the info
+    level. If False, log the command's output at the debug level.
     """
     self._PushRobustCommandScripts()
 
@@ -151,7 +154,8 @@ class BaseLinuxMixin(virtual_machine.BaseOsMixin):
       return self.RemoteCommand(' '.join(wait_command), should_log=False)
     except:
       # In case the error was with the wrapper script itself, print the log.
-      stdout, _ = self.RemoteCommand('cat %s' % wrapper_log, should_log=False)
+      stdout, _ = self.RemoteCommand('cat %s' % wrapper_log,
+                                     should_log=should_log)
       if stdout.strip():
         logging.warn('Exception during RobustRemoteCommand. '
                      'Wrapper script log:\n%s', stdout)

--- a/perfkitbenchmarker/linux_virtual_machine.py
+++ b/perfkitbenchmarker/linux_virtual_machine.py
@@ -151,11 +151,10 @@ class BaseLinuxMixin(virtual_machine.BaseOsMixin):
                     '--status', status_file,
                     '--delete']
     try:
-      return self.RemoteCommand(' '.join(wait_command), should_log=False)
+      return self.RemoteCommand(' '.join(wait_command), should_log=should_log)
     except:
       # In case the error was with the wrapper script itself, print the log.
-      stdout, _ = self.RemoteCommand('cat %s' % wrapper_log,
-                                     should_log=should_log)
+      stdout, _ = self.RemoteCommand('cat %s' % wrapper_log, should_log=False)
       if stdout.strip():
         logging.warn('Exception during RobustRemoteCommand. '
                      'Wrapper script log:\n%s', stdout)


### PR DESCRIPTION
Add a should_log option to vm.RobustRemoteCommand, which is passed through to the vm.RemoteCommand call. Then use RobustRemoteCommand in fio_benchmark.py to hopefully be more robust to ssh timeouts.