### PR TITLE
openstack: Add NOVA_ENDPOINT_TYPE flag

### DIFF
--- a/perfkitbenchmarker/openstack/utils.py
+++ b/perfkitbenchmarker/openstack/utils.py
@@ -44,6 +44,11 @@ flags.DEFINE_string('openstack_password_file',
                     'setting the password itself in $OS_PASSWORD is also '
                     'supported.')
 
+flags.DEFINE_string('openstack_nova_endpoint_type',
+                    os.getenv('NOVA_ENDPOINT_TYPE', 'publicURL'),
+                    'OpenStack Nova endpoint type, '
+                    'defaults to $NOVA_ENDPOINT_TYPE.')
+
 
 class KeystoneAuth(object):
     """
@@ -126,6 +131,7 @@ class NovaClient(object):
         self.url = FLAGS.openstack_auth_url
         self.user = FLAGS.openstack_username
         self.tenant = FLAGS.openstack_tenant
+        self.endpoint_type = FLAGS.openstack_nova_endpoint_type
         self.password = self.GetPassword()
         self.__auth = KeystoneAuth(self.url, self.tenant,
                                    self.user, self.password)
@@ -134,6 +140,7 @@ class NovaClient(object):
                                         username=self.user,
                                         auth_token=self.__auth.get_token(),
                                         tenant_id=self.__auth.get_tenant_id(),
+                                        endpoint_type=self.endpoint_type,
                                         )
 
     def reconnect(self):
@@ -146,6 +153,7 @@ class NovaClient(object):
                                         username=self.user,
                                         auth_token=self.__auth.get_token(),
                                         tenant_id=self.__auth.get_tenant_id(),
+                                        endpoint_type=self.endpoint_type,
                                         )
 
 


### PR DESCRIPTION
Add flag to change default nova endpoint type passed to the nova
client to allow the ability to use internal endpoints.

Signed-off-by: Carlos L. Torres <carlos.torres@rackspace.com>