### PR TITLE
Always parse flags

### DIFF
--- a/perfkitbenchmarker/configs/__init__.py
+++ b/perfkitbenchmarker/configs/__init__.py
@@ -220,8 +220,7 @@ def GetMergedFlags(config):
       if key not in flags_values:
         raise ValueError('Flag "%s" is not defined.' % key)
       if not flags_values[key].present:
-        flags_values[key].value = value
-        flags_values[key].present += 1
+        flags_values[key].Parse(value)
 
   return flags_values
 

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -21,7 +21,10 @@ import mock
 from perfkitbenchmarker import linux_benchmarks
 from perfkitbenchmarker import configs
 from perfkitbenchmarker import errors
+from perfkitbenchmarker import flags
 from perfkitbenchmarker import windows_benchmarks
+
+FLAGS = flags.FLAGS
 
 CONFIG_NAME = 'a'
 INVALID_NAME = 'b'
@@ -62,6 +65,11 @@ a:
   vm_groups:
     default:
       vm_spec: *anchor_does_not_exist
+"""
+LIST_FLAG_CONFIG = """
+a:
+  flags:
+    list_flag: a,b,c
 """
 
 
@@ -129,3 +137,13 @@ class ConfigsTestCase(unittest.TestCase):
     config = configs.GetUserConfig()
     self.assertEqual(config['a']['vm_groups']['default']['vm_count'], 5)
     self.assertEqual(config['a']['flags']['flag'], 'value')
+
+  def testConfigFlagStillParsed(self):
+    flags.DEFINE_list('list_flag', ['default_val'], 'List flag.')
+    list_flag_config = yaml.load(LIST_FLAG_CONFIG)
+    flag_values = configs.GetMergedFlags(list_flag_config['a'])
+
+    self.assertEqual(flag_values.list_flag,
+                     ['a', 'b', 'c'])
+
+    del FLAGS.list_flag


### PR DESCRIPTION
Use gflags parsers for flags, even when those flags come from a YAML
config file.