### PR TITLE
Fix proposed enhancement #780

### DIFF
--- a/perfkitbenchmarker/providers/openstack/flags.py
+++ b/perfkitbenchmarker/providers/openstack/flags.py
@@ -59,7 +59,7 @@ flags.DEFINE_integer('openstack_volume_size', None,
                      'Size of the volume (GB)')
 
 flags.DEFINE_string('openstack_image_username', 'ubuntu',
-                    'Ssh username for cloud image. Defaults to ubuntu')
+                    'Ssh username for cloud image')
 
 NONE = 'None'
 flags.DEFINE_enum('openstack_scheduler_policy', NONE,

--- a/perfkitbenchmarker/providers/openstack/flags.py
+++ b/perfkitbenchmarker/providers/openstack/flags.py
@@ -58,6 +58,9 @@ flags.DEFINE_boolean('openstack_boot_from_volume', False,
 flags.DEFINE_integer('openstack_volume_size', None,
                      'Size of the volume (GB)')
 
+flags.DEFINE_string('openstack_image_username', 'ubuntu',
+                    'Ssh username for cloud image. Defaults to ubuntu')
+
 NONE = 'None'
 flags.DEFINE_enum('openstack_scheduler_policy', NONE,
                   [NONE, 'affinity', 'anti-affinity'],

--- a/perfkitbenchmarker/providers/openstack/os_virtual_machine.py
+++ b/perfkitbenchmarker/providers/openstack/os_virtual_machine.py
@@ -34,7 +34,6 @@ class OpenStackVirtualMachine(virtual_machine.BaseVirtualMachine):
     """Object representing an OpenStack Virtual Machine"""
 
     CLOUD = providers.OPENSTACK
-    DEFAULT_USERNAME = 'ubuntu'
     # Subclasses should override the default image.
     DEFAULT_IMAGE = None
     _floating_ip_lock = threading.Lock()
@@ -56,7 +55,7 @@ class OpenStackVirtualMachine(virtual_machine.BaseVirtualMachine):
         )
         self.id = None
         self.pk = None
-        self.user_name = self.DEFAULT_USERNAME
+        self.user_name = FLAGS.openstack_image_username
         self.boot_wait_time = None
         self.image = self.image or self.DEFAULT_IMAGE
 


### PR DESCRIPTION
This will allow the user to specify the username that ssh will use to access the images
that are spawned.
The default username is 'ubuntu' but allow the user to override with --openstack_image_u
This change is specific for Openstack clouds
    - Ubuntu this is usually "ubuntu".
    - RHEL uses cloud-user