### PR TITLE
Add GetMachineTypeDict() to replace machine_type in Sample metadata.

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/cluster_boot_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/cluster_boot_benchmark.py
@@ -57,8 +57,9 @@ def _GetTimeToBoot(vms, vm_index):
     Sample containing the boot time.
   """
   vm = vms[vm_index]
-  metadata = {'machine_type': vm.machine_type, 'num_cpus': vm.num_cpus,
-              'machine_instance': vm_index, 'num_vms': len(vms)}
+  metadata = {'num_cpus': vm.num_cpus, 'machine_instance': vm_index,
+              'num_vms': len(vms)}
+  metadata.update(vm.GetMachineTypeDict())
   assert vm.bootable_time
   assert vm.create_start_time
   assert vm.bootable_time >= vm.create_start_time

--- a/perfkitbenchmarker/linux_benchmarks/copy_throughput_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/copy_throughput_benchmark.py
@@ -178,12 +178,11 @@ def RunScpSingleDirection(sending_vm, receiving_vm):
     A list of sample.Sample objects.
   """
   results = []
-  metadata = {
-      'sending_zone': sending_vm.zone,
-      'receiving_zone': receiving_vm.zone,
-      'server_machine_type': receiving_vm.machine_type,
-      'client_machine_type': sending_vm.machine_type,
-  }
+  metadata = {}
+  for vm_specifier, vm in ('receiving', receiving_vm), ('sending', sending_vm):
+    metadata['{0}_zone'.format(vm_specifier)] = vm.zone
+    for k, v in vm.GetMachineTypeDict().iteritems():
+      metadata['{0}_{1}'.format(vm_specifier, k)] = v
 
   cmd_template = ('sudo sync; sudo sysctl vm.drop_caches=3; '
                   'time /usr/bin/scp -o StrictHostKeyChecking=no -i %s -c %s '

--- a/perfkitbenchmarker/linux_benchmarks/coremark_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/coremark_benchmark.py
@@ -101,7 +101,8 @@ def Run(benchmark_spec):
   stdout, _ = vm.RemoteCommand(
       'cat %s/run1.log' % COREMARK_DIR, should_log=True)
   value = regex_util.ExtractFloat(r'CoreMark 1.0 : ([0-9]*\.[0-9]*)', stdout)
-  metadata = {'machine_type': vm.machine_type, 'num_cpus': vm.num_cpus}
+  metadata = {'num_cpus': vm.num_cpus}
+  metadata.update(vm.GetMachineTypeDict())
   return [sample.Sample('Coremark Score', value, '', metadata)]
 
 

--- a/perfkitbenchmarker/linux_benchmarks/oldisim_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/oldisim_benchmark.py
@@ -235,7 +235,8 @@ def Run(benchmark_spec):
     if fanout > 1 and fanout < FLAGS.oldisim_num_leaves:
       fanout_list.add(fanout)
 
-  metadata = {'machine_type': vm.machine_type, 'num_cpus': vm.num_cpus}
+  metadata = {'num_cpus': vm.num_cpus}
+  metadata.update(vm.GetMachineTypeDict())
   for fanout in sorted(fanout_list):
     qps = RunLoadTest(benchmark_spec, fanout)[2]
     qps_dict[fanout] = qps

--- a/perfkitbenchmarker/linux_benchmarks/speccpu2006_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/speccpu2006_benchmark.py
@@ -205,7 +205,8 @@ def ExtractScore(stdout, vm, keep_partial_results):
       # remove the final SPEC(int|fp) score, which has only 2 columns.
       result_section.pop()
 
-  metadata = {'machine_type': vm.machine_type, 'num_cpus': vm.num_cpus}
+  metadata = {'num_cpus': vm.num_cpus}
+  metadata.update(vm.GetMachineTypeDict())
 
   missing_results = []
 

--- a/perfkitbenchmarker/publisher.py
+++ b/perfkitbenchmarker/publisher.py
@@ -139,8 +139,9 @@ class DefaultMetadataProvider(MetadataProvider):
       name_prefix = '' if name == 'default' else name + '_'
       metadata[name_prefix + 'cloud'] = vm.CLOUD
       metadata[name_prefix + 'zone'] = vm.zone
-      metadata[name_prefix + 'machine_type'] = vm.machine_type
       metadata[name_prefix + 'image'] = vm.image
+      for k, v in vm.GetMachineTypeDict().iteritems():
+        metadata[name_prefix + k] = v
 
       if vm.scratch_disks:
         data_disk = vm.scratch_disks[0]

--- a/perfkitbenchmarker/virtual_machine.py
+++ b/perfkitbenchmarker/virtual_machine.py
@@ -235,6 +235,17 @@ class BaseVirtualMachine(resource.BaseResource):
     """
     pass
 
+  def GetMachineTypeDict(self):
+    """Returns a dict containing properties that specify the machine type.
+
+    Returns:
+      dict mapping string property key to value.
+    """
+    result = {}
+    if self.machine_type is not None:
+      result['machine_type'] = self.machine_type
+    return result
+
 
 class BaseOsMixin(object):
   """The base class for OS Mixin classes.

--- a/perfkitbenchmarker/windows_packages/ntttcp.py
+++ b/perfkitbenchmarker/windows_packages/ntttcp.py
@@ -88,13 +88,11 @@ def RunNtttcp(sending_vm, receiving_vm, receiving_ip_address, ip_type):
       ntttcp_exe_dir=ntttcp_exe_dir)
   stdout, _ = sending_vm.RemoteCommand(cat_command)
 
-  metadata = {
-      'receiving_machine_type': receiving_vm.machine_type,
-      'receiving_zone': receiving_vm.zone,
-      'sending_machine_type': sending_vm.machine_type,
-      'sending_zone': sending_vm.zone,
-      'ip_type': ip_type
-  }
+  metadata = {'ip_type': ip_type}
+  for vm_specifier, vm in ('receiving', receiving_vm), ('sending', sending_vm):
+    metadata['{0}_zone'.format(vm_specifier)] = vm.zone
+    for k, v in vm.GetMachineTypeDict().iteritems():
+      metadata['{0}_{1}'.format(vm_specifier, k)] = v
 
   return ParseNtttcpResults(stdout, metadata)
 

--- a/tests/linux_benchmarks/speccpu2006_benchmark_test.py
+++ b/tests/linux_benchmarks/speccpu2006_benchmark_test.py
@@ -218,9 +218,12 @@ EXPECTED_RESULT_BAD2 = [
 
 
 class DummyVM(object):
+
   def __init__(self):
-    self.machine_type = 'big'
     self.num_cpus = 256
+
+  def GetMachineTypeDict(self):
+    return {'machine_type': 'big'}
 
 
 class Speccpu2006BenchmarkTestCase(unittest.TestCase,

--- a/tests/publisher_test.py
+++ b/tests/publisher_test.py
@@ -251,6 +251,8 @@ class DefaultMetadataProviderTestCase(unittest.TestCase):
                                   machine_type='n1-standard-1',
                                   image='ubuntu-14-04',
                                   scratch_disks=[])
+    self.mock_vm.GetMachineTypeDict.return_value = {
+        'machine_type': self.mock_vm.machine_type}
     self.mock_spec = mock.MagicMock(vm_groups={'default': [self.mock_vm]})
 
     self.default_meta = {'perfkitbenchmarker_version': 'v1',


### PR DESCRIPTION
Supports machine types that are not defined by a single name.