### PR TITLE
kill iperf processes started by the benchmark on all machines

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/iperf_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/iperf_benchmark.py
@@ -76,6 +76,9 @@ def Prepare(benchmark_spec):
       vm.AllowPort(IPERF_PORT)
     vm.RemoteCommand('nohup iperf --server --port %s &> /dev/null &' %
                      IPERF_PORT)
+    stdout, _ = vm.RemoteCommand('pgrep -n iperf')
+    # TODO store this in a better place once we have a better place
+    vm.iperf_server_pid = stdout.strip()
 
 
 @vm_util.Retry(max_retries=IPERF_RETRIES)
@@ -189,4 +192,5 @@ def Cleanup(benchmark_spec):
         required to run the benchmark.
   """
   vms = benchmark_spec.vms
-  vms[1].RemoteCommand('pkill -9 iperf')
+  for vm in vms:
+    vm.RemoteCommand('kill -9 ' + vm.iperf_server_pid)


### PR DESCRIPTION
I noticed two minor problems in the iperf benchmark:
* It was only cleaning up iperf on one of the hosts
* It was was killing all iperf processes.

So I modified the benchmark to store the pid of the iperf process and only kill that iperf process.  