### PR TITLE
Allow benchmark specific flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,6 +687,29 @@ iperf:
         - *vm1
 ```
 
+SPECIFYING FLAGS IN CONFIGURATION FILES
+=================
+You can now specify flags in configuration files by using the `flags` key at the
+top level in a benchmark config. The expected value is a dictionary mapping
+flag names to their new default values. The flags are only defaults; it's still
+possible to override them via the command line. It's even possible to specify
+conflicting values of the same flag in different benchmarks:
+
+```
+iperf:
+  flags:
+    machine_type: n1-standard-2
+    zone: us-central1-b
+    iperf_sending_thread_count: 2
+
+netperf:
+  flags:
+    machine_type: n1-standard-8
+```
+
+The new defaults will only apply to the benchmark in which they are specified.
+
+
 HOW TO EXTEND PerfKitBenchmarker
 =================
 First start with the [CONTRIBUTING.md] (https://github.com/GoogleCloudPlatform/PerfKitBenchmarker/blob/master/CONTRIBUTING.md)

--- a/perfkitbenchmarker/__init__.py
+++ b/perfkitbenchmarker/__init__.py
@@ -12,5 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import gflags as flags  # NOQA
 import gflags_validators as flags_validators  # NOQA
+
+from perfkitbenchmarker import context
+
+# This replaces the flags module with an object which acts like
+# the flags module. This allows us to intercept calls to flags.FLAGS
+# and return our own FlagValuesProxy instance in place of the global
+# FlagValues instance. This enables benchmarks to run with different
+# and even conflicting flags.
+flags = context.FlagsModuleProxy()

--- a/perfkitbenchmarker/benchmarks/bonnie_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/bonnie_benchmark.py
@@ -17,11 +17,9 @@
 import logging
 
 from perfkitbenchmarker import configs
-from perfkitbenchmarker import flags
 from perfkitbenchmarker import regex_util
 from perfkitbenchmarker import sample
 
-FLAGS = flags.FLAGS
 
 BENCHMARK_NAME = 'bonnie++'
 BENCHMARK_CONFIG = """

--- a/perfkitbenchmarker/benchmarks/cluster_boot_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/cluster_boot_benchmark.py
@@ -17,11 +17,9 @@
 import logging
 
 from perfkitbenchmarker import configs
-from perfkitbenchmarker import flags
 from perfkitbenchmarker import vm_util
 from perfkitbenchmarker import sample
 
-FLAGS = flags.FLAGS
 
 BENCHMARK_NAME = 'cluster_boot'
 BENCHMARK_CONFIG = """

--- a/perfkitbenchmarker/benchmarks/sysbench_oltp_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/sysbench_oltp_benchmark.py
@@ -21,10 +21,7 @@ import logging
 import re
 
 from perfkitbenchmarker import configs
-from perfkitbenchmarker import flags
 from perfkitbenchmarker import sample
-
-FLAGS = flags.FLAGS
 
 BENCHMARK_NAME = 'sysbench_oltp'
 BENCHMARK_CONFIG = """

--- a/perfkitbenchmarker/configs/__init__.py
+++ b/perfkitbenchmarker/configs/__init__.py
@@ -210,6 +210,22 @@ def MergeConfigs(default_config, override_config, warn_new_key=False):
     return default_config
 
 
+def GetMergedFlags(config):
+  """Returns a copy of the flags.FLAGS merged with those in the config."""
+  config_flags = config.get('flags')
+  flags_values = copy.deepcopy(flags.GLOBAL_FLAGS)
+
+  if config_flags:
+    for key, value in config_flags.iteritems():
+      if key not in flags_values:
+        raise ValueError('Flag "%s" is not defined.' % key)
+      if not flags_values[key].present:
+        flags_values[key].value = value
+        flags_values[key].present += 1
+
+  return flags_values
+
+
 def LoadMinimalConfig(benchmark_config, benchmark_name):
   """Loads a benchmark config without using any flags in the process.
 

--- a/perfkitbenchmarker/context.py
+++ b/perfkitbenchmarker/context.py
@@ -1,0 +1,107 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for working with the current thread context."""
+
+import threading
+
+import gflags as flags
+
+
+class FlagsModuleProxy(object):
+  """Class which acts as a proxy for the flags module.
+
+  When the FLAGS attribute is accessed, BENCHMARK_FLAGS will be returned
+  rather than the global FlagValues object. BENCHMARK_FLAGS is an instance
+  of FlagValuesProxy, which enables benchmarks to run with different and
+  even conflicting flags. Accessing the GLOBAL_FLAGS attribute will return
+  the global FlagValues object. Otherwise, this will behave just like the
+  flags module.
+  """
+
+  def __getattr__(self, name):
+    if name == 'FLAGS':
+      return BENCHMARK_FLAGS
+    elif name == 'GLOBAL_FLAGS':
+      return flags.FLAGS
+    return flags.__dict__[name]
+
+
+class FlagValuesProxy(object):
+  """Class which provides the same interface as FlagValues.
+
+  By acting as a proxy for the FlagValues object (i.e. flags.FLAGS),
+  this enables benchmark specific flags. This proxy attempts to
+  use the current thread's BenchmarkSpec's FlagValues object, but
+  falls back to using flags.FLAGS if the thread has no BenchmarkSpec
+  object.
+  """
+
+  @property
+  def _thread_flag_values(self):
+    """Returns the correct FlagValues object for the current thread.
+
+    This first tries to get the BenchmarkSpec object corresponding to the
+    current thread. If there is one, it returns that spec's FlagValues
+    object. If there isn't one, it will return the global FlagValues
+    object.
+    """
+    benchmark_spec = GetThreadBenchmarkSpec()
+    if benchmark_spec:
+      return benchmark_spec.FLAGS
+    else:
+      return flags.FLAGS
+
+  def __setattr__(self, name, value):
+    self._thread_flag_values.__setattr__(name, value)
+
+  def __getattr__(self, name):
+    return self._thread_flag_values.__getattr__(name)
+
+  def __setitem__(self, key, value):
+    self._thread_flag_values.__setitem__(key, value)
+
+  def __getitem__(self, key):
+    return self._thread_flag_values.__getitem__(key)
+
+  def __call__(self, argv):
+    return self._thread_flag_values.__call__(argv)
+
+  def FlagDict(self):
+    return self._thread_flag_values.FlagDict()
+
+
+BENCHMARK_FLAGS = FlagValuesProxy()
+
+
+class _ThreadData(threading.local):
+  def __init__(self):
+    self.benchmark_spec = None
+
+
+_thread_local = _ThreadData()
+
+
+def SetThreadBenchmarkSpec(benchmark_spec):
+  """Sets the current thread's BenchmarkSpec object."""
+  _thread_local.benchmark_spec = benchmark_spec
+
+
+def GetThreadBenchmarkSpec():
+  """Gets the current thread's BenchmarkSpec object.
+
+  If SetThreadBenchmarkSpec() has not been called in either the current thread
+  or in an ancestor, then this method will return None by default.
+  """
+  return _thread_local.benchmark_spec

--- a/perfkitbenchmarker/flag_util.py
+++ b/perfkitbenchmarker/flag_util.py
@@ -179,8 +179,8 @@ class IntegerListSerializer(flags.ArgumentSerializer):
                      for val in il.groups])
 
 
-def DEFINE_integerlist(name, default, help,
-                       on_nonincreasing=None, flag_values=flags.FLAGS, **args):
+def DEFINE_integerlist(name, default, help, on_nonincreasing=None,
+                       flag_values=flags.GLOBAL_FLAGS, **args):
   """Register a flag whose value must be an integer list."""
 
   parser = IntegerListParser(on_nonincreasing=on_nonincreasing)

--- a/perfkitbenchmarker/linux_virtual_machine.py
+++ b/perfkitbenchmarker/linux_virtual_machine.py
@@ -56,8 +56,6 @@ REMOTE_KEY_PATH = '.ssh/id_rsa'
 CONTAINER_MOUNT_DIR = '/mnt'
 CONTAINER_WORK_DIR = '/root'
 
-FLAGS = flags.FLAGS
-
 # This pair of scripts used for executing long-running commands, which will be
 # resilient in the face of SSH connection errors.
 # EXECUTE_COMMAND runs a command, streaming stdout / stderr to a file, then

--- a/perfkitbenchmarker/network.py
+++ b/perfkitbenchmarker/network.py
@@ -22,10 +22,6 @@ same project.
 
 import threading
 
-from perfkitbenchmarker import flags
-
-FLAGS = flags.FLAGS
-
 
 class BaseFirewall(object):
   """An object representing the Base Firewall."""

--- a/perfkitbenchmarker/packages/hadoop.py
+++ b/perfkitbenchmarker/packages/hadoop.py
@@ -24,12 +24,8 @@ import re
 import time
 
 from perfkitbenchmarker import data
-from perfkitbenchmarker import flags
 from perfkitbenchmarker import regex_util
 from perfkitbenchmarker import vm_util
-
-
-FLAGS = flags.FLAGS
 
 HADOOP_VERSION = '2.5.2'
 HADOOP_URL = ('http://www.us.apache.org/dist/hadoop/common/hadoop-{0}/'

--- a/perfkitbenchmarker/packages/hbase.py
+++ b/perfkitbenchmarker/packages/hbase.py
@@ -22,11 +22,8 @@ import os
 import posixpath
 
 from perfkitbenchmarker import data
-from perfkitbenchmarker import flags
 from perfkitbenchmarker import vm_util
 from perfkitbenchmarker.packages import hadoop
-
-FLAGS = flags.FLAGS
 
 HBASE_VERSION = '1.0.2'
 HBASE_URL = ('http://www.us.apache.org/dist/hbase/hbase-{0}/'

--- a/perfkitbenchmarker/traces/dstat.py
+++ b/perfkitbenchmarker/traces/dstat.py
@@ -27,8 +27,6 @@ from perfkitbenchmarker import events
 from perfkitbenchmarker import flags
 from perfkitbenchmarker import vm_util
 
-FLAGS = flags.FLAGS
-
 flags.DEFINE_boolean('dstat', False,
                      'Run dstat (http://dag.wiee.rs/home-made/dstat/) '
                      'on each VM to collect system performance metrics during '

--- a/perfkitbenchmarker/windows_benchmarks/cluster_boot_benchmark.py
+++ b/perfkitbenchmarker/windows_benchmarks/cluster_boot_benchmark.py
@@ -23,11 +23,8 @@ Linux to share code.
 import logging
 
 from perfkitbenchmarker import configs
-from perfkitbenchmarker import flags
 from perfkitbenchmarker import vm_util
 from perfkitbenchmarker import sample
-
-FLAGS = flags.FLAGS
 
 BENCHMARK_NAME = 'cluster_boot'
 BENCHMARK_CONFIG = """

--- a/tests/benchmark_spec_test.py
+++ b/tests/benchmark_spec_test.py
@@ -17,6 +17,7 @@ import unittest
 
 from perfkitbenchmarker import benchmark_spec
 from perfkitbenchmarker import configs
+from perfkitbenchmarker import context
 from perfkitbenchmarker import static_virtual_machine as static_vm
 from perfkitbenchmarker.aws import aws_virtual_machine as aws_vm
 from perfkitbenchmarker.gcp import gce_virtual_machine as gce_vm
@@ -82,6 +83,10 @@ name:
 
 
 class ConstructVmsTestCase(unittest.TestCase):
+
+  def setUp(self):
+    # Reset the current benchmark spec.
+    self.addCleanup(context.SetThreadBenchmarkSpec, None)
 
   def testSimpleConfig(self):
     config = configs.LoadConfig(SIMPLE_CONFIG, {}, NAME)

--- a/tests/context_test.py
+++ b/tests/context_test.py
@@ -1,0 +1,66 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for perfkitbenchmarker.context."""
+
+import types
+import unittest
+
+import mock
+
+from perfkitbenchmarker import context
+from perfkitbenchmarker import vm_util
+
+
+class FlagModuleProxyTestCase(unittest.TestCase):
+
+  def setUp(self):
+    self.flags_module = context.FlagsModuleProxy()
+
+  def testGetAttributes(self):
+    self.assertIsInstance(self.flags_module.FLAGS, context.FlagValuesProxy)
+    self.assertIsInstance(self.flags_module.GLOBAL_FLAGS,
+                          self.flags_module.FlagValues)
+    self.assertEqual(type(self.flags_module.DEFINE_string),
+                     types.FunctionType)
+
+
+class ThreadLocalBenchmarkSpecTestCase(unittest.TestCase):
+
+  def setUp(self):
+    # Reset the current benchmark spec.
+    self.addCleanup(context.SetThreadBenchmarkSpec, None)
+
+  def testSetGet(self):
+    benchmark_spec = mock.MagicMock()
+    context.SetThreadBenchmarkSpec(benchmark_spec)
+    self.assertEqual(benchmark_spec, context.GetThreadBenchmarkSpec())
+
+  def testPropagation(self):
+    benchmark_spec = mock.MagicMock()
+    context.SetThreadBenchmarkSpec(benchmark_spec)
+
+    def _DoWork(_):
+      self.assertEqual(benchmark_spec, context.GetThreadBenchmarkSpec())
+      new_benchmark_spec = mock.MagicMock()
+      context.SetThreadBenchmarkSpec(new_benchmark_spec)
+      self.assertNotEqual(benchmark_spec, context.GetThreadBenchmarkSpec())
+      self.assertEqual(new_benchmark_spec,
+                       context.GetThreadBenchmarkSpec())
+
+    vm_util.RunThreaded(_DoWork, range(10))
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
```
./pkb.py --config_override="benchmarks=[{iperf: {flags: {iperf_sending_thread_count: 2}}}, {iperf: {flags: {iperf_sending_thread_count: 4}}}]" --parallelism=2
.....
.....
.....
-------------------------PerfKitBenchmarker Results Summary-------------------------
IPERF:
  receiving_machine_type="n1-standard-1" receiving_zone="us-central1-a" runtime_in_seconds="60" sending_machine_type="n1-standard-1" sending_zone="us-central1-a"
  Throughput                         1919.000000 Mbits/sec                      (ip_type="external" sending_thread_count="4")
  Throughput                         1993.000000 Mbits/sec                      (ip_type="internal" sending_thread_count="4")
  Throughput                         1955.000000 Mbits/sec                      (ip_type="external" sending_thread_count="4")
  Throughput                         1992.000000 Mbits/sec                      (ip_type="internal" sending_thread_count="4")
  Throughput                         1909.000000 Mbits/sec                      (ip_type="external" sending_thread_count="2")
  Throughput                         1997.000000 Mbits/sec                      (ip_type="internal" sending_thread_count="2")
  Throughput                         1758.000000 Mbits/sec                      (ip_type="external" sending_thread_count="2")
  Throughput                         1997.000000 Mbits/sec                      (ip_type="internal" sending_thread_count="2")
  End to End Runtime                  496.858173 seconds                       
  End to End Runtime                  518.701941 seconds                       

-------------------------
```