### PR TITLE
Create BenchmarkConfigSpec to aggregate benchmark input checking.

### DIFF
--- a/perfkitbenchmarker/benchmark_spec.py
+++ b/perfkitbenchmarker/benchmark_spec.py
@@ -24,7 +24,6 @@ import thread
 import threading
 import uuid
 
-from perfkitbenchmarker import configs
 from perfkitbenchmarker import context
 from perfkitbenchmarker import disk
 from perfkitbenchmarker import errors
@@ -36,6 +35,7 @@ from perfkitbenchmarker import providers
 from perfkitbenchmarker import static_virtual_machine as static_vm
 from perfkitbenchmarker import virtual_machine
 from perfkitbenchmarker import vm_util
+from perfkitbenchmarker.configs import benchmark_config_spec
 
 
 def PickleLock(lock):
@@ -51,17 +51,6 @@ def UnPickleLock(locked, *args):
 
 
 copy_reg.pickle(thread.LockType, PickleLock)
-# Config constants.
-VM_GROUPS = 'vm_groups'
-CONFIG_FLAGS = 'flags'
-DISK_COUNT = 'disk_count'
-VM_COUNT = 'vm_count'
-DEFAULT_COUNT = 1
-CLOUD = 'cloud'
-OS_TYPE = 'os_type'
-STATIC_VMS = 'static_vms'
-VM_SPEC = 'vm_spec'
-DISK_SPEC = 'disk_spec'
 
 SUPPORTED = 'strict'
 NOT_EXCLUDED = 'permissive'
@@ -101,7 +90,10 @@ class BenchmarkSpec(object):
       benchmark_uid: An identifier unique to this run of the benchmark even
         if the same benchmark is run multiple times with different configs.
     """
-    self.config = benchmark_config
+    # TODO(skschneider): Build the BenchmarkConfigSpec outside of this method,
+    # and pass it in.
+    self.config = benchmark_config_spec.BenchmarkConfigSpec(
+        benchmark_name, flag_values=FLAGS, **benchmark_config)
     self.name = benchmark_name
     self.uid = benchmark_uid
     self.vms = []
@@ -126,36 +118,8 @@ class BenchmarkSpec(object):
     are redirected to a copy that has been merged with config-provided flag
     overrides specific to this benchmark run.
     """
-    merged_flags = configs.GetMergedFlags(self.config)
-    with flag_util.FlagDictSubstitution(FLAGS, merged_flags.FlagDict):
+    with flag_util.FlagDictSubstitution(FLAGS, lambda: self.config.flags):
       yield
-
-  def _GetCloudForGroup(self, group_name):
-    """Gets the cloud for a VM group by looking at flags and the config.
-    The precedence is as follows (in decreasing order):
-      * FLAGS.cloud (if specified on the command line)
-      * The "cloud" key in the group config (set by a config override)
-      * The "cloud" key in the group config (set by the config file)
-      * FLAGS.cloud (the default value)
-    """
-    group_spec = self.config[VM_GROUPS][group_name]
-    if not FLAGS[CLOUD].present and CLOUD in group_spec:
-      return group_spec[CLOUD]
-    return FLAGS.cloud
-
-  def _GetOsTypeForGroup(self, group_name):
-    """Gets the OS type for a VM group by looking at flags and the config.
-
-    The precedence is as follows (in decreasing order):
-      * FLAGS.os_type (if specified on the command line)
-      * The "os_type" key in the group config (set by a config override)
-      * The "os_type" key in the group config (set by the config file)
-      * FLAGS.os_type (the default value)
-    """
-    group_spec = self.config[VM_GROUPS][group_name]
-    if not FLAGS[OS_TYPE].present and OS_TYPE in group_spec:
-      return group_spec[OS_TYPE]
-    return FLAGS.os_type
 
   def _CheckBenchmarkSupport(self, cloud):
     """ Throw an exception if the benchmark isn't supported."""
@@ -178,47 +142,31 @@ class BenchmarkSpec(object):
 
   def ConstructVirtualMachines(self):
     """Constructs the BenchmarkSpec's VirtualMachine objects."""
-    vm_group_specs = self.config[VM_GROUPS]
+    vm_group_specs = self.config.vm_groups
 
     zone_index = 0
     for group_name, group_spec in vm_group_specs.iteritems():
       vms = []
-      vm_count = group_spec.get(VM_COUNT, DEFAULT_COUNT)
-      if vm_count is None:
-        vm_count = FLAGS.num_vms
-      disk_count = group_spec.get(DISK_COUNT, DEFAULT_COUNT)
+      vm_count = group_spec.vm_count
+      disk_count = group_spec.disk_count
 
-      # First create the Static VMs.
-      if STATIC_VMS in group_spec:
-        static_vm_specs = group_spec[STATIC_VMS][:vm_count]
-        for static_vm_spec_index, spec_kwargs in enumerate(static_vm_specs):
-          vm_spec = static_vm.StaticVmSpec(
-              '{0}.{1}.{2}.{3}[{4}]'.format(self.name, VM_GROUPS, group_name,
-                                            STATIC_VMS, static_vm_spec_index),
-              **spec_kwargs)
+      # First create the Static VM objects.
+      if group_spec.static_vms:
+        for vm_spec in group_spec.static_vms[:vm_count]:
           static_vm_class = static_vm.GetStaticVmClass(vm_spec.os_type)
           vms.append(static_vm_class(vm_spec))
 
-      os_type = self._GetOsTypeForGroup(group_name)
-      cloud = self._GetCloudForGroup(group_name)
-      providers.LoadProvider(cloud.lower())
+      os_type = group_spec.os_type
+      cloud = group_spec.cloud
 
       # This throws an exception if the benchmark is not
       # supported.
       self._CheckBenchmarkSupport(cloud)
 
-      # Then create a VmSpec and possibly a DiskSpec which we can
-      # use to create the remaining VMs.
-      vm_spec_class = virtual_machine.GetVmSpecClass(cloud)
-      vm_spec = vm_spec_class(
-          '.'.join((self.name, VM_GROUPS, group_name, VM_SPEC, cloud)),
-          FLAGS, **group_spec[VM_SPEC][cloud])
+      # Then create the remaining VM objects using VM and disk specs.
 
-      if DISK_SPEC in group_spec:
-        disk_spec_class = disk.GetDiskSpecClass(cloud)
-        disk_spec = disk_spec_class(
-            '.'.join((self.name, VM_GROUPS, group_name, DISK_SPEC, cloud)),
-            FLAGS, **group_spec[DISK_SPEC][cloud])
+      if group_spec.disk_spec:
+        disk_spec = group_spec.disk_spec
         # disk_spec.disk_type may contain legacy values that were
         # copied from FLAGS.scratch_disk_type into
         # FLAGS.data_disk_type at the beginning of the run. We
@@ -230,14 +178,13 @@ class BenchmarkSpec(object):
       else:
         disk_spec = None
 
-      # Create the remaining VMs using the specs we created earlier.
       for _ in xrange(vm_count - len(vms)):
         # Assign a zone to each VM sequentially from the --zones flag.
         if FLAGS.zones:
-          vm_spec.zone = FLAGS.zones[zone_index]
+          group_spec.vm_spec.zone = FLAGS.zones[zone_index]
           zone_index = (zone_index + 1 if zone_index < len(FLAGS.zones) - 1
                         else 0)
-        vm = self._CreateVirtualMachine(vm_spec, os_type, cloud)
+        vm = self._CreateVirtualMachine(group_spec.vm_spec, os_type, cloud)
         if disk_spec:
           vm.disk_specs = [copy.copy(disk_spec) for _ in xrange(disk_count)]
           # In the event that we need to create multiple disks from the same
@@ -367,15 +314,22 @@ class BenchmarkSpec(object):
 
   def PickleSpec(self):
     """Pickles the spec so that it can be unpickled on a subsequent run."""
+    # Remove the config. It cannot be pickled because of an issue with how
+    # gflags dynamically defines a Checker function for flags with a lower_bound
+    # or upper_bound.
+    config, self.config = self.config, None
     with open(self.file_name, 'wb') as pickle_file:
       pickle.dump(self, pickle_file, 2)
+    self.config = config
 
   @classmethod
-  def GetSpecFromFile(cls, name):
+  def GetSpecFromFile(cls, name, config):
     """Unpickles the spec and returns it.
 
     Args:
       name: The name of the benchmark (and the name of the pickled file).
+      config: BenchmarkConfigSpec. The benchmark configuration to use while
+          running the current stage.
 
     Returns:
       A BenchmarkSpec object.
@@ -387,6 +341,7 @@ class BenchmarkSpec(object):
     except Exception as e:  # pylint: disable=broad-except
       logging.error('Unable to unpickle spec file for benchmark %s.', name)
       raise e
+    spec.config = config
     # Always let the spec be deleted after being unpickled so that
     # it's possible to run cleanup even if cleanup has already run.
     spec.deleted = False

--- a/perfkitbenchmarker/configs/benchmark_config_spec.py
+++ b/perfkitbenchmarker/configs/benchmark_config_spec.py
@@ -1,0 +1,335 @@
+# Copyright 2016 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Classes that verify and transform benchmark configuration input."""
+
+import copy
+import os
+
+from perfkitbenchmarker import disk
+from perfkitbenchmarker import errors
+from perfkitbenchmarker import flag_util
+from perfkitbenchmarker import flags
+from perfkitbenchmarker import os_types
+from perfkitbenchmarker import providers
+from perfkitbenchmarker import static_virtual_machine
+from perfkitbenchmarker import virtual_machine
+from perfkitbenchmarker.configs import option_decoders
+from perfkitbenchmarker.configs import spec
+
+
+_DEFAULT_DISK_COUNT = 1
+_DEFAULT_VM_COUNT = 1
+
+
+class _FlagsDecoder(option_decoders.TypeVerifier):
+  """Processes the flags override dictionary of a benchmark config object."""
+
+  def __init__(self, **kwargs):
+    super(_FlagsDecoder, self).__init__(default=None, none_ok=True,
+                                        valid_types=(dict,), **kwargs)
+
+  def Decode(self, value, component_full_name, flag_values):
+    """Processes the flags override dictionary of a benchmark config object.
+
+    Args:
+      value: None or dict mapping flag name string to flag override value.
+      component_full_name: string. Fully qualified name of the configurable
+          component containing the config option.
+      flag_values: flags.FlagValues. Command-line flag values.
+
+    Returns:
+      dict mapping flag name string to Flag object. The flag values to use
+      when running the benchmark.
+    """
+    config_flags = super(_FlagsDecoder, self).Decode(value, component_full_name,
+                                                     flag_values)
+    merged_flag_values = copy.deepcopy(flag_values)
+    if config_flags:
+      for key, value in config_flags.iteritems():
+        if key not in merged_flag_values:
+          raise errors.Config.UnrecognizedOption(
+              'Unrecognized option {0}.{1}. Each option within {0} must '
+              'correspond to a valid command-line flag.'.format(
+                  self._GetOptionFullName(component_full_name), key))
+        if not merged_flag_values[key].present:
+          try:
+            merged_flag_values[key].Parse(value)
+          except flags.IllegalFlagValue as e:
+            raise errors.Config.InvalidValue(
+                'Invalid {0}.{1} value: "{2}" (of type "{3}").{4}{5}'.format(
+                    self._GetOptionFullName(component_full_name), key, value,
+                    value.__class__.__name__, os.linesep, e))
+    return merged_flag_values.FlagDict()
+
+
+class _PerCloudConfigSpec(spec.BaseSpec):
+  """Contains one config dict attribute per cloud provider.
+
+  The name of each attribute is the name of the cloud provider.
+  """
+
+  @classmethod
+  def _GetOptionDecoderConstructions(cls):
+    """Gets decoder classes and constructor args for each configurable option.
+
+    Returns:
+      dict. Maps option name string to a (ConfigOptionDecoder class, dict) pair.
+      The pair specifies a decoder class and its __init__() keyword arguments
+      to construct in order to decode the named option.
+    """
+    result = super(_PerCloudConfigSpec, cls)._GetOptionDecoderConstructions()
+    for cloud in providers.VALID_CLOUDS:
+      result[cloud] = option_decoders.TypeVerifier, {'default': None,
+                                                     'valid_types': (dict,)}
+    return result
+
+
+class _PerCloudConfigDecoder(option_decoders.TypeVerifier):
+  """Decodes the disk_spec or vm_spec option of a VM group config object."""
+
+  def __init__(self, **kwargs):
+    super(_PerCloudConfigDecoder, self).__init__(valid_types=(dict,), **kwargs)
+
+  def Decode(self, value, component_full_name, flag_values):
+    """Decodes the disk_spec or vm_spec option of a VM group config object.
+
+    Args:
+      value: None or dict mapping cloud provider name string to a dict.
+      component_full_name: string. Fully qualified name of the configurable
+          component containing the config option.
+      flag_values: flags.FlagValues. Runtime flag values to be propagated to
+          BaseSpec constructors.
+
+    Returns:
+      _PerCloudConfigSpec decoded from the input dict.
+    """
+    input_dict = super(_PerCloudConfigDecoder, self).Decode(
+        value, component_full_name, flag_values)
+    return None if input_dict is None else _PerCloudConfigSpec(
+        self._GetOptionFullName(component_full_name), flag_values=flag_values,
+        **input_dict)
+
+
+class _StaticVmDecoder(option_decoders.TypeVerifier):
+  """Decodes an item of the static_vms list of a VM group config object."""
+
+  def __init__(self, **kwargs):
+    super(_StaticVmDecoder, self).__init__(valid_types=(dict,), **kwargs)
+
+  def Decode(self, value, component_full_name, flag_values):
+    """Decodes an item of the static_vms list of a VM group config object.
+
+    Args:
+      value: dict mapping static VM config option name string to corresponding
+          option value.
+      component_full_name: string. Fully qualified name of the configurable
+          component containing the config option.
+      flag_values: flags.FlagValues. Runtime flag values to be propagated to
+          BaseSpec constructors.
+
+    Returns:
+      StaticVmSpec decoded from the input dict.
+
+    Raises:
+      errors.Config.InvalidValue upon invalid input value.
+    """
+    input_dict = super(_StaticVmDecoder, self).Decode(
+        value, component_full_name, flag_values)
+    return static_virtual_machine.StaticVmSpec(
+        self._GetOptionFullName(component_full_name), **input_dict)
+
+
+class _StaticVmListDecoder(option_decoders.ListDecoder):
+  """Decodes the static_vms list of a VM group config object."""
+
+  def __init__(self, **kwargs):
+    super(_StaticVmListDecoder, self).__init__(
+        default=list, item_decoder=_StaticVmDecoder(), **kwargs)
+
+
+class _VmGroupSpec(spec.BaseSpec):
+  """Configurable options of a VM group.
+
+  Attributes:
+    cloud: string. Cloud provider of the VMs in this group.
+    disk_count: int. Number of data disks to attach to each VM in this group.
+    disk_spec: BaseDiskSpec. Configuration for all data disks to be attached to
+        VMs in this group.
+    os_type: string. OS type of the VMs in this group.
+    static_vms: None or list of StaticVmSpecs. Configuration for all static VMs
+        in this group.
+    vm_count: int. Number of VMs in this group, including static VMs and
+        provisioned VMs.
+    vm_spec: BaseVmSpec. Configuration for provisioned VMs in this group.
+  """
+
+  def __init__(self, component_full_name, flag_values=None, **kwargs):
+    super(_VmGroupSpec, self).__init__(component_full_name,
+                                       flag_values=flag_values, **kwargs)
+    providers.LoadProvider(self.cloud.lower())
+    if self.disk_spec:
+      disk_config = getattr(self.disk_spec, self.cloud, None)
+      if disk_config is None:
+        raise errors.Config.MissingOption(
+            '{0}.cloud is "{1}", but {0}.disk_spec does not contain a '
+            'configuration for "{1}".'.format(component_full_name, self.cloud))
+      disk_spec_class = disk.GetDiskSpecClass(self.cloud)
+      self.disk_spec = disk_spec_class(
+          '{0}.disk_spec.{1}'.format(component_full_name, self.cloud),
+          flag_values=flag_values, **disk_config)
+    vm_config = getattr(self.vm_spec, self.cloud, None)
+    if vm_config is None:
+      raise errors.Config.MissingOption(
+          '{0}.cloud is "{1}", but {0}.vm_spec does not contain a '
+          'configuration for "{1}".'.format(component_full_name, self.cloud))
+    vm_spec_class = virtual_machine.GetVmSpecClass(self.cloud)
+    self.vm_spec = vm_spec_class(
+        '{0}.vm_spec.{1}'.format(component_full_name, self.cloud),
+        flag_values=flag_values, **vm_config)
+
+  @classmethod
+  def _GetOptionDecoderConstructions(cls):
+    """Gets decoder classes and constructor args for each configurable option.
+
+    Returns:
+      dict. Maps option name string to a (ConfigOptionDecoder class, dict) pair.
+      The pair specifies a decoder class and its __init__() keyword arguments
+      to construct in order to decode the named option.
+    """
+    result = super(_VmGroupSpec, cls)._GetOptionDecoderConstructions()
+    result.update({
+        'cloud': (option_decoders.EnumDecoder, {
+            'valid_values': providers.VALID_CLOUDS}),
+        'disk_count': (option_decoders.IntDecoder, {
+            'default': _DEFAULT_DISK_COUNT, 'min': 0}),
+        'disk_spec': (_PerCloudConfigDecoder, {'default': None,
+                                               'none_ok': True}),
+        'os_type': (option_decoders.EnumDecoder, {
+            'valid_values': os_types.ALL}),
+        'static_vms': (_StaticVmListDecoder, {}),
+        'vm_count': (option_decoders.IntDecoder, {
+            'default': _DEFAULT_VM_COUNT, 'min': 0}),
+        'vm_spec': (_PerCloudConfigDecoder, {})})
+    return result
+
+  @classmethod
+  def _ApplyFlags(cls, config_values, flag_values):
+    """Modifies config options based on runtime flag values.
+
+    Can be overridden by derived classes to add support for specific flags.
+
+    Args:
+      config_values: dict mapping config option names to provided values. May
+          be modified by this function.
+      flag_values: flags.FlagValues. Runtime flags that may override the
+          provided config values.
+    """
+    super(_VmGroupSpec, cls)._ApplyFlags(config_values, flag_values)
+    if flag_values['cloud'].present or 'cloud' not in config_values:
+      config_values['cloud'] = flag_values.cloud
+    if flag_values['os_type'].present or 'os_type' not in config_values:
+      config_values['os_type'] = flag_values.os_type
+    if 'vm_count' in config_values and config_values['vm_count'] is None:
+      config_values['vm_count'] = flag_values.num_vms
+
+
+class _VmGroupsDecoder(option_decoders.TypeVerifier):
+  """Validates the vm_groups dictionary of a benchmark config object."""
+
+  def __init__(self, **kwargs):
+    super(_VmGroupsDecoder, self).__init__(valid_types=(dict,), **kwargs)
+
+  def Decode(self, value, component_full_name, flag_values):
+    """Verifies vm_groups dictionary of a benchmark config object.
+
+    Args:
+      value: dict mapping VM group name string to the corresponding VM group
+          config dict.
+      component_full_name: string. Fully qualified name of the configurable
+          component containing the config option.
+      flag_values: flags.FlagValues. Runtime flag values to be propagated to
+          BaseSpec constructors.
+
+    Returns:
+      dict mapping VM group name string to _VmGroupSpec.
+
+    Raises:
+      errors.Config.InvalidValue upon invalid input value.
+    """
+    vm_group_configs = super(_VmGroupsDecoder, self).Decode(
+        value, component_full_name, flag_values)
+    result = {}
+    for vm_group_name, vm_group_config in vm_group_configs.iteritems():
+      result[vm_group_name] = _VmGroupSpec(
+          '{0}.{1}'.format(self._GetOptionFullName(component_full_name),
+                           vm_group_name),
+          flag_values=flag_values, **vm_group_config)
+    return result
+
+
+class BenchmarkConfigSpec(spec.BaseSpec):
+  """Configurable options of a benchmark run.
+
+  Attributes:
+    description: string. Description of the benchmark to run.
+    flags: flags.FlagValues. Values to use for each flag while executing the
+        benchmark.
+    vm_groups: dict mapping VM group name string to _VmGroupSpec. Configurable
+        options for each VM group used by the benchmark.
+  """
+
+  @classmethod
+  def _GetOptionDecoderConstructions(cls):
+    """Gets decoder classes and constructor args for each configurable option.
+
+    Can be overridden by derived classes to add options or impose additional
+    requirements on existing options.
+
+    Returns:
+      dict. Maps option name string to a (ConfigOptionDecoder class, dict) pair.
+      The pair specifies a decoder class and its __init__() keyword arguments
+      to construct in order to decode the named option.
+    """
+    result = super(BenchmarkConfigSpec, cls)._GetOptionDecoderConstructions()
+    result.update({'description': (option_decoders.StringDecoder, {}),
+                   'flags': (_FlagsDecoder, {}),
+                   'vm_groups': (_VmGroupsDecoder, {})})
+    # TODO(skschneider): Old tests construct BenchmarkSpec without providing a
+    # description or vm_groups, but they should be required. As a separate
+    # change, those tests should be fixed, and the two lines should be removed.
+    result['description'][1]['default'] = None
+    result['vm_groups'][1]['default'] = None
+    return result
+
+  def _DecodeAndInit(self, component_full_name, config, decoders, flag_values):
+    """Initializes spec attributes from provided config option values.
+
+    Args:
+      component_full_name: string. Fully qualified name of the configurable
+          component containing the config options.
+      config: dict mapping option name string to option value.
+      flag_values: flags.FlagValues. Runtime flags that may override provided
+          config option values. These flags have already been applied to the
+          current config, but they may be passed to the decoders for propagation
+          to deeper spec constructors.
+      decoders: OrderedDict mapping option name string to ConfigOptionDecoder.
+    """
+    # Decode benchmark-specific flags first and use them while decoding the
+    # rest of the BenchmarkConfigSpec's options.
+    decoders = decoders.copy()
+    self.flags = decoders.pop('flags').Decode(config.pop('flags', None),
+                                              component_full_name, flag_values)
+    with flag_util.FlagDictSubstitution(flag_values, lambda: self.flags):
+      super(BenchmarkConfigSpec, self)._DecodeAndInit(
+          component_full_name, config, decoders, flag_values)

--- a/perfkitbenchmarker/pkb.py
+++ b/perfkitbenchmarker/pkb.py
@@ -80,6 +80,7 @@ from perfkitbenchmarker import traces
 from perfkitbenchmarker import version
 from perfkitbenchmarker import vm_util
 from perfkitbenchmarker import windows_benchmarks
+from perfkitbenchmarker.configs import benchmark_config_spec
 from perfkitbenchmarker.publisher import SampleCollector
 
 STAGE_ALL = 'all'
@@ -316,8 +317,11 @@ def _GetBenchmarkSpec(benchmark_config, benchmark_name, benchmark_uid):
     return benchmark_spec.BenchmarkSpec(benchmark_config, benchmark_name,
                                         benchmark_uid)
   else:
+    # TODO(skschneider): Build BenchmarkConfigSpec before RunBenchmark.
+    config = benchmark_config_spec.BenchmarkConfigSpec(
+        benchmark_name, flag_values=FLAGS, **benchmark_config)
     try:
-      return benchmark_spec.BenchmarkSpec.GetSpecFromFile(benchmark_uid)
+      return benchmark_spec.BenchmarkSpec.GetSpecFromFile(benchmark_uid, config)
     except IOError:
       if FLAGS.run_stage == STAGE_PREPARE:
         logging.error(

--- a/tests/background_network_workload_test.py
+++ b/tests/background_network_workload_test.py
@@ -177,9 +177,8 @@ class TestBackgroundNetworkWorkload(unittest.TestCase):
     self.mocked_flags.background_network_mbits_per_sec = 200
     self.mocked_flags.background_network_ip_type = 'IAMABADFLAGVALUE'
     config = configs.LoadConfig(ping_benchmark.BENCHMARK_CONFIG, {}, NAME)
-    spec = benchmark_spec.BenchmarkSpec(config, NAME, UID)
     with self.assertRaises(errors.Config.InvalidValue):
-      spec.ConstructVirtualMachines()
+      benchmark_spec.BenchmarkSpec(config, NAME, UID)
 
   def testBackgroundWorkloadConfig(self):
     """ Check that the config can be used to set the background iperf """
@@ -196,9 +195,8 @@ class TestBackgroundNetworkWorkload(unittest.TestCase):
     """ Check that the config with invalid ip type gets an error """
     config = configs.LoadConfig(CONFIG_WITH_BACKGROUND_NETWORK_BAD_IPFLAG,
                                 {}, NAME)
-    spec = benchmark_spec.BenchmarkSpec(config, NAME, UID)
     with self.assertRaises(errors.Config.InvalidValue):
-      spec.ConstructVirtualMachines()
+      benchmark_spec.BenchmarkSpec(config, NAME, UID)
 
   def testBackgroundWorkloadConfigGoodIp(self):
     """ Check that the config can be used with an internal ip address """

--- a/tests/benchmark_spec_test.py
+++ b/tests/benchmark_spec_test.py
@@ -19,7 +19,6 @@ import mock_flags
 from perfkitbenchmarker import benchmark_spec
 from perfkitbenchmarker import configs
 from perfkitbenchmarker import context
-from perfkitbenchmarker import errors
 from perfkitbenchmarker import flags
 from perfkitbenchmarker import static_virtual_machine as static_vm
 from perfkitbenchmarker.providers.aws import aws_virtual_machine as aws_vm
@@ -80,26 +79,6 @@ name:
          user_name: user2
          disk_specs:
            - mount_point: /scratch
-"""
-BAD_VM_PARAMETER_CONFIG = """
-name:
-  vm_groups:
-    default:
-      vm_spec:
-        GCP:
-          machine_type: n1-standard-4
-          not_a_vm_parameter: 4
-"""
-BAD_DISK_PARAMETER_CONFIG = """
-name:
-  vm_groups:
-    default:
-      vm_spec:
-        GCP:
-          machine_type: n1-standard-4
-      disk_spec:
-        GCP:
-          not_a_disk_parameter: 4
 """
 VALID_CONFIG_WITH_DISK_SPEC = """
 name:
@@ -163,24 +142,6 @@ class ConstructVmsTestCase(unittest.TestCase):
     self.assertIsInstance(vm3, gce_vm.GceVirtualMachine)
 
     self.assertEqual(vm2.disk_specs[0].mount_point, '/scratch')
-
-  def testBadVmParameter(self):
-    config = configs.LoadConfig(BAD_VM_PARAMETER_CONFIG, {}, NAME)
-    spec = benchmark_spec.BenchmarkSpec(config, NAME, UID)
-    with self.assertRaises(errors.Config.UnrecognizedOption) as cm:
-      spec.ConstructVirtualMachines()
-    self.assertEqual(str(cm.exception), (
-        'Unrecognized options were found in '
-        'name.vm_groups.default.vm_spec.GCP: not_a_vm_parameter.'))
-
-  def testBadDiskParameter(self):
-    config = configs.LoadConfig(BAD_DISK_PARAMETER_CONFIG, {}, NAME)
-    spec = benchmark_spec.BenchmarkSpec(config, NAME, UID)
-    with self.assertRaises(errors.Config.UnrecognizedOption) as cm:
-      spec.ConstructVirtualMachines()
-    self.assertEqual(str(cm.exception), (
-        'Unrecognized options were found in '
-        'name.vm_groups.default.disk_spec.GCP: not_a_disk_parameter.'))
 
   def testValidConfigWithDiskSpec(self):
     config = configs.LoadConfig(VALID_CONFIG_WITH_DISK_SPEC, {}, NAME)

--- a/tests/configs/benchmark_config_spec_test.py
+++ b/tests/configs/benchmark_config_spec_test.py
@@ -1,0 +1,466 @@
+# Copyright 2016 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for perfkitbenchmarker.configs.benchmark_config_spec."""
+
+import os
+import unittest
+
+from perfkitbenchmarker import errors
+from perfkitbenchmarker import flags
+from perfkitbenchmarker import os_types
+from perfkitbenchmarker import providers
+from perfkitbenchmarker import static_virtual_machine
+from perfkitbenchmarker import virtual_machine
+from perfkitbenchmarker.configs import benchmark_config_spec
+from perfkitbenchmarker.providers.aws import aws_disk
+from perfkitbenchmarker.providers.gcp import gce_virtual_machine
+from tests import mock_flags
+
+
+_COMPONENT = 'test_component'
+_OPTION = 'test_option'
+_GCP_ONLY_VM_CONFIG = {'GCP': {'machine_type': 'n1-standard-1'}}
+_GCP_AWS_VM_CONFIG = {'GCP': {'machine_type': 'n1-standard-1'},
+                      'AWS': {'machine_type': 'm4.large'}}
+_GCP_AWS_DISK_CONFIG = {'GCP': {}, 'AWS': {}}
+
+
+class FlagsDecoderTestCase(unittest.TestCase):
+
+  def setUp(self):
+    super(FlagsDecoderTestCase, self).setUp()
+    self._decoder = benchmark_config_spec._FlagsDecoder(option=_OPTION)
+    self._flag_values = flags.FlagValues()
+    flags.DEFINE_integer('test_flag', 0, 'Test flag.',
+                         flag_values=self._flag_values)
+
+  def assertResultIsCorrect(self, result, expected_flag_value,
+                            expected_flag_present):
+    self.assertIsInstance(result, dict)
+    self.assertEqual(len(result), 1)
+    self.assertEqual(result['test_flag'].value, expected_flag_value)
+    self.assertEqual(result['test_flag'].present, expected_flag_present)
+    self.assertIsNot(result, self._flag_values.FlagDict())
+
+  def testNone(self):
+    result = self._decoder.Decode(None, _COMPONENT, self._flag_values)
+    self.assertResultIsCorrect(result, 0, False)
+
+  def testEmptyDict(self):
+    result = self._decoder.Decode({}, _COMPONENT, self._flag_values)
+    self.assertResultIsCorrect(result, 0, False)
+
+  def testValidFlagOverride(self):
+    result = self._decoder.Decode({'test_flag': 1}, _COMPONENT,
+                                  self._flag_values)
+    self.assertResultIsCorrect(result, 1, True)
+
+  def testPresentFlagNotOverridden(self):
+    self._flag_values['test_flag'].present = True
+    result = self._decoder.Decode({'test_flag': 1}, _COMPONENT,
+                                  self._flag_values)
+    self.assertResultIsCorrect(result, 0, True)
+
+  def testInvalidValueType(self):
+    with self.assertRaises(errors.Config.InvalidValue) as cm:
+      self._decoder.Decode(0, _COMPONENT, self._flag_values)
+    self.assertEqual(str(cm.exception), (
+        'Invalid test_component.test_option value: "0" (of type "int"). Value '
+        'must be one of the following types: NoneType, dict.'))
+
+  def testInvalidFlagName(self):
+    with self.assertRaises(errors.Config.UnrecognizedOption) as cm:
+      self._decoder.Decode({'flag': 1}, _COMPONENT, self._flag_values)
+    self.assertEqual(str(cm.exception), (
+        'Unrecognized option test_component.test_option.flag. Each option '
+        'within test_component.test_option must correspond to a valid '
+        'command-line flag.'))
+
+  def testInvalidFlagValue(self):
+    with self.assertRaises(errors.Config.InvalidValue) as cm:
+      self._decoder.Decode({'test_flag': 'two'}, _COMPONENT, self._flag_values)
+    self.assertEqual(str(cm.exception), (
+        'Invalid test_component.test_option.test_flag value: "two" (of type '
+        '"str").{0}flag --test_flag=two: invalid literal for int() with base '
+        "10: 'two'".format(os.linesep)))
+
+
+class PerCloudConfigSpecTestCase(unittest.TestCase):
+
+  def setUp(self):
+    super(PerCloudConfigSpecTestCase, self).setUp()
+    self._spec_class = benchmark_config_spec._PerCloudConfigSpec
+
+  def testDefaults(self):
+    spec = self._spec_class(_COMPONENT)
+    for cloud in providers.VALID_CLOUDS:
+      self.assertIsNone(getattr(spec, cloud))
+
+  def testDict(self):
+    spec = self._spec_class(_COMPONENT, GCP={})
+    self.assertEqual(spec.GCP, {})
+    for cloud in frozenset(providers.VALID_CLOUDS).difference([providers.GCP]):
+      self.assertIsNone(getattr(spec, cloud))
+
+  def testNonDict(self):
+    with self.assertRaises(errors.Config.InvalidValue) as cm:
+      self._spec_class(_COMPONENT, GCP=[])
+    self.assertEqual(str(cm.exception), (
+        'Invalid test_component.GCP value: "[]" (of type "list"). Value must '
+        'be one of the following types: dict.'))
+
+  def testUnrecognizedCloud(self):
+    with self.assertRaises(errors.Config.UnrecognizedOption) as cm:
+      self._spec_class(_COMPONENT, fake_provider={})
+    self.assertEqual(str(cm.exception), (
+        'Unrecognized options were found in test_component: fake_provider.'))
+
+
+class PerCloudConfigDecoderTestCase(unittest.TestCase):
+
+  def setUp(self):
+    super(PerCloudConfigDecoderTestCase, self).setUp()
+    self._decoder = benchmark_config_spec._PerCloudConfigDecoder(option=_OPTION)
+
+  def testRejectNone(self):
+    with self.assertRaises(errors.Config.InvalidValue):
+      self._decoder.Decode(None, _COMPONENT, {})
+
+  def testAcceptNone(self):
+    decoder = benchmark_config_spec._PerCloudConfigDecoder(none_ok=True,
+                                                           option=_OPTION)
+    self.assertIsNone(decoder.Decode(None, _COMPONENT, {}))
+
+  def testEmptyDict(self):
+    result = self._decoder.Decode({}, _COMPONENT, {})
+    self.assertIsInstance(result, benchmark_config_spec._PerCloudConfigSpec)
+    self.assertEqual(result.__dict__, {
+        cloud: None for cloud in providers.VALID_CLOUDS})
+
+  def testNonEmptyDict(self):
+    result = self._decoder.Decode(_GCP_ONLY_VM_CONFIG, _COMPONENT, {})
+    self.assertIsInstance(result, benchmark_config_spec._PerCloudConfigSpec)
+    expected_attributes = {cloud: None for cloud in providers.VALID_CLOUDS}
+    expected_attributes['GCP'] = {'machine_type': 'n1-standard-1'}
+    self.assertEqual(result.__dict__, expected_attributes)
+
+
+class StaticVmDecoderTestCase(unittest.TestCase):
+
+  def setUp(self):
+    super(StaticVmDecoderTestCase, self).setUp()
+    self._decoder = benchmark_config_spec._StaticVmDecoder()
+
+  def testNone(self):
+    with self.assertRaises(errors.Config.InvalidValue):
+      self._decoder.Decode(None, _COMPONENT, {})
+
+  def testValidInput(self):
+    result = self._decoder.Decode({'ssh_port': 111}, _COMPONENT, {})
+    self.assertIsInstance(result, static_virtual_machine.StaticVmSpec)
+    self.assertEqual(result.ssh_port, 111)
+
+
+class StaticVmListDecoderTestCase(unittest.TestCase):
+
+  def setUp(self):
+    super(StaticVmListDecoderTestCase, self).setUp()
+    self._decoder = benchmark_config_spec._StaticVmListDecoder()
+
+  def testNone(self):
+    with self.assertRaises(errors.Config.InvalidValue):
+      self._decoder.Decode(None, _COMPONENT, {})
+
+  def testValidList(self):
+    input_list = [{'ssh_port': i} for i in xrange(3)]
+    result = self._decoder.Decode(input_list, _COMPONENT, {})
+    self.assertIsInstance(result, list)
+    self.assertEqual([vm_spec.ssh_port for vm_spec in result], range(3))
+
+  def testInvalidList(self):
+    input_list = [{'ssh_port': 0}, {'ssh_port': 1}, {'ssh_pory': 2}]
+    with self.assertRaises(errors.Config.UnrecognizedOption) as cm:
+      self._decoder.Decode(input_list, _COMPONENT, {})
+    self.assertEqual(str(cm.exception), (
+        'Unrecognized options were found in test_component[2]: ssh_pory.'))
+
+
+class VmGroupSpecTestCase(unittest.TestCase):
+
+  def setUp(self):
+    super(VmGroupSpecTestCase, self).setUp()
+    self._spec_class = benchmark_config_spec._VmGroupSpec
+    self._kwargs = {'cloud': providers.GCP, 'os_type': os_types.DEBIAN,
+                    'vm_spec': _GCP_AWS_VM_CONFIG}
+
+  def testMissingValues(self):
+    with self.assertRaises(errors.Config.MissingOption) as cm:
+      self._spec_class(_COMPONENT)
+    self.assertEqual(str(cm.exception), (
+        'Required options were missing from test_component: cloud, os_type, '
+        'vm_spec.'))
+
+  def testDefaults(self):
+    result = self._spec_class(_COMPONENT, **self._kwargs)
+    self.assertIsInstance(result, benchmark_config_spec._VmGroupSpec)
+    self.assertEqual(result.cloud, 'GCP')
+    self.assertEqual(result.disk_count, 1)
+    self.assertIsNone(result.disk_spec)
+    self.assertEqual(result.os_type, 'debian')
+    self.assertEqual(result.static_vms, [])
+    self.assertEqual(result.vm_count, 1)
+    self.assertIsInstance(result.vm_spec, gce_virtual_machine.GceVmSpec)
+
+  def testInvalidCloud(self):
+    self._kwargs['cloud'] = 'fake_provider'
+    with self.assertRaises(errors.Config.InvalidValue) as cm:
+      self._spec_class(_COMPONENT, **self._kwargs)
+    self.assertEqual(str(cm.exception), (
+        'Invalid test_component.cloud value: "fake_provider". Value must be '
+        'one of the following: {0}.'.format(', '.join(providers.VALID_CLOUDS))))
+
+  def testInvalidDiskCount(self):
+    self._kwargs['disk_count'] = None
+    with self.assertRaises(errors.Config.InvalidValue) as cm:
+      self._spec_class(_COMPONENT, **self._kwargs)
+    self.assertEqual(str(cm.exception), (
+        'Invalid test_component.disk_count value: "None" (of type "NoneType"). '
+        'Value must be one of the following types: int.'))
+    self._kwargs['disk_count'] = -1
+    with self.assertRaises(errors.Config.InvalidValue) as cm:
+      self._spec_class(_COMPONENT, **self._kwargs)
+    self.assertEqual(str(cm.exception), (
+        'Invalid test_component.disk_count value: "-1". '
+        'Value must be at least 0.'))
+
+  def testInvalidDiskSpec(self):
+    self._kwargs['disk_spec'] = {'GCP': None}
+    with self.assertRaises(errors.Config.InvalidValue) as cm:
+      self._spec_class(_COMPONENT, **self._kwargs)
+    self.assertEqual(str(cm.exception), (
+        'Invalid test_component.disk_spec.GCP value: "None" (of type '
+        '"NoneType"). Value must be one of the following types: dict.'))
+
+  def testInvalidOsType(self):
+    self._kwargs['os_type'] = 'fake_os_type'
+    with self.assertRaises(errors.Config.InvalidValue) as cm:
+      self._spec_class(_COMPONENT, **self._kwargs)
+    self.assertEqual(str(cm.exception), (
+        'Invalid test_component.os_type value: "fake_os_type". Value must be '
+        'one of the following: {0}.'.format(', '.join(os_types.ALL))))
+
+  def testInvalidStaticVms(self):
+    self._kwargs['static_vms'] = [{'fake_option': None}]
+    with self.assertRaises(errors.Config.UnrecognizedOption) as cm:
+      self._spec_class(_COMPONENT, **self._kwargs)
+    self.assertEqual(str(cm.exception), (
+        'Unrecognized options were found in test_component.static_vms[0]: '
+        'fake_option.'))
+
+  def testInvalidVmCount(self):
+    self._kwargs['vm_count'] = None
+    with self.assertRaises(errors.Config.InvalidValue) as cm:
+      self._spec_class(_COMPONENT, **self._kwargs)
+    self.assertEqual(str(cm.exception), (
+        'Invalid test_component.vm_count value: "None" (of type "NoneType"). '
+        'Value must be one of the following types: int.'))
+    self._kwargs['vm_count'] = -1
+    with self.assertRaises(errors.Config.InvalidValue) as cm:
+      self._spec_class(_COMPONENT, **self._kwargs)
+    self.assertEqual(str(cm.exception), (
+        'Invalid test_component.vm_count value: "-1". '
+        'Value must be at least 0.'))
+
+  def testInvalidVmSpec(self):
+    self._kwargs['vm_spec'] = {'GCP': None}
+    with self.assertRaises(errors.Config.InvalidValue) as cm:
+      self._spec_class(_COMPONENT, **self._kwargs)
+    self.assertEqual(str(cm.exception), (
+        'Invalid test_component.vm_spec.GCP value: "None" (of type '
+        '"NoneType"). Value must be one of the following types: dict.'))
+
+  def testValidInput(self):
+    result = self._spec_class(
+        _COMPONENT, cloud=providers.AWS, disk_count=0,
+        disk_spec=_GCP_AWS_DISK_CONFIG, os_type=os_types.WINDOWS,
+        static_vms=[{}], vm_count=0, vm_spec=_GCP_AWS_VM_CONFIG)
+    self.assertIsInstance(result, benchmark_config_spec._VmGroupSpec)
+    self.assertEqual(result.cloud, 'AWS')
+    self.assertEqual(result.disk_count, 0)
+    self.assertIsInstance(result.disk_spec, aws_disk.AwsDiskSpec)
+    self.assertEqual(result.os_type, 'windows')
+    self.assertIsInstance(result.static_vms, list)
+    self.assertEqual(len(result.static_vms), 1)
+    self.assertIsInstance(result.static_vms[0],
+                          static_virtual_machine.StaticVmSpec)
+    self.assertEqual(result.vm_count, 0)
+    self.assertIsInstance(result.vm_spec, virtual_machine.BaseVmSpec)
+
+  def testMissingCloudDiskConfig(self):
+    with self.assertRaises(errors.Config.MissingOption) as cm:
+      self._spec_class(_COMPONENT, cloud=providers.GCP, os_type=os_types.DEBIAN,
+                       disk_spec={}, vm_spec=_GCP_AWS_VM_CONFIG)
+    self.assertEqual(str(cm.exception), (
+        'test_component.cloud is "GCP", but test_component.disk_spec does not '
+        'contain a configuration for "GCP".'))
+
+  def testMissingCloudVmConfig(self):
+    with self.assertRaises(errors.Config.MissingOption) as cm:
+      self._spec_class(_COMPONENT, cloud=providers.GCP, os_type=os_types.DEBIAN,
+                       vm_spec={})
+    self.assertEqual(str(cm.exception), (
+        'test_component.cloud is "GCP", but test_component.vm_spec does not '
+        'contain a configuration for "GCP".'))
+
+  def createNonPresentFlags(self):
+    result = mock_flags.MockFlags()
+    result['cloud'].value = providers.AWS
+    result['num_vms'].value = 3
+    result['os_type'].value = os_types.WINDOWS
+    return result
+
+  def createPresentFlags(self):
+    result = self.createNonPresentFlags()
+    result['cloud'].present = True
+    result['num_vms'].present = True
+    result['os_type'].present = True
+    return result
+
+  def testPresentFlagsAndPresentConfigValues(self):
+    result = self._spec_class(_COMPONENT, flag_values=self.createPresentFlags(),
+                              vm_count=2, **self._kwargs)
+    self.assertEqual(result.cloud, 'AWS')
+    self.assertEqual(result.os_type, 'windows')
+    self.assertEqual(result.vm_count, 2)
+
+  def testPresentFlagsAndNonPresentConfigValues(self):
+    result = self._spec_class(_COMPONENT, flag_values=self.createPresentFlags(),
+                              vm_spec=_GCP_AWS_VM_CONFIG)
+    self.assertEqual(result.cloud, 'AWS')
+    self.assertEqual(result.os_type, 'windows')
+    self.assertEqual(result.vm_count, 1)
+
+  def testNonPresentFlagsAndPresentConfigValues(self):
+    result = self._spec_class(
+        _COMPONENT, flag_values=self.createNonPresentFlags(), vm_count=2,
+        **self._kwargs)
+    self.assertEqual(result.cloud, 'GCP')
+    self.assertEqual(result.os_type, 'debian')
+    self.assertEqual(result.vm_count, 2)
+
+  def testVmCountNone(self):
+    result = self._spec_class(
+        _COMPONENT, flag_values=self.createNonPresentFlags(), vm_count=None,
+        **self._kwargs)
+    self.assertEqual(result.vm_count, 3)
+
+
+class VmGroupsDecoderTestCase(unittest.TestCase):
+
+  def setUp(self):
+    super(VmGroupsDecoderTestCase, self).setUp()
+    self._decoder = benchmark_config_spec._VmGroupsDecoder()
+
+  def testNone(self):
+    with self.assertRaises(errors.Config.InvalidValue):
+      self._decoder.Decode(None, _COMPONENT, {})
+
+  def testValidInput(self):
+    result = self._decoder.Decode({
+        'default': {'cloud': providers.GCP, 'os_type': os_types.DEBIAN,
+                    'vm_spec': _GCP_AWS_VM_CONFIG}}, _COMPONENT, {})
+    self.assertIsInstance(result, dict)
+    self.assertEqual(len(result), 1)
+    self.assertIsInstance(result['default'], benchmark_config_spec._VmGroupSpec)
+    self.assertEqual(result['default'].cloud, 'GCP')
+    self.assertEqual(result['default'].os_type, 'debian')
+    self.assertIsInstance(result['default'].vm_spec,
+                          gce_virtual_machine.GceVmSpec)
+
+  def testInvalidInput(self):
+    with self.assertRaises(errors.Config.UnrecognizedOption) as cm:
+      self._decoder.Decode(
+          {'default': {'cloud': providers.GCP, 'os_type': os_types.DEBIAN,
+                       'static_vms': [{}, {'fake_option': 1.2}],
+                       'vm_spec': _GCP_AWS_VM_CONFIG}},
+          _COMPONENT, {})
+    self.assertEqual(str(cm.exception), (
+        'Unrecognized options were found in '
+        'test_component.default.static_vms[1]: fake_option.'))
+
+
+class BenchmarkConfigSpecTestCase(unittest.TestCase):
+
+  def setUp(self):
+    super(BenchmarkConfigSpecTestCase, self).setUp()
+    self._spec_class = benchmark_config_spec.BenchmarkConfigSpec
+    self._description = 'Test description.'
+    self._vm_groups = {'default': {'cloud': providers.GCP,
+                                   'os_type': os_types.DEBIAN,
+                                   'vm_spec': _GCP_AWS_VM_CONFIG}}
+    self._kwargs = {'description': self._description,
+                    'vm_groups': self._vm_groups}
+
+  def testValidInput(self):
+    result = self._spec_class(_COMPONENT, flag_values=flags.FLAGS,
+                              **self._kwargs)
+    self.assertIsInstance(result, benchmark_config_spec.BenchmarkConfigSpec)
+    self.assertEqual(result.description, 'Test description.')
+    self.assertIsInstance(result.flags, dict)
+    self.assertEqual(sorted(result.flags.keys()),
+                     sorted(flags.FLAGS.FlagDict().keys()))
+    self.assertIsNot(result.flags, flags.FLAGS.FlagDict())
+    self.assertIsInstance(result.vm_groups, dict)
+    self.assertEqual(len(result.vm_groups), 1)
+    self.assertIsInstance(result.vm_groups['default'],
+                          benchmark_config_spec._VmGroupSpec)
+    self.assertEqual(result.vm_groups['default'].cloud, 'GCP')
+    self.assertEqual(result.vm_groups['default'].os_type, 'debian')
+    self.assertIsInstance(result.vm_groups['default'].vm_spec,
+                          gce_virtual_machine.GceVmSpec)
+
+  def testInvalidVmGroups(self):
+    self._kwargs['vm_groups']['default']['static_vms'] = [{'disk_specs': [{
+        'disk_size': 0.5}]}]
+    with self.assertRaises(errors.Config.InvalidValue) as cm:
+      self._spec_class(_COMPONENT, flag_values=flags.FLAGS, **self._kwargs)
+    self.assertEqual(str(cm.exception), (
+        'Invalid test_component.vm_groups.default.static_vms[0].disk_specs[0]'
+        '.disk_size value: "0.5" (of type "float"). Value must be one of the '
+        'following types: NoneType, int.'))
+
+  def testFlagOverridesPropagate(self):
+    self._kwargs['flags'] = {'cloud': providers.AWS}
+    result = self._spec_class(_COMPONENT, flag_values=flags.FLAGS,
+                              **self._kwargs)
+    self.assertIsInstance(result, benchmark_config_spec.BenchmarkConfigSpec)
+    self.assertEqual(result.description, 'Test description.')
+    self.assertIsInstance(result.flags, dict)
+    self.assertEqual(sorted(result.flags.keys()),
+                     sorted(flags.FLAGS.FlagDict().keys()))
+    self.assertIsNot(result.flags, flags.FLAGS.FlagDict())
+    self.assertEqual(result.flags['cloud'].value, 'AWS')
+    self.assertEqual(flags.FLAGS['cloud'].value, 'GCP')
+    self.assertIsInstance(result.vm_groups, dict)
+    self.assertEqual(len(result.vm_groups), 1)
+    self.assertIsInstance(result.vm_groups['default'],
+                          benchmark_config_spec._VmGroupSpec)
+    self.assertEqual(result.vm_groups['default'].cloud, 'AWS')
+    self.assertEqual(result.vm_groups['default'].os_type, 'debian')
+    self.assertIsInstance(result.vm_groups['default'].vm_spec,
+                          virtual_machine.BaseVmSpec)
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
Part of a solution to #787.
Creating a BenchmarkConfigSpec performs verification on inputs for a
benchmark run, including creation of sub-spec objects like the VM and
disk specs and the input-checking that they contain. In a separate PR,
the creation of the BenchmarkConfigSpec will be moved out of the
`BenchmarkSpec.__init__` to before the call to RunBenchmark so that the
inputs of all configured benchmark runs can be verified before any
benchmark is started.