### PR TITLE
Move all provider names to provider_info and use those constants

### DIFF
--- a/perfkitbenchmarker/benchmark_spec.py
+++ b/perfkitbenchmarker/benchmark_spec.py
@@ -23,6 +23,7 @@ import thread
 import threading
 import uuid
 import provider_info
+import providers
 
 from perfkitbenchmarker import configs
 from perfkitbenchmarker import context
@@ -61,16 +62,6 @@ STATIC_VMS = 'static_vms'
 VM_SPEC = 'vm_spec'
 DISK_SPEC = 'disk_spec'
 
-GCP = 'GCP'
-AZURE = 'Azure'
-AWS = 'AWS'
-ALICLOUD = 'AliCloud'
-KUBERNETES = 'Kubernetes'
-DIGITALOCEAN = 'DigitalOcean'
-OPENSTACK = 'OpenStack'
-CLOUDSTACK = 'CloudStack'
-RACKSPACE = 'Rackspace'
-MESOS = 'Mesos'
 DEBIAN = 'debian'
 RHEL = 'rhel'
 WINDOWS = 'windows'
@@ -80,10 +71,9 @@ NOT_EXCLUDED = 'permissive'
 SKIP_CHECK = 'none'
 
 FLAGS = flags.FLAGS
-VALID_CLOUDS = [GCP, AZURE, AWS, DIGITALOCEAN, KUBERNETES, OPENSTACK,
-                RACKSPACE, CLOUDSTACK, ALICLOUD, MESOS]
-flags.DEFINE_enum('cloud', GCP,
-                  VALID_CLOUDS,
+
+flags.DEFINE_enum('cloud', providers.GCP,
+                  providers.VALID_CLOUDS,
                   'Name of the cloud to use.')
 flags.DEFINE_enum(
     'os_type', DEBIAN, [DEBIAN, RHEL, UBUNTU_CONTAINER, WINDOWS],

--- a/perfkitbenchmarker/linux_benchmarks/mysql_service_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/mysql_service_benchmark.py
@@ -32,7 +32,7 @@ import StringIO
 import time
 import uuid
 
-from perfkitbenchmarker import benchmark_spec as benchmark_spec_class
+from perfkitbenchmarker import providers
 from perfkitbenchmarker import configs
 from perfkitbenchmarker import flags
 from perfkitbenchmarker import sample
@@ -786,8 +786,8 @@ class GoogleCloudSQLBenchmark(object):
 
 
 MYSQL_SERVICE_BENCHMARK_DICTIONARY = {
-    benchmark_spec_class.GCP: GoogleCloudSQLBenchmark(),
-    benchmark_spec_class.AWS: RDSMySQLBenchmark()}
+    providers.GCP: GoogleCloudSQLBenchmark(),
+    providers.AWS: RDSMySQLBenchmark()}
 
 
 def Prepare(benchmark_spec):

--- a/perfkitbenchmarker/linux_benchmarks/object_storage_service_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/object_storage_service_benchmark.py
@@ -37,7 +37,7 @@ import os
 import re
 import time
 
-from perfkitbenchmarker import benchmark_spec as benchmark_spec_class
+from perfkitbenchmarker import providers
 from perfkitbenchmarker import configs
 from perfkitbenchmarker import data
 from perfkitbenchmarker import errors
@@ -46,9 +46,9 @@ from perfkitbenchmarker import sample
 from perfkitbenchmarker import vm_util
 from perfkitbenchmarker.sample import PercentileCalculator  # noqa
 
-flags.DEFINE_enum('storage', benchmark_spec_class.GCP,
-                  [benchmark_spec_class.GCP, benchmark_spec_class.AWS,
-                   benchmark_spec_class.AZURE, benchmark_spec_class.OPENSTACK],
+flags.DEFINE_enum('storage', providers.GCP,
+                  [providers.GCP, providers.AWS,
+                   providers.AZURE, providers.OPENSTACK],
                   'storage provider (GCP/AZURE/AWS/OPENSTACK) to use.')
 
 flags.DEFINE_enum('object_storage_scenario', 'all',
@@ -115,10 +115,10 @@ BOTO_LIB_VERSION = 'boto_lib_version'
 SWIFTCLIENT_LIB_VERSION = 'python-swiftclient_lib_version'
 
 OBJECT_STORAGE_CREDENTIAL_DEFAULT_LOCATION = {
-    benchmark_spec_class.GCP: '~/' + GCE_CREDENTIAL_LOCATION,
-    benchmark_spec_class.AWS: '~/' + AWS_CREDENTIAL_LOCATION,
-    benchmark_spec_class.AZURE: '~/' + AZURE_CREDENTIAL_LOCATION,
-    benchmark_spec_class.OPENSTACK: '~/'}
+    providers.GCP: '~/' + GCE_CREDENTIAL_LOCATION,
+    providers.AWS: '~/' + AWS_CREDENTIAL_LOCATION,
+    providers.AZURE: '~/' + AZURE_CREDENTIAL_LOCATION,
+    providers.OPENSTACK: '~/'}
 
 DATA_FILE = 'cloud-storage-workload.sh'
 # size of all data used in the CLI tests.
@@ -1019,10 +1019,10 @@ class SwiftStorageBenchmark(object):
 
 
 OBJECT_STORAGE_BENCHMARK_DICTIONARY = {
-    benchmark_spec_class.GCP: GoogleCloudStorageBenchmark(),
-    benchmark_spec_class.AWS: S3StorageBenchmark(),
-    benchmark_spec_class.AZURE: AzureBlobStorageBenchmark(),
-    benchmark_spec_class.OPENSTACK: SwiftStorageBenchmark()}
+    providers.GCP: GoogleCloudStorageBenchmark(),
+    providers.AWS: S3StorageBenchmark(),
+    providers.AZURE: AzureBlobStorageBenchmark(),
+    providers.OPENSTACK: SwiftStorageBenchmark()}
 
 
 def Prepare(benchmark_spec):
@@ -1040,7 +1040,7 @@ def Prepare(benchmark_spec):
   FLAGS.object_storage_credential_file = os.path.expanduser(
       FLAGS.object_storage_credential_file)
 
-  if FLAGS.storage == benchmark_spec_class.OPENSTACK:
+  if FLAGS.storage == providers.OPENSTACK:
     openstack_creds_set = ('OS_AUTH_URL' in os.environ,
                            'OS_TENANT_NAME' in os.environ,
                            'OS_USERNAME' in os.environ,
@@ -1060,8 +1060,8 @@ def Prepare(benchmark_spec):
   FLAGS.boto_file_location = os.path.expanduser(FLAGS.boto_file_location)
 
   if not os.path.isfile(FLAGS.boto_file_location):
-    if FLAGS.storage not in (benchmark_spec_class.AZURE,
-                             benchmark_spec_class.OPENSTACK):
+    if FLAGS.storage not in (providers.AZURE,
+                             providers.OPENSTACK):
       raise errors.Benchmarks.MissingObjectCredentialException(
           'Boto file cannot be found in %s but it is required for gcs or s3.',
           FLAGS.boto_file_location)

--- a/perfkitbenchmarker/provider_info.py
+++ b/perfkitbenchmarker/provider_info.py
@@ -14,10 +14,10 @@
 
 """Module containing class for provider data
 
-Currently, this is only used for IsBenchmarkSupported
+This contains the BaseProviderInfo class which is
+used for IsBenchmarkSupported
 
 """
-
 
 _PROVIDER_INFO_REGISTRY = {}
 

--- a/perfkitbenchmarker/providers/__init__.py
+++ b/perfkitbenchmarker/providers/__init__.py
@@ -24,6 +24,20 @@ from perfkitbenchmarker import import_util
 # actually loading any other provider specific modules.
 import_util.LoadModulesWithName(__path__, __name__, 'flags')
 
+GCP = 'GCP'
+AZURE = 'Azure'
+AWS = 'AWS'
+ALICLOUD = 'AliCloud'
+KUBERNETES = 'Kubernetes'
+DIGITALOCEAN = 'DigitalOcean'
+OPENSTACK = 'OpenStack'
+CLOUDSTACK = 'CloudStack'
+RACKSPACE = 'Rackspace'
+MESOS = 'Mesos'
+
+VALID_CLOUDS = [GCP, AZURE, AWS, DIGITALOCEAN, KUBERNETES, OPENSTACK,
+                RACKSPACE, CLOUDSTACK, ALICLOUD, MESOS]
+
 
 def LoadProvider(provider_name):
   """Loads the all modules in the 'provider_name' package.

--- a/perfkitbenchmarker/providers/alicloud/ali_network.py
+++ b/perfkitbenchmarker/providers/alicloud/ali_network.py
@@ -29,11 +29,10 @@ from perfkitbenchmarker import network
 from perfkitbenchmarker import vm_util
 from perfkitbenchmarker.providers.alicloud import util
 from perfkitbenchmarker import resource
-
+from perfkitbenchmarker import providers
 
 FLAGS = flags.FLAGS
 MAX_NAME_LENGTH = 128
-ALICLOUD = 'AliCloud'
 
 
 class AliVpc(resource.BaseResource):
@@ -202,7 +201,7 @@ class AliSecurityGroup(resource.BaseResource):
 class AliFirewall(network.BaseFirewall):
   """An object representing the AliCloud Firewall."""
 
-  CLOUD = ALICLOUD
+  CLOUD = providers.ALICLOUD
 
   def __init__(self):
     self.firewall_set = set()
@@ -246,7 +245,7 @@ class AliFirewall(network.BaseFirewall):
 class AliNetwork(network.BaseNetwork):
   """Object representing a AliCloud Network."""
 
-  CLOUD = ALICLOUD
+  CLOUD = providers.ALICLOUD
 
   def __init__(self, spec):
     super(AliNetwork, self).__init__(spec)

--- a/perfkitbenchmarker/providers/alicloud/ali_virtual_machine.py
+++ b/perfkitbenchmarker/providers/alicloud/ali_virtual_machine.py
@@ -31,6 +31,7 @@ from perfkitbenchmarker import disk
 from perfkitbenchmarker.providers.alicloud import ali_disk
 from perfkitbenchmarker.providers.alicloud import ali_network
 from perfkitbenchmarker.providers.alicloud import util
+from perfkitbenchmarker import providers
 
 FLAGS = flags.FLAGS
 NON_HVM_PREFIXES = ['t1', 's1', 's2', 's3', 'm1']
@@ -74,7 +75,7 @@ DEFAULT_IMAGE = "ubuntu1404_64_20G_aliaegis_20150325.vhd",
 class AliVirtualMachine(virtual_machine.BaseVirtualMachine):
   """Object representing an AliCloud Virtual Machine."""
 
-  CLOUD = 'AliCloud'
+  CLOUD = providers.ALICLOUD
   DEFAULT_ZONE = 'cn-hangzhou-d'
   DEFAULT_MACHINE_TYPE = 'ecs.s3.large'
   IMAGE_NAME_FILTER = 'ubuntu1404_64_20G_aliaegis*'

--- a/perfkitbenchmarker/providers/alicloud/provider_info.py
+++ b/perfkitbenchmarker/providers/alicloud/provider_info.py
@@ -16,11 +16,11 @@
 
 """
 
+from perfkitbenchmarker import providers
 from perfkitbenchmarker import provider_info
-from perfkitbenchmarker import benchmark_spec
 
 
 class AliCloudProviderInfo(provider_info.BaseProviderInfo):
 
   UNSUPPORTED_BENCHMARKS = ['mysql_service']
-  CLOUD = benchmark_spec.ALICLOUD
+  CLOUD = providers.ALICLOUD

--- a/perfkitbenchmarker/providers/aws/aws_disk.py
+++ b/perfkitbenchmarker/providers/aws/aws_disk.py
@@ -29,6 +29,7 @@ import threading
 from perfkitbenchmarker import disk
 from perfkitbenchmarker import vm_util
 from perfkitbenchmarker.providers.aws import util
+from perfkitbenchmarker import providers
 
 VOLUME_EXISTS_STATUSES = frozenset(['creating', 'available', 'in-use', 'error'])
 VOLUME_DELETED_STATUSES = frozenset(['deleting', 'deleted'])
@@ -90,7 +91,7 @@ disk.RegisterDiskTypeMap(AWS, DISK_TYPE)
 class AwsDiskSpec(disk.BaseDiskSpec):
   """Object holding the information needed to create an AwsDisk."""
 
-  CLOUD = 'AWS'
+  CLOUD = providers.AWS
 
   def __init__(self, iops=None, **kwargs):
     """Initializes the Disk Spec.

--- a/perfkitbenchmarker/providers/aws/aws_network.py
+++ b/perfkitbenchmarker/providers/aws/aws_network.py
@@ -31,15 +31,15 @@ from perfkitbenchmarker import network
 from perfkitbenchmarker import resource
 from perfkitbenchmarker import vm_util
 from perfkitbenchmarker.providers.aws import util
+from perfkitbenchmarker import providers
 
 FLAGS = flags.FLAGS
-AWS = 'AWS'
 
 
 class AwsFirewall(network.BaseFirewall):
   """An object representing the AWS Firewall."""
 
-  CLOUD = AWS
+  CLOUD = providers.AWS
 
   def __init__(self):
     self.firewall_set = set()
@@ -505,7 +505,7 @@ class AwsNetwork(network.BaseNetwork):
     subnet: the AwsSubnet for this zone.
   """
 
-  CLOUD = AWS
+  CLOUD = providers.AWS
 
   def __init__(self, spec):
     """Initializes AwsNetwork instances.

--- a/perfkitbenchmarker/providers/aws/aws_virtual_machine.py
+++ b/perfkitbenchmarker/providers/aws/aws_virtual_machine.py
@@ -33,6 +33,7 @@ from perfkitbenchmarker import windows_virtual_machine
 from perfkitbenchmarker.providers.aws import aws_disk
 from perfkitbenchmarker.providers.aws import aws_network
 from perfkitbenchmarker.providers.aws import util
+from perfkitbenchmarker import providers
 
 FLAGS = flags.FLAGS
 
@@ -99,7 +100,7 @@ def IsPlacementGroupCompatible(machine_type):
 class AwsVirtualMachine(virtual_machine.BaseVirtualMachine):
   """Object representing an AWS Virtual Machine."""
 
-  CLOUD = 'AWS'
+  CLOUD = providers.AWS
   IMAGE_NAME_FILTER = None
   DEFAULT_ROOT_DISK_TYPE = 'standard'
 

--- a/perfkitbenchmarker/providers/aws/provider_info.py
+++ b/perfkitbenchmarker/providers/aws/provider_info.py
@@ -17,10 +17,10 @@
 AWS provider info
 """
 
+from perfkitbenchmarker import providers
 from perfkitbenchmarker import provider_info
-from perfkitbenchmarker import benchmark_spec
 
 
 class AWSProviderInfo(provider_info.BaseProviderInfo):
 
-  CLOUD = benchmark_spec.AWS
+  CLOUD = providers.AWS

--- a/perfkitbenchmarker/providers/azure/azure_network.py
+++ b/perfkitbenchmarker/providers/azure/azure_network.py
@@ -28,10 +28,10 @@ from perfkitbenchmarker import flags
 from perfkitbenchmarker import network
 from perfkitbenchmarker import resource
 from perfkitbenchmarker import vm_util
+from perfkitbenchmarker import providers
 
 FLAGS = flags.FLAGS
 AZURE_PATH = 'azure'
-AZURE = 'Azure'
 MAX_NAME_LENGTH = 24
 SSH_PORT = 22
 # We need to prefix storage account names so that VMs won't create their own
@@ -46,7 +46,7 @@ class AzureFirewall(network.BaseFirewall):
   On Azure, endpoints are used to open ports instead of firewalls.
   """
 
-  CLOUD = AZURE
+  CLOUD = providers.AZURE
 
   def AllowPort(self, vm, port):
     """Opens a port on the firewall.
@@ -209,7 +209,7 @@ class AzureVirtualNetwork(resource.BaseResource):
 class AzureNetwork(network.BaseNetwork):
   """Object representing an Azure Network."""
 
-  CLOUD = AZURE
+  CLOUD = providers.AZURE
 
   def __init__(self, spec):
     super(AzureNetwork, self).__init__(spec)

--- a/perfkitbenchmarker/providers/azure/azure_virtual_machine.py
+++ b/perfkitbenchmarker/providers/azure/azure_virtual_machine.py
@@ -39,6 +39,7 @@ from perfkitbenchmarker import vm_util
 from perfkitbenchmarker import windows_virtual_machine
 from perfkitbenchmarker.providers.azure import azure_disk
 from perfkitbenchmarker.providers.azure import azure_network
+from perfkitbenchmarker import providers
 
 FLAGS = flags.FLAGS
 
@@ -162,7 +163,7 @@ class AzureVirtualMachine(virtual_machine.BaseVirtualMachine):
   """Object representing an Azure Virtual Machine."""
 
   __metaclass__ = AzureVirtualMachineMetaClass
-  CLOUD = 'Azure'
+  CLOUD = providers.AZURE
   # Subclasses should override the default image pattern.
   DEFAULT_IMAGE_PATTERN = None
 

--- a/perfkitbenchmarker/providers/azure/provider_info.py
+++ b/perfkitbenchmarker/providers/azure/provider_info.py
@@ -16,11 +16,11 @@
 
 """
 
+from perfkitbenchmarker import providers
 from perfkitbenchmarker import provider_info
-from perfkitbenchmarker import benchmark_spec
 
 
 class AzureProviderInfo(provider_info.BaseProviderInfo):
 
   UNSUPPORTED_BENCHMARKS = ['mysql_service']
-  CLOUD = benchmark_spec.AZURE
+  CLOUD = providers.AZURE

--- a/perfkitbenchmarker/providers/cloudstack/cloudstack_network.py
+++ b/perfkitbenchmarker/providers/cloudstack/cloudstack_network.py
@@ -16,6 +16,7 @@ from perfkitbenchmarker import flags
 from perfkitbenchmarker import network
 from perfkitbenchmarker import vm_util
 from perfkitbenchmarker.providers.cloudstack import util
+from perfkitbenchmarker import providers
 
 FLAGS = flags.FLAGS
 
@@ -23,7 +24,7 @@ FLAGS = flags.FLAGS
 class CloudStackNetwork(network.BaseNetwork):
   """Object representing a CloudStack Network."""
 
-  CLOUD = 'CloudStack'
+  CLOUD = providers.CLOUDSTACK
 
   def __init__(self, spec):
 

--- a/perfkitbenchmarker/providers/cloudstack/cloudstack_virtual_machine.py
+++ b/perfkitbenchmarker/providers/cloudstack/cloudstack_virtual_machine.py
@@ -26,6 +26,7 @@ from perfkitbenchmarker import vm_util
 from perfkitbenchmarker.providers.cloudstack import cloudstack_disk
 from perfkitbenchmarker.providers.cloudstack import cloudstack_network
 from perfkitbenchmarker.providers.cloudstack import util
+from perfkitbenchmarker import providers
 
 UBUNTU_IMAGE = 'Ubuntu 14.04.2 HVM base (64bit)'
 RHEL_IMAGE = 'CentOS 7 HVM base (64bit)'
@@ -36,7 +37,7 @@ FLAGS = flags.FLAGS
 class CloudStackVirtualMachine(virtual_machine.BaseVirtualMachine):
   """Object representing a CloudStack Virtual Machine."""
 
-  CLOUD = 'CloudStack'
+  CLOUD = providers.CLOUDSTACK
   DEFAULT_ZONE = 'QC-1'
   DEFAULT_MACHINE_TYPE = '1vCPU.1GB'
   DEFAULT_IMAGE = 'Ubuntu 14.04.2 HVM base (64bit)'

--- a/perfkitbenchmarker/providers/cloudstack/provider_info.py
+++ b/perfkitbenchmarker/providers/cloudstack/provider_info.py
@@ -16,11 +16,11 @@
 
 """
 
+from perfkitbenchmarker import providers
 from perfkitbenchmarker import provider_info
-from perfkitbenchmarker import benchmark_spec
 
 
 class CloudStackProviderInfo(provider_info.BaseProviderInfo):
 
   UNSUPPORTED_BENCHMARKS = ['mysql_service']
-  CLOUD = benchmark_spec.CLOUDSTACK
+  CLOUD = providers.CLOUDSTACK

--- a/perfkitbenchmarker/providers/digitalocean/digitalocean_virtual_machine.py
+++ b/perfkitbenchmarker/providers/digitalocean/digitalocean_virtual_machine.py
@@ -26,6 +26,7 @@ from perfkitbenchmarker import virtual_machine
 from perfkitbenchmarker import vm_util
 from perfkitbenchmarker.providers.digitalocean import digitalocean_disk
 from perfkitbenchmarker.providers.digitalocean import util
+from perfkitbenchmarker import providers
 
 FLAGS = flags.FLAGS
 
@@ -76,7 +77,7 @@ def GetErrorMessage(stdout):
 class DigitalOceanVirtualMachine(virtual_machine.BaseVirtualMachine):
   """Object representing a DigitalOcean Virtual Machine (Droplet)."""
 
-  CLOUD = 'DigitalOcean'
+  CLOUD = providers.DIGITALOCEAN
   # Subclasses should override the default image.
   DEFAULT_IMAGE = None
 

--- a/perfkitbenchmarker/providers/digitalocean/provider_info.py
+++ b/perfkitbenchmarker/providers/digitalocean/provider_info.py
@@ -17,11 +17,11 @@
 """
 
 
+from perfkitbenchmarker import providers
 from perfkitbenchmarker import provider_info
-from perfkitbenchmarker import benchmark_spec
 
 
 class DigitalOceanProviderInfo(provider_info.BaseProviderInfo):
 
   UNSUPPORTED_BENCHMARKS = ['mysql_service']
-  CLOUD = benchmark_spec.DIGITALOCEAN
+  CLOUD = providers.DIGITALOCEAN

--- a/perfkitbenchmarker/providers/gcp/gce_disk.py
+++ b/perfkitbenchmarker/providers/gcp/gce_disk.py
@@ -22,6 +22,7 @@ import json
 from perfkitbenchmarker import disk
 from perfkitbenchmarker import flags
 from perfkitbenchmarker.providers.gcp import util
+from perfkitbenchmarker.providers import GCP
 
 FLAGS = flags.FLAGS
 
@@ -48,7 +49,6 @@ DISK_METADATA = {
     }
 }
 
-GCP = 'GCP'
 disk.RegisterDiskTypeMap(GCP, DISK_TYPE)
 
 

--- a/perfkitbenchmarker/providers/gcp/gce_network.py
+++ b/perfkitbenchmarker/providers/gcp/gce_network.py
@@ -26,9 +26,9 @@ from perfkitbenchmarker import flags
 from perfkitbenchmarker import network
 from perfkitbenchmarker import resource
 from perfkitbenchmarker.providers.gcp import util
+from perfkitbenchmarker import providers
 
 FLAGS = flags.FLAGS
-GCP = 'GCP'
 NETWORK_RANGE = '10.0.0.0/16'
 ALLOW_ALL = 'tcp:1-65535,udp:1-65535,icmp'
 
@@ -79,7 +79,7 @@ class GceFirewallRule(resource.BaseResource):
 class GceFirewall(network.BaseFirewall):
   """An object representing the GCE Firewall."""
 
-  CLOUD = GCP
+  CLOUD = providers.GCP
 
   def __init__(self):
     """Initialize GCE firewall class.
@@ -162,7 +162,7 @@ class GceNetworkResource(resource.BaseResource):
 class GceNetwork(network.BaseNetwork):
   """Object representing a GCE Network."""
 
-  CLOUD = GCP
+  CLOUD = providers.GCP
 
   def __init__(self, network_spec):
     super(GceNetwork, self).__init__(network_spec)

--- a/perfkitbenchmarker/providers/gcp/gce_virtual_machine.py
+++ b/perfkitbenchmarker/providers/gcp/gce_virtual_machine.py
@@ -41,6 +41,7 @@ from perfkitbenchmarker.configs import spec
 from perfkitbenchmarker.providers.gcp import gce_disk
 from perfkitbenchmarker.providers.gcp import gce_network
 from perfkitbenchmarker.providers.gcp import util
+from perfkitbenchmarker import providers
 
 FLAGS = flags.FLAGS
 
@@ -170,7 +171,7 @@ class GceVmSpec(virtual_machine.BaseVmSpec):
     project: string or None. The project to create the VM in.
   """
 
-  CLOUD = 'GCP'
+  CLOUD = providers.GCP
 
   def __init__(self, *args, **kwargs):
     super(GceVmSpec, self).__init__(*args, **kwargs)
@@ -226,7 +227,7 @@ class GceVmSpec(virtual_machine.BaseVmSpec):
 class GceVirtualMachine(virtual_machine.BaseVirtualMachine):
   """Object representing a Google Compute Engine Virtual Machine."""
 
-  CLOUD = 'GCP'
+  CLOUD = providers.GCP
   # Subclasses should override the default image.
   DEFAULT_IMAGE = None
   BOOT_DISK_SIZE_GB = 10

--- a/perfkitbenchmarker/providers/gcp/provider_info.py
+++ b/perfkitbenchmarker/providers/gcp/provider_info.py
@@ -16,11 +16,11 @@
 
 """
 
+from perfkitbenchmarker import providers
 from perfkitbenchmarker import provider_info
-from perfkitbenchmarker import benchmark_spec
 
 
 class GCPProviderInfo(provider_info.BaseProviderInfo):
 
   UNSUPPORTED_BENCHMARKS = []
-  CLOUD = benchmark_spec.GCP
+  CLOUD = providers.GCP

--- a/perfkitbenchmarker/providers/kubernetes/kubernetes_virtual_machine.py
+++ b/perfkitbenchmarker/providers/kubernetes/kubernetes_virtual_machine.py
@@ -21,6 +21,7 @@ from perfkitbenchmarker import disk
 from perfkitbenchmarker import flags
 from perfkitbenchmarker import virtual_machine, linux_virtual_machine
 from perfkitbenchmarker import vm_util
+from perfkitbenchmarker import providers
 from perfkitbenchmarker.providers.kubernetes import kubernetes_disk
 from perfkitbenchmarker.vm_util import OUTPUT_STDOUT as STDOUT,\
     OUTPUT_STDERR as STDERR, OUTPUT_EXIT_CODE as EXIT_CODE
@@ -37,7 +38,7 @@ class KubernetesVirtualMachine(virtual_machine.BaseVirtualMachine):
   """
   Object representing a Kubernetes POD.
   """
-  CLOUD = 'Kubernetes'
+  CLOUD = providers.KUBERNETES
 
   def __init__(self, vm_spec):
     """Initialize a Kubernetes virtual machine.

--- a/perfkitbenchmarker/providers/kubernetes/provider_info.py
+++ b/perfkitbenchmarker/providers/kubernetes/provider_info.py
@@ -16,8 +16,8 @@
 
 """
 
+from perfkitbenchmarker import providers
 from perfkitbenchmarker import provider_info
-from perfkitbenchmarker import benchmark_spec
 
 
 class KubernetesProviderInfo(provider_info.BaseProviderInfo):
@@ -28,7 +28,7 @@ class KubernetesProviderInfo(provider_info.BaseProviderInfo):
                           'netperf', 'redis', 'sysbench_oltp']
   UNSUPPORTED_BENCHMARKS = ['bonnie++', 'mysql_service']
 
-  CLOUD = benchmark_spec.KUBERNETES
+  CLOUD = providers.KUBERNETES
 
   @classmethod
   def IsBenchmarkSupported(cls, benchmark):

--- a/perfkitbenchmarker/providers/mesos/mesos_docker_instance.py
+++ b/perfkitbenchmarker/providers/mesos/mesos_docker_instance.py
@@ -23,6 +23,7 @@ from perfkitbenchmarker import virtual_machine, linux_virtual_machine
 from perfkitbenchmarker import vm_util
 from perfkitbenchmarker.configs import option_decoders
 from perfkitbenchmarker.providers.mesos.mesos_disk import LocalDisk
+from perfkitbenchmarker import providers
 
 FLAGS = flags.FLAGS
 
@@ -38,7 +39,7 @@ class MesosDockerSpec(virtual_machine.BaseVmSpec):
     docker_memory_mb: None or int. Memory limit (in MB) for Docker instances.
   """
 
-  CLOUD = 'Mesos'
+  CLOUD = providers.MESOS
 
   @classmethod
   def _GetOptionDecoderConstructions(cls):
@@ -65,7 +66,7 @@ class MesosDockerInstance(virtual_machine.BaseVirtualMachine):
   Represents a Docker instance spawned by Marathon framework on a Mesos cluster
   """
 
-  CLOUD = 'Mesos'
+  CLOUD = providers.MESOS
 
   def __init__(self, vm_spec):
     super(MesosDockerInstance, self).__init__(vm_spec)

--- a/perfkitbenchmarker/providers/mesos/provider_info.py
+++ b/perfkitbenchmarker/providers/mesos/provider_info.py
@@ -16,8 +16,8 @@
 
 """
 
+from perfkitbenchmarker import providers
 from perfkitbenchmarker import provider_info
-from perfkitbenchmarker import benchmark_spec
 
 
 class MesosProviderInfo(provider_info.BaseProviderInfo):
@@ -30,7 +30,7 @@ class MesosProviderInfo(provider_info.BaseProviderInfo):
                           'sysbench_oltp']
   UNSUPPORTED_BENCHMARKS = ['bonnie++', 'mysql_service']
 
-  CLOUD = benchmark_spec.MESOS
+  CLOUD = providers.MESOS
 
   @classmethod
   def IsBenchmarkSupported(cls, benchmark):

--- a/perfkitbenchmarker/providers/openstack/os_network.py
+++ b/perfkitbenchmarker/providers/openstack/os_network.py
@@ -17,6 +17,7 @@ import time
 from perfkitbenchmarker import flags
 from perfkitbenchmarker import network
 from perfkitbenchmarker.providers.openstack import utils
+from perfkitbenchmarker import providers
 
 FLAGS = flags.FLAGS
 
@@ -28,7 +29,7 @@ class OpenStackFirewall(network.BaseFirewall):
     An object representing OpenStack Firewall based on Secure Groups.
     """
 
-    CLOUD = 'OpenStack'
+    CLOUD = providers.OPENSTACK
 
     def __init__(self):
         super(OpenStackFirewall, self).__init__()

--- a/perfkitbenchmarker/providers/openstack/os_virtual_machine.py
+++ b/perfkitbenchmarker/providers/openstack/os_virtual_machine.py
@@ -19,6 +19,7 @@ import time
 from perfkitbenchmarker import virtual_machine, linux_virtual_machine
 from perfkitbenchmarker import flags
 from perfkitbenchmarker import vm_util
+from perfkitbenchmarker import providers
 from perfkitbenchmarker.providers.openstack import os_disk
 from perfkitbenchmarker.providers.openstack import os_network
 from perfkitbenchmarker.providers.openstack import utils as os_utils
@@ -32,7 +33,7 @@ FLAGS = flags.FLAGS
 class OpenStackVirtualMachine(virtual_machine.BaseVirtualMachine):
     """Object representing an OpenStack Virtual Machine"""
 
-    CLOUD = 'OpenStack'
+    CLOUD = providers.OPENSTACK
     DEFAULT_USERNAME = 'ubuntu'
     # Subclasses should override the default image.
     DEFAULT_IMAGE = None

--- a/perfkitbenchmarker/providers/openstack/provider_info.py
+++ b/perfkitbenchmarker/providers/openstack/provider_info.py
@@ -16,11 +16,11 @@
 
 """
 
+from perfkitbenchmarker import providers
 from perfkitbenchmarker import provider_info
-from perfkitbenchmarker import benchmark_spec
 
 
 class OpenStackProviderInfo(provider_info.BaseProviderInfo):
 
   UNSUPPORTED_BENCHMARKS = ['mysql_service']
-  CLOUD = benchmark_spec.OPENSTACK
+  CLOUD = providers.OPENSTACK

--- a/perfkitbenchmarker/providers/rackspace/provider_info.py
+++ b/perfkitbenchmarker/providers/rackspace/provider_info.py
@@ -16,11 +16,11 @@
 
 """
 
+from perfkitbenchmarker import providers
 from perfkitbenchmarker import provider_info
-from perfkitbenchmarker import benchmark_spec
 
 
 class RackspaceProviderInfo(provider_info.BaseProviderInfo):
 
   UNSUPPORTED_BENCHMARKS = ['mysql_service']
-  CLOUD = benchmark_spec.RACKSPACE
+  CLOUD = providers.RACKSPACE

--- a/perfkitbenchmarker/providers/rackspace/rackspace_network.py
+++ b/perfkitbenchmarker/providers/rackspace/rackspace_network.py
@@ -24,6 +24,7 @@ from perfkitbenchmarker import flags
 from perfkitbenchmarker import network
 from perfkitbenchmarker import vm_util
 from perfkitbenchmarker.providers.rackspace import util
+from perfkitbenchmarker import providers
 
 FLAGS = flags.FLAGS
 
@@ -33,7 +34,7 @@ SSH_PORT = 22
 class RackspaceSecurityGroup(network.BaseFirewall):
     """An object representing the Rackspace Security Group."""
 
-    CLOUD = 'Rackspace'
+    CLOUD = providers.RACKSPACE
 
     def __init__(self):
         """Initialize Rackspace security group class."""

--- a/perfkitbenchmarker/providers/rackspace/rackspace_virtual_machine.py
+++ b/perfkitbenchmarker/providers/rackspace/rackspace_virtual_machine.py
@@ -41,6 +41,7 @@ from perfkitbenchmarker import flags
 from perfkitbenchmarker import linux_virtual_machine
 from perfkitbenchmarker import virtual_machine
 from perfkitbenchmarker import vm_util
+from perfkitbenchmarker import providers
 from perfkitbenchmarker.providers.rackspace import rackspace_disk
 from perfkitbenchmarker.providers.rackspace import \
     rackspace_machine_types as rax
@@ -74,7 +75,7 @@ RHEL_IMAGE = 'c07409c8-0931-40e4-a3bc-4869ecb5931e'
 
 class RackspaceVirtualMachine(virtual_machine.BaseVirtualMachine):
 
-  CLOUD = 'Rackspace'
+  CLOUD = providers.RACKSPACE
   # Subclasses should override the default image.
   DEFAULT_IMAGE = None
 

--- a/tests/background_workload_test.py
+++ b/tests/background_workload_test.py
@@ -24,6 +24,7 @@ from perfkitbenchmarker.linux_benchmarks import ping_benchmark
 from perfkitbenchmarker import benchmark_spec
 from perfkitbenchmarker import timing_util
 from perfkitbenchmarker import pkb
+from perfkitbenchmarker import providers
 
 
 NAME = 'ping'
@@ -56,7 +57,7 @@ class TestBackgroundWorkload(unittest.TestCase):
 
   def setupCommonFlags(self, mock_flags):
     mock_flags.os_type = benchmark_spec.DEBIAN
-    mock_flags.cloud = 'GCP'
+    mock_flags.cloud = providers.GCP
 
   def _CheckVMFromSpec(self, spec, num_working):
     vm0 = spec.vms[0]

--- a/tests/linux_benchmarks/object_storage_service_benchmark_test.py
+++ b/tests/linux_benchmarks/object_storage_service_benchmark_test.py
@@ -1,0 +1,52 @@
+# Copyright 2015 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ping_benchmark."""
+
+import unittest
+import mock
+from perfkitbenchmarker.linux_benchmarks import object_storage_service_benchmark
+from perfkitbenchmarker import benchmark_spec
+from perfkitbenchmarker import providers
+from tests import mock_flags
+
+PKB = 'perfkitbenchmarker'
+MOD_PATH = PKB + '.linux_benchmarks.object_storage_service_benchmark'
+
+
+class TestGenerateJobFileString(unittest.TestCase):
+
+
+  def testRunCountTest(self):
+    with mock.patch('os.path.isfile', return_value=True),\
+        mock.patch(PKB + '.data.ResourcePath', return_value=['a', 'b']),\
+        mock.patch(MOD_PATH + '.S3StorageBenchmark.Prepare') as Prepare,\
+        mock.patch(MOD_PATH
+                   + '.S3StorageBenchmark.Run') as Run, mock.patch(
+                       MOD_PATH + '.S3StorageBenchmark.Cleanup') as Cleanup:
+      flags = mock_flags.PatchTestCaseFlags(self)
+      flags.storage = providers.AWS
+      flags.object_storage_scenario = 'all'
+      vm_spec = mock.MagicMock(spec=benchmark_spec.BenchmarkSpec)
+      vm0 = mock.MagicMock()
+      vm_spec.vms = [vm0]
+      object_storage_service_benchmark.Prepare(vm_spec)
+      self.assertEqual(Prepare.call_count, 1)
+      object_storage_service_benchmark.Run(vm_spec)
+      self.assertEqual(Run.call_count, 1)
+      object_storage_service_benchmark.Cleanup(vm_spec)
+      self.assertEqual(Cleanup.call_count, 1)
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tests/provider_benchmark_test.py
+++ b/tests/provider_benchmark_test.py
@@ -16,7 +16,6 @@
 
 import unittest
 
-from perfkitbenchmarker import benchmark_spec
 from perfkitbenchmarker import providers
 from perfkitbenchmarker import provider_info
 
@@ -24,7 +23,7 @@ from perfkitbenchmarker import provider_info
 class ProviderBenchmarkChecks(unittest.TestCase):
 
   def testPingSupported(self):
-    for cloud in benchmark_spec.VALID_CLOUDS:
+    for cloud in providers.VALID_CLOUDS:
       providers.LoadProvider(cloud.lower())
       ThisProviderInfoClass = provider_info.GetProviderInfoClass(cloud)
       self.assertTrue(ThisProviderInfoClass.IsBenchmarkSupported('iperf'),
@@ -32,10 +31,10 @@ class ProviderBenchmarkChecks(unittest.TestCase):
                           cloud))
 
   def testMYSQLSupport(self):
-    for cloud in benchmark_spec.VALID_CLOUDS:
+    for cloud in providers.VALID_CLOUDS:
       providers.LoadProvider(cloud.lower())
       ThisProviderInfoClass = provider_info.GetProviderInfoClass(cloud)
-      if (cloud == benchmark_spec.AWS or cloud == benchmark_spec.GCP):
+      if (cloud == providers.AWS or cloud == providers.GCP):
         self.assertTrue(ThisProviderInfoClass.IsBenchmarkSupported(
             'mysql_service'))
       else:

--- a/tests/providers_test.py
+++ b/tests/providers_test.py
@@ -18,14 +18,14 @@ import unittest
 
 import mock
 
-from perfkitbenchmarker import benchmark_spec
 from perfkitbenchmarker import providers
+from perfkitbenchmarker import benchmark_spec
 
 
 class LoadProvidersTestCase(unittest.TestCase):
 
   def testLoadAllProviders(self):
-    for cloud in benchmark_spec.VALID_CLOUDS:
+    for cloud in providers.VALID_CLOUDS:
       providers.LoadProvider(cloud.lower())
 
   def testLoadInvalidProvider(self):


### PR DESCRIPTION
Move the provider name constants from `benchmark_spec.py` to `provider_info.py` and adjust the references those names accordingly.

I added a test for object_storage_service_benchmark in this same pull request because all the tests passed even though I'd forgotten to make a change on `object_storage_service_benchmark.py`.  