### PR TITLE
openstack: Add support for using multiple data volumes

### DIFF
--- a/perfkitbenchmarker/providers/openstack/os_disk.py
+++ b/perfkitbenchmarker/providers/openstack/os_disk.py
@@ -56,6 +56,12 @@ class OpenStackDisk(disk.BaseDisk):
     @retry_authorization(max_retries=4)
     def _Delete(self):
         from novaclient.exceptions import NotFound
+
+        if self._disk is None:
+            logging.info('Volume %s was not created. Skipping deletion.'
+                         % self.name)
+            return
+
         sleep = 1
         sleep_count = 0
         try:

--- a/perfkitbenchmarker/providers/openstack/utils.py
+++ b/perfkitbenchmarker/providers/openstack/utils.py
@@ -106,6 +106,7 @@ class NovaClient(object):
         self.user = FLAGS.openstack_username
         self.tenant = FLAGS.openstack_tenant
         self.endpoint_type = FLAGS.openstack_nova_endpoint_type
+        self.http_log_debug = FLAGS.log_level == 'debug'
         self.password = self.GetPassword()
         self.__auth = KeystoneAuth(self.url, self.tenant,
                                    self.user, self.password)
@@ -115,6 +116,7 @@ class NovaClient(object):
                                         auth_token=self.__auth.get_token(),
                                         tenant_id=self.__auth.get_tenant_id(),
                                         endpoint_type=self.endpoint_type,
+                                        http_log_debug=self.http_log_debug,
                                         )
         # Set requests library logging level to WARNING
         # so it doesn't spam logs with unhelpful messages,


### PR DESCRIPTION
Before this PR, data disks where not working. This PR fixes that and adds the ability to use multiple volumes as well.

- Fix Pickling error caused by use of generator in class attributes.
- Improve error handling of disk creation
- Add switch for enabling verbose http log