### PR TITLE
Improving the guide on how to create a Docker with SSH server installed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Perfkit uses `kubectl` binary in order to communicate with Kubernetes cluster - 
 Authentication to Kubernetes cluster is done via `kubeconfig` file (https://github.com/kubernetes/kubernetes/blob/release-1.0/docs/user-guide/kubeconfig-file.md). Its path is passed using `--kubeconfig` flag.
 
 **Image prerequisites**  
-Docker instances by default don't allow to SSH into them. Thus it is important to configure your Docker image so that it has SSH server installed. You can rely on `https://quay.io/repository/mateusz_blaszkowski/pkb-k8s ` while creating your own image.
+Docker instances by default don't allow to SSH into them. Thus it is important to configure your Docker image so that it has SSH server installed. You can use your own image or build a new one based on a Dockerfile placed in tools/docker_images directory - in this case please refer to https://github.com/GoogleCloudPlatform/PerfKitBenchmarker/tree/master/tools/docker_images document.
 
 **Kubernetes cluster configuration**  
 If your Kubernetes cluster is running on CoreOS:

--- a/tools/docker_images/Dockerfile
+++ b/tools/docker_images/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:trusty
+
+RUN apt-get update && apt-get install -y ssh
+RUN mkdir /var/run/sshd ;\
+    sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd ;\
+    sed -i 's/PermitRootLogin without-password/PermitRootLogin yes/' /etc/ssh/sshd_config ;\
+    sed -i 's/UsePAM yes/UsePAM no/' /etc/ssh/sshd_config ;\
+    echo "UseDNS no" | tee -a /etc/ssh/sshd_config ;\
+    echo "MaxSessions 1000" | tee -a /etc/ssh/sshd_config

--- a/tools/docker_images/README.md
+++ b/tools/docker_images/README.md
@@ -1,0 +1,26 @@
+# README
+
+You may use a sample Dockerfile in order to build a Docker image with SSH server installed.
+
+1. Build a docker image
+
+   ```
+   cd tools/docker_images
+   docker build -t=ubuntu_ssh --force-rm=true .
+   ```
+
+2. Save the image and copy it to each of the Kubernetes nodes
+   ```
+   docker save -o=ubuntu_ssh.tar.gz ubuntu_ssh
+   # scp ubuntu_ssh.tar.gz file to each of Kubernetes nodes
+   ```
+
+3. Load the image on each of the Kubernetes nodes
+   ```
+   docker load -i=ubuntu_ssh.tar.gz
+   ```
+
+4. The image is ready to be used by Perfkit:
+   ```
+   ./pkb.py --cloud=Kubernetes --image=ubuntu_ssh ...
+   ```


### PR DESCRIPTION
Building Docker image from a Dockerfile is a more robust way (it's clear to the user what is inside the image) than providing a link to a private already-built image from quay.

Signed-off-by: Mateusz Blaszkowski <mateusz.blaszkowski@intel.com>