### PR TITLE
Upgrade Cassandra version to 2.1.10

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,3 @@
-# v0.24.0
-
-* Enhancements:
-  * **Breaking Change** Update cassandra version to 2.1.10 (GH-577)
-
 # v0.22.1
 
 * Update the default image used in Azure tests to Ubuntu 14.04.3 (runs failed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# v0.24.0
+
+* Enhancements:
+  * **Breaking Change** Update cassandra version to 2.1.10 (GH-577)
+
 # v0.22.1
 
 * Update the default image used in Azure tests to Ubuntu 14.04.3 (runs failed

--- a/perfkitbenchmarker/benchmarks/cassandra_stress_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/cassandra_stress_benchmark.py
@@ -242,7 +242,7 @@ def CollectResults(benchmark_spec):
     A list of sample.Sample objects.
   """
   logging.info('Gathering results.')
-  vm_dict = benchmark_spec.vm_dict
+  vm_dict = benchmark_spec.vm_groups
   loader_vms = vm_dict[CLIENT_GROUP]
   raw_results = collections.defaultdict(list)
   args = [((vm, raw_results), {}) for vm in loader_vms]
@@ -253,23 +253,6 @@ def CollectResults(benchmark_spec):
               'num_loader_nodes': len(loader_vms),
               'num_cassandra_stress_threads':
               FLAGS.num_cassandra_stress_threads}
-  results = [
-      sample.Sample('Interval_op_rate', math.fsum(interval_op_rate_list),
-                    'operations per second', metadata),
-      sample.Sample('Interval_key_rate', math.fsum(interval_key_rate_list),
-                    'operations per second', metadata),
-      sample.Sample('Latency median',
-                    math.fsum(latency_median_list) / len(loader_vms),
-                    'ms', metadata),
-      sample.Sample('Latency 95th percentile',
-                    math.fsum(latency_95th_list) / len(loader_vms),
-                    'ms', metadata),
-      sample.Sample('Latency 99.9th percentile',
-                    math.fsum(latency_99_9th_list) / len(loader_vms),
-                    'ms', metadata),
-      sample.Sample('Total operation time',
-                    math.fsum(total_operation_time_list) / len(
-                        loader_vms), 'seconds', metadata)]
   results = []
   for metric in RESULTS_METRICS:
     if metric in MAXIMUM_METRICS:

--- a/perfkitbenchmarker/benchmarks/cassandra_stress_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/cassandra_stress_benchmark.py
@@ -238,7 +238,7 @@ def CollectResultFile(vm, results):
     if metric == RESULTS_METRICS[-1]:  # Total operation time
       value = value.split(':')
       results[metric].append(
-        int(value[0]) * 3600 + int(value[1]) * 60 + int(value[2]))
+          int(value[0]) * 3600 + int(value[1]) * 60 + int(value[2]))
     else:
       results[metric].append(float(value))
 

--- a/perfkitbenchmarker/data/cassandra/cassandra-env.sh.j2
+++ b/perfkitbenchmarker/data/cassandra/cassandra-env.sh.j2
@@ -157,7 +157,7 @@ JMX_PORT="7199"
 if [ "$JVM_VENDOR" != "OpenJDK" -o "$JVM_VERSION" \> "1.6.0" ] \
       || [ "$JVM_VERSION" = "1.6.0" -a "$JVM_PATCH_VERSION" -ge 23 ]
 then
-    JVM_OPTS="$JVM_OPTS -javaagent:$CASSANDRA_HOME/lib/jamm-0.2.5.jar"
+    JVM_OPTS="$JVM_OPTS -javaagent:$CASSANDRA_HOME/lib/jamm-0.3.0.jar"
 fi
 
 # enable thread priorities, primarily so we can give periodic tasks

--- a/perfkitbenchmarker/data/cassandra/cassandra.yaml.j2
+++ b/perfkitbenchmarker/data/cassandra/cassandra.yaml.j2
@@ -18,6 +18,8 @@ key_cache_size_in_mb:
 key_cache_save_period: 14400
 row_cache_size_in_mb: 0
 row_cache_save_period: 0
+counter_cache_size_in_mb:
+counter_cache_save_period: 7200
 saved_caches_directory: {{ data_path }}/saved_caches
 commitlog_sync: periodic
 commitlog_sync_period_in_ms: 10000
@@ -28,8 +30,12 @@ seed_provider:
           - seeds: "{{ seeds }}"
 concurrent_reads: 32
 concurrent_writes: {{ num_cpus * 8 }}
+concurrent_counter_writes: 32
+memtable_allocation_type: heap_buffers
 commitlog_total_space_in_mb: 4096
 memtable_flush_writers: 4
+index_summary_capacity_in_mb:
+index_summary_resize_interval_in_minutes: 60
 trickle_fsync: true
 trickle_fsync_interval_in_kb: 10240
 storage_port: 7000
@@ -48,6 +54,8 @@ snapshot_before_compaction: false
 auto_snapshot: true
 column_index_size_in_kb: 64
 compaction_throughput_mb_per_sec: 16
+compaction_large_partition_warning_threshold_mb: 100
+sstable_preemptive_open_interval_in_mb: 50
 read_request_timeout_in_ms: 10000
 range_request_timeout_in_ms: 10000
 write_request_timeout_in_ms: 10000

--- a/perfkitbenchmarker/data/cassandra/cassandra.yaml.j2
+++ b/perfkitbenchmarker/data/cassandra/cassandra.yaml.j2
@@ -30,7 +30,6 @@ concurrent_reads: 32
 concurrent_writes: {{ num_cpus * 8 }}
 commitlog_total_space_in_mb: 4096
 memtable_flush_writers: 4
-memtable_flush_queue_size: 4
 trickle_fsync: true
 trickle_fsync_interval_in_kb: 10240
 storage_port: 7000
@@ -48,10 +47,7 @@ incremental_backups: false
 snapshot_before_compaction: false
 auto_snapshot: true
 column_index_size_in_kb: 64
-in_memory_compaction_limit_in_mb: 64
-multithreaded_compaction: false
 compaction_throughput_mb_per_sec: 16
-compaction_preheat_key_cache: true
 read_request_timeout_in_ms: 10000
 range_request_timeout_in_ms: 10000
 write_request_timeout_in_ms: 10000
@@ -76,5 +72,4 @@ client_encryption_options:
     keystore_password: cassandra
 internode_compression: all
 inter_dc_tcp_nodelay: false
-preheat_kernel_page_cache: false
 

--- a/perfkitbenchmarker/packages/cassandra.py
+++ b/perfkitbenchmarker/packages/cassandra.py
@@ -27,15 +27,18 @@ import time
 from perfkitbenchmarker import data
 from perfkitbenchmarker import errors
 from perfkitbenchmarker import vm_util
+from perfkitbenchmarker.packages.ant import ANT_HOME_DIR
 
 
 JNA_JAR_URL = ('https://maven.java.net/content/repositories/releases/'
                'net/java/dev/jna/jna/4.1.0/jna-4.1.0.jar')
-CASSANDRA_TAR_URL = ('http://www.us.apache.org/dist/cassandra/2.1.10/'
+CASSANDRA_TAR_URL = ('http://archive.apache.org/dist/cassandra/2.1.10/'
                      'apache-cassandra-2.1.10-bin.tar.gz')
+CASSANDRA_GIT_REPRO = 'https://github.com/apache/cassandra.git'
+CASSANDRA_VERSION = 'cassandra-2.1.10'
 CASSANDRA_YAML_TEMPLATE = 'cassandra/cassandra.yaml.j2'
 CASSANDRA_ENV_TEMPLATE = 'cassandra/cassandra-env.sh.j2'
-CASSANDRA_DIR = posixpath.join(vm_util.VM_TMP_DIR, 'apache-cassandra')
+CASSANDRA_DIR = posixpath.join(vm_util.VM_TMP_DIR, 'cassandra')
 CASSANDRA_PID = posixpath.join(CASSANDRA_DIR, 'cassandra.pid')
 CASSANDRA_OUT = posixpath.join(CASSANDRA_DIR, 'cassandra.out')
 CASSANDRA_ERR = posixpath.join(CASSANDRA_DIR, 'cassandra.err')
@@ -62,12 +65,17 @@ def CheckPrerequisites():
 
 def _Install(vm):
   """Installs Cassandra from a tarball."""
+  vm.Install('ant')
+  vm.Install('build_tools')
   vm.Install('openjdk7')
   vm.Install('curl')
-  vm.RemoteCommand('mkdir {0} && curl -L {1} | '
-                   'tar -C {0} -xzf - --strip-components=1'.format(
-                       CASSANDRA_DIR, CASSANDRA_TAR_URL))
-
+  vm.RemoteCommand(
+      'cd {0}; git clone {1}; cd {2}; git checkout {3}; {4}/bin/ant'.format(
+          vm_util.VM_TMP_DIR,
+          CASSANDRA_GIT_REPRO,
+          CASSANDRA_DIR,
+          CASSANDRA_VERSION,
+          ANT_HOME_DIR))
   # Add JNA
   vm.RemoteCommand('cd {0} && curl -LJO {1}'.format(
       posixpath.join(CASSANDRA_DIR, 'lib'),
@@ -103,13 +111,6 @@ def Configure(vm, seed_vms):
         CASSANDRA_DIR, 'conf',
         os.path.splitext(os.path.basename(config_file))[0])
     vm.RenderTemplate(local_path, remote_path, context=context)
-
-  # Set up logging in CASSANDRA_DIR/logs
-  #vm.RemoteCommand(
-  #    'sed -i -e "s,log4j.appender.R.File=.*,'
-  #    'log4j.appender.R.File={0}/logs/system.log," {1}'.format(
-  #        CASSANDRA_DIR,
-  #        posixpath.join(CASSANDRA_DIR, 'conf', 'log4j-server.properties')))
 
 
 def Start(vm):

--- a/perfkitbenchmarker/packages/cassandra.py
+++ b/perfkitbenchmarker/packages/cassandra.py
@@ -31,8 +31,8 @@ from perfkitbenchmarker import vm_util
 
 JNA_JAR_URL = ('https://maven.java.net/content/repositories/releases/'
                'net/java/dev/jna/jna/4.1.0/jna-4.1.0.jar')
-CASSANDRA_TAR_URL = ('http://archive.apache.org/dist/cassandra/2.0.16/'
-                     'apache-cassandra-2.0.16-bin.tar.gz')
+CASSANDRA_TAR_URL = ('http://www.us.apache.org/dist/cassandra/2.1.10/'
+                     'apache-cassandra-2.1.10-bin.tar.gz')
 CASSANDRA_YAML_TEMPLATE = 'cassandra/cassandra.yaml.j2'
 CASSANDRA_ENV_TEMPLATE = 'cassandra/cassandra-env.sh.j2'
 CASSANDRA_DIR = posixpath.join(vm_util.VM_TMP_DIR, 'apache-cassandra')
@@ -105,11 +105,11 @@ def Configure(vm, seed_vms):
     vm.RenderTemplate(local_path, remote_path, context=context)
 
   # Set up logging in CASSANDRA_DIR/logs
-  vm.RemoteCommand(
-      'sed -i -e "s,log4j.appender.R.File=.*,'
-      'log4j.appender.R.File={0}/logs/system.log," {1}'.format(
-          CASSANDRA_DIR,
-          posixpath.join(CASSANDRA_DIR, 'conf', 'log4j-server.properties')))
+  #vm.RemoteCommand(
+  #    'sed -i -e "s,log4j.appender.R.File=.*,'
+  #    'log4j.appender.R.File={0}/logs/system.log," {1}'.format(
+  #        CASSANDRA_DIR,
+  #        posixpath.join(CASSANDRA_DIR, 'conf', 'log4j-server.properties')))
 
 
 def Start(vm):

--- a/perfkitbenchmarker/packages/cassandra.py
+++ b/perfkitbenchmarker/packages/cassandra.py
@@ -32,8 +32,6 @@ from perfkitbenchmarker.packages.ant import ANT_HOME_DIR
 
 JNA_JAR_URL = ('https://maven.java.net/content/repositories/releases/'
                'net/java/dev/jna/jna/4.1.0/jna-4.1.0.jar')
-CASSANDRA_TAR_URL = ('http://archive.apache.org/dist/cassandra/2.1.10/'
-                     'apache-cassandra-2.1.10-bin.tar.gz')
 CASSANDRA_GIT_REPRO = 'https://github.com/apache/cassandra.git'
 CASSANDRA_VERSION = 'cassandra-2.1.10'
 CASSANDRA_YAML_TEMPLATE = 'cassandra/cassandra.yaml.j2'


### PR DESCRIPTION
1. Update Cassandra version from 2.0.16 to 2.1.10
2. Update Cassandra package installation (due to 404 trying to download archive.apache.org).
3. Update parser in cassandra_stress benchmark. The metric name is also changed.
4. Update config files. (cassandra.yaml, cassandra-env.sh)