### PR TITLE
Extracting PTRANS metric from hpcc benchmark run output

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/hpcc_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/hpcc_benchmark.py
@@ -197,6 +197,8 @@ def ParseOutput(hpcc_output, benchmark_spec):
     results.append(sample.Sample('STREAM %s Throughput' % metric, value,
                                  'GB/s'))
 
+  value = regex_util.ExtractFloat('PTRANS_GBs=([0-9]*\\.[0-9]*)', hpcc_output)
+  results.append(sample.Sample('PTRANS Throughput', value, 'GB/s', metadata))
   return results
 
 

--- a/perfkitbenchmarker/linux_benchmarks/hpcc_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/hpcc_benchmark.py
@@ -197,7 +197,7 @@ def ParseOutput(hpcc_output, benchmark_spec):
     results.append(sample.Sample('STREAM %s Throughput' % metric, value,
                                  'GB/s'))
 
-  value = regex_util.ExtractFloat('PTRANS_GBs=([0-9]*\\.[0-9]*)', hpcc_output)
+  value = regex_util.ExtractFloat(r'PTRANS_GBs=([0-9]*\.[0-9]*)', hpcc_output)
   results.append(sample.Sample('PTRANS Throughput', value, 'GB/s', metadata))
   return results
 

--- a/tests/linux_benchmarks/hpcc_benchmark_test.py
+++ b/tests/linux_benchmarks/hpcc_benchmark_test.py
@@ -28,14 +28,14 @@ class HPCCTestCase(unittest.TestCase):
     p.start()
     self.addCleanup(p.stop)
 
-    path = os.path.join(os.path.dirname(__file__), 'data', 'hpcc-sample.txt')
+    path = os.path.join(os.path.dirname(__file__), '../data', 'hpcc-sample.txt')
     with open(path) as fp:
       self.contents = fp.read()
 
   def testParseHpcc(self):
     benchmark_spec = mock.MagicMock()
     result = hpcc_benchmark.ParseOutput(self.contents, benchmark_spec)
-    self.assertEqual(6, len(result))
+    self.assertEqual(7, len(result))
     results = {i[0]: i[1] for i in result}
 
     self.assertAlmostEqual(0.0331844, results['HPL Throughput'])
@@ -44,7 +44,7 @@ class HPCCTestCase(unittest.TestCase):
     self.assertAlmostEqual(11.6338, results['STREAM Scale Throughput'])
     self.assertAlmostEqual(12.7265, results['STREAM Add Throughput'])
     self.assertAlmostEqual(12.2433, results['STREAM Triad Throughput'])
-
+    self.assertAlmostEqual(0.338561, results['PTRANS Throughput'])
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
This minor change extracts an additional data point from the output file generated by the hpcc benchmark and adds it to the result set. Updated unit test. 