### PR TITLE
Return static VMs to the pool when deleted.

### DIFF
--- a/perfkitbenchmarker/static_virtual_machine.py
+++ b/perfkitbenchmarker/static_virtual_machine.py
@@ -25,7 +25,7 @@ All VM specifics are self-contained and the class provides methods to
 operate on the VM: boot, shutdown, etc.
 """
 
-
+import collections
 import json
 import logging
 import threading
@@ -102,7 +102,7 @@ class StaticVirtualMachine(virtual_machine.BaseVirtualMachine):
   """Object representing a Static Virtual Machine."""
 
   is_static = True
-  vm_pool = []
+  vm_pool = collections.deque()
   vm_pool_lock = threading.Lock()
 
   def __init__(self, vm_spec):
@@ -131,8 +131,9 @@ class StaticVirtualMachine(virtual_machine.BaseVirtualMachine):
     pass
 
   def _Delete(self):
-    """StaticVirtualMachines do not implement _Delete()."""
-    pass
+    """Returns the virtual machine to the pool."""
+    with self.vm_pool_lock:
+      self.vm_pool.appendleft(self)
 
   def CreateScratchDisk(self, disk_spec):
     """Create a VM's scratch disk.
@@ -269,7 +270,7 @@ class StaticVirtualMachine(virtual_machine.BaseVirtualMachine):
     """
     with cls.vm_pool_lock:
       if cls.vm_pool:
-        return cls.vm_pool.pop(0)
+        return cls.vm_pool.popleft()
       else:
         return None
 

--- a/tests/static_virtual_machine_test.py
+++ b/tests/static_virtual_machine_test.py
@@ -28,7 +28,7 @@ class StaticVirtualMachineTest(unittest.TestCase):
 
   def setUp(self):
     self._initial_pool = StaticVirtualMachine.vm_pool
-    StaticVirtualMachine.vm_pool = []
+    StaticVirtualMachine.vm_pool.clear()
     p = mock.patch(vm_util.__name__ + '.GetTempDir')
     p.start()
     self.addCleanup(p.stop)
@@ -58,7 +58,7 @@ class StaticVirtualMachineTest(unittest.TestCase):
   def testReadFromFile_Empty(self):
     fp = BytesIO('[]')
     StaticVirtualMachine.ReadStaticVirtualMachineFile(fp)
-    self.assertEqual([], StaticVirtualMachine.vm_pool)
+    self.assertEqual([], list(StaticVirtualMachine.vm_pool))
 
   def testReadFromFile_NoErr(self):
     s = ('[{'
@@ -100,6 +100,30 @@ class StaticVirtualMachineTest(unittest.TestCase):
     self.assertRaises(ValueError,
                       StaticVirtualMachine.ReadStaticVirtualMachineFile,
                       fp)
+
+  def testCreateReturn(self):
+    s = ('[{'
+         '  "ip_address": "174.12.14.1", '
+         '  "user_name": "perfkitbenchmarker", '
+         '  "keyfile_path": "perfkitbenchmarker.pem" '
+         '}, '
+         '{ '
+         '   "ip_address": "174.12.14.121", '
+         '   "user_name": "ubuntu", '
+         '   "keyfile_path": "rackspace.pem", '
+         '   "internal_ip": "10.10.10.2", '
+         '   "zone": "rackspace_dallas" '
+         '}] ')
+    fp = BytesIO(s)
+    StaticVirtualMachine.ReadStaticVirtualMachineFile(fp)
+    self.assertEqual(2, len(StaticVirtualMachine.vm_pool))
+    vm0 = StaticVirtualMachine.GetStaticVirtualMachine()
+    self.assertEqual(1, len(StaticVirtualMachine.vm_pool))
+    vm0.Delete()
+    self.assertEqual(2, len(StaticVirtualMachine.vm_pool))
+    vm1 = StaticVirtualMachine.GetStaticVirtualMachine()
+    self.assertIs(vm0, vm1)
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
Right now a static VM can be used in at most one benchmark.
This PR returns the VM to the pool of available static VMs when
`VirtualMachine.Delete()` is called.