### PR TITLE
Specifying SSH port when executing SCP command.

### DIFF
--- a/perfkitbenchmarker/linux_virtual_machine.py
+++ b/perfkitbenchmarker/linux_virtual_machine.py
@@ -392,8 +392,9 @@ class BaseLinuxMixin(virtual_machine.BaseOsMixin):
     #     OpenMPI to operate correctly.
     remote_location = '%s@%s:%s' % (
         target.user_name, target.ip_address, remote_path)
-    self.RemoteHostCommand('scp -o StrictHostKeyChecking=no -i %s %s %s' %
-                           (REMOTE_KEY_PATH, source_path, remote_location))
+    self.RemoteHostCommand('scp -P %s -o StrictHostKeyChecking=no -i %s %s %s' %
+                           (target.ssh_port, REMOTE_KEY_PATH, source_path,
+                            remote_location))
 
   def AuthenticateVm(self):
     """Authenticate a remote machine to access all peers."""


### PR DESCRIPTION
This was already done in RemoteHostCopy() method, but was not implemented
in MoveHostFile().

This resolves https://github.com/GoogleCloudPlatform/PerfKitBenchmarker/issues/547

Signed-off-by: Mateusz Blaszkowski <mateusz.blaszkowski@intel.com>