### PR TITLE
openstack: Expose availability zone

### DIFF
--- a/perfkitbenchmarker/providers/openstack/flags.py
+++ b/perfkitbenchmarker/providers/openstack/flags.py
@@ -63,3 +63,6 @@ flags.DEFINE_enum('openstack_scheduler_policy', NONE,
                   [NONE, 'affinity', 'anti-affinity'],
                   'Add possibility to use affinity or anti-affinity '
                   'policy in scheduling process')
+
+flags.DEFINE_string('openstack_availability_zone', None,
+                    'Name of availability zone to create instance(s) on.')

--- a/perfkitbenchmarker/providers/openstack/os_virtual_machine.py
+++ b/perfkitbenchmarker/providers/openstack/os_virtual_machine.py
@@ -95,6 +95,8 @@ class OpenStackVirtualMachine(virtual_machine.BaseVirtualMachine):
                               'destination_type': 'volume',
                               'delete_on_termination': True}]
 
+        availability_zone = FLAGS.openstack_availability_zone or self.zone
+
         vm = self.client.servers.create(
             name=self.name,
             image=image_id,
@@ -102,7 +104,7 @@ class OpenStackVirtualMachine(virtual_machine.BaseVirtualMachine):
             key_name=self.key_name,
             security_groups=['perfkit_sc_group'],
             nics=nics,
-            availability_zone=self.zone,
+            availability_zone=availability_zone,
             block_device_mapping_v2=boot_from_vol,
             scheduler_hints=scheduler_hints,
             config_drive=FLAGS.openstack_config_drive)


### PR DESCRIPTION
Allows to override availability zone value to place instances on
a specific host or host aggregate.