### PR TITLE
openstack: Add mechanism to specify region name

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/object_storage_service_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/object_storage_service_benchmark.py
@@ -241,7 +241,8 @@ def _MakeAzureCommandSuffix(account_name, account_key, for_cli):
     return (' --azure_account=%s --azure_key=%s') % (account_name, account_key)
 
 
-def _MakeSwiftCommandPrefix(auth_url, tenant_name, username, password):
+def _MakeSwiftCommandPrefix(auth_url, tenant_name, username, password,
+                            region_name):
   """This function returns a prefix for Swift CLI command.
 
   Args:
@@ -249,7 +250,7 @@ def _MakeSwiftCommandPrefix(auth_url, tenant_name, username, password):
     tenant_name: tenant name for obtaining auth token.
     username: username for obtaining auth token.
     password: password for obtaining auth token.
-
+    region_name: region name where Swift endpoint is located.
   Returns:
     string represents a command prefix.
   """
@@ -257,6 +258,7 @@ def _MakeSwiftCommandPrefix(auth_url, tenant_name, username, password):
              '--os-tenant-name', tenant_name,
              '--os-username', username,
              '--os-password', password,
+             '--os-region-name', region_name,
              '--insecure' if FLAGS.openstack_swift_insecure else '',)
   return ' '.join(options)
 
@@ -944,7 +946,8 @@ class SwiftStorageBenchmark(object):
     self.swift_command_prefix = _MakeSwiftCommandPrefix(vm.client.url,
                                                         vm.client.tenant,
                                                         vm.client.user,
-                                                        vm.client.password)
+                                                        vm.client.password,
+                                                        vm.client.region_name)
     vm.RemoteCommand('swift %s post %s' % (self.swift_command_prefix,
                                            vm.bucket_name))
 

--- a/perfkitbenchmarker/providers/openstack/flags.py
+++ b/perfkitbenchmarker/providers/openstack/flags.py
@@ -22,6 +22,10 @@ flags.DEFINE_string('openstack_auth_url',
                      '$OS_AUTH_URL. Required for discovery of other OpenStack '
                      'service URLs.'))
 
+flags.DEFINE_string('openstack_region',
+                    os.environ.get('OS_REGION_NAME', 'RegionOne'),
+                    'OpenStack region name, defaults to $OS_REGION_NAME')
+
 flags.DEFINE_string('openstack_username',
                     os.getenv('OS_USERNAME', 'admin'),
                     'OpenStack login username, defaults to $OS_USERNAME.')

--- a/perfkitbenchmarker/providers/openstack/os_disk.py
+++ b/perfkitbenchmarker/providers/openstack/os_disk.py
@@ -29,7 +29,7 @@ class OpenStackDisk(disk.BaseDisk):
 
     def __init__(self, disk_spec, name, zone, image=None):
         super(OpenStackDisk, self).__init__(disk_spec)
-        self.__nclient = os_utils.NovaClient()
+        self.__nclient = os_utils.NovaClient(region_name=FLAGS.openstack_region)
         self.attached_vm_name = None
         self.attached_vm_id = -1
         self.image = image

--- a/perfkitbenchmarker/providers/openstack/os_network.py
+++ b/perfkitbenchmarker/providers/openstack/os_network.py
@@ -32,7 +32,7 @@ class OpenStackFirewall(network.BaseFirewall):
 
     def __init__(self):
         super(OpenStackFirewall, self).__init__()
-        self.__nclient = utils.NovaClient()
+        self.__nclient = utils.NovaClient(region_name=FLAGS.openstack_region)
 
         if not (self.__nclient.security_groups.findall(
                 name='perfkit_sc_group')):
@@ -66,7 +66,7 @@ class OpenStackFirewall(network.BaseFirewall):
 class OpenStackPublicNetwork(object):
 
     def __init__(self, pool):
-        self.__nclient = utils.NovaClient()
+        self.__nclient = utils.NovaClient(region_name=FLAGS.openstack_region)
         self.__floating_ip_lock = threading.Lock()
         self.ip_pool_name = pool
 

--- a/perfkitbenchmarker/providers/openstack/os_virtual_machine.py
+++ b/perfkitbenchmarker/providers/openstack/os_virtual_machine.py
@@ -49,7 +49,7 @@ class OpenStackVirtualMachine(virtual_machine.BaseVirtualMachine):
         self.name = 'perfkit_vm_%d_%s' % (self.instance_number, FLAGS.run_uri)
         self.key_name = 'perfkit_key_%d_%s' % (self.instance_number,
                                                FLAGS.run_uri)
-        self.client = os_utils.NovaClient()
+        self.client = os_utils.NovaClient(region_name=FLAGS.openstack_region)
         self.public_network = os_network.OpenStackPublicNetwork(
             FLAGS.openstack_public_network
         )

--- a/perfkitbenchmarker/providers/openstack/utils.py
+++ b/perfkitbenchmarker/providers/openstack/utils.py
@@ -99,9 +99,9 @@ class NovaClient(object):
         raise Exception(error_msg + ' ' + str(e))
       raise Exception(error_msg)
 
-    def __init__(self):
+    def __init__(self, region_name=None):
         from novaclient import client as noclient
-
+        self.region_name = region_name
         self.url = FLAGS.openstack_auth_url
         self.user = FLAGS.openstack_username
         self.tenant = FLAGS.openstack_tenant
@@ -112,6 +112,7 @@ class NovaClient(object):
                                    self.user, self.password)
         self.__client = noclient.Client('2',
                                         auth_url=self.url,
+                                        region_name=self.region_name,
                                         username=self.user,
                                         auth_token=self.__auth.get_token(),
                                         tenant_id=self.__auth.get_tenant_id(),
@@ -131,6 +132,7 @@ class NovaClient(object):
                                    self.password)
         self.__client = noclient.Client('2',
                                         auth_url=self.url,
+                                        region_name=self.region_name,
                                         username=self.user,
                                         auth_token=self.__auth.get_token(),
                                         tenant_id=self.__auth.get_tenant_id(),


### PR DESCRIPTION
Either by using the --openstack-region flag or the environment variable
OS_REGION_NAME specifies which OpenStack region to use. If none
is specificed the 'RegionOne' is used as the default, which is OpenStack
default region name.

Use region name value for OpenStack Swift's object storage benchmark as well.

Addresses Issue #769 