### PR TITLE
Always use the latest version of the azure package. (If we only use v…

### DIFF
--- a/perfkitbenchmarker/benchmarks/object_storage_service_benchmark.py
+++ b/perfkitbenchmarker/benchmarks/object_storage_service_benchmark.py
@@ -898,7 +898,7 @@ def Prepare(benchmark_spec):
 
   vms[0].Install('pip')
   vms[0].RemoteCommand('sudo pip install python-gflags==2.0')
-  vms[0].RemoteCommand('sudo pip install azure==1.0.0')
+  vms[0].RemoteCommand('sudo pip install azure')
   vms[0].Install('gcs_boto_plugin')
 
   OBJECT_STORAGE_BENCHMARK_DICTIONARY[FLAGS.storage].Prepare(vms[0])


### PR DESCRIPTION
…ersion 1.0.0 we won't be able to pickup fixes and some times substantial perf improvements of the azure python package, e.g., the v1.0.2 has a 10x improvement in 1 byte request latency due to connection reuse)