### PR TITLE
Add support for GCE custom VMs.

### DIFF
--- a/perfkitbenchmarker/configs/option_decoders.py
+++ b/perfkitbenchmarker/configs/option_decoders.py
@@ -1,0 +1,182 @@
+# Copyright 2015 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Classes for verifying and decoding config option values."""
+
+import abc
+
+from perfkitbenchmarker import errors
+
+
+class ConfigOptionDecoder(object):
+  """Verifies and decodes a config option value.
+
+  Attributes:
+    component: string. Description of the component to which the option applies.
+    option: string. Name of the config option.
+    required: boolean. True if the config option is required. False if not.
+  """
+
+  def __init__(self, component, option, **kwargs):
+    """Initializes a ConfigOptionDecoder.
+
+    Args:
+      component: string. Description of the component to which the option
+          applies.
+      option: string. Name of the config option.
+      **kwargs: May optionally contain a 'default' key mapping to a value or
+          callable object. If a value is provided, the config option is
+          optional, and the provided value is the default if the user does not
+          set a value for the config option. If a callable object is provided,
+          the config option is optional, and the provided object is called to
+          determine the value if the user does not set a value for the config
+          option. If not provided, the config option is required.
+    """
+    self.component = component
+    self.option = option
+    self.required = 'default' not in kwargs
+    if not self.required:
+      self._default = kwargs.pop('default')
+    assert not kwargs, ('__init__() received unexpected keyword arguments: '
+                        '{0}'.format(kwargs))
+
+  @property
+  def default(self):
+    """Gets the config option's default value.
+
+    Returns:
+      Default value of an optional config option.
+    """
+    assert not self.required, (
+        'Attempted to get the default value of {0} required config option '
+        '"{1}".'.format(self.component, self.option))
+    if hasattr(self._default, '__call__'):
+      return self._default()
+    return self._default
+
+  @abc.abstractmethod
+  def Decode(self, value):
+    """Verifies and decodes a config option value.
+
+    Args:
+      value: The value specified in the config.
+
+    Returns:
+      The decoded value.
+
+    Raises:
+      errors.Config.InvalidValue upon invalid input value.
+    """
+    raise NotImplementedError()
+
+
+class BooleanDecoder(ConfigOptionDecoder):
+  """Verifies and decodes a config option value when a boolean is expected.
+
+  Attributes:
+    component: string. Description of the component to which the option applies.
+    option: string. Name of the config option.
+    required: boolean. True if the config option is required. False if not.
+  """
+
+  def Decode(self, value):
+    """Verifies that the provided value is a boolean.
+
+    Args:
+      value: The value specified in the config.
+
+    Returns:
+      boolean. The valid value.
+
+    Raises:
+      errors.Config.InvalidValue upon invalid input value.
+    """
+    if not isinstance(value, bool):
+      raise errors.Config.InvalidValue(
+          'Invalid {0} "{1}" value: "{2}" (of type "{3}"). Value must be a '
+          'boolean.'.format(self.component, self.option, value,
+                            value.__class__.__name__))
+    return value
+
+
+class IntDecoder(ConfigOptionDecoder):
+  """Verifies and decodes a config option value when an integer is expected.
+
+  Attributes:
+    component: string. Description of the component to which the option applies.
+    option: string. Name of the config option.
+    required: boolean. True if the config option is required. False if not.
+    max: None or int. If provided, it specifies the maximum accepted value.
+    min: None or int. If provided, it specifies the minimum accepted value.
+  """
+
+  def __init__(self, component, option, max=None, min=None, **kwargs):
+    super(IntDecoder, self).__init__(component, option, **kwargs)
+    self.max = max
+    self.min = min
+
+  def Decode(self, value):
+    """Verifies that the provided value is an int.
+
+    Args:
+      value: The value specified in the config.
+
+    Returns:
+      int. The valid value.
+
+    Raises:
+      errors.Config.InvalidValue upon invalid input value.
+    """
+    if not isinstance(value, int):
+      raise errors.Config.InvalidValue(
+          'Invalid {0} "{1}" value: "{2}" (of type "{3}"). Value must be an '
+          'integer.'.format(self.component, self.option, value,
+                            value.__class__.__name__))
+    elif self.max and value > self.max:
+      raise errors.Config.InvalidValue(
+          'Invalid {0} "{1}" value: "{2}". Value must be at most {3}.'.format(
+              self.component, self.option, value, self.max))
+    elif self.min and value < self.min:
+      raise errors.Config.InvalidValue(
+          'Invalid {0} "{1}" value: "{2}". Value must be at least {3}.'.format(
+              self.component, self.option, value, self.min))
+    return value
+
+
+class StringDecoder(ConfigOptionDecoder):
+  """Verifies and decodes a config option value when a string is expected.
+
+  Attributes:
+    component: string. Description of the component to which the option applies.
+    option: string. Name of the config option.
+    required: boolean. True if the config option is required. False if not.
+  """
+
+  def Decode(self, value):
+    """Verifies that the provided value is a string.
+
+    Args:
+      value: The value specified in the config.
+
+    Returns:
+      string. The valid value.
+
+    Raises:
+      errors.Config.InvalidValue upon invalid input value.
+    """
+    if not isinstance(value, basestring):
+      raise errors.Config.InvalidValue(
+          'Invalid {0} "{1}" value: "{2}" (of type "{3}"). Value must be a '
+          'string.'.format(self.component, self.option, value,
+                           value.__class__.__name__))
+    return value

--- a/perfkitbenchmarker/configs/option_decoders.py
+++ b/perfkitbenchmarker/configs/option_decoders.py
@@ -27,6 +27,8 @@ class ConfigOptionDecoder(object):
     required: boolean. True if the config option is required. False if not.
   """
 
+  __metaclass__ = abc.ABCMeta
+
   def __init__(self, component, option, **kwargs):
     """Initializes a ConfigOptionDecoder.
 
@@ -81,13 +83,7 @@ class ConfigOptionDecoder(object):
 
 
 class BooleanDecoder(ConfigOptionDecoder):
-  """Verifies and decodes a config option value when a boolean is expected.
-
-  Attributes:
-    component: string. Description of the component to which the option applies.
-    option: string. Name of the config option.
-    required: boolean. True if the config option is required. False if not.
-  """
+  """Verifies and decodes a config option value when a boolean is expected."""
 
   def Decode(self, value):
     """Verifies that the provided value is a boolean.
@@ -113,9 +109,6 @@ class IntDecoder(ConfigOptionDecoder):
   """Verifies and decodes a config option value when an integer is expected.
 
   Attributes:
-    component: string. Description of the component to which the option applies.
-    option: string. Name of the config option.
-    required: boolean. True if the config option is required. False if not.
     max: None or int. If provided, it specifies the maximum accepted value.
     min: None or int. If provided, it specifies the minimum accepted value.
   """
@@ -154,13 +147,7 @@ class IntDecoder(ConfigOptionDecoder):
 
 
 class StringDecoder(ConfigOptionDecoder):
-  """Verifies and decodes a config option value when a string is expected.
-
-  Attributes:
-    component: string. Description of the component to which the option applies.
-    option: string. Name of the config option.
-    required: boolean. True if the config option is required. False if not.
-  """
+  """Verifies and decodes a config option value when a string is expected."""
 
   def Decode(self, value):
     """Verifies that the provided value is a string.

--- a/perfkitbenchmarker/errors.py
+++ b/perfkitbenchmarker/errors.py
@@ -151,6 +151,18 @@ class Resource(object):
 class Config(object):
   """Errors related to configs."""
 
+  class InvalidValue(Error):
+    """User provided an invalid value for a config option."""
+    pass
+
+  class MissingOption(Error):
+    """User did not provide a value for a required config option."""
+    pass
+
   class ParseError(Error):
     """Error raised when a config can't be loaded properly."""
+    pass
+
+  class UnrecognizedOption(Error):
+    """User provided a value for an unrecognized config option."""
     pass

--- a/perfkitbenchmarker/providers/gcp/gce_virtual_machine.py
+++ b/perfkitbenchmarker/providers/gcp/gce_virtual_machine.py
@@ -35,6 +35,7 @@ from perfkitbenchmarker import linux_virtual_machine as linux_vm
 from perfkitbenchmarker import virtual_machine
 from perfkitbenchmarker import vm_util
 from perfkitbenchmarker import windows_virtual_machine
+from perfkitbenchmarker.configs import option_decoders
 from perfkitbenchmarker.providers.gcp import gce_disk
 from perfkitbenchmarker.providers.gcp import gce_network
 from perfkitbenchmarker.providers.gcp import util
@@ -48,26 +49,95 @@ RHEL_IMAGE = 'rhel-7'
 WINDOWS_IMAGE = 'windows-2012-r2'
 
 
+class MemoryDecoder(option_decoders.StringDecoder):
+  """Verifies and decodes a config option value specifying a memory size.
+
+  Attributes:
+    component: string. Description of the component to which the option applies.
+    option: string. Name of the config option.
+    required: boolean. True if the config option is required. False if not.
+  """
+
+  _CONFIG_MEMORY_PATTERN = re.compile(r'([0-9.]+)([GM]B)')
+
+  def Decode(self, value):
+    """Decodes memory size in MB from a string.
+
+    The value specified in the config must be a string representation of the
+    memory size expressed in MB or GB. It must be an integer number of MB
+    Examples: "1280MB", "7.5GB".
+
+    Args:
+      value: The value specified in the config.
+
+    Returns:
+      int. Memory size in MB.
+
+    Raises:
+      errors.Config.InvalidValue upon invalid input value.
+    """
+    string = super(MemoryDecoder, self).Decode(value)
+    match = self._CONFIG_MEMORY_PATTERN.match(string)
+    if not match:
+      raise errors.Config.InvalidValue(
+          'Invalid {0} "{1}" value: "{2}". Examples of valid values: '
+          '"1280MB", "7.5GB".'.format(self.component, self.option, string))
+    try:
+      memory_value = float(match.group(1))
+    except ValueError:
+      raise errors.Config.InvalidValue(
+          'Invalid {0} "{1}" value: "{2}". "{3}" is not a valid '
+          'float.'.format(self.component, self.option, string, match.group(1)))
+    memory_units = match.group(2)
+    if memory_units == 'GB':
+      memory_value *= 1024
+    memory_mb_int = int(memory_value)
+    if memory_value != memory_mb_int:
+      raise errors.Config.InvalidValue(
+          'Invalid {0} "{1}" value: "{2}". The specified size must be an '
+          'integer number of MB.'.format(self.component, self.option, string))
+    return memory_mb_int
+
+
 class GceVmSpec(virtual_machine.BaseVmSpec):
-  """Object containing the information needed to create a GceVirtualMachine."""
+  """Object containing the information needed to create a GceVirtualMachine.
+
+  Attributes:
+    cpus: None or int. Number of vCPUs for custom VMs.
+    install_packages: boolean. If False, no packages will be installed. This is
+        useful if benchmark dependencies have already been installed.
+    image: string or None. The disk image to boot from.
+    machine_type: string or None. The instance type name for non-custom VMs.
+        Example: 'n1-standard-8'.
+    memory: None or string. For custom VMs, a string representation of the size
+        of memory, expressed in MB or GB. Must be an integer number of MB (e.g.
+        "1280MB", "7.5GB").
+    num_local_ssds: int. The number of local SSDs to attach to the instance.
+    preemptible: boolean. True if the VM should be preemptible, False otherwise.
+    project: string or None. The project to create the VM in.
+    zone: string or None. The region / zone in which to launch the VM.
+  """
 
   CLOUD = 'GCP'
 
-  def __init__(self, project=None, num_local_ssds=0,
-               preemptible=False, **kwargs):
-    """Initializes the VmSpec.
+  @classmethod
+  def _GetOptionDecoderConstructions(cls):
+    """Gets decoder classes and constructor args for each configurable option.
 
-    Args:
-      num_local_ssds: The number of local ssds to attach to the instance.
-      project: The project to create the VM in.
-      preemptible: True if the VM should be preemptible and False otherwise.
-      kwargs: The key word arguments to virtual_machine.BaseVmSpec's __init__
-        method.
+    Returns:
+      dict. Maps option name string to a (ConfigOptionDecoder class, dict) pair.
+          The pair specifies a decoder class and its __init__() keyword
+          arguments to construct in order to decode the named option.
     """
-    super(GceVmSpec, self).__init__(**kwargs)
-    self.project = project
-    self.num_local_ssds = num_local_ssds
-    self.preemptible = preemptible
+    result = super(GceVmSpec, cls)._GetOptionDecoderConstructions()
+    result.update({
+        'cpus': (option_decoders.IntDecoder, {'default': None, 'min': 1}),
+        'memory': (MemoryDecoder, {'default': None}),
+        'num_local_ssds': (option_decoders.IntDecoder, {'default': 0,
+                                                        'min': 0}),
+        'preemptible': (option_decoders.BooleanDecoder, {'default': False}),
+        'project': (option_decoders.StringDecoder, {'default': None})})
+    return result
 
   def ApplyFlags(self, flags):
     """Apply flags to the VmSpec."""
@@ -93,17 +163,34 @@ class GceVirtualMachine(virtual_machine.BaseVirtualMachine):
 
     Args:
       vm_spec: virtual_machine.BaseVirtualMachineSpec object of the vm.
+
+    Raises:
+      errors.Config.MissingOption: If the spec does not include a "machine_type"
+          or both "cpus" and "memory".
+      errors.Config.InvalidValue: If the spec contains both "machine_type" and
+          at least one of "cpus" or "memory".
     """
     super(GceVirtualMachine, self).__init__(vm_spec)
+    self.boot_metadata = {}
+    self.cpus = vm_spec.cpus
     self.image = self.image or self.DEFAULT_IMAGE
+    self.max_local_disks = vm_spec.num_local_ssds
+    self.memory_mb = vm_spec.memory
+    self.preemptible = vm_spec.preemptible
     self.project = vm_spec.project
+    # TODO(skschneider): This can be moved into the VM spec if the ApplyFlags
+    # behavior is moved into BaseVmSpec.__init__.
+    if self.machine_type is None:
+      if self.cpus is None or self.memory_mb is None:
+        raise errors.Config.MissingOption(
+            'A GCP VM must have either a "machine_type" or both "cpus" and '
+            '"memory" configured.')
+    elif self.cpus is not None or self.memory_mb is not None:
+      raise errors.Config.InvalidValue(
+          'A GCP VM cannot have both a "machine_type" and either "cpus" or '
+          '"memory" configured.')
     self.network = gce_network.GceNetwork.GetNetwork(self)
     self.firewall = gce_network.GceFirewall.GetFirewall()
-    self.max_local_disks = vm_spec.num_local_ssds
-    self.boot_metadata = {}
-
-    self.preemptible = vm_spec.preemptible
-
     events.sample_created.connect(self.AnnotateSample, weak=False)
 
   def _GenerateCreateCommand(self, ssh_keys_path):
@@ -120,7 +207,11 @@ class GceVirtualMachine(virtual_machine.BaseVirtualMachine):
     cmd.flags['image'] = self.image
     cmd.flags['boot-disk-size'] = self.BOOT_DISK_SIZE_GB
     cmd.flags['boot-disk-type'] = self.BOOT_DISK_TYPE
-    cmd.flags['machine-type'] = self.machine_type
+    if self.machine_type is None:
+      cmd.flags['custom-cpu'] = self.cpus
+      cmd.flags['custom-memory'] = '{0}MiB'.format(self.memory_mb)
+    else:
+      cmd.flags['machine-type'] = self.machine_type
     cmd.flags['tags'] = 'perfkitbenchmarker'
     cmd.flags['no-restart-on-failure'] = True
     cmd.flags['metadata-from-file'] = 'sshKeys=%s' % ssh_keys_path
@@ -229,6 +320,19 @@ class GceVirtualMachine(virtual_machine.BaseVirtualMachine):
 
   def AnnotateSample(self, unused_sender, benchmark_spec, sample):
     sample['metadata']['preemptible'] = self.preemptible
+
+  def GetMachineTypeDict(self):
+    """Returns a dict containing properties that specify the machine type.
+
+    Returns:
+      dict mapping string property key to value.
+    """
+    result = super(GceVirtualMachine, self).GetMachineTypeDict()
+    for attr_name in 'cpus', 'memory_mb', 'preemptible':
+      attr_value = getattr(self, attr_name)
+      if attr_value:
+        result[attr_name] = attr_value
+    return result
 
 
 class ContainerizedGceVirtualMachine(GceVirtualMachine,

--- a/perfkitbenchmarker/virtual_machine.py
+++ b/perfkitbenchmarker/virtual_machine.py
@@ -30,6 +30,7 @@ from perfkitbenchmarker import errors
 from perfkitbenchmarker import flags
 from perfkitbenchmarker import resource
 from perfkitbenchmarker import vm_util
+from perfkitbenchmarker.configs import option_decoders
 
 FLAGS = flags.FLAGS
 DEFAULT_USERNAME = 'perfkit'
@@ -52,11 +53,13 @@ class AutoRegisterVmSpecMeta(type):
   """Metaclass which allows VmSpecs to automatically be registered."""
 
   def __init__(cls, name, bases, dct):
+    super(AutoRegisterVmSpecMeta, cls).__init__(name, bases, dct)
     if cls.CLOUD in _VM_SPEC_REGISTRY:
       raise Exception('BaseVmSpec subclasses must have a CLOUD attribute.')
-    else:
-      _VM_SPEC_REGISTRY[cls.CLOUD] = cls
-    super(AutoRegisterVmSpecMeta, cls).__init__(name, bases, dct)
+    _VM_SPEC_REGISTRY[cls.CLOUD] = cls
+    cls._init_decoders_lock = threading.Lock()
+    cls._decoders = {}
+    cls._required_options = set()
 
 
 class AutoRegisterVmMeta(abc.ABCMeta):
@@ -89,12 +92,98 @@ class BaseVmSpec(object):
   __metaclass__ = AutoRegisterVmSpecMeta
   CLOUD = None
 
-  def __init__(self, zone=None, machine_type=None, image=None,
-               install_packages=True):
-    self.zone = zone
-    self.machine_type = machine_type
-    self.image = image
-    self.install_packages = install_packages
+  # Each subclass has its own copy of the following three variables. They are
+  # initialized by AutoRegisterVmSpecMeta.__init__ and later populated by
+  # _InitDecoders when the first instance of the subclass is created.
+  _init_decoders_lock = None  # threading.Lock that protects the next two vars.
+  _decoders = None  # dict mapping config option name to ConfigOptionDecoder.
+  _required_options = None  # set of strings. Required config options.
+
+  def __init__(self, **kwargs):
+    """Initializes a BaseVmSpec.
+
+    Translates keyword arguments via the class's decoders and assigns the
+    corresponding instance attribute. Derived classes can register decoders
+    for additional attributes by overriding _GetOptionDecoderConstructions.
+
+    Args:
+      **kwargs: Dict mapping config option names to provided values.
+
+    Raises:
+      errors.Config.MissingOption: If a config option is required, but a value
+          was not provided in kwargs.
+      errors.Config.UnrecognizedOption: If an unrecognized config option is
+          provided with a value in kwargs.
+    """
+    if not self._decoders:
+      self._InitDecoders()
+    # TODO(skschneider): Remove ApplyFlags from the benchmark spec. Call it
+    # here to modify kwargs prior to these decoder verifications.
+    provided_options = frozenset(k for k, v in kwargs.iteritems()
+                                 if v is not None)
+    missing_options = self._required_options.difference(provided_options)
+    if missing_options:
+      raise errors.Config.MissingOption(
+          'Required options were missing from a {0} config: {1}.'.format(
+              self._GetComponentDescription(),
+              ', '.join(sorted(missing_options))))
+    unrecognized_options = frozenset(provided_options).difference(
+        self._decoders)
+    if unrecognized_options:
+      raise errors.Config.UnrecognizedOption(
+          'Unrecognized options were found in a {0} config: {1}.'.format(
+              self._GetComponentDescription(),
+              ', '.join(sorted(unrecognized_options))))
+    for option, decoder in self._decoders.iteritems():
+      if option in provided_options:
+        value = decoder.Decode(kwargs[option])
+      else:
+        value = decoder.default
+      setattr(self, option, value)
+
+  @classmethod
+  def _GetComponentDescription(cls):
+    """Describes the type of component that this spec configures.
+
+    Returns:
+      string. Description of the type of component that this spec configures.
+    """
+    return 'VM' if cls.CLOUD is None else cls.CLOUD + ' VM'
+
+  @classmethod
+  def _GetOptionDecoderConstructions(cls):
+    """Gets decoder classes and constructor args for each configurable option.
+
+    Can be overridden to add options or impose additional requirements on
+    existing options.
+
+    Returns:
+      dict. Maps option name string to a (ConfigOptionDecoder class, dict) pair.
+          The pair specifies a decoder class and its __init__() keyword
+          arguments to construct in order to decode the named option.
+    """
+    return {
+        'image': (option_decoders.StringDecoder, {'default': None}),
+        'install_packages': (option_decoders.BooleanDecoder, {'default': True}),
+        'machine_type': (option_decoders.StringDecoder, {'default': None}),
+        'zone': (option_decoders.StringDecoder, {'default': None})}
+
+  @classmethod
+  def _InitDecoders(cls):
+    """Creates a ConfigOptionDecoder for each config option.
+
+    Populates cls._decoders and cls._required_options.
+    """
+    with cls._init_decoders_lock:
+      if not cls._decoders:
+        component = cls._GetComponentDescription()
+        decoder_constructions = cls._GetOptionDecoderConstructions()
+        for option, decoder_construction in decoder_constructions.iteritems():
+          decoder_class, init_args = decoder_construction
+          decoder = decoder_class(component, option, **init_args)
+          cls._decoders[option] = decoder
+          if decoder.required:
+            cls._required_options.add(option)
 
   def ApplyFlags(self, flags):
     """Applies flags to the VmSpec."""

--- a/tests/benchmark_spec_test.py
+++ b/tests/benchmark_spec_test.py
@@ -18,6 +18,7 @@ import unittest
 from perfkitbenchmarker import benchmark_spec
 from perfkitbenchmarker import configs
 from perfkitbenchmarker import context
+from perfkitbenchmarker import errors
 from perfkitbenchmarker import static_virtual_machine as static_vm
 from perfkitbenchmarker.providers.aws import aws_virtual_machine as aws_vm
 from perfkitbenchmarker.providers.gcp import gce_virtual_machine as gce_vm
@@ -129,5 +130,5 @@ class ConstructVmsTestCase(unittest.TestCase):
   def testBadParameter(self):
     config = configs.LoadConfig(BAD_VM_PARAMETER_CONFIG, {}, NAME)
     spec = benchmark_spec.BenchmarkSpec(config, NAME, UID)
-    with self.assertRaises(ValueError):
+    with self.assertRaises(errors.Config.UnrecognizedOption):
       spec.ConstructVirtualMachines()

--- a/tests/configs/__init__.py
+++ b/tests/configs/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2015 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/configs/option_decoders_test.py
+++ b/tests/configs/option_decoders_test.py
@@ -1,0 +1,139 @@
+# Copyright 2015 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for perfkitbenchmarker.configs.option_decoders."""
+
+import unittest
+
+from perfkitbenchmarker import errors
+from perfkitbenchmarker.configs import option_decoders
+
+
+_COMPONENT = 'test_component'
+_OPTION = 'test_option'
+
+
+def _ReturnFive():
+  return 5
+
+
+class _PassThroughDecoder(option_decoders.ConfigOptionDecoder):
+
+  def Decode(self, value):
+    return value
+
+
+class ConfigOptionDecoderTestCase(unittest.TestCase):
+
+  def testNoDefault(self):
+    decoder = _PassThroughDecoder(_COMPONENT, _OPTION)
+    self.assertTrue(decoder.required)
+    with self.assertRaises(AssertionError) as cm:
+      decoder.default
+    self.assertEqual(str(cm.exception), (
+        'Attempted to get the default value of test_component required config '
+        'option "test_option".'))
+
+  def testDefaultValue(self):
+    decoder = _PassThroughDecoder(_COMPONENT, _OPTION, default=None)
+    self.assertFalse(decoder.required)
+    self.assertEqual(decoder.default, None)
+
+  def testDefaultCallable(self):
+    decoder = _PassThroughDecoder(_COMPONENT, _OPTION, default=_ReturnFive)
+    self.assertFalse(decoder.required)
+    self.assertEqual(decoder.default, 5)
+
+
+class BooleanDecoderTestCase(unittest.TestCase):
+
+  def testDefault(self):
+    decoder = option_decoders.BooleanDecoder(_COMPONENT, _OPTION, default=None)
+    self.assertFalse(decoder.required)
+    self.assertEqual(decoder.default, None)
+
+  def testNonBoolean(self):
+    decoder = option_decoders.BooleanDecoder(_COMPONENT, _OPTION)
+    with self.assertRaises(errors.Config.InvalidValue) as cm:
+      decoder.Decode(5)
+    self.assertEqual(str(cm.exception), (
+        'Invalid test_component "test_option" value: "5" (of type "int"). '
+        'Value must be a boolean.'))
+
+  def testValidBoolean(self):
+    decoder = option_decoders.BooleanDecoder(_COMPONENT, _OPTION)
+    self.assertEqual(decoder.Decode(True), True)
+
+
+class IntDecoderTestCase(unittest.TestCase):
+
+  def testDefault(self):
+    decoder = option_decoders.IntDecoder(_COMPONENT, _OPTION, default=5)
+    self.assertFalse(decoder.required)
+    self.assertEqual(decoder.default, 5)
+
+  def testNonInt(self):
+    decoder = option_decoders.IntDecoder(_COMPONENT, _OPTION)
+    with self.assertRaises(errors.Config.InvalidValue) as cm:
+      decoder.Decode('5')
+    self.assertEqual(str(cm.exception), (
+        'Invalid test_component "test_option" value: "5" (of type "str"). '
+        'Value must be an integer.'))
+
+  def testValidInt(self):
+    decoder = option_decoders.IntDecoder(_COMPONENT, _OPTION)
+    self.assertEqual(decoder.Decode(5), 5)
+
+  def testMax(self):
+    decoder = option_decoders.IntDecoder(_COMPONENT, _OPTION, max=2)
+    with self.assertRaises(errors.Config.InvalidValue) as cm:
+      decoder.Decode(5)
+    self.assertEqual(str(cm.exception), (
+        'Invalid test_component "test_option" value: "5". Value must be at '
+        'most 2.'))
+    self.assertEqual(decoder.Decode(2), 2)
+    self.assertEqual(decoder.Decode(1), 1)
+
+  def testMin(self):
+    decoder = option_decoders.IntDecoder(_COMPONENT, _OPTION, min=10)
+    with self.assertRaises(errors.Config.InvalidValue) as cm:
+      decoder.Decode(5)
+    self.assertEqual(str(cm.exception), (
+        'Invalid test_component "test_option" value: "5". Value must be at '
+        'least 10.'))
+    self.assertEqual(decoder.Decode(10), 10)
+    self.assertEqual(decoder.Decode(15), 15)
+
+
+class StringDecoderTestCase(unittest.TestCase):
+
+  def testDefault(self):
+    decoder = option_decoders.StringDecoder(_COMPONENT, _OPTION, default=None)
+    self.assertFalse(decoder.required)
+    self.assertEqual(decoder.default, None)
+
+  def testNonString(self):
+    decoder = option_decoders.StringDecoder(_COMPONENT, _OPTION)
+    with self.assertRaises(errors.Config.InvalidValue) as cm:
+      decoder.Decode(5)
+    self.assertEqual(str(cm.exception), (
+        'Invalid test_component "test_option" value: "5" (of type "int"). '
+        'Value must be a string.'))
+
+  def testValidString(self):
+    decoder = option_decoders.StringDecoder(_COMPONENT, _OPTION)
+    self.assertEqual(decoder.Decode('red'), 'red')
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tests/configs/option_decoders_test.py
+++ b/tests/configs/option_decoders_test.py
@@ -54,6 +54,12 @@ class ConfigOptionDecoderTestCase(unittest.TestCase):
     self.assertFalse(decoder.required)
     self.assertEqual(decoder.default, 5)
 
+  def testIncompleteDerivedClass(self):
+    class IncompleteDerivedClass(option_decoders.ConfigOptionDecoder):
+      pass
+    with self.assertRaises(TypeError):
+      IncompleteDerivedClass(_COMPONENT, _OPTION)
+
 
 class BooleanDecoderTestCase(unittest.TestCase):
 

--- a/tests/disk_types_renaming_test.py
+++ b/tests/disk_types_renaming_test.py
@@ -30,6 +30,7 @@ class GcpDiskTypeRenamingTest(unittest.TestCase):
                 'cloud': 'GCP',
                 'vm_spec': {
                     'GCP': {
+                        'machine_type': 'test_machine_type',
                     }
                 },
                 'disk_spec': {
@@ -55,6 +56,7 @@ class GcpDiskTypeRenamingTest(unittest.TestCase):
                 'cloud': 'GCP',
                 'vm_spec': {
                     'GCP': {
+                        'machine_type': 'test_machine_type',
                     }
                 },
                 'disk_spec': {

--- a/tests/gce_virtual_machine_test.py
+++ b/tests/gce_virtual_machine_test.py
@@ -31,29 +31,29 @@ class MemoryDecoderTestCase(unittest.TestCase):
     self.decoder = gce_virtual_machine.MemoryDecoder('GCP VM', 'memory')
 
   def testValidStrings(self):
-    self.assertEqual(self.decoder.Decode('1280MB'), 1280)
-    self.assertEqual(self.decoder.Decode('7.5GB'), 7680)
+    self.assertEqual(self.decoder.Decode('1280MiB'), 1280)
+    self.assertEqual(self.decoder.Decode('7.5GiB'), 7680)
 
   def testImproperPattern(self):
     with self.assertRaises(errors.Config.InvalidValue) as cm:
       self.decoder.Decode('1280')
     self.assertEqual(str(cm.exception), (
         'Invalid GCP VM "memory" value: "1280". Examples of valid values: '
-        '"1280MB", "7.5GB".'))
+        '"1280MiB", "7.5GiB".'))
 
   def testInvalidFloat(self):
     with self.assertRaises(errors.Config.InvalidValue) as cm:
-      self.decoder.Decode('1280.9.8MB')
+      self.decoder.Decode('1280.9.8MiB')
     self.assertEqual(str(cm.exception), (
-        'Invalid GCP VM "memory" value: "1280.9.8MB". "1280.9.8" is not a '
+        'Invalid GCP VM "memory" value: "1280.9.8MiB". "1280.9.8" is not a '
         'valid float.'))
 
-  def testNonIntegerMB(self):
+  def testNonIntegerMiB(self):
     with self.assertRaises(errors.Config.InvalidValue) as cm:
-      self.decoder.Decode('7.6GB')
+      self.decoder.Decode('7.6GiB')
     self.assertEqual(str(cm.exception), (
-        'Invalid GCP VM "memory" value: "7.6GB". The specified size must be an '
-        'integer number of MB.'))
+        'Invalid GCP VM "memory" value: "7.6GiB". The specified size must be '
+        'an integer number of MiB.'))
 
 
 class GceVirtualMachineTestCase(unittest.TestCase):
@@ -99,15 +99,15 @@ class GceVirtualMachineTestCase(unittest.TestCase):
         'machine_type': 'test_machine_type', 'preemptible': True})
 
   def testCustomVmNonPreemptible(self):
-    spec = gce_virtual_machine.GceVmSpec(cpus=1, memory='1.0GB')
+    spec = gce_virtual_machine.GceVmSpec(cpus=1, memory='1.0GiB')
     vm = gce_virtual_machine.GceVirtualMachine(spec)
-    self.assertEqual(vm.GetMachineTypeDict(), {'cpus': 1, 'memory_mb': 1024})
+    self.assertEqual(vm.GetMachineTypeDict(), {'cpus': 1, 'memory_mib': 1024})
 
   def testCustomVmPreemptible(self):
-    spec = gce_virtual_machine.GceVmSpec(cpus=1, memory='1.0GB',
+    spec = gce_virtual_machine.GceVmSpec(cpus=1, memory='1.0GiB',
                                          preemptible=True)
     vm = gce_virtual_machine.GceVirtualMachine(spec)
-    self.assertEqual(vm.GetMachineTypeDict(), {'cpus': 1, 'memory_mb': 1024,
+    self.assertEqual(vm.GetMachineTypeDict(), {'cpus': 1, 'memory_mib': 1024,
                                                'preemptible': True})
 
 

--- a/tests/scratch_disk_test.py
+++ b/tests/scratch_disk_test.py
@@ -145,7 +145,7 @@ class GceScratchDiskTest(ScratchDiskTestMixin, unittest.TestCase):
     self.patches.append(mock.patch(gce_disk.__name__ + '.GceDisk'))
 
   def _CreateVm(self):
-    vm_spec = gce_virtual_machine.GceVmSpec()
+    vm_spec = gce_virtual_machine.GceVmSpec(machine_type='test_machine_type')
     return gce_virtual_machine.DebianBasedGceVirtualMachine(vm_spec)
 
   def _GetDiskClass(self):

--- a/tests/virtual_machine_test.py
+++ b/tests/virtual_machine_test.py
@@ -1,0 +1,84 @@
+# Copyright 2015 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for perfkitbenchmarker.virtual_machine."""
+
+import unittest
+
+from perfkitbenchmarker import errors
+from perfkitbenchmarker import virtual_machine
+from perfkitbenchmarker.configs import option_decoders
+
+
+class TestVmSpec(virtual_machine.BaseVmSpec):
+
+  CLOUD = 'test_cloud'
+
+  @classmethod
+  def _GetOptionDecoderConstructions(cls):
+    result = super(TestVmSpec, cls)._GetOptionDecoderConstructions()
+    result['required_string'] = (option_decoders.StringDecoder, {})
+    result['required_int'] = (option_decoders.IntDecoder, {})
+    return result
+
+
+class BaseVmSpecTestCase(unittest.TestCase):
+
+  def testDefaults(self):
+    spec = virtual_machine.BaseVmSpec()
+    self.assertEqual(spec.image, None)
+    self.assertEqual(spec.install_packages, True)
+    self.assertEqual(spec.machine_type, None)
+    self.assertEqual(spec.zone, None)
+
+  def testProvidedValid(self):
+    spec = virtual_machine.BaseVmSpec(
+        image='test_image', install_packages=False,
+        machine_type='test_machine_type', zone='test_zone')
+    self.assertEqual(spec.image, 'test_image')
+    self.assertEqual(spec.install_packages, False)
+    self.assertEqual(spec.machine_type, 'test_machine_type')
+    self.assertEqual(spec.zone, 'test_zone')
+
+  def testUnrecognizedOptions(self):
+    with self.assertRaises(errors.Config.UnrecognizedOption) as cm:
+      virtual_machine.BaseVmSpec(color='red', flavor='cherry')
+    self.assertEqual(str(cm.exception), (
+        'Unrecognized options were found in a VM config: color, flavor.'))
+
+  def testMissingOptions(self):
+    with self.assertRaises(errors.Config.MissingOption) as cm:
+      TestVmSpec()
+    self.assertEqual(str(cm.exception), (
+        'Required options were missing from a test_cloud VM config: '
+        'required_int, required_string.'))
+
+  def testInvalidImage(self):
+    with self.assertRaises(errors.Config.InvalidValue):
+      virtual_machine.BaseVmSpec(image=0)
+
+  def testInvalidInstallPackages(self):
+    with self.assertRaises(errors.Config.InvalidValue):
+      virtual_machine.BaseVmSpec(install_packages='yes')
+
+  def testInvalidMachineType(self):
+    with self.assertRaises(errors.Config.InvalidValue):
+      virtual_machine.BaseVmSpec(machine_type=True)
+
+  def testInvalidZone(self):
+    with self.assertRaises(errors.Config.InvalidValue):
+      virtual_machine.BaseVmSpec(zone=0)
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
Add ConfigOptionDecoder classes.
Add 'cpus' and 'memory' options to the GCE VM spec.
Add 'cpus', 'memory_mb', and 'preemptible' to GCE VM Sample metadata.
Modify gcloud VM provisioning command to use custom VM flags.