### PR TITLE
Add a missing "--region" flag to AWS command

### DIFF
--- a/perfkitbenchmarker/providers/aws/aws_network.py
+++ b/perfkitbenchmarker/providers/aws/aws_network.py
@@ -110,6 +110,7 @@ class AwsVpc(resource.BaseResource):
     cmd = util.AWS_PREFIX + [
         'ec2',
         'describe-security-groups',
+        '--region', self.region,
         '--filters',
         'Name=group-name,Values=default',
         'Name=vpc-id,Values=' + self.id]


### PR DESCRIPTION
The current code fails when a VPC is created outside of the user's
default region.