### PR TITLE
Tomcat/wrk tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ In its current release these are the benchmarks that are executed:
   - `scimark2`: public domain (http://math.nist.gov/scimark2/credits.html)
   - `speccpu2006`: Spec CPU2006 (http://www.spec.org/cpu2006/)
   - `sysbench_oltp`: GPL v2 (https://github.com/akopytov/sysbench)
+  * `tomcat`: Apache v2. (http://tomcat.apache.org)
   - `unixbench`: GPL v2 (https://code.google.com/p/byte-unixbench/)
+  * `wrk`: Apache v2 (https://github.com/wg/wrk)
   - `ycsb` (used by `mongodb`, `hbase_ycsb`, and others): Apache V2 (https://github.com/brianfrankcooper/YCSB/blob/master/LICENSE.txt)
 
 Some of the benchmarks invoked require Java. You must also agree with the following license:

--- a/perfkitbenchmarker/benchmark_sets.py
+++ b/perfkitbenchmarker/benchmark_sets.py
@@ -78,7 +78,7 @@ BENCHMARK_SETS = {
     'google_set': {
         MESSAGE: ('This benchmark set is maintained by Google Cloud Platform '
                   'Performance Team.'),
-        BENCHMARK_LIST: [STANDARD_SET, 'oldisim']
+        BENCHMARK_LIST: [STANDARD_SET, 'oldisim', 'tomcat_wrk']
     },
     'intel_set': {
         MESSAGE: 'Intel benchmark set.',

--- a/perfkitbenchmarker/data/wrk_latency.lua
+++ b/perfkitbenchmarker/data/wrk_latency.lua
@@ -1,0 +1,36 @@
+-- Copyright 2015 Google Inc. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Write stats to stdout in CSV format, for simpler parsing by PKB.
+function done(summary, latency, requests)
+        io.write("==CSV==\n")
+        io.write("variable,value,unit\n")
+        for _, p in pairs({ 5, 25, 50, 75, 90, 99, 99.9 }) do
+                n = latency:percentile(p)
+                io.write(string.format("p%g latency,%g,ms\n", p, n / 1000))
+        end
+        local errors = summary.errors.connect + summary.errors.read +
+            summary.errors.write + summary.errors.timeout
+        local data = {
+                {'bytes transferred', summary.bytes, 'bytes'},
+                {'errors', errors, 'n'},
+                {'requests', summary.requests, 'n'},
+                {'throughput',
+                 summary.requests / summary.duration * 1e6,
+                 'requests/sec'}
+        }
+        for _, p in pairs(data) do
+                io.write(string.format("%s,%g,%s\n", p[1], p[2], p[3]))
+        end
+end

--- a/perfkitbenchmarker/linux_benchmarks/tomcat_wrk_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/tomcat_wrk_benchmark.py
@@ -1,0 +1,193 @@
+# Copyright 2015 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Run wrk against a simple Tomcat web server.
+
+This is close to HTTP-RR:
+
+  * Connections are reused.
+  * The server does very little work.
+
+Doubles connections up to a fixed count, reports single connection latency and
+maximum error-free throughput.
+
+`wrk` is a scalable web load generator.
+`tomcat` is a popular Java web server.
+"""
+
+import functools
+import logging
+import operator
+import urlparse
+
+from perfkitbenchmarker import configs
+from perfkitbenchmarker import flags
+from perfkitbenchmarker import vm_util
+from perfkitbenchmarker.linux_packages import tomcat
+from perfkitbenchmarker.linux_packages import wrk
+
+
+flags.DEFINE_integer('tomcat_wrk_test_length', 120,
+                     'Length of time, in seconds, to run wrk for each '
+                     'connction count', lower_bound=1)
+flags.DEFINE_integer('tomcat_wrk_max_connections', 128,
+                     'Maximum number of simultaneous connections to attempt',
+                     lower_bound=1)
+
+# Stop when >= 1% of requests have errors
+MAX_ERROR_RATE = 0.01
+
+FLAGS = flags.FLAGS
+
+BENCHMARK_NAME = 'tomcat_wrk'
+BENCHMARK_CONFIG = """
+tomcat_wrk:
+  description: Run wrk against tomcat.
+  vm_groups:
+    server:
+      vm_spec: *default_single_core
+    client:
+      vm_spec: *default_single_core
+"""
+
+MAX_OPEN_FILES = 65536
+WARM_UP_DURATION = 30
+# Target: simple sample page that generates an SVG.
+SAMPLE_PAGE_PATH = 'examples/jsp/jsp2/jspx/textRotate.jspx?name=JSPX'
+NOFILE_LIMIT_CONF = '/etc/security/limits.d/pkb-tomcat.conf'
+
+
+def GetConfig(user_config):
+  return configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
+
+
+def _IncreaseMaxOpenFiles(vm):
+  vm.RemoteCommand(('echo "{0} soft nofile {1}\n{0} hard nofile {1}" | '
+                    'sudo tee {2}').format(vm.user_name, MAX_OPEN_FILES,
+                                           NOFILE_LIMIT_CONF))
+
+
+def _RemoveOpenFileLimit(vm):
+  vm.RemoteCommand('sudo rm -f {0}'.format(NOFILE_LIMIT_CONF))
+
+
+def _PrepareServer(vm):
+  """Installs tomcat on the server."""
+  vm.Install('tomcat')
+  _IncreaseMaxOpenFiles(vm)
+  tomcat.Start(vm)
+
+
+def _PrepareClient(vm):
+  """Install wrk on the client VM."""
+  _IncreaseMaxOpenFiles(vm)
+  vm.Install('curl')
+  vm.Install('wrk')
+
+
+def Prepare(benchmark_spec):
+  """Install tomcat on one VM and wrk on another.
+
+  Args:
+    benchmark_spec: The benchmark specification. Contains all data that is
+        required to run the benchmark.
+  """
+  tomcat_vm = benchmark_spec.vm_groups['server'][0]
+  wrk_vm = benchmark_spec.vm_groups['client'][0]
+
+  tomcat_vm.AllowPort(tomcat.TOMCAT_HTTP_PORT)
+
+  vm_util.RunThreaded((lambda f: f()),
+                      [functools.partial(_PrepareServer, tomcat_vm),
+                       functools.partial(_PrepareClient, wrk_vm)])
+
+
+def Run(benchmark_spec):
+  """Run wrk against tomcat.
+
+  Args:
+    benchmark_spec: The benchmark specification. Contains all data that is
+        required to run the benchmark.
+
+  Returns:
+    A list of sample.Sample objects.
+  """
+  tomcat_vm = benchmark_spec.vm_groups['server'][0]
+  wrk_vm = benchmark_spec.vm_groups['client'][0]
+
+  samples = []
+  errors = 0
+  connections = 1
+  duration = FLAGS.tomcat_wrk_test_length
+  max_connections = FLAGS.tomcat_wrk_max_connections
+
+  target = urlparse.urljoin('http://{0}:{1}'.format(tomcat_vm.ip_address,
+                                                    tomcat.TOMCAT_HTTP_PORT),
+                            SAMPLE_PAGE_PATH)
+
+  logging.info('Warming up for %ds', WARM_UP_DURATION)
+  list(wrk.Run(wrk_vm, connections=1, target=target, duration=WARM_UP_DURATION))
+
+  max_throughput = None
+  while connections <= max_connections:
+    run_samples = list(wrk.Run(wrk_vm, connections=connections, target=target,
+                               duration=duration))
+
+    by_metric = {i.metric: i for i in run_samples}
+    errors = by_metric['errors'].value
+    requests = by_metric['requests'].value
+    throughput = by_metric['throughput']
+    if requests < 1:
+      logging.warn('No requests issued for %d connections.',
+                   connections)
+      error_rate = 1.0
+    else:
+      error_rate = float(errors) / requests
+
+    # Single connection latency
+    if connections == 1:
+      samples.extend(s for s in run_samples if 'latency' in s.metric)
+      max_throughput = throughput
+
+    if error_rate <= MAX_ERROR_RATE:
+      max_throughput = max((max_throughput, throughput),
+                           key=operator.attrgetter('value'))
+    else:
+      logging.warn('Error rate exceeded maximum (%g > %g)', error_rate,
+                   MAX_ERROR_RATE)
+
+    logging.info('Ran with %d connections; %.2f%% errors, %.2f req/s',
+                 connections, error_rate, throughput.value)
+
+    # Retry with double the connections
+    connections *= 2
+
+  samples.append(max_throughput)
+
+  for sample in samples:
+    sample.metadata.update(ip_type='external', runtime_in_seconds=duration)
+
+  return samples
+
+
+def Cleanup(benchmark_spec):
+  """Remove tomcat and wrk.
+
+  Args:
+    benchmark_spec: The benchmark specification. Contains all data that is
+        required to run the benchmark.
+  """
+  tomcat_vm = benchmark_spec.vm_groups['server'][0]
+  tomcat.Stop(tomcat_vm)
+  vm_util.RunThreaded(_RemoveOpenFileLimit, benchmark_spec.vms)

--- a/perfkitbenchmarker/linux_packages/tomcat.py
+++ b/perfkitbenchmarker/linux_packages/tomcat.py
@@ -1,0 +1,90 @@
+# Copyright 2015 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module containing Apache Tomcat installation and cleanup functions.
+
+Installing Tomcat via this module makes some changes to the default settings:
+
+  * Http11Nio2Protocol is used (non-blocking).
+  * Request logging is disabled.
+  * The session timeout is decreased to 1 minute.
+
+https://tomcat.apache.org/
+"""
+import posixpath
+from perfkitbenchmarker import vm_util
+
+
+TOMCAT_URL = ('http://www.us.apache.org/dist/tomcat/tomcat-8/v8.0.28/bin/'
+              'apache-tomcat-8.0.28.tar.gz')
+TOMCAT_DIR = posixpath.join(vm_util.VM_TMP_DIR, 'tomcat')
+TOMCAT_HTTP_PORT = 8080
+
+# Start / stop scripts
+_TOMCAT_START = posixpath.join(TOMCAT_DIR, 'bin', 'startup.sh')
+_TOMCAT_STOP = posixpath.join(TOMCAT_DIR, 'bin', 'shutdown.sh')
+_TOMCAT_SERVER_CONF = posixpath.join(TOMCAT_DIR, 'conf', 'server.xml')
+_TOMCAT_LOGGING_CONF = posixpath.join(TOMCAT_DIR, 'conf', 'logging.properties')
+_TOMCAT_WEB_CONF = posixpath.join(TOMCAT_DIR, 'conf', 'web.xml')
+
+_TOMCAT_PROTOCOL = 'org.apache.coyote.http11.Http11Nio2Protocol'
+
+
+def _Install(vm):
+  vm.Install('openjdk7')
+  vm.Install('curl')
+  vm.RemoteCommand(
+      ('mkdir -p {0} && curl -L {1} | '
+       'tar -C {0} --strip-components 1 -xzf -').format(TOMCAT_DIR, TOMCAT_URL))
+
+  # Use a non-blocking protocool, and disable access logging (which isn't very
+  # helpful during load tests).
+  vm.RemoteCommand(
+      ("""sed -i.bak -e '/Connector port="8080"/ """
+       's/protocol="[^"]\\+"/protocol="{0}"/\' '
+       '-e "/org.apache.catalina.valves.AccessLogValve/,+3d" '
+       '{1}').format(
+           _TOMCAT_PROTOCOL, _TOMCAT_SERVER_CONF))
+  # Quiet down localhost logs.
+  vm.RemoteCommand(
+      ("sed -i.bak "
+       r"-e 's/\(2localhost.org.apache.*.level\)\s\+=.*$/\1 = WARN/' "
+       ' {0}').format(_TOMCAT_LOGGING_CONF))
+
+  # Expire sessions quickly.
+  vm.RemoteCommand(
+      ("sed -i.bak "
+       r"-e 's,\(<session-timeout>\)30\(</session-timeout>\),\11\2,' "
+       " {0}").format(_TOMCAT_WEB_CONF))
+
+
+def YumInstall(vm):
+  """Installs the Tomcat package on the VM."""
+  _Install(vm)
+
+
+def AptInstall(vm):
+  """Installs the Tomcat package on the VM."""
+  _Install(vm)
+
+
+def Start(vm):
+  """Starts Tomcat on "vm"."""
+  # CentOS7 uses systemd as an init system
+  vm.RemoteCommand('bash ' + _TOMCAT_START)
+
+
+def Stop(vm):
+  """Stops Tomcat on "vm"."""
+  vm.RemoteCommand('bash ' + _TOMCAT_STOP)

--- a/perfkitbenchmarker/linux_packages/wrk.py
+++ b/perfkitbenchmarker/linux_packages/wrk.py
@@ -1,0 +1,106 @@
+# Copyright 2015 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Module containing wrk installation and cleanup functions.
+
+WRK is an extremely scalable HTTP benchmarking tool.
+https://github.com/wg/wrk
+"""
+
+import csv
+import io
+import posixpath
+
+from perfkitbenchmarker import sample
+from perfkitbenchmarker import vm_util
+
+
+WRK_URL = 'https://github.com/wg/wrk/archive/4.0.1.tar.gz'
+WRK_DIR = posixpath.join(vm_util.VM_TMP_DIR, 'wrk')
+WRK_PATH = posixpath.join(WRK_DIR, 'wrk')
+
+# Rather than parse WRK's free text output, this script is used to generate a
+# CSV report
+_LUA_SCRIPT_NAME = 'wrk_latency.lua'
+_LUA_SCRIPT_PATH = posixpath.join(WRK_DIR, _LUA_SCRIPT_NAME)
+# WRK always outputs a free text report. _LUA_SCRIPT_NAME (above)
+# writes this prefix before the CSV output begins.
+_CSV_PREFIX = '==CSV==\n'
+
+
+def _Install(vm):
+  vm.Install('build_tools')
+  vm.Install('curl')
+  vm.Install('openssl')
+
+  vm.RemoteCommand(('mkdir -p {0} && curl -L {1} '
+                    '| tar --strip-components=1 -C {0} -xzf -').format(
+                        WRK_DIR,
+                        WRK_URL))
+  vm.RemoteCommand('cd {} && make'.format(WRK_DIR))
+  vm.PushDataFile(_LUA_SCRIPT_NAME, _LUA_SCRIPT_PATH)
+
+
+def YumInstall(vm):
+  """Installs wrk on the VM."""
+  _Install(vm)
+
+
+def AptInstall(vm):
+  """Installs wrk on the VM."""
+  _Install(vm)
+
+
+def _ParseOutput(output_text):
+  """Parses the output of _LUA_SCRIPT_NAME.
+
+  Yields:
+    (variable_name, value, unit) tuples.
+  """
+  if _CSV_PREFIX not in output_text:
+    raise ValueError('{0} not found in\n{1}'.format(_CSV_PREFIX, output_text))
+  csv_fp = io.BytesIO(str(output_text).rsplit(_CSV_PREFIX, 1)[-1])
+  reader = csv.DictReader(csv_fp)
+  if (frozenset(reader.fieldnames) !=
+      frozenset(['variable', 'value', 'unit'])):
+    raise ValueError('Unexpected fields: {}'.format(reader.fieldnames))
+  for row in reader:
+    yield row['variable'], float(row['value']), row['unit']
+
+
+def Run(vm, target, connections=1, duration=60):
+  """Runs wrk against a given target.
+
+  Args:
+    vm: Virtual machine.
+    target: URL to fetch.
+    connections: Number of concurrent connections.
+    duration: Duration of the test, in seconds.
+  Yields:
+    sample.Sample objects with results.
+  """
+  threads = min(connections, vm.num_cpus)
+  cmd = ('{wrk} --connections={connections} --threads={threads} '
+         '--duration={duration} '
+         '--script={script} {target}').format(
+             wrk=WRK_PATH, connections=connections, threads=threads,
+             script=_LUA_SCRIPT_PATH, target=target,
+             duration=duration)
+  stdout, _ = vm.RemoteCommand(cmd)
+  for variable, value, unit in _ParseOutput(stdout):
+    yield sample.Sample(variable, value, unit,
+                        metadata={'connections': connections,
+                                  'threads': threads,
+                                  'duration': duration})

--- a/tests/data/wrk_result.txt
+++ b/tests/data/wrk_result.txt
@@ -1,0 +1,19 @@
+Running 1m test @ http://10.240.0.46/OK
+  2 threads and 2 connections
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency   218.37us  284.24us  11.60ms   98.94%
+    Req/Sec     4.83k   470.08     5.55k    76.21%
+  577297 requests in 1.00m, 143.12MB read
+Requests/sec:   9605.69
+Transfer/sec:      2.38MB
+==CSV==
+variable,value,unit
+p5 latency,0.162,ms
+p50 latency,0.187,ms
+p90 latency,0.256,ms
+p99 latency,0.519,ms
+p99.9 latency,5.196,ms
+bytes transferred,1.50068e+08,bytes
+errors,0,n
+requests,577297,n
+throughput,9605.69,requests/sec

--- a/tests/linux_packages/wrk_test.py
+++ b/tests/linux_packages/wrk_test.py
@@ -1,0 +1,51 @@
+# Copyright 2015 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for perfkitbenchmarker.packages.wrk."""
+
+import os
+import unittest
+
+
+from perfkitbenchmarker.linux_packages import wrk
+
+
+class WrkParseOutputTestCase(unittest.TestCase):
+
+  def setUp(self):
+    data_dir = os.path.join(os.path.dirname(__file__), '..', 'data')
+    result_path = os.path.join(data_dir, 'wrk_result.txt')
+    with open(result_path) as result_file:
+      self.wrk_results = result_file.read()
+
+  def testParsesSample(self):
+    expected = [('p5 latency', 0.162, 'ms'),
+                ('p50 latency', 0.187, 'ms'),
+                ('p90 latency', 0.256, 'ms'),
+                ('p99 latency', 0.519, 'ms'),
+                ('p99.9 latency', 5.196, 'ms'),
+                ('bytes transferred', 150068000.0, 'bytes'),
+                ('errors', 0.0, 'n'),
+                ('requests', 577297.0, 'n'),
+                ('throughput', 9605.69, 'requests/sec')]
+
+    actual = list(wrk._ParseOutput(self.wrk_results))
+    self.assertItemsEqual(expected, actual)
+
+  def testFailsForEmptyString(self):
+    with self.assertRaisesRegexp(ValueError, 'bar'):
+      list(wrk._ParseOutput('bar'))
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
This is a continuation of #593. Using `nginx` stressed the client more than the server.
To get a (relatively) simple web-serving workload, I've switched to Tomcat on the server side.
The server eventually becomes CPU-bound.

There is also some overlap with #427 and #451, both of which simulate a more realistic, layered web service deployment. This aims to be more of a microbenchmark: single client, single server, no database, with a small amount of server-side work per request (generating an SVG with rotated text).

We could also omit this in favor of #427 or #451 if there's too much overlap.
Comments appreciated (cc: @kivio, @rmend016).