### PR TITLE
Allow providers to selectively support benchmarks

### DIFF
--- a/perfkitbenchmarker/benchmark_spec.py
+++ b/perfkitbenchmarker/benchmark_spec.py
@@ -22,6 +22,7 @@ import os
 import thread
 import threading
 import uuid
+import provider_info
 
 from perfkitbenchmarker import configs
 from perfkitbenchmarker import context
@@ -72,6 +73,9 @@ DEBIAN = 'debian'
 RHEL = 'rhel'
 WINDOWS = 'windows'
 UBUNTU_CONTAINER = 'ubuntu_container'
+SUPPORTED = 'strict'
+NOT_EXCLUDED = 'permissive'
+SKIP_CHECK = 'none'
 
 FLAGS = flags.FLAGS
 VALID_CLOUDS = [GCP, AZURE, AWS, DIGITALOCEAN, KUBERNETES, OPENSTACK,
@@ -90,6 +94,15 @@ flags.DEFINE_string('scratch_dir', None,
                     'Base name for all scratch disk directories in the VM.'
                     'Upon creation, these directories will have numbers'
                     'appended to them (for example /scratch0, /scratch1, etc).')
+flags.DEFINE_enum('benchmark_compatibility_checking', SUPPORTED,
+                  [SUPPORTED, NOT_EXCLUDED, SKIP_CHECK],
+                  'Method used to check compatibility between the benchmark '
+                  ' and the cloud.  ' + SUPPORTED + ' runs the benchmark only'
+                  ' if the cloud provider has declared it supported. ' +
+                  NOT_EXCLUDED + ' runs the benchmark unless it has been '
+                  ' declared not supported by the could provider. ' +
+                  SKIP_CHECK + ' does not do the compatibility'
+                  ' check. The default is ' + SUPPORTED)
 
 
 class BenchmarkSpec(object):
@@ -133,7 +146,6 @@ class BenchmarkSpec(object):
 
   def _GetCloudForGroup(self, group_name):
     """Gets the cloud for a VM group by looking at flags and the config.
-
     The precedence is as follows (in decreasing order):
       * FLAGS.cloud (if specified on the command line)
       * The "cloud" key in the group config (set by a config override)
@@ -159,6 +171,25 @@ class BenchmarkSpec(object):
       return group_spec[OS_TYPE]
     return FLAGS.os_type
 
+  def _CheckBenchmarkSupport(self, cloud):
+    """ Throw an exception if the benchmark isn't supported."""
+
+    if FLAGS.benchmark_compatibility_checking is SKIP_CHECK:
+      return
+
+    provider_info_class = provider_info.GetProviderInfoClass(cloud)
+    benchmark_ok = provider_info_class.IsBenchmarkSupported(self.name)
+    if FLAGS.benchmark_compatibility_checking is NOT_EXCLUDED:
+      if benchmark_ok is None:
+        benchmark_ok = True
+
+    if not benchmark_ok:
+      raise ValueError('Provider {0} does not support {1}.  Use '
+                       '--benchmark_compatibility_checking=none '
+                       'to override this check.'.format(
+                           provider_info_class.CLOUD,
+                           self.name))
+
   def ConstructVirtualMachines(self):
     """Constructs the BenchmarkSpec's VirtualMachine objects."""
     vm_group_specs = self.config[VM_GROUPS]
@@ -182,6 +213,10 @@ class BenchmarkSpec(object):
         os_type = self._GetOsTypeForGroup(group_name)
         cloud = self._GetCloudForGroup(group_name)
         providers.LoadProvider(cloud.lower())
+
+        # This throws an exception if the benchmark is not
+        # supported.
+        self._CheckBenchmarkSupport(cloud)
 
         # Then create a VmSpec and possibly a DiskSpec which we can
         # use to create the remaining VMs.

--- a/perfkitbenchmarker/linux_benchmarks/mysql_service_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/mysql_service_benchmark.py
@@ -135,22 +135,6 @@ def GetConfig(user_config):
   return configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
 
 
-def CheckPrerequisites():
-  """Verifies that we are running on a cloud provider that supports managed
-     MySQL service.
-
-  Raises:
-    ProviderNotSupportedError
-  """
-  if FLAGS.cloud != 'GCP' and FLAGS.cloud != 'AWS':
-    raise ProviderNotSupportedError('Provider %s is not supported yet.' %
-                                    FLAGS.cloud)
-
-
-class ProviderNotSupportedError(Exception):
-  pass
-
-
 class DBStatusQueryError(Exception):
   pass
 

--- a/perfkitbenchmarker/provider_info.py
+++ b/perfkitbenchmarker/provider_info.py
@@ -1,0 +1,52 @@
+# Copyright 2015 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module containing class for provider data
+
+Currently, this is only used for IsBenchmarkSupported
+
+"""
+
+
+_PROVIDER_INFO_REGISTRY = {}
+
+
+def GetProviderInfoClass(cloud):
+  """Returns the provider info class corresponding to the cloud"""
+  return _PROVIDER_INFO_REGISTRY.get(cloud, BaseProviderInfo)
+
+
+class AutoRegisterProviderInfoMeta(type):
+  """Metaclass which allows ProviderInfos to automatically be registered"""
+
+  def __init__(cls, name, bases, dct):
+    super(AutoRegisterProviderInfoMeta, cls).__init__(name, bases, dct)
+    if cls.CLOUD is not None:
+      _PROVIDER_INFO_REGISTRY[cls.CLOUD] = cls
+
+
+class BaseProviderInfo():
+  """Class that holds provider-related data ."""
+  __metaclass__ = AutoRegisterProviderInfoMeta
+
+  CLOUD = None
+
+  UNSUPPORTED_BENCHMARKS = []
+
+  @classmethod
+  def IsBenchmarkSupported(cls, benchmark):
+    if benchmark in cls.UNSUPPORTED_BENCHMARKS:
+      return False
+    else:
+      return True

--- a/perfkitbenchmarker/providers/alicloud/provider_info.py
+++ b/perfkitbenchmarker/providers/alicloud/provider_info.py
@@ -1,0 +1,26 @@
+# Copyright 2015 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+""" Provider info for AliCloud
+
+"""
+
+from perfkitbenchmarker import provider_info
+from perfkitbenchmarker import benchmark_spec
+
+
+class AliCloudProviderInfo(provider_info.BaseProviderInfo):
+
+  UNSUPPORTED_BENCHMARKS = ['mysql_service']
+  CLOUD = benchmark_spec.ALICLOUD

--- a/perfkitbenchmarker/providers/aws/provider_info.py
+++ b/perfkitbenchmarker/providers/aws/provider_info.py
@@ -1,0 +1,26 @@
+# Copyright 2015 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""
+AWS provider info
+"""
+
+from perfkitbenchmarker import provider_info
+from perfkitbenchmarker import benchmark_spec
+
+
+class AWSProviderInfo(provider_info.BaseProviderInfo):
+
+  CLOUD = benchmark_spec.AWS

--- a/perfkitbenchmarker/providers/azure/provider_info.py
+++ b/perfkitbenchmarker/providers/azure/provider_info.py
@@ -1,0 +1,26 @@
+# Copyright 2015 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+""" Provider info for Azure
+
+"""
+
+from perfkitbenchmarker import provider_info
+from perfkitbenchmarker import benchmark_spec
+
+
+class AzureProviderInfo(provider_info.BaseProviderInfo):
+
+  UNSUPPORTED_BENCHMARKS = ['mysql_service']
+  CLOUD = benchmark_spec.AZURE

--- a/perfkitbenchmarker/providers/cloudstack/provider_info.py
+++ b/perfkitbenchmarker/providers/cloudstack/provider_info.py
@@ -1,0 +1,26 @@
+# Copyright 2015 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+""" Provider info for CloudStack
+
+"""
+
+from perfkitbenchmarker import provider_info
+from perfkitbenchmarker import benchmark_spec
+
+
+class CloudStackProviderInfo(provider_info.BaseProviderInfo):
+
+  UNSUPPORTED_BENCHMARKS = ['mysql_service']
+  CLOUD = benchmark_spec.CLOUDSTACK

--- a/perfkitbenchmarker/providers/digitalocean/provider_info.py
+++ b/perfkitbenchmarker/providers/digitalocean/provider_info.py
@@ -1,0 +1,27 @@
+# Copyright 2015 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+""" Provider info for Digitial Ocean
+
+"""
+
+
+from perfkitbenchmarker import provider_info
+from perfkitbenchmarker import benchmark_spec
+
+
+class DigitalOceanProviderInfo(provider_info.BaseProviderInfo):
+
+  UNSUPPORTED_BENCHMARKS = ['mysql_service']
+  CLOUD = benchmark_spec.DIGITALOCEAN

--- a/perfkitbenchmarker/providers/gcp/provider_info.py
+++ b/perfkitbenchmarker/providers/gcp/provider_info.py
@@ -1,0 +1,26 @@
+# Copyright 2015 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+""" Provider info for Google Cloud Platform
+
+"""
+
+from perfkitbenchmarker import provider_info
+from perfkitbenchmarker import benchmark_spec
+
+
+class GCPProviderInfo(provider_info.BaseProviderInfo):
+
+  UNSUPPORTED_BENCHMARKS = []
+  CLOUD = benchmark_spec.GCP

--- a/perfkitbenchmarker/providers/kubernetes/provider_info.py
+++ b/perfkitbenchmarker/providers/kubernetes/provider_info.py
@@ -1,0 +1,40 @@
+# Copyright 2015 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+""" Provider info for Kubernetes
+
+"""
+
+from perfkitbenchmarker import provider_info
+from perfkitbenchmarker import benchmark_spec
+
+
+class KubernetesProviderInfo(provider_info.BaseProviderInfo):
+
+  SUPPORTED_BENCHMARKS = ['block_storage_workload', 'cassandra_ycsb',
+                          'cassandra_stress', 'cluster_boot', 'fio',
+                          'iperf', 'mesh_network', 'mongodb_ycsb',
+                          'netperf', 'redis', 'sysbench_oltp']
+  UNSUPPORTED_BENCHMARKS = ['bonnie++', 'mysql_service']
+
+  CLOUD = benchmark_spec.KUBERNETES
+
+  @classmethod
+  def IsBenchmarkSupported(cls, benchmark):
+    if benchmark in cls.SUPPORTED_BENCHMARKS:
+      return True
+    elif benchmark in cls.UNSUPPORTED_BENCHMARKS:
+      return False
+    else:
+      return None

--- a/perfkitbenchmarker/providers/openstack/provider_info.py
+++ b/perfkitbenchmarker/providers/openstack/provider_info.py
@@ -1,0 +1,26 @@
+# Copyright 2015 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+""" Provider info for Open Stack Platform
+
+"""
+
+from perfkitbenchmarker import provider_info
+from perfkitbenchmarker import benchmark_spec
+
+
+class OpenStackProviderInfo(provider_info.BaseProviderInfo):
+
+  UNSUPPORTED_BENCHMARKS = ['mysql_service']
+  CLOUD = benchmark_spec.OPENSTACK

--- a/perfkitbenchmarker/providers/rackspace/provider_info.py
+++ b/perfkitbenchmarker/providers/rackspace/provider_info.py
@@ -1,0 +1,26 @@
+# Copyright 2015 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+""" Provider info for Rackspace
+
+"""
+
+from perfkitbenchmarker import provider_info
+from perfkitbenchmarker import benchmark_spec
+
+
+class RackspaceProviderInfo(provider_info.BaseProviderInfo):
+
+  UNSUPPORTED_BENCHMARKS = ['mysql_service']
+  CLOUD = benchmark_spec.RACKSPACE

--- a/tests/provider_benchmark_test.py
+++ b/tests/provider_benchmark_test.py
@@ -1,0 +1,45 @@
+# Copyright 2015 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for perfkitbenchmarker.providers"""
+
+import unittest
+
+from perfkitbenchmarker import benchmark_spec
+from perfkitbenchmarker import providers
+from perfkitbenchmarker import provider_info
+
+
+class ProviderBenchmarkChecks(unittest.TestCase):
+
+  def testPingSupported(self):
+    for cloud in benchmark_spec.VALID_CLOUDS:
+      providers.LoadProvider(cloud.lower())
+      ThisProviderInfoClass = provider_info.GetProviderInfoClass(cloud)
+      self.assertTrue(ThisProviderInfoClass.IsBenchmarkSupported('iperf'),
+                      'provider {0} does not support iperf'.format(
+                          cloud))
+
+  def testMYSQLSupport(self):
+    for cloud in benchmark_spec.VALID_CLOUDS:
+      providers.LoadProvider(cloud.lower())
+      ThisProviderInfoClass = provider_info.GetProviderInfoClass(cloud)
+      if (cloud == benchmark_spec.AWS or cloud == benchmark_spec.GCP):
+        self.assertTrue(ThisProviderInfoClass.IsBenchmarkSupported(
+            'mysql_service'))
+      else:
+        self.assertFalse(ThisProviderInfoClass.IsBenchmarkSupported(
+            'mysql_service'),
+            'Cloud {0} is not supposed to support mysql_service {1}'
+            .format(cloud, ThisProviderInfoClass.__name__))


### PR DESCRIPTION
This change allows providers to selectively support benchmarks.  

For Kubernetes, I used in the information in #671 to create a supported set.  The `mysql` benchmark is set to be only supported by AWS and GCP, but all other benchmarks are supported by all platforms. 