### PR TITLE
Speed up Cassandra cluster boot.

### DIFF
--- a/perfkitbenchmarker/data/cassandra/cassandra.yaml.j2
+++ b/perfkitbenchmarker/data/cassandra/cassandra.yaml.j2
@@ -2,6 +2,7 @@
 # See http://wiki.apache.org/cassandra/StorageConfiguration
 cluster_name: '{{ cluster_name }}'
 num_tokens: 256
+auto_bootstrap: false
 hinted_handoff_enabled: true
 max_hint_window_in_ms: 10800000 # 3 hours
 hinted_handoff_throttle_in_kb: 1024

--- a/perfkitbenchmarker/linux_packages/cassandra.py
+++ b/perfkitbenchmarker/linux_packages/cassandra.py
@@ -45,9 +45,9 @@ NODETOOL = posixpath.join(CASSANDRA_DIR, 'bin', 'nodetool')
 
 # Number of times to attempt to start the cluster.
 CLUSTER_START_TRIES = 10
-CLUSTER_START_SLEEP = 120
+CLUSTER_START_SLEEP = 60
 # Time, in seconds, to sleep between node starts.
-NODE_START_SLEEP = 30
+NODE_START_SLEEP = 5
 
 
 def CheckPrerequisites():
@@ -205,6 +205,7 @@ def StartCluster(seed_vm, vms):
     raise ValueError('Cassandra failed to start on seed.')
 
   if vms:
+    logging.info('Starting remaining %d nodes', len(vms))
     # Start the VMs with a small pause in between each, to allow the node to
     # join.
     # Starting Cassandra nodes fails when multiple nodes attempt to join the
@@ -222,8 +223,8 @@ def StartCluster(seed_vm, vms):
       logging.info('All %d nodes up!', vm_count)
       break
 
-    logging.warn('Try %d: only %s of %s up. Sleeping %ds', i, vms_up,
-                 vm_count, NODE_START_SLEEP)
+    logging.warn('Try %d: only %s of %s up. Restarting and sleeping %ds', i,
+                 vms_up, vm_count, NODE_START_SLEEP)
     vm_util.RunThreaded(_StartCassandraIfNotRunning, vms)
     time.sleep(NODE_START_SLEEP)
   else:


### PR DESCRIPTION
By setting "auto_bootstrap" to false (only acceptable for new clusters),
multiple nodes can join in a shorter period of time. This significantly speeds up startup.