### PR TITLE
Manually specify pep8 version in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ usedevelop = True
 commands = flake8 perfkitbenchmarker tests pkb.py
 deps =
     flake8==2.4.1
+    pep8==1.5.7
 
 [flake8]
 ignore = E111,E129,E303


### PR DESCRIPTION
Specify 1.5.7 for now, because that is the latest version that does
not complain about the current state of the PKB code.