### PR TITLE
Add background network workload support

### DIFF
--- a/perfkitbenchmarker/configs/option_decoders.py
+++ b/perfkitbenchmarker/configs/option_decoders.py
@@ -83,6 +83,50 @@ class ConfigOptionDecoder(object):
     raise NotImplementedError()
 
 
+class EnumDecoder(ConfigOptionDecoder):
+  """ Verifies that the config options value is in the allowed set.
+
+  Passes through the value unmodified
+  """
+
+  def __init__(self, option, valid_values, **kwargs):
+    """Initializes the EnumVerifier.
+
+    Args:
+    option: string.  Name of the config option.
+    valid_values: list of the allowed values
+    **kwargs: Keyword arguments to pass to the base class.
+    """
+    super(EnumDecoder, self).__init__(option, **kwargs)
+    self.valid_values = valid_values
+
+  def Decode(self, value, component_full_name, flag_values):
+    """ Verifies that the provided value is in the allowed set.
+
+    Args:
+      value: The value specified in the config.
+      component_full_name: string.  Fully qualified name of the
+          configurable component containing the config option.
+      flag_values: flags.FlagValues.  Runtime flag values to be
+          propagated to the BaseSpec constructors.
+
+    Returns:
+      The valid value.
+
+    Raises:
+      errors.Config.InvalidValue upon invalid input value.
+    """
+    if value in self.valid_values:
+     return value
+    else:
+      raise errors.Config.InvalidValue(
+          'Invalid {0}.{1} value: "{2}". Value must be one '
+          'of the following: {3}.'.format(
+              component_full_name, self.option, value,
+              ', '.join(str(t) for t in self.valid_values)))
+
+
+
 class TypeVerifier(ConfigOptionDecoder):
   """Verifies that a config option value's type belongs to an allowed set.
 

--- a/perfkitbenchmarker/virtual_machine.py
+++ b/perfkitbenchmarker/virtual_machine.py
@@ -87,6 +87,10 @@ class BaseVmSpec(spec.BaseSpec):
         useful if benchmark dependencies have already been installed.
     background_cpu_threads: The number of threads of background CPU usage
         while running the benchmark.
+    background_network_mbits_per_sec: The number of megabits per second of
+        background network traffic during the benchmark.
+    background_network_ip_type: The IP address type (INTERNAL or
+        EXTERNAL) to use for generating background network workload.
   """
 
   __metaclass__ = AutoRegisterVmSpecMeta
@@ -118,6 +122,12 @@ class BaseVmSpec(spec.BaseSpec):
     if flag_values['background_cpu_threads'].present:
       config_values['background_cpu_threads'] = (
           flag_values.background_cpu_threads)
+    if flag_values['background_network_mbits_per_sec'].present:
+      config_values['background_network_mbits_per_sec'] = (
+          flag_values.background_network_mbits_per_sec)
+    if flag_values['background_network_ip_type'].present:
+      config_values['background_network_ip_type'] = (
+          flag_values.background_network_ip_type)
 
   @classmethod
   def _GetOptionDecoderConstructions(cls):
@@ -140,6 +150,12 @@ class BaseVmSpec(spec.BaseSpec):
                                                          'default': None}),
         'zone': (option_decoders.StringDecoder, {'none_ok': True,
                                                  'default': None}),
+        'background_network_mbits_per_sec': (option_decoders.IntDecoder, {
+            'none_ok': True, 'default': None}),
+        'background_network_ip_type': (option_decoders.EnumDecoder, {
+            'default': vm_util.IpAddressSubset.EXTERNAL,
+            'valid_values': [vm_util.IpAddressSubset.EXTERNAL,
+                             vm_util.IpAddressSubset.INTERNAL]}),
         'background_cpu_threads': (option_decoders.IntDecoder, {
             'none_ok': True, 'default': None})})
     return result
@@ -171,6 +187,10 @@ class BaseVirtualMachine(resource.BaseResource):
       scratch disks or that can be striped together.
     background_cpu_threads: The number of threads of background CPU usage
       while running the benchmark.
+    background_network_mbits_per_sec: Number of mbits/sec of background network
+      usage while running the benchmark.
+    background_network_ip_type: Type of IP address to use for generating
+      background network workload
   """
 
   __metaclass__ = AutoRegisterVmMeta
@@ -207,6 +227,9 @@ class BaseVirtualMachine(resource.BaseResource):
     self.local_disk_counter = 0
     self.remote_disk_counter = 0
     self.background_cpu_threads = vm_spec.background_cpu_threads
+    self.background_network_mbits_per_sec = (
+        vm_spec.background_network_mbits_per_sec)
+    self.background_network_ip_type = vm_spec.background_network_ip_type
 
     self.network = None
     self.firewall = None
@@ -555,15 +578,15 @@ class BaseOsMixin(object):
 
   def StartBackgroundWorkload(self):
     """Start the background workload"""
-    if self.background_cpu_threads:
+    if self.background_cpu_threads or self.background_network_mbits_per_sec:
       raise NotImplementedError()
 
   def StopBackgroundWorkload(self):
     """Stop the background workoad"""
-    if self.background_cpu_threads:
+    if self.background_cpu_threads or self.background_network_mbits_per_sec:
       raise NotImplementedError()
 
   def PrepareBackgroundWorkload(self):
     """Prepare for the background workload"""
-    if self.background_cpu_threads:
+    if self.background_cpu_threads or self.background_network_mbits_per_sec:
       raise NotImplementedError()

--- a/perfkitbenchmarker/vm_util.py
+++ b/perfkitbenchmarker/vm_util.py
@@ -77,6 +77,10 @@ flags.DEFINE_integer('burn_cpu_threads', 1, 'Number of threads to use to '
 flags.DEFINE_integer('background_cpu_threads', None,
                      'Number of threads of background cpu usage while '
                      'running a benchmark')
+flags.DEFINE_integer('background_network_mbits_per_sec', None,
+                     'Number of megabits per second of background '
+                     'network traffic to generate during the run phase '
+                     'of the benchmark')
 
 
 class IpAddressSubset(object):
@@ -94,6 +98,11 @@ flags.DEFINE_enum('ip_addresses', IpAddressSubset.REACHABLE,
                   'IP addresses (BOTH), external and internal only if '
                   'the receiving VM is reachable by internal IP (REACHABLE), '
                   'external IP only (EXTERNAL) or internal IP only (INTERNAL)')
+
+flags.DEFINE_enum('background_network_ip_type', IpAddressSubset.EXTERNAL,
+                  (IpAddressSubset.INTERNAL, IpAddressSubset.EXTERNAL),
+                  'IP address type to use when generating background network '
+                  'traffic')
 
 
 def GetTempDir():

--- a/tests/background_cpu_test.py
+++ b/tests/background_cpu_test.py
@@ -12,23 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for background workload"""
+"""Tests for background cpu workload """
 
-import functools
-import unittest
-
-import mock
 from mock import patch
-
 from perfkitbenchmarker import benchmark_spec
 from perfkitbenchmarker import configs
 from perfkitbenchmarker import os_types
-from perfkitbenchmarker import pkb
 from perfkitbenchmarker import providers
-from perfkitbenchmarker import timing_util
 from perfkitbenchmarker.linux_benchmarks import ping_benchmark
 from tests import mock_flags
-
+import unittest
 
 NAME = 'ping'
 UID = 'name0'
@@ -50,13 +43,6 @@ ping:
 
 
 class TestBackgroundWorkload(unittest.TestCase):
-
-  def setUp(self):
-    self.last_call = 0
-
-  def _CheckAndIncrement(self, throwaway=None, expected_last_call=None):
-    self.assertEqual(self.last_call, expected_last_call)
-    self.last_call += 1
 
   def setupCommonFlags(self, mock_flags):
     mock_flags.os_type = os_types.DEBIAN
@@ -82,38 +68,6 @@ class TestBackgroundWorkload(unittest.TestCase):
                        expected_remote_post_stop)
 
 
-  def testBackgroundWorkloadSpec(self):
-    """ Check that the benchmark spec calls the prepare, stop, and start
-    methods on the vms """
-
-    with mock_flags.PatchFlags() as mocked_flags:
-      self.setupCommonFlags(mocked_flags)
-      mocked_flags.background_cpu_threads = 1
-      collector = mock.MagicMock()
-      config = configs.LoadConfig(ping_benchmark.BENCHMARK_CONFIG, {}, NAME)
-      spec = benchmark_spec.BenchmarkSpec(config, NAME, UID)
-      vm0 = mock.MagicMock()
-      vm1 = mock.MagicMock()
-      spec.ConstructVirtualMachines()
-      spec.vms = [vm0, vm1]
-      timer = timing_util.IntervalTimer()
-      pkb.DoPreparePhase(ping_benchmark, NAME, spec, timer)
-      for vm in spec.vms:
-        self.assertEqual(vm.PrepareBackgroundWorkload.call_count, 1)
-
-      with mock.patch(ping_benchmark.__name__ + '.Run'):
-        ping_benchmark.Run.side_effect = functools.partial(
-            self._CheckAndIncrement, expected_last_call=1)
-        vm0.StartBackgroundWorkload.side_effect = functools.partial(
-            self._CheckAndIncrement, expected_last_call=0)
-        vm0.StopBackgroundWorkload.side_effect = functools.partial(
-            self._CheckAndIncrement, expected_last_call=2)
-        pkb.DoRunPhase(ping_benchmark, NAME, spec, collector, timer)
-        self.assertEqual(ping_benchmark.Run.call_count, 1)
-        for vm in spec.vms:
-          self.assertEqual(vm.StartBackgroundWorkload.call_count, 1)
-          self.assertEqual(vm.StopBackgroundWorkload.call_count, 1)
-
   def testWindowsVMCausesError(self):
     """ windows vm with background_cpu_threads raises exception """
     with mock_flags.PatchFlags() as mocked_flags:
@@ -123,15 +77,15 @@ class TestBackgroundWorkload(unittest.TestCase):
       config = configs.LoadConfig(ping_benchmark.BENCHMARK_CONFIG, {}, NAME)
       spec = benchmark_spec.BenchmarkSpec(config, NAME, UID)
       spec.ConstructVirtualMachines()
-      with self.assertRaises(Exception):
+      with self.assertRaisesRegexp(Exception, 'NotImplementedError'):
         spec.Prepare()
-      with self.assertRaises(Exception):
+      with self.assertRaisesRegexp(Exception, 'NotImplementedError'):
         spec.StartBackgroundWorkload()
-      with self.assertRaises(Exception):
+      with self.assertRaisesRegexp(Exception, 'NotImplementedError'):
         spec.StopBackgroundWorkload()
 
   def testBackgroundWorkloadVM(self):
-    """ Check that the vm background workload calls work """
+    """ Check that the background_cpu_threads causes calls """
     with mock_flags.PatchFlags() as mocked_flags:
       self.setupCommonFlags(mocked_flags)
       mocked_flags.background_cpu_threads = 1
@@ -144,13 +98,12 @@ class TestBackgroundWorkload(unittest.TestCase):
     """ Test that nothing happens with the vanilla config """
     with mock_flags.PatchFlags() as mocked_flags:
       self.setupCommonFlags(mocked_flags)
-      mocked_flags.background_cpu_threads = None
       config = configs.LoadConfig(ping_benchmark.BENCHMARK_CONFIG, {}, NAME)
       spec = benchmark_spec.BenchmarkSpec(config, NAME, UID)
       spec.ConstructVirtualMachines()
-
       for vm in spec.vms:
         self.assertIsNone(vm.background_cpu_threads)
+        self.assertIsNone(vm.background_network_mbits_per_sec)
       self._CheckVMFromSpec(spec, 0)
 
   def testBackgroundWorkloadWindows(self):
@@ -165,11 +118,12 @@ class TestBackgroundWorkload(unittest.TestCase):
 
       for vm in spec.vms:
         self.assertIsNone(vm.background_cpu_threads)
+        self.assertIsNone(vm.background_network_mbits_per_sec)
       self._CheckVMFromSpec(spec, 0)
 
 
   def testBackgroundWorkloadVanillaConfigFlag(self):
-    """ Check that the flag overrides the config """
+    """ Check that the background_cpu_threads flags overrides the config """
     with mock_flags.PatchFlags() as mocked_flags:
       self.setupCommonFlags(mocked_flags)
       mocked_flags.background_cpu_threads = 2
@@ -182,7 +136,7 @@ class TestBackgroundWorkload(unittest.TestCase):
 
 
   def testBackgroundWorkloadConfig(self):
-    """ Check that the config can be used to set the background cpu threads """
+    """ Check that the config can be used to set background_cpu_threads """
     with mock_flags.PatchFlags() as mocked_flags:
       self.setupCommonFlags(mocked_flags)
       config = configs.LoadConfig(CONFIG_WITH_BACKGROUND_CPU, {}, NAME)

--- a/tests/background_network_workload_test.py
+++ b/tests/background_network_workload_test.py
@@ -1,0 +1,216 @@
+# Copyright 2016 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for background network workload"""
+
+import unittest
+from mock import patch
+from tests import mock_flags
+from perfkitbenchmarker import configs
+from perfkitbenchmarker.linux_benchmarks import ping_benchmark
+from perfkitbenchmarker import benchmark_spec
+from perfkitbenchmarker import providers
+from perfkitbenchmarker import errors
+from perfkitbenchmarker import os_types
+
+NAME = 'ping'
+UID = 'name0'
+
+CONFIG_WITH_BACKGROUND_NETWORK = """
+ping:
+    description: Benchmarks ping latency over internal IP addresses
+    vm_groups:
+      vm_1:
+        vm_spec:
+          GCP:
+            machine_type: n1-standard-1
+      vm_2:
+        vm_spec:
+          GCP:
+            background_network_mbits_per_sec: 300
+            machine_type: n1-standard-1
+"""
+
+CONFIG_WITH_BACKGROUND_NETWORK_BAD_IPFLAG = """
+ping:
+    description: Benchmarks ping latency over internal IP addresses
+    vm_groups:
+      vm_1:
+        vm_spec:
+          GCP:
+            machine_type: n1-standard-1
+            background_network_mbits_per_sec: 200
+            background_network_ip_type: BOTH
+      vm_2:
+        vm_spec:
+          GCP:
+            background_network_mbits_per_sec: 300
+            machine_type: n1-standard-1
+"""
+
+CONFIG_WITH_BACKGROUND_NETWORK_IPFLAG = """
+ping:
+    description: Benchmarks ping latency over internal IP addresses
+    vm_groups:
+      vm_1:
+        vm_spec:
+          GCP:
+            machine_type: n1-standard-1
+      vm_2:
+        vm_spec:
+          GCP:
+            background_network_mbits_per_sec: 300
+            background_network_ip_type: INTERNAL
+            machine_type: n1-standard-1
+"""
+
+
+class TestBackgroundNetworkWorkload(unittest.TestCase):
+
+  def setUp(self):
+    super(TestBackgroundNetworkWorkload, self).setUp()
+    self.mocked_flags = mock_flags.PatchTestCaseFlags(self)
+    self.mocked_flags.os_type = os_types.DEBIAN
+    self.mocked_flags.cloud = providers.GCP
+
+  def _CheckVMFromSpec(self, spec, num_working):
+    vm0 = spec.vms[0]
+    with patch.object(vm0.__class__, 'RemoteCommand'):
+      with patch.object(vm0.__class__, 'Install'):
+        with patch.object(vm0.__class__, 'AllowPort'):
+          expected_install_post_prepare = num_working
+          # one call for client, one call for server, one call for each pid
+          expected_remote_post_start = 4 * num_working
+          # all the start calls, plus stop server and stop client
+          expected_remote_post_stop = (expected_remote_post_start +
+                                       2 * num_working)
+          side_effect_list = []
+          for i in range(expected_remote_post_stop):
+            side_effect_list.append((str(i), ' '))
+          vm0.RemoteCommand.side_effect = side_effect_list
+          spec.Prepare()
+          self.assertEqual(vm0.Install.call_count,
+                           expected_install_post_prepare)
+          spec.StartBackgroundWorkload()
+          self.assertEqual(vm0.RemoteCommand.call_count,
+                           expected_remote_post_start)
+          self.assertEqual(vm0.AllowPort.call_count,
+                           num_working)
+          spec.StopBackgroundWorkload()
+          self.assertEqual(vm0.RemoteCommand.call_count,
+                           expected_remote_post_stop)
+
+  def makeSpec(self, yaml_benchmark_config=ping_benchmark.BENCHMARK_CONFIG):
+    config = configs.LoadConfig(yaml_benchmark_config, {}, NAME)
+    spec = benchmark_spec.BenchmarkSpec(config, NAME, UID)
+    spec.ConstructVirtualMachines()
+    return spec
+
+  def testWindowsVMCausesError(self):
+    """ windows vm with background_network_mbits_per_sec raises exception """
+    self.mocked_flags.background_network_mbits_per_sec = 200
+    self.mocked_flags.os_type = os_types.WINDOWS
+    spec = self.makeSpec()
+    with self.assertRaisesRegexp(Exception, 'NotImplementedError'):
+      spec.Prepare()
+    with self.assertRaisesRegexp(Exception, 'NotImplementedError'):
+      spec.StartBackgroundWorkload()
+    with self.assertRaisesRegexp(Exception, 'NotImplementedError'):
+      spec.StopBackgroundWorkload()
+
+  def testBackgroundWorkloadVM(self):
+    """ Check that the vm background workload calls work """
+    self.mocked_flags.background_network_mbits_per_sec = 200
+    spec = self.makeSpec()
+    self._CheckVMFromSpec(spec, 2)
+
+  def testBackgroundWorkloadVanillaConfig(self):
+    """ Test that nothing happens with the vanilla config """
+    # background_network_mbits_per_sec defaults to None
+    spec = self.makeSpec()
+    for vm in spec.vms:
+      self.assertIsNone(vm.background_network_mbits_per_sec)
+    self._CheckVMFromSpec(spec, 0)
+
+  def testBackgroundWorkloadWindows(self):
+    """ Test that nothing happens with the vanilla config """
+    self.mocked_flags.os_type = os_types.WINDOWS
+    # background_network_mbits_per_sec defaults to None.
+    spec = self.makeSpec()
+
+    for vm in spec.vms:
+      self.assertIsNone(vm.background_network_mbits_per_sec)
+    self._CheckVMFromSpec(spec, 0)
+
+  def testBackgroundWorkloadVanillaConfigFlag(self):
+    """ Check that the flag overrides the config """
+    self.mocked_flags.background_network_mbits_per_sec = 200
+    spec = self.makeSpec()
+    for vm in spec.vms:
+      self.assertEqual(vm.background_network_mbits_per_sec, 200)
+      self.assertEqual(vm.background_network_ip_type, 'EXTERNAL')
+    self._CheckVMFromSpec(spec, 2)
+
+  def testBackgroundWorkloadVanillaConfigFlagIpType(self):
+    """ Check that the flag overrides the config """
+    self.mocked_flags.background_network_mbits_per_sec = 200
+    self.mocked_flags.background_network_ip_type = 'INTERNAL'
+    spec = self.makeSpec()
+    for vm in spec.vms:
+      self.assertEqual(vm.background_network_mbits_per_sec, 200)
+      self.assertEqual(vm.background_network_ip_type, 'INTERNAL')
+    self._CheckVMFromSpec(spec, 2)
+
+  def testBackgroundWorkloadVanillaConfigBadIpTypeFlag(self):
+    """ Check that the flag overrides the config """
+    self.mocked_flags.background_network_mbits_per_sec = 200
+    self.mocked_flags.background_network_ip_type = 'IAMABADFLAGVALUE'
+    config = configs.LoadConfig(ping_benchmark.BENCHMARK_CONFIG, {}, NAME)
+    spec = benchmark_spec.BenchmarkSpec(config, NAME, UID)
+    with self.assertRaises(errors.Config.InvalidValue):
+      spec.ConstructVirtualMachines()
+
+  def testBackgroundWorkloadConfig(self):
+    """ Check that the config can be used to set the background iperf """
+    spec = self.makeSpec(
+        yaml_benchmark_config=CONFIG_WITH_BACKGROUND_NETWORK)
+    for vm in spec.vm_groups['vm_1']:
+      self.assertIsNone(vm.background_network_mbits_per_sec)
+    for vm in spec.vm_groups['vm_2']:
+      self.assertEqual(vm.background_network_mbits_per_sec, 300)
+    self.assertEqual(vm.background_network_ip_type, 'EXTERNAL')
+    self._CheckVMFromSpec(spec, 1)
+
+  def testBackgroundWorkloadConfigBadIp(self):
+    """ Check that the config with invalid ip type gets an error """
+    config = configs.LoadConfig(CONFIG_WITH_BACKGROUND_NETWORK_BAD_IPFLAG,
+                                {}, NAME)
+    spec = benchmark_spec.BenchmarkSpec(config, NAME, UID)
+    with self.assertRaises(errors.Config.InvalidValue):
+      spec.ConstructVirtualMachines()
+
+  def testBackgroundWorkloadConfigGoodIp(self):
+    """ Check that the config can be used with an internal ip address """
+    spec = self.makeSpec(
+        yaml_benchmark_config=CONFIG_WITH_BACKGROUND_NETWORK_IPFLAG)
+    for vm in spec.vm_groups['vm_1']:
+      self.assertIsNone(vm.background_network_mbits_per_sec)
+    for vm in spec.vm_groups['vm_2']:
+      self.assertEqual(vm.background_network_mbits_per_sec, 300)
+      self.assertEqual(vm.background_network_ip_type, 'INTERNAL')
+    self._CheckVMFromSpec(spec, 1)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tests/background_workload_framework_test.py
+++ b/tests/background_workload_framework_test.py
@@ -1,0 +1,79 @@
+# Copyright 2015 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for background workload framework"""
+
+import unittest
+import mock
+import functools
+from tests import mock_flags
+from perfkitbenchmarker import configs
+from perfkitbenchmarker.linux_benchmarks import ping_benchmark
+from perfkitbenchmarker import benchmark_spec
+from perfkitbenchmarker import timing_util
+from perfkitbenchmarker import os_types
+from perfkitbenchmarker import pkb
+from perfkitbenchmarker import providers
+
+
+NAME = 'ping'
+UID = 'name0'
+
+
+class TestBackgroundWorkloadFramework(unittest.TestCase):
+
+  def setUp(self):
+    self.last_call = 0
+    super(TestBackgroundWorkloadFramework, self).setUp()
+    self.mocked_flags = mock_flags.PatchTestCaseFlags(self)
+    self.mocked_flags.os_type = os_types.DEBIAN
+    self.mocked_flags.cloud = providers.GCP
+
+  def _CheckAndIncrement(self, throwaway=None, expected_last_call=None):
+    self.assertEqual(self.last_call, expected_last_call)
+    self.last_call += 1
+
+  def testBackgroundWorkloadSpec(self):
+    """ Check that the benchmark spec calls the prepare, stop, and start
+    methods on the vms """
+
+    collector = mock.MagicMock()
+    config = configs.LoadConfig(ping_benchmark.BENCHMARK_CONFIG, {}, NAME)
+    spec = benchmark_spec.BenchmarkSpec(config, NAME, UID)
+    vm0 = mock.MagicMock()
+    vm1 = mock.MagicMock()
+    spec.ConstructVirtualMachines()
+    spec.vms = [vm0, vm1]
+    timer = timing_util.IntervalTimer()
+    pkb.DoPreparePhase(ping_benchmark, NAME, spec, timer)
+    for vm in spec.vms:
+      self.assertEqual(vm.PrepareBackgroundWorkload.call_count, 1)
+
+    with mock.patch(ping_benchmark.__name__ + '.Run'):
+      ping_benchmark.Run.side_effect = functools.partial(
+          self._CheckAndIncrement, expected_last_call=1)
+      vm0.StartBackgroundWorkload.side_effect = functools.partial(
+          self._CheckAndIncrement, expected_last_call=0)
+      vm0.StopBackgroundWorkload.side_effect = functools.partial(
+          self._CheckAndIncrement, expected_last_call=2)
+      pkb.DoRunPhase(ping_benchmark, NAME, spec, collector, timer)
+      self.assertEqual(ping_benchmark.Run.call_count, 1)
+      for vm in spec.vms:
+        self.assertEqual(vm.StartBackgroundWorkload.call_count, 1)
+        self.assertEqual(vm.StopBackgroundWorkload.call_count, 1)
+        self.assertEqual(vm.PrepareBackgroundWorkload.call_count, 1)
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
Simulate background network workload by sending traffic from a VM to itself via its external IP address.   (Part of supporting #436)

Sending from a VM to itself isn't exactly the same as sending from one VM to another, so I did some testing to determine if it looked close enough.

To determine whether the effect is likely to be similar in the self-to-self case and the self-to-other case, I compared the throughput of the iperf benchmark to a self-iperf benchmark.  If these two gave substantially different results, I'd conclude that modeling background network workload by sending from a VM to itself is a bad approach.  However, they look similar-enough to me.

| type | mean throughput | min | max | notes | 
|-------|---------|-------|-------| ---------------------|
| different | 1169 | 701 | 1346 | ten bi-directional runs, so 20 data points |
| self | 968 | 734 | 1216 |  ten runs, for a total of ten data points |


