### PR TITLE
Increase preload thread count for YCSB.

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/cloud_bigtable_ycsb_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/cloud_bigtable_ycsb_benchmark.py
@@ -277,7 +277,12 @@ def Run(benchmark_spec):
       'columnfamily': COLUMN_FAMILY,
       'clientbuffering': 'false'}
   load_kwargs = run_kwargs.copy()
+
+  # During the load stage, use a buffered mutator with a single thread.
+  # The BufferedMutator will handle multiplexing RPCs.
   load_kwargs['clientbuffering'] = 'true'
+  if not FLAGS['ycsb_preload_threads'].present:
+    load_kwargs['threads'] = 1
   samples = list(executor.LoadAndRun(vms,
                                      load_kwargs=load_kwargs,
                                      run_kwargs=run_kwargs))

--- a/perfkitbenchmarker/linux_benchmarks/hbase_ycsb_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/hbase_ycsb_benchmark.py
@@ -236,7 +236,12 @@ def Run(benchmark_spec):
   run_kwargs = {'columnfamily': COLUMN_FAMILY,
                 'clientbuffering': 'false'}
   load_kwargs = run_kwargs.copy()
+
+  # During the load stage, use a buffered mutator with a single thread.
+  # The BufferedMutator will handle multiplexing RPCs.
   load_kwargs['clientbuffering'] = 'true'
+  if not FLAGS['ycsb_preload_threads'].present:
+    load_kwargs['threads'] = 1
   samples = list(executor.LoadAndRun(loaders,
                                      load_kwargs=load_kwargs,
                                      run_kwargs=run_kwargs))


### PR DESCRIPTION
The current default was set for HBase, which buffers mutations and sends
them in batches. 1 loading thread makes for very long
`{MongoDB,Aerospike,Cassandra}` YCSB tests. Changing to 32, and
overriding the default for HBase / Cloud Bigtable.