### PR TITLE
Fix for benchmark_compatibility_checking flag.

### DIFF
--- a/perfkitbenchmarker/benchmark_spec.py
+++ b/perfkitbenchmarker/benchmark_spec.py
@@ -174,12 +174,12 @@ class BenchmarkSpec(object):
   def _CheckBenchmarkSupport(self, cloud):
     """ Throw an exception if the benchmark isn't supported."""
 
-    if FLAGS.benchmark_compatibility_checking is SKIP_CHECK:
+    if FLAGS.benchmark_compatibility_checking == SKIP_CHECK:
       return
 
     provider_info_class = provider_info.GetProviderInfoClass(cloud)
     benchmark_ok = provider_info_class.IsBenchmarkSupported(self.name)
-    if FLAGS.benchmark_compatibility_checking is NOT_EXCLUDED:
+    if FLAGS.benchmark_compatibility_checking == NOT_EXCLUDED:
       if benchmark_ok is None:
         benchmark_ok = True
 


### PR DESCRIPTION
Comparing string values using 'is' always returned False because the string
objects were not identical (although they were assigned equal value).

Signed-off-by: Mateusz Blaszkowski <mateusz.blaszkowski@intel.com>