### PR TITLE
Pretty print complete results

### DIFF
--- a/perfkitbenchmarker/publisher.py
+++ b/perfkitbenchmarker/publisher.py
@@ -20,6 +20,7 @@ import itertools
 import json
 import logging
 import operator
+import pprint
 import sys
 import time
 import uuid
@@ -336,6 +337,7 @@ class LogPublisher(SamplePublisher):
   def __init__(self, level=logging.INFO, logger=None):
     self.level = level
     self.logger = logger or logging.getLogger()
+    self._pprinter = pprint.PrettyPrinter()
 
   def __repr__(self):
     return '<{0} logger={1} level={2}>'.format(type(self).__name__, self.logger,
@@ -346,7 +348,7 @@ class LogPublisher(SamplePublisher):
         '\n' + '-' * 25 + 'PerfKitBenchmarker Complete Results' + '-' * 25 +
         '\n']
     for sample in samples:
-      data.append('%s\n' % sample)
+      data.append('%s\n' % self._pprinter.pformat(sample))
     self.logger.log(self.level, ''.join(data))
 
 


### PR DESCRIPTION
The complete test results printed from pkb.py is hardly readable. A simple cluster_boot benchmark result looks like the following:

>
-------------------------PerfKitBenchmarker Complete Results-------------------------
{'timestamp': 1450312479.973475, 'metric': 'Boot Time', 'official': False, 'value': 59.9663450717926, 'owner': 'wonderfly', 'run_uri': 'c9f62dd1-64cc-4a0d-9c83-012cc7849e23', 'test': 'cluster_boot', 'sample_uri': 'e5af7ee2-147c-4c87-a659-821b2f2a252a', 'product_name': 'PerfKitBenchmarker', 'unit': 'seconds', 'metadata': {'num_vms': 1, 'zone': 'us-central1-a', 'num_cpus': 1, 'preemptible': False, 'machine_instance': 0, 'machine_type': 'n1-standard-1', 'image': 'xxxx', 'perfkitbenchmarker_version': 'v1.0.1-74-g8365980', 'cloud': 'GCP', 'vm_count': 1}}
{'timestamp': 1450312576.500457, 'metric': 'End to End Runtime', 'official': False, 'value': 291.40025305747986, 'owner': 'wonderfly', 'run_uri': 'c9f62dd1-64cc-4a0d-9c83-012cc7849e23', 'test': 'cluster_boot', 'sample_uri': '1da4c281-cd2c-4315-9c14-f3df06b9d0f1', 'product_name': 'PerfKitBenchmarker', 'unit': 'seconds', 'metadata': {'zone': 'us-central1-a', 'perfkitbenchmarker_version': 'v1.0.1-74-g8365980', 'preemptible': False, 'machine_type': 'n1-standard-1', 'image': 'xxxx', 'cloud': 'GCP', 'vm_count': 1}}

Although the "Results Summary" is more useful, I like to check the complete results to confirm some configurations from time to time. A pretty printed dictionary makes it a lot easier.

The same benchmark with this change resulted in the following:

```
-------------------------PerfKitBenchmarker Complete Results-------------------------
{'metadata': {'cloud': 'GCP',
              'image': 'xxxx',
              'machine_instance': 0,
              'machine_type': 'n1-standard-1',
              'num_cpus': 1,
              'num_vms': 1,
              'perfkitbenchmarker_version': 'v0.23.0-338-gc5b4a37',
              'preemptible': False,
              'vm_count': 1,
              'zone': 'us-central1-a'},
 'metric': 'Boot Time',
 'official': False,
 'owner': 'wonderfly',
 'product_name': 'PerfKitBenchmarker',
 'run_uri': '51615bd5-d894-4fc1-80ce-06776338cb1f',
 'sample_uri': 'c5847106-b076-4ab8-8aca-6d78fbd24696',
 'test': 'cluster_boot',
 'timestamp': 1450314964.548062,
 'unit': 'seconds',
 'value': 47.85341215133667}
{'metadata': {'cloud': 'GCP',
              'image': 'xxxx',
              'machine_type': 'n1-standard-1',
              'perfkitbenchmarker_version': 'v0.23.0-338-gc5b4a37',
              'preemptible': False,
              'vm_count': 1,
              'zone': 'us-central1-a'},
 'metric': 'End to End Runtime',
 'official': False,
 'owner': 'wonderfly',
 'product_name': 'PerfKitBenchmarker',
 'run_uri': '51615bd5-d894-4fc1-80ce-06776338cb1f',
 'sample_uri': 'f3a617d9-0d35-4028-8ebf-dda61dfff1e2',
 'test': 'cluster_boot',
 'timestamp': 1450315123.128893,
 'unit': 'seconds',
 'value': 349.3611161708832}
```
@voellm @cmccoy 