### PR TITLE
openstack: Use only available floating-ips

### DIFF
--- a/perfkitbenchmarker/providers/openstack/os_network.py
+++ b/perfkitbenchmarker/providers/openstack/os_network.py
@@ -87,7 +87,8 @@ class OpenStackPublicNetwork(object):
         with self.__floating_ip_lock:
             floating_ips = self.__nclient.floating_ips.findall(
                 fixed_ip=None,
-                pool=self.ip_pool_name
+                pool=self.ip_pool_name,
+                status='Down'
             )
         if floating_ips:
             return floating_ips[0]


### PR DESCRIPTION
Prior this patch when it searches for a floating ip to use, it
might return floating IPs that might have been already allocated
for another instance and causes a conflict error.

This patch make sures that only 'Down', or available, floating ips
are requested.