### PR TITLE
Add ListDecoder for verifying a config option that expects list values.

### DIFF
--- a/perfkitbenchmarker/configs/option_decoders.py
+++ b/perfkitbenchmarker/configs/option_decoders.py
@@ -23,17 +23,17 @@ class ConfigOptionDecoder(object):
   """Verifies and decodes a config option value.
 
   Attributes:
-    option: string. Name of the config option.
+    option: None or string. Name of the config option.
     required: boolean. True if the config option is required. False if not.
   """
 
   __metaclass__ = abc.ABCMeta
 
-  def __init__(self, option, **kwargs):
+  def __init__(self, option=None, **kwargs):
     """Initializes a ConfigOptionDecoder.
 
     Args:
-      option: string. Name of the config option.
+      option: None or string. Name of the config option.
       **kwargs: May optionally contain a 'default' key mapping to a value or
           callable object. If a value is provided, the config option is
           optional, and the provided value is the default if the user does not
@@ -48,6 +48,16 @@ class ConfigOptionDecoder(object):
       self._default = kwargs.pop('default')
     assert not kwargs, ('__init__() received unexpected keyword arguments: '
                         '{0}'.format(kwargs))
+
+  def _GetOptionFullName(self, component_full_name):
+    """Returns the fully qualified name of a config option.
+
+    Args:
+      component_full_name: string. Fully qualified name of a configurable object
+          to which the option belongs.
+    """
+    return (component_full_name if self.option is None
+            else '{0}.{1}'.format(component_full_name, self.option))
 
   @property
   def default(self):
@@ -89,15 +99,14 @@ class EnumDecoder(ConfigOptionDecoder):
   Passes through the value unmodified
   """
 
-  def __init__(self, option, valid_values, **kwargs):
+  def __init__(self, valid_values, **kwargs):
     """Initializes the EnumVerifier.
 
     Args:
-    option: string.  Name of the config option.
-    valid_values: list of the allowed values
-    **kwargs: Keyword arguments to pass to the base class.
+      valid_values: list of the allowed values
+      **kwargs: Keyword arguments to pass to the base class.
     """
-    super(EnumDecoder, self).__init__(option, **kwargs)
+    super(EnumDecoder, self).__init__(**kwargs)
     self.valid_values = valid_values
 
   def Decode(self, value, component_full_name, flag_values):
@@ -120,11 +129,9 @@ class EnumDecoder(ConfigOptionDecoder):
      return value
     else:
       raise errors.Config.InvalidValue(
-          'Invalid {0}.{1} value: "{2}". Value must be one '
-          'of the following: {3}.'.format(
-              component_full_name, self.option, value,
-              ', '.join(str(t) for t in self.valid_values)))
-
+          'Invalid {0} value: "{1}". Value must be one of the following: '
+          '{2}.'.format(self._GetOptionFullName(component_full_name), value,
+                        ', '.join(str(t) for t in self.valid_values)))
 
 
 class TypeVerifier(ConfigOptionDecoder):
@@ -133,16 +140,15 @@ class TypeVerifier(ConfigOptionDecoder):
   Passes value through unmodified.
   """
 
-  def __init__(self, option, valid_types, none_ok=False, **kwargs):
+  def __init__(self, valid_types, none_ok=False, **kwargs):
     """Initializes a TypeVerifier.
 
     Args:
-      option: string. Name of the config option.
       valid_types: tuple of allowed types.
       none_ok: boolean. If True, None is also an allowed option value.
       **kwargs: Keyword arguments to pass to the base class.
     """
-    super(TypeVerifier, self).__init__(option, **kwargs)
+    super(TypeVerifier, self).__init__(**kwargs)
     if none_ok:
       self._valid_types = (types.NoneType,) + valid_types
     else:
@@ -166,9 +172,10 @@ class TypeVerifier(ConfigOptionDecoder):
     """
     if not isinstance(value, self._valid_types):
       raise errors.Config.InvalidValue(
-          'Invalid {0}.{1} value: "{2}" (of type "{3}"). Value must be one '
-          'of the following types: {4}.'.format(
-              component_full_name, self.option, value, value.__class__.__name__,
+          'Invalid {0} value: "{1}" (of type "{2}"). Value must be one of the '
+          'following types: {3}.'.format(
+              self._GetOptionFullName(component_full_name), value,
+              value.__class__.__name__,
               ', '.join(t.__name__ for t in self._valid_types)))
     return value
 
@@ -176,8 +183,8 @@ class TypeVerifier(ConfigOptionDecoder):
 class BooleanDecoder(TypeVerifier):
   """Verifies and decodes a config option value when a boolean is expected."""
 
-  def __init__(self, option, **kwargs):
-    super(BooleanDecoder, self).__init__(option, (bool,), **kwargs)
+  def __init__(self, **kwargs):
+    super(BooleanDecoder, self).__init__((bool,), **kwargs)
 
 
 class IntDecoder(TypeVerifier):
@@ -188,8 +195,8 @@ class IntDecoder(TypeVerifier):
     min: None or int. If provided, it specifies the minimum accepted value.
   """
 
-  def __init__(self, option, max=None, min=None, **kwargs):
-    super(IntDecoder, self).__init__(option, (int,), **kwargs)
+  def __init__(self, max=None, min=None, **kwargs):
+    super(IntDecoder, self).__init__((int,), **kwargs)
     self.max = max
     self.min = min
 
@@ -214,12 +221,12 @@ class IntDecoder(TypeVerifier):
     if value is not None:
       if self.max and value > self.max:
         raise errors.Config.InvalidValue(
-            'Invalid {0}.{1} value: "{2}". Value must be at most '
-            '{3}.'.format(component_full_name, self.option, value, self.max))
+            'Invalid {0} value: "{1}". Value must be at most {2}.'.format(
+                self._GetOptionFullName(component_full_name), value, self.max))
       if self.min and value < self.min:
         raise errors.Config.InvalidValue(
-            'Invalid {0}.{1} value: "{2}". Value must be at least '
-            '{3}.'.format(component_full_name, self.option, value, self.min))
+            'Invalid {0} value: "{1}". Value must be at least {2}.'.format(
+                self._GetOptionFullName(component_full_name), value, self.min))
     return value
 
 
@@ -231,8 +238,8 @@ class FloatDecoder(TypeVerifier):
     min: None or float. If provided, it specifies the minimum accepted value.
   """
 
-  def __init__(self, option, max=None, min=None, **kwargs):
-    super(FloatDecoder, self).__init__(option, (float, int), **kwargs)
+  def __init__(self, max=None, min=None, **kwargs):
+    super(FloatDecoder, self).__init__((float, int), **kwargs)
     self.max = max
     self.min = min
 
@@ -257,17 +264,61 @@ class FloatDecoder(TypeVerifier):
     if value is not None:
       if self.max and value > self.max:
         raise errors.Config.InvalidValue(
-            'Invalid {0}.{1} value: "{2}". Value must be at most '
-            '{3}.'.format(component_full_name, self.option, value, self.max))
+            'Invalid {0} value: "{1}". Value must be at most {2}.'.format(
+                self._GetOptionFullName(component_full_name), value, self.max))
       if self.min and value < self.min:
         raise errors.Config.InvalidValue(
-            'Invalid {0}.{1} value: "{2}". Value must be at least '
-            '{3}.'.format(component_full_name, self.option, value, self.min))
+            'Invalid {0} value: "{1}". Value must be at least {2}.'.format(
+                self._GetOptionFullName(component_full_name), value, self.min))
     return value
 
 
 class StringDecoder(TypeVerifier):
   """Verifies and decodes a config option value when a string is expected."""
 
-  def __init__(self, option, **kwargs):
-    super(StringDecoder, self).__init__(option, (basestring,), **kwargs)
+  def __init__(self, **kwargs):
+    super(StringDecoder, self).__init__((basestring,), **kwargs)
+
+
+class ListDecoder(TypeVerifier):
+  """Verifies and decodes a config option value when a list is expected."""
+
+  def __init__(self, item_decoder, **kwargs):
+    """Initializes a ListDecoder.
+
+    Args:
+      item_decoder: ConfigOptionDecoder. Used to decode the items of an input
+          list.
+      **kwargs: Keyword arguments to pass to the base class.
+    """
+    super(ListDecoder, self).__init__((list,), **kwargs)
+    self._item_decoder = item_decoder
+
+  def Decode(self, value, component_full_name, flag_values):
+    """Verifies that the provided value is a list with appropriate items.
+
+    Args:
+      value: The value specified in the config.
+      component_full_name: string. Fully qualified name of the configurable
+          component containing the config option.
+      flag_values: flags.FlagValues. Runtime flag values to be propagated to
+          BaseSpec constructors.
+
+    Returns:
+      None if the input value was None. Otherwise, a list containing the decoded
+      value of each item in the input list.
+
+    Raises:
+      errors.Config.InvalidValue upon invalid input value.
+    """
+    input_list = super(ListDecoder, self).Decode(value, component_full_name,
+                                                 flag_values)
+    if input_list is None:
+      return None
+    list_full_name = self._GetOptionFullName(component_full_name)
+    result = []
+    for index, input_item in enumerate(input_list):
+      item_full_name = '{0}[{1}]'.format(list_full_name, index)
+      result.append(self._item_decoder.Decode(input_item, item_full_name,
+                                              flag_values))
+    return result

--- a/perfkitbenchmarker/configs/spec.py
+++ b/perfkitbenchmarker/configs/spec.py
@@ -94,7 +94,7 @@ class BaseSpec(object):
         constructions = cls._GetOptionDecoderConstructions()
         for option, decoder_construction in sorted(constructions.iteritems()):
           decoder_class, init_args = decoder_construction
-          decoder = decoder_class(option, **init_args)
+          decoder = decoder_class(option=option, **init_args)
           cls._decoders[option] = decoder
           if decoder.required:
             cls._required_options.add(option)

--- a/perfkitbenchmarker/providers/gcp/gce_virtual_machine.py
+++ b/perfkitbenchmarker/providers/gcp/gce_virtual_machine.py
@@ -82,22 +82,25 @@ class MemoryDecoder(option_decoders.StringDecoder):
     match = self._CONFIG_MEMORY_PATTERN.match(string)
     if not match:
       raise errors.Config.InvalidValue(
-          'Invalid {0}.{1} value: "{2}". Examples of valid values: "1280MiB", '
-          '"7.5GiB".'.format(component_full_name, self.option, string))
+          'Invalid {0} value: "{1}". Examples of valid values: "1280MiB", '
+          '"7.5GiB".'.format(self._GetOptionFullName(component_full_name),
+                             string))
     try:
       memory_value = float(match.group(1))
     except ValueError:
       raise errors.Config.InvalidValue(
-          'Invalid {0}.{1} value: "{2}". "{3}" is not a valid float.'.format(
-              component_full_name, self.option, string, match.group(1)))
+          'Invalid {0} value: "{1}". "{2}" is not a valid float.'.format(
+              self._GetOptionFullName(component_full_name), string,
+              match.group(1)))
     memory_units = match.group(2)
     if memory_units == 'GiB':
       memory_value *= 1024
     memory_mib_int = int(memory_value)
     if memory_value != memory_mib_int:
       raise errors.Config.InvalidValue(
-          'Invalid {0}.{1} value: "{2}". The specified size must be an integer '
-          'number of MiB.'.format(component_full_name, self.option, string))
+          'Invalid {0} value: "{1}". The specified size must be an integer '
+          'number of MiB.'.format(self._GetOptionFullName(component_full_name),
+                                  string))
     return memory_mib_int
 
 
@@ -128,9 +131,8 @@ class CustomMachineTypeSpec(spec.BaseSpec):
 class MachineTypeDecoder(option_decoders.TypeVerifier):
   """Decodes the machine_type option of a GCE VM config."""
 
-  def __init__(self, option, **kwargs):
-    super(MachineTypeDecoder, self).__init__(option, (basestring, dict),
-                                             **kwargs)
+  def __init__(self, **kwargs):
+    super(MachineTypeDecoder, self).__init__((basestring, dict), **kwargs)
 
   def Decode(self, value, component_full_name, flag_values):
     """Decodes the machine_type option of a GCE VM config.
@@ -154,7 +156,7 @@ class MachineTypeDecoder(option_decoders.TypeVerifier):
                                            flag_values)
     if isinstance(value, basestring):
       return value
-    return CustomMachineTypeSpec('.'.join((component_full_name, self.option)),
+    return CustomMachineTypeSpec(self._GetOptionFullName(component_full_name),
                                  flag_values=flag_values, **value)
 
 

--- a/tests/configs/option_decoders_test.py
+++ b/tests/configs/option_decoders_test.py
@@ -37,7 +37,7 @@ class _PassThroughDecoder(option_decoders.ConfigOptionDecoder):
 class ConfigOptionDecoderTestCase(unittest.TestCase):
 
   def testNoDefault(self):
-    decoder = _PassThroughDecoder(_OPTION)
+    decoder = _PassThroughDecoder(option=_OPTION)
     self.assertIs(decoder.required, True)
     with self.assertRaises(AssertionError) as cm:
       decoder.default
@@ -46,12 +46,12 @@ class ConfigOptionDecoderTestCase(unittest.TestCase):
         '"test_option".'))
 
   def testDefaultValue(self):
-    decoder = _PassThroughDecoder(_OPTION, default=None)
+    decoder = _PassThroughDecoder(default=None, option=_OPTION)
     self.assertIs(decoder.required, False)
     self.assertIsNone(decoder.default)
 
   def testDefaultCallable(self):
-    decoder = _PassThroughDecoder(_OPTION, default=_ReturnFive)
+    decoder = _PassThroughDecoder(default=_ReturnFive, option=_OPTION)
     self.assertIs(decoder.required, False)
     self.assertIs(decoder.default, 5)
 
@@ -59,13 +59,14 @@ class ConfigOptionDecoderTestCase(unittest.TestCase):
     class IncompleteDerivedClass(option_decoders.ConfigOptionDecoder):
       pass
     with self.assertRaises(TypeError):
-      IncompleteDerivedClass(_OPTION)
+      IncompleteDerivedClass(option=_OPTION)
 
 
 class TypeVerifierTestCase(unittest.TestCase):
 
   def testRejectNone(self):
-    decoder = option_decoders.TypeVerifier(_OPTION, (int, float), default=None)
+    decoder = option_decoders.TypeVerifier((int, float), default=None,
+                                           option=_OPTION)
     self.assertIs(decoder.required, False)
     self.assertIsNone(decoder.default)
     self.assertIs(decoder.Decode(5, _COMPONENT, _FLAGS), 5)
@@ -82,8 +83,8 @@ class TypeVerifierTestCase(unittest.TestCase):
         'Value must be one of the following types: int, float.'))
 
   def testAcceptNone(self):
-    decoder = option_decoders.TypeVerifier(_OPTION, (int, float), none_ok=True,
-                                           default=None)
+    decoder = option_decoders.TypeVerifier((int, float), default=None,
+                                           none_ok=True, option=_OPTION)
     self.assertIs(decoder.required, False)
     self.assertIsNone(decoder.default)
     self.assertIs(decoder.Decode(5, _COMPONENT, _FLAGS), 5)
@@ -99,19 +100,19 @@ class TypeVerifierTestCase(unittest.TestCase):
 class BooleanDecoderTestCase(unittest.TestCase):
 
   def testDefault(self):
-    decoder = option_decoders.BooleanDecoder(_OPTION, default=None)
+    decoder = option_decoders.BooleanDecoder(default=None, option=_OPTION)
     self.assertIs(decoder.required, False)
     self.assertIsNone(decoder.default)
 
   def testNone(self):
-    decoder = option_decoders.BooleanDecoder(_OPTION, none_ok=True)
+    decoder = option_decoders.BooleanDecoder(none_ok=True, option=_OPTION)
     self.assertIsNone(decoder.Decode(None, _COMPONENT, _FLAGS))
-    decoder = option_decoders.BooleanDecoder(_OPTION)
+    decoder = option_decoders.BooleanDecoder(option=_OPTION)
     with self.assertRaises(errors.Config.InvalidValue):
       decoder.Decode(None, _COMPONENT, _FLAGS)
 
   def testNonBoolean(self):
-    decoder = option_decoders.BooleanDecoder(_OPTION)
+    decoder = option_decoders.BooleanDecoder(option=_OPTION)
     with self.assertRaises(errors.Config.InvalidValue) as cm:
       decoder.Decode(5, _COMPONENT, _FLAGS)
     self.assertEqual(str(cm.exception), (
@@ -119,26 +120,26 @@ class BooleanDecoderTestCase(unittest.TestCase):
         'Value must be one of the following types: bool.'))
 
   def testValidBoolean(self):
-    decoder = option_decoders.BooleanDecoder(_OPTION)
+    decoder = option_decoders.BooleanDecoder(option=_OPTION)
     self.assertIs(decoder.Decode(True, _COMPONENT, _FLAGS), True)
 
 
 class IntDecoderTestCase(unittest.TestCase):
 
   def testDefault(self):
-    decoder = option_decoders.IntDecoder(_OPTION, default=5)
+    decoder = option_decoders.IntDecoder(default=5, option=_OPTION)
     self.assertIs(decoder.required, False)
     self.assertIs(decoder.default, 5)
 
   def testNone(self):
-    decoder = option_decoders.IntDecoder(_OPTION, none_ok=True)
+    decoder = option_decoders.IntDecoder(none_ok=True, option=_OPTION)
     self.assertIsNone(decoder.Decode(None, _COMPONENT, _FLAGS))
-    decoder = option_decoders.IntDecoder(_OPTION)
+    decoder = option_decoders.IntDecoder(option=_OPTION)
     with self.assertRaises(errors.Config.InvalidValue):
       decoder.Decode(None, _COMPONENT, _FLAGS)
 
   def testNonInt(self):
-    decoder = option_decoders.IntDecoder(_OPTION)
+    decoder = option_decoders.IntDecoder(option=_OPTION)
     with self.assertRaises(errors.Config.InvalidValue) as cm:
       decoder.Decode('5', _COMPONENT, _FLAGS)
     self.assertEqual(str(cm.exception), (
@@ -146,11 +147,11 @@ class IntDecoderTestCase(unittest.TestCase):
         'Value must be one of the following types: int.'))
 
   def testValidInt(self):
-    decoder = option_decoders.IntDecoder(_OPTION)
+    decoder = option_decoders.IntDecoder(option=_OPTION)
     self.assertEqual(decoder.Decode(5, _COMPONENT, _FLAGS), 5)
 
   def testMax(self):
-    decoder = option_decoders.IntDecoder(_OPTION, max=2)
+    decoder = option_decoders.IntDecoder(max=2, option=_OPTION)
     with self.assertRaises(errors.Config.InvalidValue) as cm:
       decoder.Decode(5, _COMPONENT, _FLAGS)
     self.assertEqual(str(cm.exception), (
@@ -160,7 +161,7 @@ class IntDecoderTestCase(unittest.TestCase):
     self.assertIs(decoder.Decode(1, _COMPONENT, _FLAGS), 1)
 
   def testMin(self):
-    decoder = option_decoders.IntDecoder(_OPTION, min=10)
+    decoder = option_decoders.IntDecoder(min=10, option=_OPTION)
     with self.assertRaises(errors.Config.InvalidValue) as cm:
       decoder.Decode(5, _COMPONENT, _FLAGS)
     self.assertEqual(str(cm.exception), (
@@ -173,19 +174,19 @@ class IntDecoderTestCase(unittest.TestCase):
 class StringDecoderTestCase(unittest.TestCase):
 
   def testDefault(self):
-    decoder = option_decoders.StringDecoder(_OPTION, default=None)
+    decoder = option_decoders.StringDecoder(default=None, option=_OPTION)
     self.assertFalse(decoder.required)
     self.assertIsNone(decoder.default)
 
   def testNone(self):
-    decoder = option_decoders.IntDecoder(_OPTION, none_ok=True)
+    decoder = option_decoders.IntDecoder(none_ok=True, option=_OPTION)
     self.assertIsNone(decoder.Decode(None, _COMPONENT, _FLAGS))
-    decoder = option_decoders.IntDecoder(_OPTION)
+    decoder = option_decoders.IntDecoder(option=_OPTION)
     with self.assertRaises(errors.Config.InvalidValue):
       decoder.Decode(None, _COMPONENT, _FLAGS)
 
   def testNonString(self):
-    decoder = option_decoders.StringDecoder(_OPTION)
+    decoder = option_decoders.StringDecoder(option=_OPTION)
     with self.assertRaises(errors.Config.InvalidValue) as cm:
       decoder.Decode(5, _COMPONENT, _FLAGS)
     self.assertEqual(str(cm.exception), (
@@ -193,26 +194,26 @@ class StringDecoderTestCase(unittest.TestCase):
         'Value must be one of the following types: basestring.'))
 
   def testValidString(self):
-    decoder = option_decoders.StringDecoder(_OPTION)
+    decoder = option_decoders.StringDecoder(option=_OPTION)
     self.assertEqual(decoder.Decode('red', _COMPONENT, _FLAGS), 'red')
 
 
 class FloatDecoderTestCase(unittest.TestCase):
 
   def testDefault(self):
-    decoder = option_decoders.FloatDecoder(_OPTION, default=2.5)
+    decoder = option_decoders.FloatDecoder(default=2.5, option=_OPTION)
     self.assertIs(decoder.required, False)
     self.assertIs(decoder.default, 2.5)
 
   def testNone(self):
-    decoder = option_decoders.FloatDecoder(_OPTION, none_ok=True)
+    decoder = option_decoders.FloatDecoder(none_ok=True, option=_OPTION)
     self.assertIsNone(decoder.Decode(None, _COMPONENT, _FLAGS))
-    decoder = option_decoders.IntDecoder(_OPTION)
+    decoder = option_decoders.IntDecoder(option=_OPTION)
     with self.assertRaises(errors.Config.InvalidValue):
       decoder.Decode(None, _COMPONENT, _FLAGS)
 
   def testNonFloat(self):
-    decoder = option_decoders.FloatDecoder(_OPTION)
+    decoder = option_decoders.FloatDecoder(option=_OPTION)
     with self.assertRaises(errors.Config.InvalidValue) as cm:
       decoder.Decode('5', _COMPONENT, _FLAGS)
     self.assertEqual(str(cm.exception), (
@@ -220,16 +221,16 @@ class FloatDecoderTestCase(unittest.TestCase):
         'Value must be one of the following types: float, int.'))
 
   def testValidFloat(self):
-    decoder = option_decoders.FloatDecoder(_OPTION)
+    decoder = option_decoders.FloatDecoder(option=_OPTION)
     self.assertEqual(decoder.Decode(2.5, _COMPONENT, _FLAGS), 2.5)
 
   def testValidFloatAsInt(self):
-    decoder = option_decoders.FloatDecoder(_OPTION)
+    decoder = option_decoders.FloatDecoder(option=_OPTION)
     self.assertEqual(decoder.Decode(2, _COMPONENT, _FLAGS), 2)
 
   def testMaxFloat(self):
     MAX = 2.0
-    decoder = option_decoders.FloatDecoder(_OPTION, max=MAX)
+    decoder = option_decoders.FloatDecoder(max=MAX, option=_OPTION)
     with self.assertRaises(errors.Config.InvalidValue) as cm:
       decoder.Decode(5, _COMPONENT, _FLAGS)
     self.assertEqual(str(cm.exception), (
@@ -241,7 +242,7 @@ class FloatDecoderTestCase(unittest.TestCase):
 
   def testMaxInt(self):
     MAX = 2
-    decoder = option_decoders.FloatDecoder(_OPTION, max=MAX)
+    decoder = option_decoders.FloatDecoder(max=MAX, option=_OPTION)
     with self.assertRaises(errors.Config.InvalidValue) as cm:
       decoder.Decode(2.01, _COMPONENT, _FLAGS)
     self.assertEqual(str(cm.exception), (
@@ -253,7 +254,7 @@ class FloatDecoderTestCase(unittest.TestCase):
 
   def testMinFloat(self):
     MIN = 2.0
-    decoder = option_decoders.FloatDecoder(_OPTION, min=MIN)
+    decoder = option_decoders.FloatDecoder(min=MIN, option=_OPTION)
     with self.assertRaises(errors.Config.InvalidValue) as cm:
       decoder.Decode(0, _COMPONENT, _FLAGS)
     self.assertEqual(str(cm.exception), (
@@ -265,7 +266,7 @@ class FloatDecoderTestCase(unittest.TestCase):
 
   def testMinInt(self):
     MIN = 2
-    decoder = option_decoders.FloatDecoder(_OPTION, min=MIN)
+    decoder = option_decoders.FloatDecoder(min=MIN, option=_OPTION)
     with self.assertRaises(errors.Config.InvalidValue) as cm:
       decoder.Decode(0, _COMPONENT, _FLAGS)
     self.assertEqual(str(cm.exception), (
@@ -274,6 +275,36 @@ class FloatDecoderTestCase(unittest.TestCase):
     self.assertIs(decoder.Decode(MIN, _COMPONENT, _FLAGS), MIN)
     self.assertIs(decoder.Decode(2.0, _COMPONENT, _FLAGS), 2.0)
     self.assertIs(decoder.Decode(5, _COMPONENT, _FLAGS), 5)
+
+
+class ListDecoderTestCase(unittest.TestCase):
+
+  def setUp(self):
+    super(ListDecoderTestCase, self).setUp()
+    self._int_decoder = option_decoders.IntDecoder()
+
+  def testNonListInputType(self):
+    decoder = option_decoders.ListDecoder(item_decoder=self._int_decoder,
+                                          option=_OPTION)
+    with self.assertRaises(errors.Config.InvalidValue) as cm:
+      decoder.Decode(5, _COMPONENT, _FLAGS)
+    self.assertEqual(str(cm.exception), (
+        'Invalid test_component.test_option value: "5" (of type "int"). '
+        'Value must be one of the following types: list.'))
+
+  def testNone(self):
+    decoder = option_decoders.ListDecoder(item_decoder=self._int_decoder,
+                                          none_ok=True, option=_OPTION)
+    self.assertIsNone(decoder.Decode(None, _COMPONENT, _FLAGS))
+
+  def testInvalidItem(self):
+    decoder = option_decoders.ListDecoder(item_decoder=self._int_decoder,
+                                          option=_OPTION)
+    with self.assertRaises(errors.Config.InvalidValue) as cm:
+      decoder.Decode([5, 4, 3.5], _COMPONENT, _FLAGS)
+    self.assertEqual(str(cm.exception), (
+        'Invalid test_component.test_option[2] value: "3.5" (of type "float"). '
+        'Value must be one of the following types: int.'))
 
 
 if __name__ == '__main__':

--- a/tests/gce_virtual_machine_test.py
+++ b/tests/gce_virtual_machine_test.py
@@ -34,7 +34,7 @@ class MemoryDecoderTestCase(unittest.TestCase):
 
   def setUp(self):
     super(MemoryDecoderTestCase, self).setUp()
-    self.decoder = gce_virtual_machine.MemoryDecoder('memory')
+    self.decoder = gce_virtual_machine.MemoryDecoder(option='memory')
 
   def testValidStrings(self):
     self.assertEqual(self.decoder.Decode('1280MiB', _COMPONENT, _FLAGS), 1280)
@@ -108,7 +108,7 @@ class MachineTypeDecoderTestCase(unittest.TestCase):
 
   def setUp(self):
     super(MachineTypeDecoderTestCase, self).setUp()
-    self.decoder = gce_virtual_machine.MachineTypeDecoder('machine_type')
+    self.decoder = gce_virtual_machine.MachineTypeDecoder(option='machine_type')
 
   def testDecodeString(self):
     result = self.decoder.Decode('n1-standard-8', _COMPONENT, {})


### PR DESCRIPTION
As part of this change, make the ConfigOptionDecoder's option attribute
optional.