### PR TITLE
Fix path joining so that the log location is correct on windows

### DIFF
--- a/perfkitbenchmarker/vm_util.py
+++ b/perfkitbenchmarker/vm_util.py
@@ -112,7 +112,7 @@ def GetTempDir():
 
 def PrependTempDir(file_name):
   """Returns the file name prepended with the tmp dir of the current run."""
-  return '%s/%s' % (GetTempDir(), file_name)
+  return os.path.join(GetTempDir(), file_name)
 
 
 def GenTempDir():


### PR DESCRIPTION
On windows, the following message was printing out with the last slash in the wrong direction: `2016-02-03 19:40:35,526 1791fcee MainThread INFO     Complete logs can be found at: c:\users\hildrum\appdata\local\temp\2\perfkitbenchmarker\run_1791fcee/pkb.log ` 

This uses `os.path.join` rather than using `%s/%s` to create the full path.