### PR TITLE
Check requirements.txt and requirements-*.txt at runtime.

### DIFF
--- a/perfkitbenchmarker/configs/benchmark_config_spec.py
+++ b/perfkitbenchmarker/configs/benchmark_config_spec.py
@@ -181,7 +181,10 @@ class _VmGroupSpec(spec.BaseSpec):
   def __init__(self, component_full_name, flag_values=None, **kwargs):
     super(_VmGroupSpec, self).__init__(component_full_name,
                                        flag_values=flag_values, **kwargs)
-    providers.LoadProvider(self.cloud.lower())
+    ignore_package_requirements = (
+        getattr(flag_values, 'ignore_package_requirements', True) if flag_values
+        else True)
+    providers.LoadProvider(self.cloud.lower(), ignore_package_requirements)
     if self.disk_spec:
       disk_config = getattr(self.disk_spec, self.cloud, None)
       if disk_config is None:

--- a/perfkitbenchmarker/errors.py
+++ b/perfkitbenchmarker/errors.py
@@ -24,6 +24,10 @@ class Error(Exception):
 class Setup(object):
   """Errors raised in setting up PKB."""
 
+  class PythonPackageRequirementUnfulfilled(Error):
+    """Error raised when a Python package requirement is unfulfilled."""
+    pass
+
   class MissingExecutableError(Error):
     """Error raised when we cannot find an executable we need."""
     pass

--- a/perfkitbenchmarker/pkb.py
+++ b/perfkitbenchmarker/pkb.py
@@ -74,6 +74,7 @@ from perfkitbenchmarker import flags
 from perfkitbenchmarker import linux_benchmarks
 from perfkitbenchmarker import log_util
 from perfkitbenchmarker import os_types
+from perfkitbenchmarker import requirements
 from perfkitbenchmarker import static_virtual_machine
 from perfkitbenchmarker import timing_util
 from perfkitbenchmarker import traces
@@ -182,6 +183,10 @@ flags.DEFINE_bool(
     'execution ends. When False, benchmarks continue to be scheduled. Does not '
     'apply to keyboard interrupts, which will always prevent further '
     'benchmarks from being scheduled.')
+flags.DEFINE_boolean(
+    'ignore_package_requirements', False,
+    'Disables Python package requirement runtime checks.')
+
 
 # Support for using a proxy in the cloud environment.
 flags.DEFINE_string('http_proxy', '',
@@ -430,6 +435,8 @@ def SetUpPKB():
   SetUpPKB() also modifies the local file system by creating a temp
   directory and storing new SSH keys.
   """
+  if not FLAGS.ignore_package_requirements:
+    requirements.CheckBasicRequirements()
 
   for executable in REQUIRED_EXECUTABLES:
     if not vm_util.ExecutableOnPath(executable):

--- a/perfkitbenchmarker/providers/__init__.py
+++ b/perfkitbenchmarker/providers/__init__.py
@@ -16,6 +16,7 @@ import logging
 import os
 
 from perfkitbenchmarker import import_util
+from perfkitbenchmarker import requirements
 
 # This unconditionally loads any modules in any provider
 # directory with the name 'flags'. It is expected that providers
@@ -39,18 +40,23 @@ VALID_CLOUDS = [GCP, AZURE, AWS, DIGITALOCEAN, KUBERNETES, OPENSTACK,
                 RACKSPACE, CLOUDSTACK, ALICLOUD, MESOS]
 
 
-def LoadProvider(provider_name):
+def LoadProvider(provider_name, ignore_package_requirements=True):
   """Loads the all modules in the 'provider_name' package.
 
-  This function loads all modules in the provided package. By loading these
-  modules, relevant classes (e.g. VMs) will register themselves. This should
-  be called with the exact name of the package, which is usually the name of
-  the provider in lower case (e.g. the package name for the 'GCP' provider
-  is 'gcp').
+  This function first checks the specified provider's Python package
+  requirements file, if one exists, and verifies that all requirements are met.
+  Next, it loads all modules in the specified provider's package. By loading
+  these modules, relevant classes (e.g. VMs) will register themselves.
 
   Args:
     provider_name: The name of the package whose modules should be loaded.
+        Usually the name of the provider in lower case (e.g. the package name
+        for the 'GCP' provider is 'gcp'.
+    ignore_package_requirements: boolean. If True, the provider's Python package
+        requirements file is ignored.
   """
+  if not ignore_package_requirements:
+    requirements.CheckProviderRequirements(provider_name)
   provider_package_path = os.path.join(__path__[0], provider_name)
   try:
     # Iterating through this generator will load all modules in the provider

--- a/perfkitbenchmarker/requirements.py
+++ b/perfkitbenchmarker/requirements.py
@@ -1,0 +1,79 @@
+# Copyright 2016 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Functions for checking that required Python packages are installed."""
+
+import os
+
+import pkg_resources
+
+from perfkitbenchmarker import errors
+
+
+# Path of the root of the current git branch.
+_BRANCH_ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
+
+
+def _CheckRequirements(requirements_file_path):
+  """Checks that all package requirements specified in a file are met.
+
+  Args:
+    requirements_file_path: string. Path to a pip requirements file.
+  """
+  try:
+    with open(requirements_file_path, 'rb') as fp:
+      for line in fp:
+        pkg_resources.require(line)
+  except (pkg_resources.DistributionNotFound,
+          pkg_resources.VersionConflict) as e:
+    # In newer versions of setuptools, these exception classes have a report
+    # method that provides a readable description of the error.
+    report = getattr(e, 'report', None)
+    err_msg = report() if report else str(e)
+    raise errors.Setup.PythonPackageRequirementUnfulfilled(
+        'A Python package requirement was not met while checking "{path}": '
+        '{msg}{linesep}To install required packages, execute the following '
+        'command:{linesep}pip install -r "{path}"{linesep}To bypass package '
+        'requirement checks, run PerfKit Benchmarker with the '
+        '--ignore_package_requirements flag.'.format(
+            linesep=os.linesep, msg=err_msg, path=requirements_file_path))
+
+
+def CheckBasicRequirements():
+  """Checks that all basic package requirements are met.
+
+  The basic requirements include packages used by modules that are imported
+  regardless of the specified cloud providers. The list of required packages
+  and versions is found in the requirements.txt file in the git branch's root
+  directory.
+  """
+  requirements_file_path = os.path.join(_BRANCH_ROOT_DIR, 'requirements.txt')
+  _CheckRequirements(requirements_file_path)
+
+
+def CheckProviderRequirements(provider):
+  """Checks that all provider-specific requirements are met.
+
+  The provider-specific requirements include packages used by modules that are
+  imported when using a particular cloud provider. The list of required packages
+  is found in the requirements-<provider>.txt file in the git branch's root
+  directory. If such a file does not exist, then no additional requirements are
+  necessary.
+
+  Args:
+    provider: string. Lowercase name of the cloud provider (e.g. 'gcp').
+  """
+  requirements_file_path = os.path.join(_BRANCH_ROOT_DIR,
+                                        'requirements-{0}.txt'.format(provider))
+  if os.path.isfile(requirements_file_path):
+    _CheckRequirements(requirements_file_path)

--- a/tests/requirements_test.py
+++ b/tests/requirements_test.py
@@ -1,0 +1,107 @@
+# Copyright 2016 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for perfkitbenchmarker.requirements."""
+
+import contextlib
+import StringIO
+import unittest
+
+import mock
+
+from perfkitbenchmarker import errors
+from perfkitbenchmarker import requirements
+
+
+_PATH = 'path'
+
+
+class _MockOpenRequirementsFile(object):
+
+  def __init__(self, file_content):
+    self._io = StringIO.StringIO(file_content)
+
+  def __enter__(self):
+    return self._io
+
+  def __exit__(self, *unused_args, **unused_kwargs):
+    pass
+
+
+class CheckRequirementsTestCase(unittest.TestCase):
+
+  @contextlib.contextmanager
+  def _MockOpen(self, file_content):
+    mocked_open = _MockOpenRequirementsFile(file_content)
+    with mock.patch(requirements.__name__ + '.open', return_value=mocked_open):
+      yield
+
+  def testFulfilledRequirement(self):
+    requirements_content = """
+    # Comment line, blank line, and a fulfilled requirement.
+
+    python-gflags>=2.0
+    """
+    with self._MockOpen(requirements_content):
+      requirements._CheckRequirements(_PATH)
+
+  def testMissingPackage(self):
+    requirements_content = """
+    # This is not a real package.
+    perfkitbenchmarker-fake-package>=1.2
+    """
+    with self._MockOpen(requirements_content):
+      with self.assertRaises(errors.Setup.PythonPackageRequirementUnfulfilled):
+        requirements._CheckRequirements(_PATH)
+
+  def testInstalledVersionLowerThanRequirement(self):
+    requirements_content = """
+    # The version of the installed python-gflags will be less than 42.
+    python-gflags>=42
+    """
+    with self._MockOpen(requirements_content):
+      with self.assertRaises(errors.Setup.PythonPackageRequirementUnfulfilled):
+        requirements._CheckRequirements(_PATH)
+
+  def testInstalledVersionGreaterThanRequirement(self):
+    requirements_content = """
+    # The version of the installed python-gflags will be greater than 0.5.
+    python-gflags==0.5
+    """
+    with self._MockOpen(requirements_content):
+      with self.assertRaises(errors.Setup.PythonPackageRequirementUnfulfilled):
+        requirements._CheckRequirements(_PATH)
+
+
+class CheckBasicRequirementsTestCase(unittest.TestCase):
+
+  def testAllRequirementsFulfilled(self):
+    requirements.CheckBasicRequirements()
+
+
+class CheckProviderRequirementsTestCase(unittest.TestCase):
+
+  def testNoRequirementsFile(self):
+    # If a provider does not have a requirements file, then there can be no
+    # unfulfilled requirement.
+    requirements.CheckProviderRequirements('fakeprovider')
+
+  def testUnfulfilledRequirements(self):
+    # AWS does have a requirements file, but it contains packages that are not
+    # installed as part of the test environment.
+    with self.assertRaises(errors.Setup.PythonPackageRequirementUnfulfilled):
+      requirements.CheckProviderRequirements('aws')
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
Previously, users have had problems because an installed Python package did not match the version required by PKB. This change checks the versions of required packages against the requirements.txt and requirements-*.txt files and raises an error if there is a mismatch.