### PR TITLE
Change MockFlags to be more like the real FlagValues.

### DIFF
--- a/tests/background_cpu_test.py
+++ b/tests/background_cpu_test.py
@@ -72,8 +72,8 @@ class TestBackgroundWorkload(unittest.TestCase):
     """ windows vm with background_cpu_threads raises exception """
     with mock_flags.PatchFlags() as mocked_flags:
       self.setupCommonFlags(mocked_flags)
-      mocked_flags.background_cpu_threads = 1
-      mocked_flags.os_type = os_types.WINDOWS
+      mocked_flags['background_cpu_threads'].Parse(1)
+      mocked_flags['os_type'].Parse(os_types.WINDOWS)
       config = configs.LoadConfig(ping_benchmark.BENCHMARK_CONFIG, {}, NAME)
       spec = benchmark_spec.BenchmarkSpec(config, NAME, UID)
       spec.ConstructVirtualMachines()
@@ -88,7 +88,7 @@ class TestBackgroundWorkload(unittest.TestCase):
     """ Check that the background_cpu_threads causes calls """
     with mock_flags.PatchFlags() as mocked_flags:
       self.setupCommonFlags(mocked_flags)
-      mocked_flags.background_cpu_threads = 1
+      mocked_flags['background_cpu_threads'].Parse(1)
       config = configs.LoadConfig(ping_benchmark.BENCHMARK_CONFIG, {}, NAME)
       spec = benchmark_spec.BenchmarkSpec(config, NAME, UID)
       spec.ConstructVirtualMachines()
@@ -110,8 +110,7 @@ class TestBackgroundWorkload(unittest.TestCase):
     """ Test that nothing happens with the vanilla config """
     with mock_flags.PatchFlags() as mocked_flags:
       self.setupCommonFlags(mocked_flags)
-      mocked_flags.os_type = os_types.WINDOWS
-      mocked_flags.background_cpu_threads = None
+      mocked_flags['os_type'].Parse(os_types.WINDOWS)
       config = configs.LoadConfig(ping_benchmark.BENCHMARK_CONFIG, {}, NAME)
       spec = benchmark_spec.BenchmarkSpec(config, NAME, UID)
       spec.ConstructVirtualMachines()
@@ -126,7 +125,7 @@ class TestBackgroundWorkload(unittest.TestCase):
     """ Check that the background_cpu_threads flags overrides the config """
     with mock_flags.PatchFlags() as mocked_flags:
       self.setupCommonFlags(mocked_flags)
-      mocked_flags.background_cpu_threads = 2
+      mocked_flags['background_cpu_threads'].Parse(2)
       config = configs.LoadConfig(ping_benchmark.BENCHMARK_CONFIG, {}, NAME)
       spec = benchmark_spec.BenchmarkSpec(config, NAME, UID)
       spec.ConstructVirtualMachines()

--- a/tests/background_network_workload_test.py
+++ b/tests/background_network_workload_test.py
@@ -119,8 +119,8 @@ class TestBackgroundNetworkWorkload(unittest.TestCase):
 
   def testWindowsVMCausesError(self):
     """ windows vm with background_network_mbits_per_sec raises exception """
-    self.mocked_flags.background_network_mbits_per_sec = 200
-    self.mocked_flags.os_type = os_types.WINDOWS
+    self.mocked_flags['background_network_mbits_per_sec'].Parse(200)
+    self.mocked_flags['os_type'].Parse(os_types.WINDOWS)
     spec = self.makeSpec()
     with self.assertRaisesRegexp(Exception, 'NotImplementedError'):
       spec.Prepare()
@@ -131,7 +131,7 @@ class TestBackgroundNetworkWorkload(unittest.TestCase):
 
   def testBackgroundWorkloadVM(self):
     """ Check that the vm background workload calls work """
-    self.mocked_flags.background_network_mbits_per_sec = 200
+    self.mocked_flags['background_network_mbits_per_sec'].Parse(200)
     spec = self.makeSpec()
     self._CheckVMFromSpec(spec, 2)
 
@@ -155,7 +155,7 @@ class TestBackgroundNetworkWorkload(unittest.TestCase):
 
   def testBackgroundWorkloadVanillaConfigFlag(self):
     """ Check that the flag overrides the config """
-    self.mocked_flags.background_network_mbits_per_sec = 200
+    self.mocked_flags['background_network_mbits_per_sec'].Parse(200)
     spec = self.makeSpec()
     for vm in spec.vms:
       self.assertEqual(vm.background_network_mbits_per_sec, 200)
@@ -164,8 +164,8 @@ class TestBackgroundNetworkWorkload(unittest.TestCase):
 
   def testBackgroundWorkloadVanillaConfigFlagIpType(self):
     """ Check that the flag overrides the config """
-    self.mocked_flags.background_network_mbits_per_sec = 200
-    self.mocked_flags.background_network_ip_type = 'INTERNAL'
+    self.mocked_flags['background_network_mbits_per_sec'].Parse(200)
+    self.mocked_flags['background_network_ip_type'].Parse('INTERNAL')
     spec = self.makeSpec()
     for vm in spec.vms:
       self.assertEqual(vm.background_network_mbits_per_sec, 200)
@@ -174,8 +174,8 @@ class TestBackgroundNetworkWorkload(unittest.TestCase):
 
   def testBackgroundWorkloadVanillaConfigBadIpTypeFlag(self):
     """ Check that the flag overrides the config """
-    self.mocked_flags.background_network_mbits_per_sec = 200
-    self.mocked_flags.background_network_ip_type = 'IAMABADFLAGVALUE'
+    self.mocked_flags['background_network_mbits_per_sec'].Parse(200)
+    self.mocked_flags['background_network_ip_type'].Parse('IAMABADFLAGVALUE')
     config = configs.LoadConfig(ping_benchmark.BENCHMARK_CONFIG, {}, NAME)
     spec = benchmark_spec.BenchmarkSpec(config, NAME, UID)
     with self.assertRaises(errors.Config.InvalidValue):

--- a/tests/disk_test.py
+++ b/tests/disk_test.py
@@ -101,10 +101,10 @@ class BaseDiskSpecTestCase(unittest.TestCase):
 
   def testPresentFlagsOverrideConfigs(self):
     flags = mock_flags.MockFlags()
-    flags.data_disk_size = 100
-    flags.data_disk_type = 'flag_disk_type'
-    flags.num_striped_disks = 3
-    flags.scratch_dir = '/flag_scratch_dir'
+    flags['data_disk_size'].Parse(100)
+    flags['data_disk_type'].Parse('flag_disk_type')
+    flags['num_striped_disks'].Parse(3)
+    flags['scratch_dir'].Parse('/flag_scratch_dir')
     spec = disk.BaseDiskSpec(
         _COMPONENT, flags, device_path='config_device_path', disk_number=1,
         disk_size=75, disk_type='config_disk_type', mount_point='/mountpoint',

--- a/tests/gce_virtual_machine_test.py
+++ b/tests/gce_virtual_machine_test.py
@@ -155,7 +155,7 @@ class GceVmSpecTestCase(unittest.TestCase):
 
   def testStringMachineTypeFlagOverride(self):
     flags = mock_flags.MockFlags()
-    flags.machine_type = 'n1-standard-8'
+    flags['machine_type'].Parse('n1-standard-8')
     result = gce_virtual_machine.GceVmSpec(
         _COMPONENT, flag_values=flags,
         machine_type={'cpus': 1, 'memory': '7.5GiB'})
@@ -165,7 +165,7 @@ class GceVmSpecTestCase(unittest.TestCase):
 
   def testCustomMachineTypeFlagOverride(self):
     flags = mock_flags.MockFlags()
-    flags.machine_type = '{cpus: 1, memory: 7.5GiB}'
+    flags['machine_type'].Parse('{cpus: 1, memory: 7.5GiB}')
     result = gce_virtual_machine.GceVmSpec(
         _COMPONENT, flag_values=flags, machine_type='n1-standard-8')
     self.assertEqual(result.machine_type, None)
@@ -236,7 +236,7 @@ class GCEVMFlagsTestCase(unittest.TestCase):
   def testPreemptibleVMFlag(self):
     with self._PatchCriticalObjects() as mocked_env:
       issue_command, mocked_flags = mocked_env
-      mocked_flags.gce_preemptible_vms = True
+      mocked_flags['gce_preemptible_vms'].Parse(True)
       vm_spec = gce_virtual_machine.GceVmSpec(
           'test_vm_spec.GCP', mocked_flags, image='image',
           machine_type='test_machine_type')

--- a/tests/mock_flags_test.py
+++ b/tests/mock_flags_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Tests for tests.mock_flags."""
 
+import copy
 import unittest
 
 from perfkitbenchmarker import flags
@@ -35,11 +36,32 @@ class MockFlagsTestCase(unittest.TestCase):
     self.assertFalse(flag.present)
     self.assertIsNone(flag.value)
 
-  def testSetAndGetFlag(self):
+  def testSetViaAttribute(self):
     self.flags.test_flag = 5
     self.assertEqual(self.flags.test_flag, 5)
+    self.assertFalse(self.flags['test_flag'].present)
+    self.assertEqual(self.flags['test_flag'].value, 5)
+
+  def testSetViaItemAttribute(self):
+    self.flags['test_flag'].value = 5
+    self.assertFalse(self.flags['test_flag'].present)
+    self.assertEqual(self.flags['test_flag'].value, 5)
+    self.flags['test_flag'].present = True
     self.assertTrue(self.flags['test_flag'].present)
     self.assertEqual(self.flags['test_flag'].value, 5)
+
+  def testSetViaParse(self):
+    self.flags['test_flag'].Parse(5)
+    self.assertTrue(self.flags['test_flag'].present)
+    self.assertEqual(self.flags['test_flag'].value, 5)
+
+  def testCopy(self):
+    copied_flags = copy.deepcopy(self.flags)
+    copied_flags['test_flag'].Parse(5)
+    self.assertFalse(self.flags['test_flag'].present)
+    self.assertIsNone(self.flags['test_flag'].value)
+    self.assertTrue(copied_flags['test_flag'].present)
+    self.assertEqual(copied_flags['test_flag'].value, 5)
 
 
 class PatchFlagsTestCase(unittest.TestCase):
@@ -49,7 +71,7 @@ class PatchFlagsTestCase(unittest.TestCase):
     self.flags = mock_flags.MockFlags()
 
   def testGetFlag(self):
-    self.flags.test_flag = 5
+    self.flags['test_flag'].Parse(5)
     with mock_flags.PatchFlags(self.flags):
       self.assertEqual(FLAGS.test_flag, 5)
       self.assertTrue(FLAGS['test_flag'].present)
@@ -73,6 +95,18 @@ class PatchFlagsTestCase(unittest.TestCase):
     self.assertEqual(FLAGS.test_flag, 0)
     self.assertFalse(FLAGS['test_flag'].present)
     self.assertEqual(FLAGS['test_flag'].value, 0)
+
+  def testCopyPatchedFlags(self):
+    with mock_flags.PatchFlags(self.flags):
+      FLAGS.test_flag = 1
+      copied_flags = copy.deepcopy(FLAGS)
+      copied_flags.test_flag = 2
+      self.assertEqual(FLAGS.test_flag, 1)
+      self.assertEqual(self.flags.test_flag, 1)
+      self.assertEqual(copied_flags.test_flag, 2)
+    self.assertEqual(FLAGS.test_flag, 0)
+    self.assertEqual(self.flags.test_flag, 1)
+    self.assertEqual(copied_flags.test_flag, 2)
 
 
 class PatchTestCaseFlagsTestCase(unittest.TestCase):

--- a/tests/providers/aws/aws_disk_test.py
+++ b/tests/providers/aws/aws_disk_test.py
@@ -66,8 +66,8 @@ class AwsDiskSpecTestCase(unittest.TestCase):
 
   def testPresentFlagsOverrideConfigs(self):
     flags = mock_flags.MockFlags()
-    flags.aws_provisioned_iops = 2000
-    flags.data_disk_size = 100
+    flags['aws_provisioned_iops'].Parse(2000)
+    flags['data_disk_size'].Parse(100)
     spec = aws_disk.AwsDiskSpec(_COMPONENT, flags, disk_size=75, iops=1000)
     self.assertEqual(spec.disk_size, 100)
     self.assertEqual(spec.iops, 2000)


### PR DESCRIPTION
Handles use cases of ```FlagValues``` that were previously unsupported, such
as deep-copying the ```FlagValues``` or substituting the inner flag dictionary.

Changes the behavior of the ```MockFlags.__setattr__``` to no longer set the
present attribute (to be more like the real ```FlagValues.__setattr__```). The new
way to set both the value and present attributes is to use
`MockFlags[<flag_name>].Parse(<value>)`.