### PR TITLE
Add provider-specific requirements.txt files

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Make sure you have installed pip (see the section above).
 Install `python-novaclient` via the following command:
 
 ```bash
-$ sudo pip install python-novaclient
+$ sudo pip install -r requirements-openstack.txt
 ```
 
 You must specify authentication information for test execution, including user
@@ -316,10 +316,10 @@ Make sure your Mesos-slave nodes are reachable (by hostname) from the machine wh
 **Image prerequisites**  
 Please refer to the [Image prerequisites for Docker based clouds](#image-prerequisites-for-docker-based-clouds).
 
-### Cloudstack: Install `csapi` and set the API keys
+### Cloudstack: Install dependencies and set the API keys
 
 ```bash
-$ sudo pip install csapi
+$ sudo pip install -r requirements-cloudstack.txt
 ```
 
 Get the API key and SECRET from Cloudstack. Set the following environement variables.
@@ -343,7 +343,7 @@ Make sure you have installed pip (see the section above).
 Follow instructions at http://aws.amazon.com/cli/ or run the following command (omit the 'sudo' on Windows)
 
 ```bash
-$ sudo pip install awscli
+$ sudo pip install -r requirements-aws.txt
 ```
 
 Navigate to the AWS console to create access credentials: https://console.aws.amazon.com/ec2/
@@ -407,19 +407,13 @@ Run the following command to install `aliyuncli` (omit the `sudo` on Windows)
 2. Install aliyuncli tool and python SDK for ECS:
 
    ```bash
-   $ sudo pip install aliyuncli
+   $ sudo pip install -r requirements-alicloud.txt
    ```
 
    To check if AliCloud is installed:
 
    ```bash
    $ aliyuncli --help
-   ```
-
-   Install python SDK for ECS:
-
-   ```bash
-   $ sudo pip install aliyun-python-sdk-ecs
    ```
 
    Check if `aliyuncli ecs` command is ready:
@@ -506,8 +500,7 @@ To run PerfKit Benchmarker against Rackspace is very easy. First, install the
 CLI clients as follows:
 
 ```bash
-$ pip install -U rackspace-neutronclient
-$ pip install -U rackspace-novaclient
+$ pip install -r requirements-rackspace.txt
 ```
 
 Once these are installed, all we need to do is to set 3 environment variables:

--- a/requirements-alicloud.txt
+++ b/requirements-alicloud.txt
@@ -1,4 +1,4 @@
-# Copyright 2014 PerfKitBenchmarker Authors. All rights reserved.
+# Copyright 2015 PerfKitBenchmarker Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,10 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-python-gflags==2.0
-jinja2>=2.7
-setuptools
-colorlog[windows]==2.6.0
-blinker>=1.3
-futures>=3.0.3
-PyYAML==3.11
+
+# Additional requirements (beyond those in requirements.txt) for running
+# PerfKitBenchmarker on AliCloud.
+aliyuncli>=2.1
+aliyun-python-sdk-ecs>=0.1.4
+paramiko>=1.15

--- a/requirements-aws.txt
+++ b/requirements-aws.txt
@@ -1,4 +1,5 @@
-# Copyright 2014 PerfKitBenchmarker Authors. All rights reserved.
+
+# Copyright 2015 PerfKitBenchmarker Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,10 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-python-gflags==2.0
-jinja2>=2.7
-setuptools
-colorlog[windows]==2.6.0
-blinker>=1.3
-futures>=3.0.3
-PyYAML==3.11
+# Additional requirements (beyond those in requirements.txt) for running
+# PerfKitBenchmarker on AWS.
+awscli

--- a/requirements-cloudstack.txt
+++ b/requirements-cloudstack.txt
@@ -1,4 +1,4 @@
-# Copyright 2014 PerfKitBenchmarker Authors. All rights reserved.
+# Copyright 2015 PerfKitBenchmarker Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,8 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-mock>=1.0.1
-nose>=1.3
-flake8>=2.1.0
-futures>=2.1.0
-psutil==3.0.0
+
+# Additional requirements (beyond those in requirements.txt) for running
+# PerfKitBenchmarker on CloudStack.
+csapi>=0.0.7

--- a/requirements-openstack.txt
+++ b/requirements-openstack.txt
@@ -1,4 +1,4 @@
-# Copyright 2014 PerfKitBenchmarker Authors. All rights reserved.
+# Copyright 2015 PerfKitBenchmarker Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,10 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-python-gflags==2.0
-jinja2>=2.7
-setuptools
-colorlog[windows]==2.6.0
-blinker>=1.3
-futures>=3.0.3
-PyYAML==3.11
+
+# Additional requirements (beyond those in requirements.txt) for running
+# PerfKitBenchmarker on OpenStack.
+python-novaclient

--- a/requirements-rackspace.txt
+++ b/requirements-rackspace.txt
@@ -1,4 +1,4 @@
-# Copyright 2014 PerfKitBenchmarker Authors. All rights reserved.
+# Copyright 2015 PerfKitBenchmarker Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,10 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-python-gflags==2.0
-jinja2>=2.7
-setuptools
-colorlog[windows]==2.6.0
-blinker>=1.3
-futures>=3.0.3
-PyYAML==3.11
+
+# Additional requirements (beyond those in requirements.txt) for running
+# PerfKitBenchmarker on Rackspace.
+rackspace-neutronclient
+rackspace-novaclient

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,0 +1,31 @@
+# Copyright 2015 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# All requirements for running PerfKitBenchmarker unit tests.
+
+# Standard PerfKitBenchmarker requirements
+-rrequirements.txt
+
+# AliCloud and CloudStack dependencies are required for the providers to be
+# imported.
+# Other cloud provider requirements are either conditionally imported
+# or install command-line tools, and are not needed for unit tests.
+-rrequirements-alicloud.txt
+-rrequirements-cloudstack.txt
+
+# Test requirements
+mock>=1.0.1
+nose>=1.3
+flake8>=2.1.0
+psutil==3.0.0

--- a/tools/side-by-side/README.md
+++ b/tools/side-by-side/README.md
@@ -11,12 +11,11 @@ See:
 
 ## Requirements
 
-Listed in `requirements.txt` and `test-requirements.txt` at the root of this repository.
+Listed in `requirements.txt` and `requirements-testing.txt` at the root of this repository.
 
 From this directory:
 
-    pip install -r ../../requirements.txt
-    pip install -r ../../test-requirements.txt
+    pip install -r ../../requirements-testing.txt
 
 ## Example: testing two different revisions
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,10 +12,7 @@ skip_install = True
 commands = nosetests {toxinidir}/tests []
 passenv = PERFKIT_INTEGRATION
 deps =
-    -rrequirements.txt
-    mock==1.0.1
-    nose==1.3.7
-    psutil==3.0.1
+    -rrequirements-testing.txt
 
 [testenv:flake8]
 skip_install = True


### PR DESCRIPTION
Adds a `requirements-<provider-name>.txt` file for cloud providers with additional dependencies.
Changes installation instructions to refer to those files, rather than installing packages manually with `pip`.
Some of these are trivial (a single package), but it seems worth it to me to a consistent way to install provider Python dependencies.

Addresses #735.

cc: @meteorfox, @hicrazyboy, @syed, @kivio 