### PR TITLE
gce_virtual_machine: Add support for image_project

### DIFF
--- a/perfkitbenchmarker/providers/gcp/gce_virtual_machine.py
+++ b/perfkitbenchmarker/providers/gcp/gce_virtual_machine.py
@@ -194,6 +194,8 @@ class GceVirtualMachine(virtual_machine.BaseVirtualMachine):
     cmd.flags['network'] = self.network.network_resource.name
     cmd.flags['image'] = self.image
     cmd.flags['boot-disk-auto-delete'] = True
+    if FLAGS.image_project:
+      cmd.flags['image-project'] = FLAGS.image_project
     cmd.flags['boot-disk-size'] = self.BOOT_DISK_SIZE_GB
     cmd.flags['boot-disk-type'] = self.BOOT_DISK_TYPE
     if self.machine_type is None:


### PR DESCRIPTION
Although ```providers/gcp/flags.py``` claims it supports the flag ```image_project```,
when creating an instance, it is never used in ```gce_virtual_machine.py```, or passed
to the underlining ```gcloud``` cli.

A sample failure trying to creating an instance with an image in another
project:

```
$ ./pkb.py --project=wonderfly-playground --machine_type=f1-micro
--image=test-image --image_project=test-image-project --os_type=ubuntu_container
--benchmarks=cluster_boot
```
A subset of the error message I got:
>
2015-11-23 15:58:27,143 3fa6ceaf Thread-6 cluster_boot(1/1) INFO     Ran gcloud
compute instances create pkb-3fa6ceaf-0 --format json --quiet --project
wonderfly-playground --zone us-central1-a --network pkb-network-3fa6ceaf --image
test-image --boot-disk-size 10 --boot-disk-type pd-standard --machine-type
f1-micro --tags perfkitbenchmarker --no-restart-on-failure --metadata-from-file
sshKeys=/tmp/perfkitbenchmarker/run_3fa6ceaf/key-metadatanXAmr1 --metadata
owner=wonderfly --maintenance-policy TERMINATE.
Got return code (1).
STDOUT:
STDERR: WARNING: You have selected a disk size of under [200GB]. This may result
in poor I/O performance. For more information, see:
https://developers.google.com/compute/docs/disks/persistent-disks#pdperformance.
ERROR: (gcloud.compute.instances.create) Some requests did not succeed:
 - Invalid value for field 'resource.disk.initializeParams.sourceImage':
   'https://www.googleapis.com/compute/v1/projects/wonderfly-playground/global/images/test-image'.
   Referenced resource was not found.

This change actually enables the ```image_project``` flag, and adds a unit test to
verify it.

Tested with ```python test/gce_virtual_machine_test.py``` and the same command line as
shown above.

@voellm @cmccoy 