### PR TITLE
Kubernetes: adapting provider to work with different versions of kubectl.

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,15 +160,17 @@ echo topsecretpassword > ~/.config/openstack-password.txt
 ```
 
 ## Kubernetes configuration and credentials
-Perfkit uses `kubectl` binary in order to communicate with Kubernetes cluster - you need to pass the path to `kubectl` binary using `--kubectl` flag.  
+Perfkit uses `kubectl` binary in order to communicate with Kubernetes cluster - you need to pass the path to `kubectl` binary using `--kubectl` flag. It's recommended to use version 1.0.1 (available to download here: https://storage.googleapis.com/kubernetes-release/release/v1.0.1/bin/linux/amd64/kubectl).
 Authentication to Kubernetes cluster is done via `kubeconfig` file (https://github.com/kubernetes/kubernetes/blob/release-1.0/docs/user-guide/kubeconfig-file.md). Its path is passed using `--kubeconfig` flag.
 
 **Image prerequisites**  
-Docker instances by default doesn't allow to SSH into them. Thus it is important to configure your Docker image so that it has SSH server installed. You can rely on `https://quay.io/repository/mateusz_blaszkowski/pkb-k8s ` while creating your own image.
+Docker instances by default don't allow to SSH into them. Thus it is important to configure your Docker image so that it has SSH server installed. You can rely on `https://quay.io/repository/mateusz_blaszkowski/pkb-k8s ` while creating your own image.
 
 **Kubernetes cluster configuration**  
 If your Kubernetes cluster is running on CoreOS:
+
 1. Fix `$PATH` environment variable so that the appropriate binaries can be found:
+
    ```
    sudo mkdir /etc/systemd/system/kubelet.service.d
    sudo vim /etc/systemd/system/kubelet.service.d/10-env.conf
@@ -185,10 +187,13 @@ If your Kubernetes cluster is running on CoreOS:
 Note that some benchmark require to run within a privileged container. By default Kubernetes doesn't allow to schedule Dockers in privileged mode - you have to add `--allow-privileged=true` flag to `kube-apiserver` and each `kubelet` startup commands.
 
 **Ceph integration**  
-Currently only Ceph volumes are supported. Running benchmarks which require scratch volume is only permitted if you have Kubernetes cluster integrated with Ceph. There are some configuration steps you need to follow before you will be able to spawn Kubernetes PODs with Ceph volume. On each of Kubernetes-Nodes do the following:
-1. Copy /etc/ceph directory from Ceph-host
+When you run benchmarks with standard scratch disk type (`--scratch_disk_type=standard` - which is a default option), Ceph storage will be used. There are some configuration steps you need to follow before you will be able to spawn Kubernetes PODs with Ceph volume. On each of Kubernetes-Nodes and on the machine which is running Perfkit benchmarks do the following:
+
+1. Copy `/etc/ceph` directory from Ceph-host  
 2. Install `ceph-common` package so that `rbd` command is available
+
   * If your Kubernetes cluster is running on CoreOS, then you need to create a bash script called `rbd` which will run `rbd` command inside a Docker container:
+
       ```
       #!/usr/bin/bash
       /usr/bin/docker run -v /etc/ceph:/etc/ceph -v /dev:/dev -v /sys:/sys  --net=host --privileged=true --rm=true ceph/rbd $@
@@ -209,7 +214,15 @@ Currently only Ceph volumes are supported. Running benchmarks which require scra
       sudo cp 50-rbd.rules /etc/udev/rules.d
       sudo reboot
       ```
-3. Create Ceph Secret which will be used by Kubernetes in order to authenticate with Ceph. Retrieve base64-encoded Ceph admin key:
+
+
+
+You have two Ceph authentication options available (http://kubernetes.io/v1.0/examples/rbd/README.html):
+
+1. Keyring - pass the path to the keyring file using `--ceph_keyring` flag
+2. Secret. In this case you have to create a secret first:
+
+   Retrieve base64-encoded Ceph admin key:
    ```
    ceph auth get-key client.admin | base64
    QVFEYnpPWlZWWnJLQVJBQXdtNDZrUDlJUFo3OXdSenBVTUdYNHc9PQ==  

--- a/perfkitbenchmarker/benchmark_sets.py
+++ b/perfkitbenchmarker/benchmark_sets.py
@@ -82,6 +82,13 @@ BENCHMARK_SETS = {
                          'cluster_boot', 'redis', 'cassandra_stress',
                          'object_storage_service', 'sysbench_oltp']
     },
+    'kubernetes_set': {
+        MESSAGE: 'Kubernetes benchmark set.',
+        BENCHMARK_LIST: ['block_storage_workload', 'cassandra_ycsb',
+                         'cassandra_stress', 'cluster_boot', 'fio', 'iperf',
+                         'mesh_network', 'mongodb_ycsb', 'netperf', 'redis',
+                         'sysbench_oltp']
+    },
     'mellanox_set': {
         MESSAGE: 'Mellanox benchmark set.',
         BENCHMARK_LIST: [STANDARD_SET]

--- a/perfkitbenchmarker/kubernetes/kubernetes_disk.py
+++ b/perfkitbenchmarker/kubernetes/kubernetes_disk.py
@@ -153,7 +153,7 @@ class CephDisk(KubernetesDisk):
           rbd_device = output[STDOUT].rstrip()
           break
 
-    cmd = ['mkfs.ext4', rbd_device]
+    cmd = ['/sbin/mkfs.ext4', rbd_device]
     output = vm_util.IssueCommand(cmd)
     if output[EXIT_CODE] != 0:
       raise Exception("Formatting partition failed: %s" % output[STDERR])

--- a/perfkitbenchmarker/kubernetes/kubernetes_disk.py
+++ b/perfkitbenchmarker/kubernetes/kubernetes_disk.py
@@ -188,7 +188,7 @@ class CephDisk(KubernetesDisk):
         }
     }
     if FLAGS.ceph_secret:
-      ceph_volume["rbd"]["secretRef"] = {"name" : FLAGS.ceph_secret}
+      ceph_volume["rbd"]["secretRef"] = {"name": FLAGS.ceph_secret}
     volumes.append(ceph_volume)
 
   def SetDevicePath(self, vm):

--- a/perfkitbenchmarker/kubernetes/kubernetes_disk.py
+++ b/perfkitbenchmarker/kubernetes/kubernetes_disk.py
@@ -26,10 +26,16 @@ FLAGS = flags.FLAGS
 
 flags.DEFINE_string('ceph_secret', None,
                     'Name of the Ceph Secret used by Kubernetes in order to '
-                    'authenticate with Ceph.')
+                    'authenticate with Ceph. If provided, overrides keyring.')
+
+flags.DEFINE_string('ceph_keyring', '/etc/ceph/keyring',
+                    'Path to the Ceph keyring file.')
 
 flags.DEFINE_string('rbd_pool', 'rbd',
                     'Name of RBD pool for Ceph volumes.')
+
+flags.DEFINE_string('rbd_user', 'admin',
+                    'Name of RADOS user.')
 
 flags.DEFINE_list('ceph_monitors', [],
                   'IP addresses and ports of Ceph Monitors. '
@@ -175,13 +181,14 @@ class CephDisk(KubernetesDisk):
             "monitors": FLAGS.ceph_monitors,
             "pool": FLAGS.rbd_pool,
             "image": self.name,
-            "secretRef": {
-                "name": FLAGS.ceph_secret
-            },
+            "keyring": FLAGS.ceph_keyring,
+            "user": FLAGS.rbd_user,
             "fsType": "ext4",
             "readOnly": False
         }
     }
+    if FLAGS.ceph_secret:
+      ceph_volume["rbd"]["secretRef"] = {"name" : FLAGS.ceph_secret}
     volumes.append(ceph_volume)
 
   def SetDevicePath(self, vm):

--- a/perfkitbenchmarker/kubernetes/kubernetes_virtual_machine.py
+++ b/perfkitbenchmarker/kubernetes/kubernetes_virtual_machine.py
@@ -182,6 +182,7 @@ class KubernetesVirtualMachine(virtual_machine.BaseVirtualMachine):
       if len(endpoint['subsets']) > 0:
         logging.info("Endpoint found. Service is successfully matched"
                      "with POD.")
+        return
 
     raise Exception("Endpoint %s not found. Retrying." % self.name)
 

--- a/perfkitbenchmarker/kubernetes/kubernetes_virtual_machine.py
+++ b/perfkitbenchmarker/kubernetes/kubernetes_virtual_machine.py
@@ -112,11 +112,6 @@ class KubernetesVirtualMachine(virtual_machine.BaseVirtualMachine):
       raise Exception('Please provide path to kubeconfig using --kubeconfig '
                       'flag. Exiting.')
     if self.disk_specs and self.disk_specs[0].disk_type == disk.STANDARD:
-      # Verify Ceph prerequisites:
-      if not FLAGS.ceph_secret:
-        raise Exception('Please provide the name of Ceph Secret used by '
-                        'Kubernetes in order to authenticate with Ceph '
-                        '(--ceph_secret flag).')
       if not FLAGS.ceph_monitors:
         raise Exception('Please provide a list of Ceph Monitors using '
                         '--ceph_monitors flag.')
@@ -126,7 +121,7 @@ class KubernetesVirtualMachine(virtual_machine.BaseVirtualMachine):
     Creates a POD (Docker container with optional volumes).
     """
     create_cmd = [FLAGS.kubectl, '--kubeconfig=%s' % FLAGS.kubeconfig,
-                  'create', '-f', '-']
+                  'create', '--validate=false', '-f', '-']
     create_rc_body = self._BuildPodBody()
     output = vm_util.IssueCommand(create_cmd, input=create_rc_body)
     if output[EXIT_CODE]:


### PR DESCRIPTION
I got rid of 'jsonpath' output format which is not available in older
versions of kubectl. On the other hand, '--validate=false' flag was used
in order to work with the latest kubectl.

I also removed the unnecessary selectors.