### PR TITLE
openstack: Make AllowPort open not just TCP but UDP ports as well

### DIFF
--- a/perfkitbenchmarker/providers/openstack/os_network.py
+++ b/perfkitbenchmarker/providers/openstack/os_network.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+import logging
 import threading
 import time
 
@@ -30,35 +32,90 @@ class OpenStackFirewall(network.BaseFirewall):
     """
 
     CLOUD = providers.OPENSTACK
+    _lock = threading.Lock()
 
     def __init__(self):
-        super(OpenStackFirewall, self).__init__()
+        self.sec_group_rules_set = set()
         self.__nclient = utils.NovaClient()
 
-        if not (self.__nclient.security_groups.findall(
-                name='perfkit_sc_group')):
-            self.sec_group = self.__nclient.security_groups.create(
-                'perfkit_sc_group',
-                'Firewall configuration for Perfkit Benchmarker'
-            )
-        else:
-            self.sec_group = self.__nclient.security_groups.findall(
-                name='perfkit_sc_group')[0]
+        with self._lock:
+            if not (self.__nclient.security_groups.findall(
+                    name='perfkit_sc_group')):
+                self.sec_group = self.__nclient.security_groups.create(
+                    'perfkit_sc_group',
+                    'Firewall configuration for Perfkit Benchmarker'
+                )
+            else:
+                self.sec_group = self.__nclient.security_groups.findall(
+                    name='perfkit_sc_group')[0]
 
-        self.AllowPort(None, -1, protocol='icmp')
-        self.AllowPort(None, 1, MAX_PORT)
+    def AllowICMP(self, vm, icmp_type=-1, icmp_code=-1):
+        """Creates a Security Group Rule on the Firewall to allow/disallow
+        ICMP traffic.
 
-    def AllowPort(self, vm, from_port, to_port=None, protocol='tcp'):
+        Args:
+          vm: The BaseVirtualMachine object to allow ICMP traffic to.
+          icmp_type: ICMP type to allow. If none given then allows all types.
+          icmp_code: ICMP code to allow. If none given then allows all codes.
+        """
+        if vm.is_static:
+            return
+
+        from novaclient.exceptions import BadRequest
+
+        sec_group_rule = ('icmp', icmp_type, icmp_code, self.sec_group.id)
+        if sec_group_rule in self.sec_group_rules_set:
+            return
+
+        with self._lock:
+            if sec_group_rule in self.sec_group_rules_set:
+                return
+
+            try:
+                self.__nclient.security_group_rules.create(self.sec_group.id,
+                                                           ip_protocol='icmp',
+                                                           from_port=icmp_type,
+                                                           to_port=icmp_code)
+            except BadRequest:
+                logging.debug('Rule icmp:%d-%d already exists' % (icmp_type,
+                                                                  icmp_code))
+            self.sec_group_rules_set.add(sec_group_rule)
+
+    def AllowPort(self, vm, port, to_port=None):
+        """Creates a Security Group Rule on the Firewall to allow for both TCP
+        and UDP network traffic on given port, or port range.
+
+        Args:
+          vm: The BaseVirtualMachine object to open the port for.
+          port: The local port to open.
+          to_port: The last port to open in range of ports to open. If None,
+              then only the single 'port' is open.
+        """
+        if vm.is_static:
+            return
+
+        from novaclient.exceptions import BadRequest
+
         if to_port is None:
-            to_port = from_port
+            to_port = port
 
-        try:
-            self.__nclient.security_group_rules.create(self.sec_group.id,
-                                                       ip_protocol=protocol,
-                                                       from_port=from_port,
-                                                       to_port=to_port)
-        except Exception:
-            pass
+        sec_group_rule = (port, to_port, self.sec_group.id)
+        if sec_group_rule in self.sec_group_rules_set:
+            return
+
+        with self._lock:
+            if sec_group_rule in self.sec_group_rules_set:
+                return
+            for prot in ('tcp', 'udp',):
+                try:
+                    self.__nclient.security_group_rules.create(
+                        self.sec_group.id, ip_protocol=prot,
+                        from_port=port, to_port=to_port)
+                except BadRequest:
+                    logging.debug('Rule %s:%d-%d already exists',
+                                  prot, port, to_port)
+
+            self.sec_group_rules_set.add(sec_group_rule)
 
     def DisallowAllPorts(self):
         pass
@@ -91,6 +148,7 @@ class OpenStackPublicNetwork(object):
                 pool=self.ip_pool_name,
                 status='Down'
             )
+        # FIXME(meteorfox) Floating IP allocation must be done within the lock
         if floating_ips:
             return floating_ips[0]
         else:

--- a/perfkitbenchmarker/providers/openstack/os_virtual_machine.py
+++ b/perfkitbenchmarker/providers/openstack/os_virtual_machine.py
@@ -46,6 +46,8 @@ class OpenStackVirtualMachine(virtual_machine.BaseVirtualMachine):
         """
         super(OpenStackVirtualMachine, self).__init__(vm_spec)
         self.firewall = os_network.OpenStackFirewall.GetFirewall()
+        self.firewall.AllowICMP(self)
+        self.firewall.AllowPort(self, 1, os_network.MAX_PORT)
         self.name = 'perfkit_vm_%d_%s' % (self.instance_number, FLAGS.run_uri)
         self.key_name = 'perfkit_key_%d_%s' % (self.instance_number,
                                                FLAGS.run_uri)


### PR DESCRIPTION
Re-factor AllowPort() to follow the implementations of other provider
that open both TCP and UDP ports. When static VMs are used, AllowPort()
becomes a NO-OP.

Introduce lock to avoid race condition when checking/creating security
group, and security group rules.

Addresses issue #804