### PR TITLE
Broaden exception caught during PKB run.

### DIFF
--- a/perfkitbenchmarker/pkb.py
+++ b/perfkitbenchmarker/pkb.py
@@ -367,7 +367,7 @@ def RunBenchmark(benchmark, collector, sequence_number, total_benchmarks,
           detailed_timer.GenerateSamples(include_runtimes, include_timestamps),
           benchmark_name, spec)
 
-    except Exception:
+    except:
       # Resource cleanup (below) can take a long time. Log the error to give
       # immediate feedback, then re-throw.
       logging.exception('Error during benchmark %s', benchmark_name)


### PR DESCRIPTION
The current version does not catch KeyboardInterrupt or SystemExit (see [here](https://docs.python.org/2/library/exceptions.html#exceptions.KeyboardInterrupt)),
and we want to clean up in the first case. The exception is re-raised regardless.