### PR TITLE
Create AWS/GCE default access rules before creating instance.

### DIFF
--- a/perfkitbenchmarker/benchmark_spec.py
+++ b/perfkitbenchmarker/benchmark_spec.py
@@ -340,9 +340,9 @@ class BenchmarkSpec(object):
     logging.info('Waiting for boot completion.')
     for port in vm.remote_access_ports:
       vm.AllowPort(port)
+    vm.WaitForBootCompletion()
     vm.AddMetadata(benchmark=self.name, perfkit_uuid=self.uuid,
                    benchmark_uid=self.uid)
-    vm.WaitForBootCompletion()
     vm.OnStartup()
     if any((spec.disk_type == disk.LOCAL for spec in vm.disk_specs)):
       vm.SetupLocalDisks()

--- a/perfkitbenchmarker/benchmark_spec.py
+++ b/perfkitbenchmarker/benchmark_spec.py
@@ -338,8 +338,7 @@ class BenchmarkSpec(object):
     vm.Create()
     logging.info('VM: %s', vm.ip_address)
     logging.info('Waiting for boot completion.')
-    for port in vm.remote_access_ports:
-      vm.AllowPort(port)
+    vm.AllowRemoteAccessPorts()
     vm.WaitForBootCompletion()
     vm.AddMetadata(benchmark=self.name, perfkit_uuid=self.uuid,
                    benchmark_uid=self.uid)

--- a/perfkitbenchmarker/providers/aws/aws_virtual_machine.py
+++ b/perfkitbenchmarker/providers/aws/aws_virtual_machine.py
@@ -220,8 +220,7 @@ class AwsVirtualMachine(virtual_machine.BaseVirtualMachine):
     # _GetDefaultImage calls the AWS CLI.
     self.image = self.image or self._GetDefaultImage(self.machine_type,
                                                      self.region)
-    for port in self.remote_access_ports:
-      self.AllowPort(port)
+    self.AllowRemoteAccessPorts()
 
   def _DeleteDependencies(self):
     """Delete VM dependencies."""

--- a/perfkitbenchmarker/providers/gcp/gce_virtual_machine.py
+++ b/perfkitbenchmarker/providers/gcp/gce_virtual_machine.py
@@ -248,6 +248,14 @@ class GceVirtualMachine(virtual_machine.BaseVirtualMachine):
       create_cmd = self._GenerateCreateCommand(tf.name)
       create_cmd.Issue()
 
+  def _CreateDependencies(self):
+    # GCE firewall rules are created for all instances in a network.
+    # Create necessary VM access rules *prior* to creating the VM, such that it
+    # doesn't affect boot time.
+    super(GceVirtualMachine, self)._CreateDependencies()
+    for port in self.remote_access_ports:
+      self.AllowPort(port)
+
   @vm_util.Retry()
   def _PostCreate(self):
     """Get the instance's data."""

--- a/perfkitbenchmarker/providers/gcp/gce_virtual_machine.py
+++ b/perfkitbenchmarker/providers/gcp/gce_virtual_machine.py
@@ -249,12 +249,11 @@ class GceVirtualMachine(virtual_machine.BaseVirtualMachine):
       create_cmd.Issue()
 
   def _CreateDependencies(self):
+    super(GceVirtualMachine, self)._CreateDependencies()
     # GCE firewall rules are created for all instances in a network.
     # Create necessary VM access rules *prior* to creating the VM, such that it
     # doesn't affect boot time.
-    super(GceVirtualMachine, self)._CreateDependencies()
-    for port in self.remote_access_ports:
-      self.AllowPort(port)
+    self.AllowRemoteAccessPorts()
 
   @vm_util.Retry()
   def _PostCreate(self):

--- a/perfkitbenchmarker/providers/openstack/os_virtual_machine.py
+++ b/perfkitbenchmarker/providers/openstack/os_virtual_machine.py
@@ -173,6 +173,7 @@ class OpenStackVirtualMachine(virtual_machine.BaseVirtualMachine):
 
     def _CreateDependencies(self):
         self.ImportKeyfile()
+        self.AllowRemoteAccessPorts()
 
     def _DeleteDependencies(self):
         self.DeleteKeyfile()

--- a/perfkitbenchmarker/virtual_machine.py
+++ b/perfkitbenchmarker/virtual_machine.py
@@ -251,6 +251,11 @@ class BaseVirtualMachine(resource.BaseResource):
     if self.firewall:
       self.firewall.AllowPort(self, port)
 
+  def AllowRemoteAccessPorts(self):
+    """Allow all ports in self.remote_access_ports."""
+    for port in self.remote_access_ports:
+      self.AllowPort(port)
+
   def AddMetadata(self, **kwargs):
     """Add key/value metadata to the instance.
 


### PR DESCRIPTION
A better fix for #717.

Azure endpoints target individual instances, so they can't be created before the VM.
On AWS, `authorize-security-group-ingress` uses the default security group from the instance create command.

This PR just modifies GCP and AWS instance creation, creating remote access rules prior to creating the VM. Azure requires the VM to be created before authorizing ingress.