### PR TITLE
Create remote access rules before creating VMs.

### DIFF
--- a/perfkitbenchmarker/benchmark_spec.py
+++ b/perfkitbenchmarker/benchmark_spec.py
@@ -325,11 +325,11 @@ class BenchmarkSpec(object):
     Args:
         vm: The BaseVirtualMachine object representing the VM.
     """
+    for port in vm.remote_access_ports:
+      vm.AllowPort(port)
     vm.Create()
     logging.info('VM: %s', vm.ip_address)
     logging.info('Waiting for boot completion.')
-    for port in vm.remote_access_ports:
-      vm.AllowPort(port)
     vm.AddMetadata(benchmark=self.name, perfkit_uuid=self.uuid,
                    benchmark_uid=self.uid)
     vm.WaitForBootCompletion()


### PR DESCRIPTION
Addresses #717.

For a 4 VM test on GCP, reported VM-to-SSHable time decreased from ~99 seconds
(range: 98.4s to 100.2s) to ~54 seconds (range: 54.1s to 55.9s).