### PR TITLE
Move published run_uri to benchmark spec, add to VM metadata

### DIFF
--- a/perfkitbenchmarker/benchmark_spec.py
+++ b/perfkitbenchmarker/benchmark_spec.py
@@ -21,6 +21,7 @@ import copy_reg
 import os
 import thread
 import threading
+import uuid
 
 from perfkitbenchmarker import disk
 from perfkitbenchmarker import errors
@@ -204,6 +205,7 @@ class BenchmarkSpec(object):
     self.vm_groups = {}
     self.deleted = False
     self.file_name = os.path.join(vm_util.GetTempDir(), self.uid)
+    self.uuid = str(uuid.uuid4())
     self.always_call_cleanup = False
 
   def _GetCloudForGroup(self, group_name):
@@ -372,7 +374,7 @@ class BenchmarkSpec(object):
     logging.info('Waiting for boot completion.')
     for port in vm.remote_access_ports:
       vm.AllowPort(port)
-    vm.AddMetadata(benchmark=self.uid)
+    vm.AddMetadata(benchmark=self.uid, perfkit_uuid=self.uuid)
     vm.WaitForBootCompletion()
     vm.OnStartup()
     if FLAGS.scratch_disk_type == disk.LOCAL:

--- a/perfkitbenchmarker/publisher.py
+++ b/perfkitbenchmarker/publisher.py
@@ -502,8 +502,6 @@ class SampleCollector(object):
 
     logging.debug('Using publishers: {0}'.format(self.publishers))
 
-    self.run_uri = str(uuid.uuid4())
-
   @classmethod
   def _DefaultPublishers(cls):
     """Gets a list of default publishers."""
@@ -546,7 +544,7 @@ class SampleCollector(object):
       sample['product_name'] = FLAGS.product_name
       sample['official'] = FLAGS.official
       sample['owner'] = FLAGS.owner
-      sample['run_uri'] = self.run_uri
+      sample['run_uri'] = benchmark_spec.uuid
       sample['sample_uri'] = str(uuid.uuid4())
       events.sample_created.send(benchmark_spec=benchmark_spec,
                                  sample=sample)


### PR DESCRIPTION
Publishes a per-benchmark UUID as VM metadata, includes is as run_uid in the output samples.