### PR TITLE
Move BenchmarkConfigSpec construction to before RunBenchmark.

### DIFF
--- a/perfkitbenchmarker/benchmark_spec.py
+++ b/perfkitbenchmarker/benchmark_spec.py
@@ -35,7 +35,6 @@ from perfkitbenchmarker import providers
 from perfkitbenchmarker import static_virtual_machine as static_vm
 from perfkitbenchmarker import virtual_machine
 from perfkitbenchmarker import vm_util
-from perfkitbenchmarker.configs import benchmark_config_spec
 
 
 def PickleLock(lock):
@@ -83,17 +82,13 @@ class BenchmarkSpec(object):
     """Initialize a BenchmarkSpec object.
 
     Args:
-      benchmark_config: A Python dictionary representation of the configuration
-        for the benchmark. For a complete explanation, see
-        perfkitbenchmarker/configs/__init__.py.
+      benchmark_config: BenchmarkConfigSpec. The configuration for the
+          benchmark.
       benchmark_name: string. Name of the benchmark.
       benchmark_uid: An identifier unique to this run of the benchmark even
-        if the same benchmark is run multiple times with different configs.
+          if the same benchmark is run multiple times with different configs.
     """
-    # TODO(skschneider): Build the BenchmarkConfigSpec outside of this method,
-    # and pass it in.
-    self.config = benchmark_config_spec.BenchmarkConfigSpec(
-        benchmark_name, flag_values=FLAGS, **benchmark_config)
+    self.config = benchmark_config
     self.name = benchmark_name
     self.uid = benchmark_uid
     self.vms = []

--- a/perfkitbenchmarker/configs/__init__.py
+++ b/perfkitbenchmarker/configs/__init__.py
@@ -54,6 +54,10 @@ Valid VM group keys:
 
 For valid VM spec keys, see virtual_machine.BaseVmSpec and derived classes.
 For valid disk spec keys, see disk.BaseDiskSpec and derived classes.
+
+See configs.spec.BaseSpec for more information about adding additional keys to
+VM specs, disk specs, or any component of the benchmark configuration
+dictionary.
 """
 
 import copy
@@ -80,37 +84,6 @@ flags.DEFINE_multistring(
     'a higher priority than that config. The value of the flag should be '
     'fully.qualified.key=value (e.g. --config_override=cluster_boot.vm_groups.'
     'default.vm_count=4). This flag can be repeated.')
-
-# Config keys.
-VM_GROUPS = 'vm_groups'
-DESCRIPTION = 'description'
-CONFIG_FLAGS = 'flags'
-CONFIG_VALUE_TYPES = {
-    VM_GROUPS: [dict],
-    DESCRIPTION: [str],
-    CONFIG_FLAGS: [dict]
-}
-VALID_CONFIG_KEYS = frozenset(CONFIG_VALUE_TYPES.keys())
-REQUIRED_CONFIG_KEYS = frozenset([VM_GROUPS])
-# Group keys.
-VM_SPEC = 'vm_spec'
-DISK_SPEC = 'disk_spec'
-VM_COUNT = 'vm_count'
-DISK_COUNT = 'disk_count'
-CLOUD = 'cloud'
-OS_TYPE = 'os_type'
-STATIC_VMS = 'static_vms'
-GROUP_VALUE_TYPES = {
-    VM_SPEC: [dict],
-    DISK_SPEC: [dict],
-    VM_COUNT: [int, type(None)],
-    DISK_COUNT: [int],
-    CLOUD: [str],
-    OS_TYPE: [str],
-    STATIC_VMS: [list]
-}
-VALID_GROUP_KEYS = frozenset(GROUP_VALUE_TYPES.keys())
-REQUIRED_GROUP_KEYS = frozenset([VM_SPEC])
 
 
 def _LoadUserConfig(path):
@@ -210,22 +183,6 @@ def MergeConfigs(default_config, override_config, warn_new_key=False):
     return default_config
 
 
-def GetMergedFlags(config):
-  """Returns a copy of the flags.FLAGS merged with those in the config."""
-  config_flags = config.get('flags')
-  flags_values = copy.deepcopy(flags.FLAGS)
-
-  if config_flags:
-    for key, value in config_flags.iteritems():
-      if key not in flags_values:
-        raise ValueError('Flag "%s" is not defined.' % key)
-      if not flags_values[key].present:
-        flags_values[key].value = value
-        flags_values[key].present += 1
-
-  return flags_values
-
-
 def LoadMinimalConfig(benchmark_config, benchmark_name):
   """Loads a benchmark config without using any flags in the process.
 
@@ -259,62 +216,6 @@ def LoadMinimalConfig(benchmark_config, benchmark_name):
   return config[benchmark_name]
 
 
-def _ValidateGroup(group_name, group):
-  """Raises an exception if the group config is not valid."""
-  group_keys = frozenset(group.keys())
-
-  invalid_group_keys = group_keys - VALID_GROUP_KEYS
-  if invalid_group_keys:
-    raise ValueError(
-        'Invalid key(s) found in group "%s": %s' %
-        (group_name, ' '.join(invalid_group_keys)))
-
-  missing_group_keys = REQUIRED_GROUP_KEYS - group_keys
-  if missing_group_keys:
-    raise ValueError(
-        'Missing required key(s) in group "%s": %s' %
-        (group_name, ' '.join(missing_group_keys)))
-
-  bad_types = []
-  for key in group_keys:
-    value_type = type(group[key])
-    if value_type not in GROUP_VALUE_TYPES[key]:
-      bad_types.append('Key:%s Value Type: %s Expected Type(s): %s' %
-                       (key, value_type, GROUP_VALUE_TYPES[key]))
-  if bad_types:
-    raise ValueError(
-        'Value(s) in group "%s" didn\'t match expected type(s): %s' %
-        (group_name, ','.join(bad_types)))
-
-
-def _ValidateConfig(config):
-  """Raises an exception if the config is not valid."""
-  config_keys = frozenset(config.keys())
-
-  invalid_config_keys = config_keys - VALID_CONFIG_KEYS
-  if invalid_config_keys:
-    raise ValueError('Invalid key(s) found in config: %s' %
-                     ' '.join(invalid_config_keys))
-
-  missing_config_keys = REQUIRED_CONFIG_KEYS - config_keys
-  if missing_config_keys:
-    raise ValueError('Missing required key(s) in config: %s' %
-                     ' '.join(missing_config_keys))
-  bad_types = []
-  for key in config_keys:
-    value_type = type(config[key])
-    if value_type not in CONFIG_VALUE_TYPES[key]:
-      bad_types.append('Key:%s Value Type: %s Expected Type(s): %s' %
-                       (key, value_type, CONFIG_VALUE_TYPES[key]))
-  if bad_types:
-    raise ValueError(
-        "Values(s) didn't match expected type(s): %s" % ','.join(bad_types))
-
-
-  for group_name, group in config[VM_GROUPS].iteritems():
-    _ValidateGroup(group_name, group)
-
-
 def LoadConfig(benchmark_config, user_config, benchmark_name):
   """Loads a benchmark configuration.
 
@@ -333,7 +234,4 @@ def LoadConfig(benchmark_config, user_config, benchmark_name):
   """
   config = LoadMinimalConfig(benchmark_config, benchmark_name)
   config = MergeConfigs(config, user_config, warn_new_key=True)
-
-  _ValidateConfig(config)
-
   return config

--- a/perfkitbenchmarker/configs/benchmark_config_spec.py
+++ b/perfkitbenchmarker/configs/benchmark_config_spec.py
@@ -11,7 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Classes that verify and transform benchmark configuration input."""
+"""Classes that verify and transform benchmark configuration input.
+
+See perfkitbenchmarker/configs/__init__.py for more information about
+configuration files.
+"""
 
 import copy
 import os
@@ -282,7 +286,7 @@ class BenchmarkConfigSpec(spec.BaseSpec):
   """Configurable options of a benchmark run.
 
   Attributes:
-    description: string. Description of the benchmark to run.
+    description: None or string. Description of the benchmark to run.
     flags: flags.FlagValues. Values to use for each flag while executing the
         benchmark.
     vm_groups: dict mapping VM group name string to _VmGroupSpec. Configurable
@@ -302,14 +306,10 @@ class BenchmarkConfigSpec(spec.BaseSpec):
       to construct in order to decode the named option.
     """
     result = super(BenchmarkConfigSpec, cls)._GetOptionDecoderConstructions()
-    result.update({'description': (option_decoders.StringDecoder, {}),
-                   'flags': (_FlagsDecoder, {}),
-                   'vm_groups': (_VmGroupsDecoder, {})})
-    # TODO(skschneider): Old tests construct BenchmarkSpec without providing a
-    # description or vm_groups, but they should be required. As a separate
-    # change, those tests should be fixed, and the two lines should be removed.
-    result['description'][1]['default'] = None
-    result['vm_groups'][1]['default'] = None
+    result.update({
+        'description': (option_decoders.StringDecoder, {'default': None}),
+        'flags': (_FlagsDecoder, {}),
+        'vm_groups': (_VmGroupsDecoder, {})})
     return result
 
   def _DecodeAndInit(self, component_full_name, config, decoders, flag_values):

--- a/perfkitbenchmarker/test_util.py
+++ b/perfkitbenchmarker/test_util.py
@@ -16,7 +16,13 @@
 import os
 
 from perfkitbenchmarker import benchmark_spec
+from perfkitbenchmarker import flags
 from perfkitbenchmarker import sample
+from perfkitbenchmarker.configs import benchmark_config_spec
+
+
+_BENCHMARK_NAME = 'test_benchmark'
+_BENCHMARK_UID = 'uid'
 
 
 class SamplesTestMixin(object):
@@ -97,7 +103,10 @@ def assertDiskMounts(benchmark_config, mount_point):
   vm_group = benchmark_config['vm_groups'].itervalues().next()
   assert vm_group.get('num_vms', 1) == 1
 
-  spec = benchmark_spec.BenchmarkSpec(benchmark_config, 'test_benchmark', 'uid')
+  config_spec = benchmark_config_spec.BenchmarkConfigSpec(
+      _BENCHMARK_NAME, flag_values=flags.FLAGS, **benchmark_config)
+  spec = benchmark_spec.BenchmarkSpec(config_spec, _BENCHMARK_NAME,
+                                      _BENCHMARK_UID)
   with spec.RedirectGlobalFlags():
     try:
       spec.ConstructVirtualMachines()

--- a/tests/background_cpu_test.py
+++ b/tests/background_cpu_test.py
@@ -14,14 +14,19 @@
 
 """Tests for background cpu workload """
 
+import unittest
+
 from mock import patch
+
 from perfkitbenchmarker import benchmark_spec
 from perfkitbenchmarker import configs
+from perfkitbenchmarker import context
 from perfkitbenchmarker import os_types
 from perfkitbenchmarker import providers
+from perfkitbenchmarker.configs import benchmark_config_spec
 from perfkitbenchmarker.linux_benchmarks import ping_benchmark
 from tests import mock_flags
-import unittest
+
 
 NAME = 'ping'
 UID = 'name0'
@@ -44,9 +49,17 @@ ping:
 
 class TestBackgroundWorkload(unittest.TestCase):
 
-  def setupCommonFlags(self, mock_flags):
-    mock_flags.os_type = os_types.DEBIAN
-    mock_flags.cloud = providers.GCP
+  def setUp(self):
+    self._mocked_flags = mock_flags.PatchTestCaseFlags(self)
+    self._mocked_flags.cloud = providers.GCP
+    self._mocked_flags.os_type = os_types.DEBIAN
+    self.addCleanup(context.SetThreadBenchmarkSpec, None)
+
+  def _CreateBenchmarkSpec(self, benchmark_config_yaml):
+    config = configs.LoadConfig(benchmark_config_yaml, {}, NAME)
+    config_spec = benchmark_config_spec.BenchmarkConfigSpec(
+        NAME, flag_values=self._mocked_flags, **config)
+    return benchmark_spec.BenchmarkSpec(config_spec, NAME, UID)
 
   def _CheckVMFromSpec(self, spec, num_working):
     vm0 = spec.vms[0]
@@ -67,85 +80,64 @@ class TestBackgroundWorkload(unittest.TestCase):
       self.assertEqual(vm0.RemoteCommand.call_count,
                        expected_remote_post_stop)
 
-
   def testWindowsVMCausesError(self):
     """ windows vm with background_cpu_threads raises exception """
-    with mock_flags.PatchFlags() as mocked_flags:
-      self.setupCommonFlags(mocked_flags)
-      mocked_flags['background_cpu_threads'].Parse(1)
-      mocked_flags['os_type'].Parse(os_types.WINDOWS)
-      config = configs.LoadConfig(ping_benchmark.BENCHMARK_CONFIG, {}, NAME)
-      spec = benchmark_spec.BenchmarkSpec(config, NAME, UID)
-      spec.ConstructVirtualMachines()
-      with self.assertRaisesRegexp(Exception, 'NotImplementedError'):
-        spec.Prepare()
-      with self.assertRaisesRegexp(Exception, 'NotImplementedError'):
-        spec.StartBackgroundWorkload()
-      with self.assertRaisesRegexp(Exception, 'NotImplementedError'):
-        spec.StopBackgroundWorkload()
+    self._mocked_flags['background_cpu_threads'].Parse(1)
+    self._mocked_flags['os_type'].Parse(os_types.WINDOWS)
+    spec = self._CreateBenchmarkSpec(ping_benchmark.BENCHMARK_CONFIG)
+    spec.ConstructVirtualMachines()
+    with self.assertRaisesRegexp(Exception, 'NotImplementedError'):
+      spec.Prepare()
+    with self.assertRaisesRegexp(Exception, 'NotImplementedError'):
+      spec.StartBackgroundWorkload()
+    with self.assertRaisesRegexp(Exception, 'NotImplementedError'):
+      spec.StopBackgroundWorkload()
 
   def testBackgroundWorkloadVM(self):
     """ Check that the background_cpu_threads causes calls """
-    with mock_flags.PatchFlags() as mocked_flags:
-      self.setupCommonFlags(mocked_flags)
-      mocked_flags['background_cpu_threads'].Parse(1)
-      config = configs.LoadConfig(ping_benchmark.BENCHMARK_CONFIG, {}, NAME)
-      spec = benchmark_spec.BenchmarkSpec(config, NAME, UID)
-      spec.ConstructVirtualMachines()
-      self._CheckVMFromSpec(spec, 2)
+    self._mocked_flags['background_cpu_threads'].Parse(1)
+    spec = self._CreateBenchmarkSpec(ping_benchmark.BENCHMARK_CONFIG)
+    spec.ConstructVirtualMachines()
+    self._CheckVMFromSpec(spec, 2)
 
   def testBackgroundWorkloadVanillaConfig(self):
     """ Test that nothing happens with the vanilla config """
-    with mock_flags.PatchFlags() as mocked_flags:
-      self.setupCommonFlags(mocked_flags)
-      config = configs.LoadConfig(ping_benchmark.BENCHMARK_CONFIG, {}, NAME)
-      spec = benchmark_spec.BenchmarkSpec(config, NAME, UID)
-      spec.ConstructVirtualMachines()
-      for vm in spec.vms:
-        self.assertIsNone(vm.background_cpu_threads)
-        self.assertIsNone(vm.background_network_mbits_per_sec)
-      self._CheckVMFromSpec(spec, 0)
+    spec = self._CreateBenchmarkSpec(ping_benchmark.BENCHMARK_CONFIG)
+    spec.ConstructVirtualMachines()
+    for vm in spec.vms:
+      self.assertIsNone(vm.background_cpu_threads)
+      self.assertIsNone(vm.background_network_mbits_per_sec)
+    self._CheckVMFromSpec(spec, 0)
 
   def testBackgroundWorkloadWindows(self):
     """ Test that nothing happens with the vanilla config """
-    with mock_flags.PatchFlags() as mocked_flags:
-      self.setupCommonFlags(mocked_flags)
-      mocked_flags['os_type'].Parse(os_types.WINDOWS)
-      config = configs.LoadConfig(ping_benchmark.BENCHMARK_CONFIG, {}, NAME)
-      spec = benchmark_spec.BenchmarkSpec(config, NAME, UID)
-      spec.ConstructVirtualMachines()
-
-      for vm in spec.vms:
-        self.assertIsNone(vm.background_cpu_threads)
-        self.assertIsNone(vm.background_network_mbits_per_sec)
-      self._CheckVMFromSpec(spec, 0)
-
+    self._mocked_flags['os_type'].Parse(os_types.WINDOWS)
+    spec = self._CreateBenchmarkSpec(ping_benchmark.BENCHMARK_CONFIG)
+    spec.ConstructVirtualMachines()
+    for vm in spec.vms:
+      self.assertIsNone(vm.background_cpu_threads)
+      self.assertIsNone(vm.background_network_mbits_per_sec)
+    self._CheckVMFromSpec(spec, 0)
 
   def testBackgroundWorkloadVanillaConfigFlag(self):
     """ Check that the background_cpu_threads flags overrides the config """
-    with mock_flags.PatchFlags() as mocked_flags:
-      self.setupCommonFlags(mocked_flags)
-      mocked_flags['background_cpu_threads'].Parse(2)
-      config = configs.LoadConfig(ping_benchmark.BENCHMARK_CONFIG, {}, NAME)
-      spec = benchmark_spec.BenchmarkSpec(config, NAME, UID)
-      spec.ConstructVirtualMachines()
-      for vm in spec.vms:
-        self.assertEqual(vm.background_cpu_threads, 2)
-      self._CheckVMFromSpec(spec, 2)
-
+    self._mocked_flags['background_cpu_threads'].Parse(2)
+    spec = self._CreateBenchmarkSpec(ping_benchmark.BENCHMARK_CONFIG)
+    spec.ConstructVirtualMachines()
+    for vm in spec.vms:
+      self.assertEqual(vm.background_cpu_threads, 2)
+    self._CheckVMFromSpec(spec, 2)
 
   def testBackgroundWorkloadConfig(self):
     """ Check that the config can be used to set background_cpu_threads """
-    with mock_flags.PatchFlags() as mocked_flags:
-      self.setupCommonFlags(mocked_flags)
-      config = configs.LoadConfig(CONFIG_WITH_BACKGROUND_CPU, {}, NAME)
-      spec = benchmark_spec.BenchmarkSpec(config, NAME, UID)
-      spec.ConstructVirtualMachines()
-      for vm in spec.vm_groups['vm_1']:
-        self.assertIsNone(vm.background_cpu_threads)
-      for vm in spec.vm_groups['vm_2']:
-        self.assertEqual(vm.background_cpu_threads, 3)
-      self._CheckVMFromSpec(spec, 1)
+    spec = self._CreateBenchmarkSpec(CONFIG_WITH_BACKGROUND_CPU)
+    spec.ConstructVirtualMachines()
+    for vm in spec.vm_groups['vm_1']:
+      self.assertIsNone(vm.background_cpu_threads)
+    for vm in spec.vm_groups['vm_2']:
+      self.assertEqual(vm.background_cpu_threads, 3)
+    self._CheckVMFromSpec(spec, 1)
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/tests/gce_virtual_machine_test.py
+++ b/tests/gce_virtual_machine_test.py
@@ -21,11 +21,16 @@ import unittest
 from perfkitbenchmarker import benchmark_spec
 from perfkitbenchmarker import context
 from perfkitbenchmarker import errors
+from perfkitbenchmarker import os_types
+from perfkitbenchmarker import providers
 from perfkitbenchmarker import vm_util
+from perfkitbenchmarker.configs import benchmark_config_spec
 from perfkitbenchmarker.providers.gcp import gce_virtual_machine
 from tests import mock_flags
 
 
+_BENCHMARK_NAME = 'name'
+_BENCHMARK_UID = 'benchmark_uid'
 _COMPONENT = 'test_component'
 _FLAGS = None
 
@@ -217,28 +222,32 @@ class GceVirtualMachineTestCase(unittest.TestCase):
 class GCEVMFlagsTestCase(unittest.TestCase):
 
   def setUp(self):
-    # VM Creation depends on there being a BenchmarkSpec.
-    self.spec = benchmark_spec.BenchmarkSpec({}, 'name', 'benchmark_uid')
+    self._mocked_flags = mock_flags.PatchTestCaseFlags(self)
+    self._mocked_flags.cloud = providers.GCP
+    self._mocked_flags.gcloud_path = 'test_gcloud'
+    self._mocked_flags.os_type = os_types.DEBIAN
+    self._mocked_flags.run_uri = 'aaaaaa'
+    # Creating a VM object causes network objects to be added to the current
+    # thread's benchmark spec. Create such a benchmark spec for these tests.
     self.addCleanup(context.SetThreadBenchmarkSpec, None)
+    config_spec = benchmark_config_spec.BenchmarkConfigSpec(
+        _BENCHMARK_NAME, flag_values=self._mocked_flags, vm_groups={})
+    self._benchmark_spec = benchmark_spec.BenchmarkSpec(
+        config_spec, _BENCHMARK_NAME, _BENCHMARK_UID)
 
   @contextlib.contextmanager
   def _PatchCriticalObjects(self):
     """A context manager that patches a few critical objects with mocks."""
     with mock.patch(vm_util.__name__ + '.IssueCommand') as issue_command, \
             mock.patch('__builtin__.open'), \
-            mock.patch(vm_util.__name__ + '.NamedTemporaryFile'), \
-            mock_flags.PatchFlags() as mocked_flags:
-      mocked_flags.gcloud_path = 'test_gcloud'
-      mocked_flags.gcloud_scopes = None
-      mocked_flags.run_uri = 'aaaaaa'
-      yield issue_command, mocked_flags
+            mock.patch(vm_util.__name__ + '.NamedTemporaryFile'):
+      yield issue_command
 
   def testPreemptibleVMFlag(self):
-    with self._PatchCriticalObjects() as mocked_env:
-      issue_command, mocked_flags = mocked_env
-      mocked_flags['gce_preemptible_vms'].Parse(True)
+    with self._PatchCriticalObjects() as issue_command:
+      self._mocked_flags['gce_preemptible_vms'].Parse(True)
       vm_spec = gce_virtual_machine.GceVmSpec(
-          'test_vm_spec.GCP', mocked_flags, image='image',
+          'test_vm_spec.GCP', self._mocked_flags, image='image',
           machine_type='test_machine_type')
       vm = gce_virtual_machine.GceVirtualMachine(vm_spec)
       vm._Create()
@@ -247,11 +256,10 @@ class GCEVMFlagsTestCase(unittest.TestCase):
 
   def testImageProjectFlag(self):
     """Tests that custom image_project flag is supported."""
-    with self._PatchCriticalObjects() as mocked_env:
-      issue_command, mocked_flags = mocked_env
-      mocked_flags.image_project = 'bar'
+    with self._PatchCriticalObjects() as issue_command:
+      self._mocked_flags.image_project = 'bar'
       vm_spec = gce_virtual_machine.GceVmSpec(
-          'test_vm_spec.GCP', mocked_flags, image='image',
+          'test_vm_spec.GCP', self._mocked_flags, image='image',
           machine_type='test_machine_type')
       vm = gce_virtual_machine.GceVirtualMachine(vm_spec)
       vm._Create()

--- a/tests/providers_test.py
+++ b/tests/providers_test.py
@@ -19,7 +19,8 @@ import unittest
 import mock
 
 from perfkitbenchmarker import providers
-from perfkitbenchmarker import benchmark_spec
+from perfkitbenchmarker.configs import benchmark_config_spec
+from tests import mock_flags
 
 
 class LoadProvidersTestCase(unittest.TestCase):
@@ -32,7 +33,7 @@ class LoadProvidersTestCase(unittest.TestCase):
     with self.assertRaises(ImportError):
       providers.LoadProvider('InvalidCloud')
 
-  def testBenchmarkSpecLoadsProvider(self):
+  def testBenchmarkConfigSpecLoadsProvider(self):
     p = mock.patch(providers.__name__ + '.LoadProvider')
     p.start()
     self.addCleanup(p.stop)
@@ -40,11 +41,13 @@ class LoadProvidersTestCase(unittest.TestCase):
         'vm_groups': {
             'group1': {
                 'cloud': 'AWS',
+                'os_type': 'debian',
                 'vm_count': 0,
                 'vm_spec': {'AWS': {}}
             }
         }
     }
-    spec = benchmark_spec.BenchmarkSpec(config, 'name', 'uid')
-    spec.ConstructVirtualMachines()
+    with mock_flags.PatchFlags() as mocked_flags:
+      benchmark_config_spec.BenchmarkConfigSpec(
+          'name', flag_values=mocked_flags, **config)
     providers.LoadProvider.assert_called_with('aws')

--- a/tests/scratch_disk_test.py
+++ b/tests/scratch_disk_test.py
@@ -23,7 +23,10 @@ from perfkitbenchmarker import context
 from perfkitbenchmarker import disk
 from perfkitbenchmarker import errors
 from perfkitbenchmarker import linux_virtual_machine
+from perfkitbenchmarker import os_types
+from perfkitbenchmarker import providers
 from perfkitbenchmarker import virtual_machine
+from perfkitbenchmarker.configs import benchmark_config_spec
 from perfkitbenchmarker.providers.aws import aws_disk
 from perfkitbenchmarker.providers.aws import aws_virtual_machine
 from perfkitbenchmarker.providers.aws import util as aws_util
@@ -31,8 +34,11 @@ from perfkitbenchmarker.providers.azure import azure_disk
 from perfkitbenchmarker.providers.azure import azure_virtual_machine
 from perfkitbenchmarker.providers.gcp import gce_disk
 from perfkitbenchmarker.providers.gcp import gce_virtual_machine
+from tests import mock_flags
 
 
+_BENCHMARK_NAME = 'name'
+_BENCHMARK_UID = 'uid'
 _COMPONENT = 'test_component'
 
 
@@ -55,6 +61,9 @@ class ScratchDiskTestMixin(object):
     pass
 
   def setUp(self):
+    mocked_flags = mock_flags.PatchTestCaseFlags(self)
+    mocked_flags.cloud = providers.GCP
+    mocked_flags.os_type = os_types.DEBIAN
     self.patches = []
 
     vm_prefix = linux_virtual_machine.__name__ + '.BaseLinuxMixin'
@@ -79,7 +88,10 @@ class ScratchDiskTestMixin(object):
         lambda *args, **kwargs: mock.MagicMock(is_striped=False))
 
     # VM Creation depends on there being a BenchmarkSpec.
-    self.spec = benchmark_spec.BenchmarkSpec({}, 'name', 'uid')
+    config_spec = benchmark_config_spec.BenchmarkConfigSpec(
+        _BENCHMARK_NAME, flag_values=mocked_flags, vm_groups={})
+    self.spec = benchmark_spec.BenchmarkSpec(config_spec, _BENCHMARK_NAME,
+                                             _BENCHMARK_UID)
     self.addCleanup(context.SetThreadBenchmarkSpec, None)
 
   def testScratchDisks(self):


### PR DESCRIPTION
Check config input before starting any benchmark resource provisioning.
Change `BenchmarkSpec` constructor to accept a `BenchmarkConfigSpec`.
Remove previous input checking from `configs/__init__.py`.
Update tests that were constructing a `BenchmarkSpec` the old way.
Fix tests where the thread's `BenchmarkSpec` was not being reset.