### PR TITLE
Move AWS and Azure _GetDefaultImage calls to _CreateDependencies.

### DIFF
--- a/perfkitbenchmarker/providers/aws/aws_virtual_machine.py
+++ b/perfkitbenchmarker/providers/aws/aws_virtual_machine.py
@@ -208,6 +208,9 @@ class AwsVirtualMachine(virtual_machine.BaseVirtualMachine):
   def _CreateDependencies(self):
     """Create VM dependencies."""
     self.ImportKeyfile()
+    # _GetDefaultImage calls the AWS CLI.
+    self.image = self.image or self._GetDefaultImage(self.machine_type,
+                                                     self.region)
 
   def _DeleteDependencies(self):
     """Delete VM dependencies."""
@@ -219,11 +222,6 @@ class AwsVirtualMachine(virtual_machine.BaseVirtualMachine):
     if IsPlacementGroupCompatible(self.machine_type):
       placement += ',GroupName=%s' % self.network.placement_group.name
     block_device_map = GetBlockDeviceMap(self.machine_type)
-
-    if self.image is None:
-      # This is here and not in the __init__ method bceauese _GetDefaultImage
-      # does a nontrivial amount of work (it calls the AWS CLI).
-      self.image = self._GetDefaultImage(self.machine_type, self.region)
 
     create_cmd = util.AWS_PREFIX + [
         'ec2',

--- a/perfkitbenchmarker/providers/azure/azure_virtual_machine.py
+++ b/perfkitbenchmarker/providers/azure/azure_virtual_machine.py
@@ -180,11 +180,12 @@ class AzureVirtualMachine(virtual_machine.BaseVirtualMachine):
     disk_spec = disk.BaseDiskSpec()
     self.os_disk = azure_disk.AzureDisk(disk_spec, self.name)
     self.max_local_disks = 1
-    self.image = self.image or _GetDefaultImage(self.OS_TYPE)
 
   def _CreateDependencies(self):
     """Create VM dependencies."""
     self.service.Create()
+    # _GetDefaultImage may call the Azure CLI.
+    self.image = self.image or _GetDefaultImage(self.OS_TYPE)
 
   def _DeleteDependencies(self):
     """Delete VM dependencies."""

--- a/tests/scratch_disk_test.py
+++ b/tests/scratch_disk_test.py
@@ -130,9 +130,6 @@ class AzureScratchDiskTest(ScratchDiskTestMixin, unittest.TestCase):
 
   def _PatchCloudSpecific(self):
     self.patches.append(mock.patch(azure_disk.__name__ + '.AzureDisk'))
-    self.patches.append(mock.patch(
-        azure_virtual_machine.__name__ + '._GetDefaultImage',
-        return_value='test_image'))
 
   def _CreateVm(self):
     vm_spec = virtual_machine.BaseVmSpec()


### PR DESCRIPTION
Prevents counting toward boot time.
Prevents interacting with CLI until the VM is created.
