### PR TITLE
openstack: Pin novaclient and keystoneclient package versions

### DIFF
--- a/requirements-openstack.txt
+++ b/requirements-openstack.txt
@@ -14,4 +14,5 @@
 
 # Additional requirements (beyond those in requirements.txt) for running
 # PerfKitBenchmarker on OpenStack.
-python-novaclient
+python-keystoneclient==2.1.1
+python-novaclient==2.35.0


### PR DESCRIPTION
Addresses issue #819 

Tested on OpenStack Kilo. For future versions of OpenStack, from Liberty and up, the requirements have to be revisited since some of the OpenStack python-*client libraries (i.e. keystoneclient) have been deprecated in favor of the OpenStackClient (python-openstackclient).