### PR TITLE
Generate per-vm-group SSH aliases.

### DIFF
--- a/perfkitbenchmarker/benchmark_spec.py
+++ b/perfkitbenchmarker/benchmark_spec.py
@@ -224,7 +224,7 @@ class BenchmarkSpec(object):
     if self.vms:
       vm_util.RunThreaded(self.PrepareVm, self.vms)
       if FLAGS.os_type != WINDOWS:
-        vm_util.GenerateSSHConfig(self.vms)
+        vm_util.GenerateSSHConfig(self)
 
   def Delete(self):
     if FLAGS.run_stage not in ['all', 'cleanup'] or self.deleted:

--- a/perfkitbenchmarker/data/ssh_config.j2
+++ b/perfkitbenchmarker/data/ssh_config.j2
@@ -24,6 +24,7 @@ Host *
   ServerAliveCountMax=10
   BatchMode=yes
 
+{# Numeric / name-based access -#}
 {% for vm in vms %}
 Host {{ vm.name }} vm{{ loop.index0 }}
   HostName={{ vm.ip_address }}
@@ -31,3 +32,14 @@ Host {{ vm.name }} vm{{ loop.index0 }}
   Port={{ vm.ssh_port }}
   IdentityFile={{ vm.ssh_private_key }}
 {% endfor %}
+
+{# Group-based access -#}
+{% for group, group_vms in vm_groups.iteritems() %}
+{% for vm in group_vms %}
+Host {{group}}-{{ loop.index0 }}
+  HostName={{ vm.ip_address }}
+  User={{ vm.user_name }}
+  Port={{ vm.ssh_port }}
+  IdentityFile={{ vm.ssh_private_key }}
+{% endfor -%}
+{% endfor -%}


### PR DESCRIPTION
Enables SSH-ing to VMs within a group, e.g.:

    ssh -F /path/to/ssh_config cassandra_nodes-0