### PR TITLE
Add os_type to cluster_boot benchmark

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/cluster_boot_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/cluster_boot_benchmark.py
@@ -58,7 +58,7 @@ def _GetTimeToBoot(vms, vm_index):
   """
   vm = vms[vm_index]
   metadata = {'num_cpus': vm.num_cpus, 'machine_instance': vm_index,
-              'num_vms': len(vms)}
+              'num_vms': len(vms), 'os_type': vm.OS_TYPE}
   metadata.update(vm.GetMachineTypeDict())
   assert vm.bootable_time
   assert vm.create_start_time


### PR DESCRIPTION
Unlike #824, makes no changes to what's measured, just adds `os_type` to the metadata for the `Boot Time` metric.

The metadata does already contain an `image` attribute, but determining the os type from the image is cloud-dependent.  