### PR TITLE
Introduce GCE disk integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -724,6 +724,22 @@ file we have added a lot of comments into the code to make it easy to;
 
 Even with lots of comments we make to support more detailed documention.  You will find the documatation we have on the [Wiki pages] (https://github.com/GoogleCloudPlatform/PerfKitBenchmarker/wiki).  Missing documentation you want?  Start a page and/or open an [issue] (https://github.com/GoogleCloudPlatform/PerfKitBenchmarker/issues) to get it added.
 
+INTEGRATION TESTING
+===================
+
+In addition to regular unit tests, which are run via `hooks/check-everything`,
+PerfKitBenchmarker has integration tests, which create actual cloud resources
+and take time and money to run. For this reason, they will only run when the
+variable PERFKIT_INTEGRATION is defined in the environment. For instance, the
+command
+
+  `PERFKIT_INTEGRATION=1 hooks/check-everything`
+
+will run the integration tests. The integration tests depend on having installed
+and configured all of the relevant cloud provider SDKs, and will fail if you
+have not done so.
+
+
 PLANNED IMPROVEMENTS
 =======================
 Many... please add new requests via GitHub issues.

--- a/perfkitbenchmarker/benchmark_spec.py
+++ b/perfkitbenchmarker/benchmark_spec.py
@@ -365,7 +365,7 @@ class BenchmarkSpec(object):
     vm.AddMetadata(benchmark=self.uid)
     vm.WaitForBootCompletion()
     vm.OnStartup()
-    if FLAGS.scratch_disk_type == disk.LOCAL:
+    if any((d.disk_type == disk.LOCAL for d in vm.disk_specs)):
       vm.SetupLocalDisks()
     for disk_spec in vm.disk_specs:
       vm.CreateScratchDisk(disk_spec)

--- a/perfkitbenchmarker/benchmark_spec.py
+++ b/perfkitbenchmarker/benchmark_spec.py
@@ -393,7 +393,7 @@ class BenchmarkSpec(object):
     vm.AddMetadata(benchmark=self.uid, perfkit_uuid=self.uuid)
     vm.WaitForBootCompletion()
     vm.OnStartup()
-    if any((d.disk_type == disk.LOCAL for d in vm.disk_specs)):
+    if any((spec.disk_type == disk.LOCAL for spec in vm.disk_specs)):
       vm.SetupLocalDisks()
     for disk_spec in vm.disk_specs:
       vm.CreateScratchDisk(disk_spec)

--- a/perfkitbenchmarker/errors.py
+++ b/perfkitbenchmarker/errors.py
@@ -21,6 +21,22 @@ class Error(Exception):
   pass
 
 
+class Setup(object):
+  """Errors raised in setting up PKB."""
+
+  class MissingExecutableError(Error):
+    """Error raised when we cannot find an executable we need."""
+    pass
+
+  class NoRunURIError(Error):
+    """Error raised when we were not given a run_uri and cannot infer it."""
+    pass
+
+  class BadRunURIError(Error):
+    """Error raised when the given run_uri is invalid."""
+    pass
+
+
 class VirtualMachine(object):
   """Errors raised by virtual_machine.py."""
 

--- a/perfkitbenchmarker/pkb.py
+++ b/perfkitbenchmarker/pkb.py
@@ -65,6 +65,7 @@ from perfkitbenchmarker import benchmark_sets
 from perfkitbenchmarker import benchmark_spec
 from perfkitbenchmarker import configs
 from perfkitbenchmarker import disk
+from perfkitbenchmarker import errors
 from perfkitbenchmarker import events
 from perfkitbenchmarker import flags
 from perfkitbenchmarker import log_util
@@ -331,23 +332,17 @@ def _LogCommandLineFlags():
   logging.info('Flag values:\n%s', '\n'.join(result))
 
 
-def RunBenchmarks(publish=True):
-  """Runs all benchmarks in PerfKitBenchmarker.
+def SetUpPKB():
+  """Set globals and environment variables for PKB.
 
-  Args:
-    publish: A boolean indicating whether results should be published.
-
-  Returns:
-    Exit status for the process.
+  Having this function separate from functions that do any work lets
+  us call this to set up integration tests.
   """
-  if FLAGS.version:
-    print version.VERSION
-    return
 
   for executable in REQUIRED_EXECUTABLES:
     if not vm_util.ExecutableOnPath(executable):
       logging.error('Could not find required executable "%s".' % executable)
-      return 1
+      raise errors.Error()
 
   if FLAGS.run_uri is None:
     if FLAGS.run_stage not in [STAGE_ALL, STAGE_PREPARE]:
@@ -361,13 +356,13 @@ def RunBenchmarks(publish=True):
       else:
         logging.error(
             'No run_uri specified. Could not run "%s".', FLAGS.run_stage)
-        return 1
+        raise errors.Error()
     else:
       FLAGS.run_uri = str(uuid.uuid4())[-8:]
   elif not FLAGS.run_uri.isalnum() or len(FLAGS.run_uri) > MAX_RUN_URI_LENGTH:
     logging.error('run_uri must be alphanumeric and less than or equal '
                   'to 8 characters in length.')
-    return 1
+    raise errors.Error()
 
   vm_util.GenTempDir()
   log_util.ConfigureLogging(
@@ -375,6 +370,26 @@ def RunBenchmarks(publish=True):
       log_path=vm_util.PrependTempDir(LOG_FILE_NAME),
       run_uri=FLAGS.run_uri)
   logging.info('PerfKitBenchmarker version: %s', version.VERSION)
+
+  vm_util.SSHKeyGen()
+
+  events.initialization_complete.send(parsed_flags=FLAGS)
+
+
+def RunBenchmarks(publish=True):
+
+  """Runs all benchmarks in PerfKitBenchmarker.
+
+  Args:
+    publish: A boolean indicating whether results should be published.
+
+  Returns:
+    Exit status for the process.
+  """
+  if FLAGS.version:
+    print version.VERSION
+    return
+
   _LogCommandLineFlags()
 
   if FLAGS.os_type == benchmark_spec.WINDOWS and not vm_util.RunningOnWindows():
@@ -382,9 +397,7 @@ def RunBenchmarks(publish=True):
                   'running on Windows.')
     return 1
 
-  vm_util.SSHKeyGen()
   collector = SampleCollector()
-  events.initialization_complete.send(parsed_flags=FLAGS)
 
   if FLAGS.static_vm_file:
     with open(FLAGS.static_vm_file) as fp:
@@ -489,6 +502,12 @@ def Main(argv=sys.argv):
   except flags.FlagsError as e:
     logging.error(
         '%s\nUsage: %s ARGS\n%s', e, sys.argv[0], FLAGS)
+    sys.exit(1)
+
+  try:
+    SetUpPKB()
+  except Exception as e:
+    logging.error('Got exception %s', e)
     sys.exit(1)
 
   return RunBenchmarks()

--- a/perfkitbenchmarker/pkb.py
+++ b/perfkitbenchmarker/pkb.py
@@ -340,7 +340,7 @@ def SetUpPKB():
   """Set globals and environment variables for PKB.
 
   After SetUpPKB() returns, it should be possible to call PKB
-  functions, like benchark_spec.Prepare() or benchmark_spec.Run().
+  functions, like benchmark_spec.Prepare() or benchmark_spec.Run().
 
   SetUpPKB() also modifies the local file system by creating a temp
   directory and storing new SSH keys.

--- a/perfkitbenchmarker/test_util.py
+++ b/perfkitbenchmarker/test_util.py
@@ -71,7 +71,23 @@ class SamplesTestMixin(object):
         raise ex
 
 
-def testDiskMounts(benchmark_config, mount_point):
+def assertDiskMounts(benchmark_config, mount_point):
+  """Test whether a disk mounts in a given configuration.
+
+  Sets up a virtual machine following benchmark_config and then tests
+  whether the path mount_point contains a working disk by trying to
+  create a file there. Returns nothing if file creation works;
+  otherwise raises an exception.
+
+  Args:
+    benchmark_config: a dict in the format of benchmark_spec.BenchmarkSpec.
+    mount_point: a path, represented as a string.
+
+  Raises:
+    RemoteCommandError if it cannot create a file at mount_point and
+    verify that the file exists.
+  """
+
   spec = benchmark_spec.BenchmarkSpec(benchmark_config, 'uid')
 
   try:

--- a/perfkitbenchmarker/test_util.py
+++ b/perfkitbenchmarker/test_util.py
@@ -80,13 +80,22 @@ def assertDiskMounts(benchmark_config, mount_point):
   otherwise raises an exception.
 
   Args:
-    benchmark_config: a dict in the format of benchmark_spec.BenchmarkSpec.
+    benchmark_config: a dict in the format of
+      benchmark_spec.BenchmarkSpec. The config must specify exactly
+      one virtual machine.
     mount_point: a path, represented as a string.
 
   Raises:
     RemoteCommandError if it cannot create a file at mount_point and
     verify that the file exists.
+
+    AssertionError if benchmark_config does not specify exactly one
+    virtual machine.
   """
+
+  assert len(benchmark_config['vm_groups']) == 1
+  vm_group = benchmark_config['vm_groups'].itervalues().next()
+  assert vm_group.get('num_vms', 1) == 1
 
   spec = benchmark_spec.BenchmarkSpec(benchmark_config, 'uid')
 

--- a/tests/aws_disk_integration_test.py
+++ b/tests/aws_disk_integration_test.py
@@ -1,0 +1,95 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for AWS scratch disks."""
+
+import os
+import unittest
+
+from perfkitbenchmarker import pkb
+from perfkitbenchmarker import test_util
+
+MOUNT_POINT = '/scratch'
+
+
+@unittest.skipUnless('PERFKIT_INTEGRATION' in os.environ,
+                     'PERFKIT_INTEGRATION not in environment')
+class AwsScratchDiskIntegrationTest(unittest.TestCase):
+  def setUp(self):
+    pkb.SetUpPKB()
+
+  def testEBSStandard(self):
+    test_util.testDiskMounts({
+        'vm_groups': {
+            'vm_group_1': {
+                'cloud': 'AWS',
+                'vm_spec': {
+                    'AWS': {
+                        'machine_type': 'm4.large',
+                        'zone': 'us-east-1a'
+                    }
+                },
+                'disk_spec': {
+                    'AWS': {
+                        'disk_type': 'standard',
+                        'disk_size': 2,
+                        'mount_point': MOUNT_POINT
+                    }
+                }
+            }
+        }
+    }, MOUNT_POINT)
+
+  def testEBSGP(self):
+    test_util.testDiskMounts({
+        'vm_groups': {
+            'vm_group_1': {
+                'cloud': 'AWS',
+                'vm_spec': {
+                    'AWS': {
+                        'machine_type': 'm4.large',
+                        'zone': 'us-east-1a'
+                    }
+                },
+                'disk_spec': {
+                    'AWS': {
+                        'disk_type': 'remote_ssd',
+                        'disk_size': 2,
+                        'mount_point': MOUNT_POINT
+                    }
+                }
+            }
+        }
+    }, MOUNT_POINT)
+
+  def testLocalSSD(self):
+    test_util.testDiskMounts({
+        'vm_groups': {
+            'vm_group_1': {
+                'cloud': 'AWS',
+                'vm_spec': {
+                    'AWS': {
+                        'machine_type': 'm3.medium',
+                        'zone': 'us-east-1a'
+                    }
+                },
+                'disk_spec': {
+                    'AWS': {
+                        'disk_type': 'local',
+                        'mount_point': MOUNT_POINT
+                    }
+                }
+            }
+        }
+    }, MOUNT_POINT)

--- a/tests/aws_disk_integration_test.py
+++ b/tests/aws_disk_integration_test.py
@@ -26,11 +26,16 @@ MOUNT_POINT = '/scratch'
 @unittest.skipUnless('PERFKIT_INTEGRATION' in os.environ,
                      'PERFKIT_INTEGRATION not in environment')
 class AwsScratchDiskIntegrationTest(unittest.TestCase):
+  """Integration tests for AWS disks.
+
+  Please see the section on integration testing in the README.
+  """
+
   def setUp(self):
     pkb.SetUpPKB()
 
   def testEBSStandard(self):
-    test_util.testDiskMounts({
+    test_util.assertDiskMounts({
         'vm_groups': {
             'vm_group_1': {
                 'cloud': 'AWS',
@@ -52,7 +57,7 @@ class AwsScratchDiskIntegrationTest(unittest.TestCase):
     }, MOUNT_POINT)
 
   def testEBSGP(self):
-    test_util.testDiskMounts({
+    test_util.assertDiskMounts({
         'vm_groups': {
             'vm_group_1': {
                 'cloud': 'AWS',
@@ -74,7 +79,7 @@ class AwsScratchDiskIntegrationTest(unittest.TestCase):
     }, MOUNT_POINT)
 
   def testLocalSSD(self):
-    test_util.testDiskMounts({
+    test_util.assertDiskMounts({
         'vm_groups': {
             'vm_group_1': {
                 'cloud': 'AWS',

--- a/tests/gce_disk_integration_test.py
+++ b/tests/gce_disk_integration_test.py
@@ -1,0 +1,96 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for GCE scratch disks."""
+
+import os
+import unittest
+
+from perfkitbenchmarker import pkb
+from perfkitbenchmarker import test_util
+
+MOUNT_POINT = '/scratch'
+
+
+@unittest.skipUnless('PERFKIT_INTEGRATION' in os.environ,
+                     'PERFKIT_INTEGRATION not in environment')
+class GcpScratchDiskIntegrationTest(unittest.TestCase):
+  def setUp(self):
+    pkb.SetUpPKB()
+
+  def testPDStandard(self):
+    test_util.testDiskMounts({
+        'vm_groups': {
+            'vm_group_1': {
+                'cloud': 'GCP',
+                'vm_spec': {
+                    'GCP': {
+                        'machine_type': 'n1-standard-2',
+                        'zone': 'us-central1-a'
+                    }
+                },
+                'disk_spec': {
+                    'GCP': {
+                        'disk_type': 'standard',
+                        'disk_size': 2,
+                        'mount_point': MOUNT_POINT
+                    }
+                }
+            }
+        }
+    }, MOUNT_POINT)
+
+  def testPDSSD(self):
+    test_util.testDiskMounts({
+        'vm_groups': {
+            'vm_group_1': {
+                'cloud': 'GCP',
+                'vm_spec': {
+                    'GCP': {
+                        'machine_type': 'n1-standard-2',
+                        'zone': 'us-central1-a'
+                    }
+                },
+                'disk_spec': {
+                    'GCP': {
+                        'disk_type': 'remote_ssd',
+                        'disk_size': 2,
+                        'mount_point': MOUNT_POINT
+                    }
+                }
+            }
+        }
+    }, MOUNT_POINT)
+
+  def testLocalSSD(self):
+    test_util.testDiskMounts({
+        'vm_groups': {
+            'vm_group_1': {
+                'cloud': 'GCP',
+                'vm_spec': {
+                    'GCP': {
+                        'machine_type': 'n1-standard-2',
+                        'zone': 'us-central1-a',
+                        'num_local_ssds': 1
+                    }
+                },
+                'disk_spec': {
+                    'GCP': {
+                        'disk_type': 'local',
+                        'mount_point': MOUNT_POINT
+                    }
+                }
+            }
+        }
+    }, MOUNT_POINT)

--- a/tests/gce_disk_integration_test.py
+++ b/tests/gce_disk_integration_test.py
@@ -26,11 +26,16 @@ MOUNT_POINT = '/scratch'
 @unittest.skipUnless('PERFKIT_INTEGRATION' in os.environ,
                      'PERFKIT_INTEGRATION not in environment')
 class GcpScratchDiskIntegrationTest(unittest.TestCase):
+  """Integration tests for GCE disks.
+
+  Please see the section on integration testing in the README.
+  """
+
   def setUp(self):
     pkb.SetUpPKB()
 
   def testPDStandard(self):
-    test_util.testDiskMounts({
+    test_util.assertDiskMounts({
         'vm_groups': {
             'vm_group_1': {
                 'cloud': 'GCP',
@@ -52,7 +57,7 @@ class GcpScratchDiskIntegrationTest(unittest.TestCase):
     }, MOUNT_POINT)
 
   def testPDSSD(self):
-    test_util.testDiskMounts({
+    test_util.assertDiskMounts({
         'vm_groups': {
             'vm_group_1': {
                 'cloud': 'GCP',
@@ -74,7 +79,7 @@ class GcpScratchDiskIntegrationTest(unittest.TestCase):
     }, MOUNT_POINT)
 
   def testLocalSSD(self):
-    test_util.testDiskMounts({
+    test_util.assertDiskMounts({
         'vm_groups': {
             'vm_group_1': {
                 'cloud': 'GCP',

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ envlist = py27,flake8
 usedevelop = True
 skip_install = True
 commands = nosetests {toxinidir}/tests []
+passenv = PERFKIT_INTEGRATION
 deps =
     -rrequirements.txt
     mock==1.0.1


### PR DESCRIPTION
Refactor pkb.py slightly to make it easy to initialize PKB without
running benchmarks. Use this ability to add a GCE disk integration test,
which uses configs to actually allocate a GCE VM with a disk attached
and check that everything worked properly. Add a convenience function in
test_util.py to make this easier.