### PR TITLE
Ensure that windows vms still work with background_cpu_threads

### DIFF
--- a/perfkitbenchmarker/virtual_machine.py
+++ b/perfkitbenchmarker/virtual_machine.py
@@ -552,3 +552,18 @@ class BaseOsMixin(object):
   def _TestReachable(self, ip):
     """Returns True if the VM can reach the ip address and False otherwise."""
     raise NotImplementedError()
+
+  def StartBackgroundWorkload(self):
+    """Start the background workload"""
+    if self.background_cpu_threads:
+      raise NotImplementedError()
+
+  def StopBackgroundWorkload(self):
+    """Stop the background workoad"""
+    if self.background_cpu_threads:
+      raise NotImplementedError()
+
+  def PrepareBackgroundWorkload(self):
+    """Prepare for the background workload"""
+    if self.background_cpu_threads:
+      raise NotImplementedError()

--- a/perfkitbenchmarker/vm_util.py
+++ b/perfkitbenchmarker/vm_util.py
@@ -76,7 +76,7 @@ flags.DEFINE_integer('burn_cpu_threads', 1, 'Number of threads to use to '
                      'burn cpu before starting benchmark.')
 flags.DEFINE_integer('background_cpu_threads', None,
                      'Number of threads of background cpu usage while '
-                     'running benchmark')
+                     'running a benchmark')
 
 
 class IpAddressSubset(object):


### PR DESCRIPTION
Fix bug which made windows VMs give errors even when background_cpu_threads was not set.  