### PR TITLE
Enhance config usage by multi-node benchmarks.

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/aerospike_ycsb_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/aerospike_ycsb_benchmark.py
@@ -57,7 +57,8 @@ def GetConfig(user_config):
       FLAGS.data_disk_type != disk.LOCAL):
     config['vm_groups']['workers']['disk_count'] = 1
 
-  config['vm_groups']['clients']['vm_count'] = FLAGS.ycsb_client_vms
+  if FLAGS['ycsb_client_vms'].present:
+    config['vm_groups']['clients']['vm_count'] = FLAGS.ycsb_client_vms
 
   return config
 

--- a/perfkitbenchmarker/linux_benchmarks/aerospike_ycsb_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/aerospike_ycsb_benchmark.py
@@ -21,7 +21,6 @@ YCSB and workloads described in perfkitbenchmarker.linux_packages.ycsb.
 """
 
 import functools
-import logging
 
 from perfkitbenchmarker import configs
 from perfkitbenchmarker import disk
@@ -41,7 +40,9 @@ aerospike_ycsb:
     installation. Specify the number of YCSB VMs with
     --ycsb_client_vms.
   vm_groups:
-    default:
+    clients:
+      vm_spec: *default_single_core
+    workers:
       vm_spec: *default_single_core
       disk_spec: *default_500_gb
       vm_count: null
@@ -54,10 +55,9 @@ def GetConfig(user_config):
 
   if (FLAGS.aerospike_storage_type == aerospike_server.DISK and
       FLAGS.data_disk_type != disk.LOCAL):
-    config['vm_groups']['default']['disk_count'] = 1
+    config['vm_groups']['workers']['disk_count'] = 1
 
-  config['vm_groups']['default']['vm_count'] = (FLAGS.ycsb_client_vms +
-                                                FLAGS.num_vms)
+  config['vm_groups']['clients']['vm_count'] = FLAGS.ycsb_client_vms
 
   return config
 
@@ -71,14 +71,6 @@ def CheckPrerequisites():
   ycsb.CheckPrerequisites()
 
 
-def _GetVMsByRole(vms):
-  """Gets a dictionary mapping role to a list of VMs."""
-  aerospike_vms = vms[:-FLAGS.ycsb_client_vms]
-  return {'vms': vms,
-          'aerospike_vms': aerospike_vms,
-          'loaders': vms[-FLAGS.ycsb_client_vms:]}
-
-
 def Prepare(benchmark_spec):
   """Prepare the virtual machines to run YCSB against Aerospike.
 
@@ -86,15 +78,13 @@ def Prepare(benchmark_spec):
     benchmark_spec: The benchmark specification. Contains all data that is
         required to run the benchmark.
   """
-  vms = benchmark_spec.vms
-  by_role = _GetVMsByRole(benchmark_spec.vms)
-
-  loaders = by_role['loaders']
-  assert loaders, vms
+  loaders = benchmark_spec.vm_groups['clients']
+  assert loaders, benchmark_spec.vm_groups
 
   # Aerospike cluster
-  aerospike_vms = by_role['aerospike_vms']
-  assert aerospike_vms, 'No aerospike VMs: {0}'.format(by_role)
+  aerospike_vms = benchmark_spec.vm_groups['workers']
+  assert aerospike_vms, 'No aerospike VMs: {0}'.format(
+      benchmark_spec.vm_groups)
 
   seed_ips = [vm.internal_ip for vm in aerospike_vms]
   aerospike_install_fns = [functools.partial(aerospike_server.ConfigureAndStart,
@@ -116,11 +106,8 @@ def Run(benchmark_spec):
   Returns:
     A list of sample.Sample instances.
   """
-  vms = benchmark_spec.vms
-  loaders = _GetVMsByRole(vms)['loaders']
-  aerospike_vms = _GetVMsByRole(vms)['aerospike_vms']
-  logging.debug('Loaders: %s', loaders)
-  vms = benchmark_spec.vms
+  loaders = benchmark_spec.vm_groups['clients']
+  aerospike_vms = benchmark_spec.vm_groups['workers']
 
   executor = ycsb.YCSBExecutor('aerospike',
                                **{'as.host': aerospike_vms[0].internal_ip,
@@ -149,6 +136,5 @@ def Cleanup(benchmark_spec):
                          aerospike_server.AEROSPIKE_DIR)
     server.RemoteCommand('sudo rm -rf aerospike*')
 
-  vms = benchmark_spec.vms
-  aerospike_vms = _GetVMsByRole(vms)['aerospike_vms']
+  aerospike_vms = benchmark_spec.vm_groups['workers']
   vm_util.RunThreaded(StopAerospike, aerospike_vms)

--- a/perfkitbenchmarker/linux_benchmarks/cassandra_stress_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/cassandra_stress_benchmark.py
@@ -152,16 +152,16 @@ BENCHMARK_CONFIG = """
 cassandra_stress:
   description: Benchmark Cassandra using cassandra-stress
   vm_groups:
-    cassandra_nodes:
+    workers:
       vm_spec: *default_single_core
       disk_spec: *default_500_gb
       vm_count: 3
-    stress_client:
+    client:
       vm_spec: *default_single_core
 """
 
-CASSANDRA_GROUP = 'cassandra_nodes'
-CLIENT_GROUP = 'stress_client'
+CASSANDRA_GROUP = 'workers'
+CLIENT_GROUP = 'client'
 
 SLEEP_BETWEEN_CHECK_IN_SECONDS = 5
 TEMP_PROFILE_PATH = posixpath.join(vm_util.VM_TMP_DIR, 'profile.yaml')

--- a/perfkitbenchmarker/linux_benchmarks/cassandra_ycsb_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/cassandra_ycsb_benchmark.py
@@ -62,7 +62,8 @@ def GetConfig(user_config):
   config = configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
   num_vms = max(FLAGS.num_vms, 3)
   config['vm_groups']['workers']['vm_count'] = num_vms
-  config['vm_groups']['clients']['vm_count'] = FLAGS.ycsb_client_vms
+  if FLAGS['ycsb_client_vms'].present:
+    config['vm_groups']['clients']['vm_count'] = FLAGS.ycsb_client_vms
   return config
 
 

--- a/perfkitbenchmarker/linux_benchmarks/cassandra_ycsb_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/cassandra_ycsb_benchmark.py
@@ -41,10 +41,11 @@ cassandra_ycsb:
       Cassandra cluster size with --num_vms. Specify the number
       of YCSB VMs with --ycsb_client_vms.
   vm_groups:
-    default:
+    workers:
       vm_spec: *default_single_core
       disk_spec: *default_500_gb
-      vm_count: null
+    clients:
+      vm_spec: *default_single_core
 """
 
 # TODO: Add flags.
@@ -60,7 +61,8 @@ CREATE_TABLE_SCRIPT = 'cassandra/create-ycsb-table.cql.j2'
 def GetConfig(user_config):
   config = configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
   num_vms = max(FLAGS.num_vms, 3)
-  config['vm_groups']['default']['vm_count'] = num_vms + FLAGS.ycsb_client_vms
+  config['vm_groups']['workers']['vm_count'] = num_vms
+  config['vm_groups']['clients']['vm_count'] = FLAGS.ycsb_client_vms
   return config
 
 
@@ -101,14 +103,15 @@ def _CreateYCSBTable(vm, keyspace=KEYSPACE_NAME, column_family=COLUMN_FAMILY,
   vm.RemoteCommand(command, should_log=True)
 
 
-def _GetVMsByRole(vms):
+def _GetVMsByRole(benchmark_spec):
   """Gets a dictionary mapping role to a list of VMs."""
-  cassandra_vms = vms[:-FLAGS.ycsb_client_vms]
-  return {'vms': vms,
+  cassandra_vms = benchmark_spec.vm_groups['workers']
+  clients = benchmark_spec.vm_groups['clients']
+  return {'vms': benchmark_spec.vms,
           'cassandra_vms': cassandra_vms,
           'seed_vm': cassandra_vms[0],
           'non_seed_cassandra_vms': cassandra_vms[1:],
-          'loaders': vms[-FLAGS.ycsb_client_vms:]}
+          'clients': clients}
 
 
 def Prepare(benchmark_spec):
@@ -119,9 +122,9 @@ def Prepare(benchmark_spec):
         required to run the benchmark.
   """
   vms = benchmark_spec.vms
-  by_role = _GetVMsByRole(benchmark_spec.vms)
+  by_role = _GetVMsByRole(benchmark_spec)
 
-  loaders = by_role['loaders']
+  loaders = by_role['clients']
   assert loaders, vms
 
   # Cassandra cluster
@@ -153,11 +156,9 @@ def Run(benchmark_spec):
   Returns:
     A list of sample.Sample instances.
   """
-  vms = benchmark_spec.vms
-  loaders = _GetVMsByRole(vms)['loaders']
-  cassandra_vms = _GetVMsByRole(vms)['cassandra_vms']
+  loaders = _GetVMsByRole(benchmark_spec)['clients']
+  cassandra_vms = _GetVMsByRole(benchmark_spec)['cassandra_vms']
   logging.debug('Loaders: %s', loaders)
-  vms = benchmark_spec.vms
 
   executor = ycsb.YCSBExecutor(
       'cassandra-10',
@@ -190,6 +191,6 @@ def Cleanup(benchmark_spec):
     benchmark_spec: The benchmark specification. Contains all data that is
         required to run the benchmark.
   """
-  cassandra_vms = _GetVMsByRole(benchmark_spec.vms)['cassandra_vms']
+  cassandra_vms = _GetVMsByRole(benchmark_spec)['cassandra_vms']
   vm_util.RunThreaded(cassandra.Stop, cassandra_vms)
   vm_util.RunThreaded(cassandra.CleanNode, cassandra_vms)

--- a/perfkitbenchmarker/linux_benchmarks/cloudsuite_web_serving_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/cloudsuite_web_serving_benchmark.py
@@ -15,8 +15,10 @@
 """Runs Cloudsuite2.0 Web Serving benchmark
    More info: http://parsa.epfl.ch/cloudsuite/web.html
 """
+import logging
 import posixpath
 import re
+import time
 
 from perfkitbenchmarker import configs
 from perfkitbenchmarker import sample
@@ -41,9 +43,6 @@ OLIO_BUILD = '%s/apache-olio-php-src-0.2/workload/php/trunk/' % BASE_DIR
 # File names
 MY_CNF = '/etc/my.cnf'
 NGINX_CONF = '%s/nginx.conf' % BASE_DIR
-CL = 0
-BK = 1
-FR = 2
 
 flags.DEFINE_integer('cloudsuite_web_serving_load_scale', 100,
                      'The maximum number of concurrent users '
@@ -55,16 +54,20 @@ BENCHMARK_CONFIG = """
 cloudsuite_web_serving:
   description: Runs Cloudsuite Web Serving benchmark
   vm_groups:
-    default:
+    backend:
       vm_spec: *default_single_core
       disk_spec: *default_500_gb
-      vm_count: 3
+    frontend:
+      vm_spec: *default_single_core
+      disk_spec: *default_500_gb
+    client:
+      vm_spec: *default_single_core
 """
 
 
 def _SetupFrontend(benchmark_spec):
-  frontend = benchmark_spec.vms[FR]
-  backend = benchmark_spec.vms[BK]
+  frontend = benchmark_spec.vm_groups['frontend'][0]
+  backend = benchmark_spec.vm_groups['backend'][0]
   frontend.Install('nginx')
   frontend.RemoteCommand('perl -pi -e "s/%s/%s/g" %s'
                          % ('APP_DIR', re.escape(APP_DIR), NGINX_CONF))
@@ -129,11 +132,10 @@ def _SetupFrontend(benchmark_spec):
 
 
 def _SetupBackend(benchmark_spec):
-  vms = benchmark_spec.vms
-  backend = vms[BK]
-  frontend = vms[FR]
-  CLIENT_IP = vms[CL].ip_address
-  FRONTEND_IP = frontend.ip_address
+  frontend = benchmark_spec.vm_groups['frontend'][0]
+  backend = benchmark_spec.vm_groups['backend'][0]
+  client_ip = benchmark_spec.vm_groups['client'][0].ip_address
+  frontend_ip = frontend.ip_address
   backend.Install('libaio')
   untar_command = ('cd %s && tar xzf %s')
   backend.RemoteCommand(untar_command %
@@ -143,6 +145,10 @@ def _SetupBackend(benchmark_spec):
   db_install_command = ('cd %s && scripts/mysql_install_db')
   backend.RemoteCommand(db_install_command % (MYSQL_HOME))
   backend.RobustRemoteCommand('cd %s && ./bin/mysqld_safe &' % MYSQL_HOME)
+
+  # Wait for mysql to start
+  logging.info('Sleeping 30s for mysql to come up')
+  time.sleep(30)
   sql_cmd = 'create user \'olio\'@\'%\' identified by \'olio\';'
   backend.RemoteCommand('cd %s && '
                         './bin/mysql -uroot -e "%s"' % (MYSQL_HOME, sql_cmd))
@@ -151,7 +157,7 @@ def _SetupBackend(benchmark_spec):
                         'identified by \'olio\' with grant option; '
                         'grant all privileges on *.* to '
                         '\'olio\'@\'%s\' identified by \'olio\' with grant '
-                        'option;"' % (MYSQL_HOME, FRONTEND_IP))
+                        'option;"' % (MYSQL_HOME, frontend_ip))
   backend.RemoteCommand('cd %s && ./bin/mysql -uroot -e "create database olio;'
                         'use olio; \. %s/benchmarks/OlioDriver/bin/schema.sql"'
                         % (MYSQL_HOME, FABAN_HOME))
@@ -173,7 +179,7 @@ def _SetupBackend(benchmark_spec):
   backend.RemoteCommand(build_tomcat % (JAVA_HOME, CATALINA_HOME))
   backend.RemoteCommand('mkdir %s' % GEOCODER_HOME)
   backend.RemoteCommand('scp -r -o StrictHostKeyChecking=no %s:%s/geocoder %s' %
-                        (CLIENT_IP, OLIO_HOME, GEOCODER_HOME))
+                        (client_ip, OLIO_HOME, GEOCODER_HOME))
   backend.RemoteCommand('cd %s/geocoder && cp build.properties.template '
                         'build.properties' % GEOCODER_HOME)
   editor_command = ('perl -pi -e '
@@ -190,10 +196,9 @@ def _SetupBackend(benchmark_spec):
 
 
 def _SetupClient(benchmark_spec):
-  vms = benchmark_spec.vms
-  client = vms[CL]
-  frontend = vms[FR]
-  backend = vms[BK]
+  frontend = benchmark_spec.vm_groups['frontend'][0]
+  backend = benchmark_spec.vm_groups['backend'][0]
+  client = benchmark_spec.vm_groups['client'][0]
   fw = client.firewall
   fw.AllowPort(client, 9980)
   CLIENT_IP = client.ip_address
@@ -299,16 +304,6 @@ def _PrepareVms(vm):
                    'tar xzf web.tar.gz' % vm_util.VM_TMP_DIR)
 
 
-def _SetupVM(benchmark_spec, thread_id):
-  """Passes the vm to either the backend or frontend setup functions.
-     Used to run frontend and backend threaded.
-  """
-  if thread_id == BK:
-    _SetupBackend(benchmark_spec)
-  if thread_id == FR:
-    _SetupFrontend(benchmark_spec)
-
-
 def Prepare(benchmark_spec):
   """Install Java, apache ant, authenticate vms
      Set up the client machine, backend machine, and frontend
@@ -317,11 +312,11 @@ def Prepare(benchmark_spec):
     benchmark_spec: The benchmark specification. Contains all data that is
         required to run the benchmark.
   """
+  frontend = benchmark_spec.vm_groups['frontend'][0]
+  backend = benchmark_spec.vm_groups['backend'][0]
+  client = benchmark_spec.vm_groups['client'][0]
   vms = benchmark_spec.vms
   vm_util.RunThreaded(PreparePrivateKey, vms)
-  client = vms[CL]
-  backend = vms[BK]
-  frontend = vms[FR]
   vm_util.RunThreaded(_PrepareVms, vms)
   frontend.RemoteCommand('cd %s && '
                          'wget parsa.epfl.ch/cloudsuite/software/perfkit/'
@@ -332,8 +327,8 @@ def Prepare(benchmark_spec):
                          (client.ip_address, FABAN_HOME, BASE_DIR))
   backend.RemoteCommand('scp -r -o StrictHostKeyChecking=no %s:%s %s' %
                         (client.ip_address, FABAN_HOME, BASE_DIR))
-  args = [((benchmark_spec, BK), {}), ((benchmark_spec, FR), {})]
-  vm_util.RunThreaded(_SetupVM, args)
+  setup_functions = [_SetupBackend, _SetupFrontend]
+  vm_util.RunThreaded(lambda f: f(benchmark_spec), setup_functions)
 
 
 def ParseOutput(client):
@@ -350,7 +345,7 @@ def ParseOutput(client):
 
 
 def Run(benchmark_spec):
-  client = benchmark_spec.vms[CL]
+  client = benchmark_spec.vm_groups['client'][0]
   set_faban_home = ('export FABAN_HOME=%s && cd %s && ./run.sh')
   client.RobustRemoteCommand(set_faban_home % (FABAN_HOME, FABAN_HOME))
   results = []
@@ -371,15 +366,16 @@ def Cleanup(benchmark_spec):
     benchmark_spec: The benchmark specification. Contains all data
         that is required to run the benchmark.
   """
-  vms = benchmark_spec.vms
+  backend = benchmark_spec.vm_groups['backend'][0]
+  client = benchmark_spec.vm_groups['client'][0]
   set_java = ('export JAVA_HOME=%s && %s/master/bin/shutdown.sh')
-  vms[CL].RemoteCommand(set_java % (JAVA_HOME, FABAN_HOME))
-  vms[BK].RemoteCommand('cd %s && sudo ./bin/mysqladmin shutdown' % MYSQL_HOME)
-  cleanupFrontend(benchmark_spec)
+  client.RemoteCommand(set_java % (JAVA_HOME, FABAN_HOME))
+  backend.RemoteCommand('cd %s && sudo ./bin/mysqladmin shutdown' % MYSQL_HOME)
+  _CleanupFrontend(benchmark_spec)
 
 
-def cleanupFrontend(benchmark_spec):
-  frontend = benchmark_spec.vms[FR]
+def _CleanupFrontend(benchmark_spec):
+  frontend = benchmark_spec.vm_groups['frontend'][0]
   frontend.RemoteCommand('sudo killall -9 php-fpm')
   nginx.Stop(frontend)
   filestore = posixpath.join(frontend.GetScratchDir(), 'filestore')

--- a/perfkitbenchmarker/linux_benchmarks/hbase_ycsb_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/hbase_ycsb_benchmark.py
@@ -67,7 +67,7 @@ hbase_ycsb:
       cluster size with --num_vms. Specify the number of YCSB VMs
       with --ycsb_client_vms.
   vm_groups:
-    loaders:
+    clients:
       vm_spec: *default_single_core
     master:
       vm_spec: *default_single_core
@@ -90,7 +90,7 @@ def GetConfig(user_config):
   num_vms = max(FLAGS.num_vms, 2)
   if FLAGS['num_vms'].present and FLAGS.num_vms < 2:
     raise ValueError('hbase_ycsb requires at least 2 HBase VMs.')
-  config['vm_groups']['loaders']['vm_count'] = FLAGS.ycsb_client_vms
+  config['vm_groups']['clients']['vm_count'] = FLAGS.ycsb_client_vms
   if FLAGS['num_vms'].present:
     config['vm_groups']['workers']['vm_count'] = num_vms - 1
   return config
@@ -148,16 +148,16 @@ def _GetVMsByRole(vm_groups):
 
   Returns:
     A dictionary with keys 'vms', 'hbase_vms', 'master', 'zk_quorum', 'workers',
-    and 'loaders'.
+    and 'clients'.
   """
   hbase_vms = vm_groups['master'] + vm_groups['workers']
-  vms = hbase_vms + vm_groups['loaders']
+  vms = hbase_vms + vm_groups['clients']
   return {'vms': vms,
           'hbase_vms': hbase_vms,
           'master': vm_groups['master'][0],
           'zk_quorum': hbase_vms[:FLAGS.hbase_zookeeper_nodes],
           'workers': vm_groups['workers'],
-          'loaders': vm_groups['loaders']}
+          'clients': vm_groups['clients']}
 
 
 def Prepare(benchmark_spec):
@@ -169,7 +169,7 @@ def Prepare(benchmark_spec):
   """
   by_role = _GetVMsByRole(benchmark_spec.vm_groups)
 
-  loaders = by_role['loaders']
+  loaders = by_role['clients']
   assert loaders, 'No loader VMs: {0}'.format(by_role)
 
   # HBase cluster
@@ -219,7 +219,7 @@ def Run(benchmark_spec):
     A list of sample.Sample objects.
   """
   by_role = _GetVMsByRole(benchmark_spec.vm_groups)
-  loaders = by_role['loaders']
+  loaders = by_role['clients']
   logging.info('Loaders: %s', loaders)
 
   executor = ycsb.YCSBExecutor('hbase-10')

--- a/perfkitbenchmarker/linux_benchmarks/hbase_ycsb_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/hbase_ycsb_benchmark.py
@@ -90,7 +90,8 @@ def GetConfig(user_config):
   num_vms = max(FLAGS.num_vms, 2)
   if FLAGS['num_vms'].present and FLAGS.num_vms < 2:
     raise ValueError('hbase_ycsb requires at least 2 HBase VMs.')
-  config['vm_groups']['clients']['vm_count'] = FLAGS.ycsb_client_vms
+  if FLAGS['ycsb_client_vms'].present:
+    config['vm_groups']['clients']['vm_count'] = FLAGS.ycsb_client_vms
   if FLAGS['num_vms'].present:
     config['vm_groups']['workers']['vm_count'] = num_vms - 1
   return config

--- a/perfkitbenchmarker/linux_benchmarks/mongodb_ycsb_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/mongodb_ycsb_benchmark.py
@@ -40,15 +40,19 @@ BENCHMARK_CONFIG = """
 mongodb_ycsb:
   description: Run YCSB against a single MongoDB node.
   vm_groups:
-    default:
+    workers:
       vm_spec: *default_single_core
       disk_spec: *default_500_gb
-      vm_count: 2
+      vm_count: null
+    clients:
+      vm_spec: *default_single_core
 """
 
 
 def GetConfig(user_config):
-  return configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
+  config = configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
+  config['vm_groups']['clients']['vm_count'] = FLAGS.ycsb_client_vms
+  return config
 
 
 def _GetDataDir(vm):
@@ -85,12 +89,12 @@ def Prepare(benchmark_spec):
     benchmark_spec: The benchmark specification. Contains all data that is
         required to run the benchmark.
   """
-  vms = benchmark_spec.vms
-  mongo_vm, ycsb_vm = vms[:2]
+  server_partials = [functools.partial(_PrepareServer, mongo_vm)
+                     for mongo_vm in benchmark_spec.vm_groups['workers']]
+  client_partials = [functools.partial(_PrepareClient, client)
+                     for client in benchmark_spec.vm_groups['clients']]
 
-  vm_util.RunThreaded((lambda f: f()),
-                      [functools.partial(_PrepareServer, mongo_vm),
-                       functools.partial(_PrepareClient, ycsb_vm)])
+  vm_util.RunThreaded((lambda f: f()), server_partials + client_partials)
 
 
 def Run(benchmark_spec):
@@ -103,15 +107,14 @@ def Run(benchmark_spec):
   Returns:
     A list of sample.Sample objects.
   """
-  vms = benchmark_spec.vms
-  vm = vms[1]
 
   executor = ycsb.YCSBExecutor('mongodb', cp=ycsb.YCSB_DIR)
+  server = benchmark_spec.vm_groups['workers'][0]
   kwargs = {
-      'mongodb.url': 'mongodb://%s:27017/' % vms[0].internal_ip,
+      'mongodb.url': 'mongodb://%s:27017/' % server.internal_ip,
       'mongodb.writeConcern': FLAGS.mongodb_writeconcern}
-  samples = list(executor.LoadAndRun([vm], load_kwargs=kwargs,
-                                     run_kwargs=kwargs))
+  samples = list(executor.LoadAndRun(benchmark_spec.vm_groups['clients'],
+                                     load_kwargs=kwargs, run_kwargs=kwargs))
   return samples
 
 
@@ -122,8 +125,9 @@ def Cleanup(benchmark_spec):
     benchmark_spec: The benchmark specification. Contains all data that is
         required to run the benchmark.
   """
-  vms = benchmark_spec.vms
-  mongo_vm = vms[0]
-  mongo_vm.RemoteCommand('sudo service %s stop' %
-                         mongo_vm.GetServiceName('mongodb_server'))
-  mongo_vm.RemoteCommand('rm -rf %s' % _GetDataDir(mongo_vm))
+  def CleanupServer(server):
+    server.RemoteCommand('sudo service %s stop' %
+                         server.GetServiceName('mongodb_server'))
+    server.RemoteCommand('rm -rf %s' % _GetDataDir(server))
+
+  vm_util.RunThreaded(CleanupServer, benchmark_spec.vm_groups['workers'][0])

--- a/perfkitbenchmarker/linux_benchmarks/mongodb_ycsb_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/mongodb_ycsb_benchmark.py
@@ -51,7 +51,8 @@ mongodb_ycsb:
 
 def GetConfig(user_config):
   config = configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
-  config['vm_groups']['clients']['vm_count'] = FLAGS.ycsb_client_vms
+  if FLAGS['ycsb_client_vms'].present:
+    config['vm_groups']['clients']['vm_count'] = FLAGS.ycsb_client_vms
   return config
 
 

--- a/perfkitbenchmarker/linux_benchmarks/ping_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/ping_benchmark.py
@@ -28,9 +28,10 @@ BENCHMARK_CONFIG = """
 ping:
   description: Benchmarks ping latency over internal IP addresses
   vm_groups:
-    default:
+    vm_1:
       vm_spec: *default_single_core
-      vm_count: 2
+    vm_2:
+      vm_spec: *default_single_core
 """
 
 METRICS = ('Min Latency', 'Average Latency', 'Max Latency', 'Latency Std Dev')

--- a/perfkitbenchmarker/linux_benchmarks/redis_ycsb_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/redis_ycsb_benchmark.py
@@ -45,7 +45,8 @@ REDIS_PID_FILE = posixpath.join(redis_server.REDIS_DIR, 'redis.pid')
 
 def GetConfig(user_config):
   config = configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
-  config['vm_groups']['clients']['vm_count'] = FLAGS.ycsb_client_vms
+  if FLAGS['ycsb_client_vms'].present:
+    config['vm_groups']['clients']['vm_count'] = FLAGS.ycsb_client_vms
   return config
 
 


### PR DESCRIPTION
See #512.

* Standardizes names for VM groups in database and Hadoop benchmarks to
  `workers` (data serving / processing nodes) and `clients` (load generating
  nodes). Systems with a master have an additional `master` node.
* Splits out VM roles for CloudSuite benchmarks.
* Adds multi-server support to Aerospike benchmark.