### PR TITLE
Add helper for mocking FLAGS across all modules.

### DIFF
--- a/perfkitbenchmarker/mock_flags_test.py
+++ b/perfkitbenchmarker/mock_flags_test.py
@@ -1,0 +1,74 @@
+# Copyright 2015 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for tests.mock_flags."""
+
+import unittest
+
+from perfkitbenchmarker import flags
+from tests import mock_flags
+
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_integer('test_flag', 0, 'Test flag.')
+
+
+class MockFlagsTestCase(unittest.TestCase):
+
+  def setUp(self):
+    super(MockFlagsTestCase, self).setUp()
+    self.flags = mock_flags.MockFlags()
+
+  def testGetUnsetFlag(self):
+    self.assertIs(self.flags['test_flag'].present, False)
+
+  def testSetAndGetFlag(self):
+    self.flags.test_flag = 5
+    self.assertIs(self.flags.test_flag, 5)
+    self.assertIs(self.flags['test_flag'].present, True)
+    self.assertIs(self.flags['test_flag'].value, 5)
+
+
+class PatchFlagsTestCase(unittest.TestCase):
+
+  def setUp(self):
+    super(PatchFlagsTestCase, self).setUp()
+    self.flags = mock_flags.MockFlags()
+
+  def testGetFlag(self):
+    self.flags.test_flag = 5
+    with mock_flags.PatchFlags(self.flags):
+      self.assertIs(FLAGS.test_flag, 5)
+      self.assertIs(FLAGS['test_flag'].present, True)
+      self.assertIs(FLAGS['test_flag'].value, 5)
+    self.assertIs(FLAGS.test_flag, 0)
+    self.assertIs(FLAGS['test_flag'].present, False)
+    self.assertIs(FLAGS['test_flag'].value, 0)
+
+  def testSetFlag(self):
+    with mock_flags.PatchFlags(self.flags):
+      FLAGS.test_flag = 5
+      self.assertIs(FLAGS.test_flag, 5)
+      self.assertIs(FLAGS['test_flag'].present, True)
+      self.assertIs(FLAGS['test_flag'].value, 5)
+    self.assertIs(self.flags.test_flag, 5)
+    self.assertIs(self.flags['test_flag'].present, True)
+    self.assertIs(self.flags['test_flag'].value, 5)
+    self.assertIs(FLAGS.test_flag, 0)
+    self.assertIs(self.flags['test_flag'].present, False)
+    self.assertIs(self.flags['test_flag'].value, 0)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2015 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/mock_flags.py
+++ b/tests/mock_flags.py
@@ -1,0 +1,86 @@
+# Copyright 2015 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Class for mocking a FlagValues object."""
+
+import contextlib
+
+import mock
+
+from perfkitbenchmarker import context
+
+
+class MockFlags(object):
+  """Class for mocking a FlagValues object.
+
+  Supports setting flag values via __setattr__, getting flag values via
+  __getattr__, and getting mock Flag-like objects via __getitem__, where the
+  Flag-like object supports the 'present' and 'value' attributes.
+
+  Attempting to get a Flag that does not exist will generate a new MagicMock
+  with the 'present' attribute initialized to False.
+  """
+
+  def __init__(self):
+    super(MockFlags, self).__setattr__('_dict', {})
+
+  def __setattr__(self, key, value):
+    mock_flag = self[key]
+    mock_flag.present = True
+    mock_flag.value = value
+
+  def __getattr__(self, key):
+    return self[key].value
+
+  def __getitem__(self, key):
+    if key not in self._dict:
+      mock_flag = mock.MagicMock()
+      mock_flag.present = False
+      self._dict[key] = mock_flag
+    return self._dict[key]
+
+
+@contextlib.contextmanager
+def PatchFlags(mock_flags=None):
+  """Patches read and write access to perfkitbenchmarker.flags.FLAGS.
+
+  By patching the underlying FlagValuesProxy instance, this method affects all
+  modules that have read FLAGS from perfkitbenchmarker.flags. For example, a
+  module my_module.py may have the code
+      from perfkitbenchmarker import flags
+      FLAGS = flags.FLAGS
+      ...
+      def Func():
+        my_flag = FLAGS['cloud']
+        my_value = FLAGS.cloud
+        FLAGS.cloud = my_override_value
+  Within the effect of the PatchFlags contextmanager, calling my_module.Func()
+  will cause my_flag and my_value to be initialized from mock_flags rather than
+  an actual FlagValues instance. Similarly, mock_flags.cloud will be set with
+  my_override_value.
+
+  Args:
+    mock_flags: None or MockFlags. If provided, the source of mocked flag
+        values. If not provided, a new MockFlags object will be used.
+
+  Yields:
+    MockFlags. Either mock_flags or the newly created MockFlags value.
+  """
+  mock_flags = mock_flags or MockFlags()
+  patches = []
+  for method_name in '__setattr__', '__getattr__', '__getitem__':
+    patches.append(mock.patch.object(
+        '{0}.BENCHMARK_FLAGS.{1}'.format(context.__name__, method_name),
+        new=getattr(mock_flags, method_name)))
+  with contextlib.nested(*patches):
+    yield mock_flags


### PR DESCRIPTION
No need to patch module1.FLAGS and module2.FLAGS separately.