### PR TITLE
Add MultiStreamThroughput benchmark to object storage benchmarks

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/object_storage_service_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/object_storage_service_benchmark.py
@@ -34,6 +34,7 @@ Documentation: https://goto.google.com/perfkitbenchmarker-storage
 import json
 import logging
 import os
+import posixpath
 import re
 import time
 
@@ -42,6 +43,7 @@ from perfkitbenchmarker import configs
 from perfkitbenchmarker import data
 from perfkitbenchmarker import errors
 from perfkitbenchmarker import flags
+from perfkitbenchmarker import flag_util
 from perfkitbenchmarker import sample
 from perfkitbenchmarker import vm_util
 from perfkitbenchmarker.sample import PercentileCalculator  # noqa
@@ -58,13 +60,16 @@ flags.DEFINE_string('object_storage_gcs_multiregion', None,
                     'Storage multiregion for GCS in object storage benchmark.')
 
 flags.DEFINE_enum('object_storage_scenario', 'all',
-                  ['all', 'cli', 'api_data', 'api_namespace'],
+                  ['all', 'cli', 'api_data', 'api_namespace',
+                   'api_multistream'],
                   'select all, or one particular scenario to run: \n'
                   'ALL: runs all scenarios. This is the default. \n'
                   'cli: runs the command line only scenario. \n'
                   'api_data: runs API based benchmarking for data paths. \n'
                   'api_namespace: runs API based benchmarking for namespace '
-                  'operations.')
+                  'operations. \n'
+                  'api_multistream: runs API-based benchmarking with multiple '
+                  'upload/download streams.')
 
 flags.DEFINE_enum('cli_test_size', 'normal',
                   ['normal', 'large'],
@@ -85,6 +90,20 @@ flags.DEFINE_string('azure_lib_version', None,
 flags.DEFINE_boolean('openstack_swift_insecure', False,
                      'Allow swiftclient to access Swift service without \n'
                      'having to verify the SSL certificate')
+
+flags.DEFINE_integer('object_storage_multistream_objects_per_stream', 1000,
+                     'Number of objects to send and/or receive per stream. '
+                     'Only applies to the api_multistream scenario.',
+                     lower_bound=1)
+flag_util.DEFINE_yaml('object_storage_object_sizes', '1KB',
+                      'Size of objects to send and/or receive. Only applies to '
+                      'the api_multistream scenario. Examples: 1KB, '
+                      '{1KB: 50%, 10KB: 50%}')
+flags.DEFINE_integer('object_storage_multistream_num_streams', 10,
+                     'Number of independent streams to send and/or receive on. '
+                     'Only applies to the api_multistream scenario.',
+                     lower_bound=1)
+
 
 FLAGS = flags.FLAGS
 
@@ -202,6 +221,18 @@ OBJECT_STORAGE_GCS_MULTIREGION = 'object_storage_gcs_multiregion'
 GCS_MULTIREGION_LOCATION = 'gcs_multiregion_location'
 DEFAULT = 'default'
 
+# This accounts for the overhead of running RemoteCommand() on a VM.
+MULTISTREAM_DELAY_PER_VM = 5.0
+# We wait this many seconds for each stream. Note that this is
+# multiplied by the number of streams per VM, not the total number of
+# streams.
+MULTISTREAM_DELAY_PER_STREAM = 0.1
+
+# The multistream write benchmark writes a file in the VM's /tmp with
+# the objects it has written, which is used by the multistream read
+# benchmark. This is the filename.
+OBJECTS_WRITTEN_FILE = 'pkb-objects-written'
+
 
 def GetConfig(user_config):
   return configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
@@ -293,9 +324,80 @@ def _MakeSwiftCommandPrefix(auth_url, tenant_name, username, password):
   return ' '.join(options)
 
 
+def _ParseMultiStreamResults(raw_result, metadata=None):
+  """Read results from the api_multistream worker process.
+
+  Args:
+    raw_result: string. The stdout of the worker process.
+    metadata: dict. Base sample metadata
+
+  Returns:
+    A list of sample.Sample objects.
+  """
+
+  if metadata is None:
+    metadata = {}
+
+  records = json.loads(raw_result)
+  results = []
+
+  for record in records:
+    metric = 'Multi-stream %s latency' % record['operation']
+    md = metadata.copy()
+    md['stream_num'] = record['stream_num']
+    md['object_size_b'] = record['size']
+
+    results.append(sample.Sample(metric,
+                                 record['latency'],
+                                 'sec',
+                                 md,
+                                 record['start_time']))
+
+  return results
+
+
+def _DistributionToBackendFormat(dist):
+  """Convert an object size distribution to the format needed by the backend.
+
+  Args:
+    dist: a distribution, given as a dictionary mapping size to
+    frequency. Size will be a string with a quantity and a
+    unit. Frequency will be a percentage, including a '%'
+    character. dist may also be a string, in which case it represents
+    a single object size which applies to 100% of objects.
+
+  Returns:
+    A dictionary giving an object size distribution. Sizes will be
+    integers representing bytes. Frequencies will be floating-point
+    numbers in [0,100], representing percentages.
+
+  Raises:
+    ValueError if dist is not a valid distribution.
+  """
+
+  if isinstance(dist, dict):
+    val = {flag_util.StringToBytes(size):
+           flag_util.StringToRawPercent(frequency)
+           for size, frequency in dist.iteritems()}
+  else:
+    # We allow compact notation for point distributions. For instance,
+    # '1KB' is an abbreviation for '{1KB: 100%}'.
+    val = {flag_util.StringToBytes(dist): 100.0}
+
+  # I'm requiring exact addition to 100, which can always be satisfied
+  # with integer percentages. If we want to allow general decimal
+  # percentages, all we have to do is replace this equality check with
+  # approximate equality.
+  if sum(val.itervalues()) != 100.0:
+    raise ValueError("Frequencies in %s don't add to 100%%!" % dist)
+
+  return val
+
+
 def ApiBasedBenchmarks(results, metadata, vm, storage, test_script_path,
                        bucket_name, regional_bucket_name=None,
                        azure_command_suffix=None, host_to_connect=None):
+
     """This function contains all api-based benchmarks.
        It uses the value of the global flag "object_storage_scenario" to
        decide which scenario to run inside this function. The caller simply
@@ -447,6 +549,76 @@ def ApiBasedBenchmarks(results, metadata, vm, storage, test_script_path,
                                          metric_name,
                                          LATENCY_UNIT,
                                          metadata)
+
+    if (FLAGS.object_storage_scenario == 'all' or
+        FLAGS.object_storage_scenario == 'api_multistream'):
+
+      logging.info('Starting multi-stream write test.')
+
+      # Add metadata specific to the multistream throughput test.
+      multistream_metadata = metadata.copy()
+      multistream_metadata['num_streams'] = (
+          FLAGS.object_storage_multistream_num_streams)
+      multistream_metadata['objects_per_stream'] = (
+          FLAGS.object_storage_multistream_objects_per_stream)
+
+      objects_written_file = posixpath.join(vm_util.VM_TMP_DIR,
+                                            OBJECTS_WRITTEN_FILE)
+
+      size_distribution = _DistributionToBackendFormat(
+          FLAGS.object_storage_object_sizes)
+
+      write_start_time = (
+          time.time() +
+          MULTISTREAM_DELAY_PER_VM +
+          MULTISTREAM_DELAY_PER_STREAM *
+          FLAGS.object_storage_multistream_num_streams)
+
+      logging.info('Write start time is %s', write_start_time)
+
+      multi_stream_write_cmd = BuildBenchmarkScriptCommand([
+          '--bucket=%s' % bucket_name,
+          '--objects_per_stream=%s' % (
+              FLAGS.object_storage_multistream_objects_per_stream),
+          '--object_sizes="%s"' % size_distribution,
+          '--num_streams=%s' % FLAGS.object_storage_multistream_num_streams,
+          '--start_time=%s' % write_start_time,
+          '--objects_written_file=%s' % objects_written_file,
+          '--scenario=MultiStreamWrite'])
+      write_out, _ = vm.RobustRemoteCommand(
+          multi_stream_write_cmd, should_log=True)
+      results.extend(
+          _ParseMultiStreamResults(write_out, metadata=multistream_metadata))
+
+      logging.info('Finished multi-stream write test. Starting multi-stream '
+                   'read test.')
+
+      read_start_time = (
+          time.time() +
+          MULTISTREAM_DELAY_PER_VM +
+          MULTISTREAM_DELAY_PER_STREAM *
+          FLAGS.object_storage_multistream_num_streams)
+
+      logging.info('Read start time is %s', read_start_time)
+
+      multi_stream_read_cmd = BuildBenchmarkScriptCommand([
+          '--bucket=%s' % bucket_name,
+          '--objects_per_stream=%s' % (
+              FLAGS.object_storage_multistream_objects_per_stream),
+          '--num_streams=%s' % FLAGS.object_storage_multistream_num_streams,
+          '--start_time=%s' % read_start_time,
+          '--objects_written_file=%s' % objects_written_file,
+          '--scenario=MultiStreamRead'])
+      try:
+        read_out, _ = vm.RobustRemoteCommand(
+            multi_stream_read_cmd, should_log=True)
+        results.extend(
+            _ParseMultiStreamResults(read_out, metadata=multistream_metadata))
+      except Exception as ex:
+        logging.info('MultiStreamRead test failed with exception %s. Still '
+                     'recording write data.', ex.msg)
+
+      logging.info('Finished multi-stream read test.')
 
 
 def DeleteBucketWithRetry(vm, remove_content_cmd, remove_bucket_cmd):
@@ -1125,6 +1297,7 @@ def Prepare(benchmark_spec):
 
   vms[0].Install('pip')
   vms[0].RemoteCommand('sudo pip install python-gflags==2.0')
+  vms[0].RemoteCommand('sudo pip install pyyaml')
   azure_version_string = ''
   if FLAGS.azure_lib_version is not None:
     azure_version_string = '==%s' % FLAGS.azure_lib_version
@@ -1196,3 +1369,7 @@ def Cleanup(benchmark_spec):
   vms = benchmark_spec.vms
   OBJECT_STORAGE_BENCHMARK_DICTIONARY[FLAGS.storage].Cleanup(vms[0])
   vms[0].RemoteCommand('rm -rf %s/run/' % vms[0].GetScratchDir())
+
+  objects_written_file = posixpath.join(vm_util.VM_TMP_DIR,
+                                        OBJECTS_WRITTEN_FILE)
+  vms[0].RemoteCommand('rm -f %s' % objects_written_file)

--- a/perfkitbenchmarker/scripts/object_storage_api_tests.py
+++ b/perfkitbenchmarker/scripts/object_storage_api_tests.py
@@ -22,13 +22,19 @@
    run this script.
 """
 
+import cStringIO
 import json
 import logging
+import os
+import Queue
 import sys
 from threading import Thread
+import threading
 import string
 import random
 import time
+
+import yaml
 
 import boto
 import gflags as flags
@@ -57,15 +63,41 @@ flags.DEFINE_string('azure_key', None,
 
 flags.DEFINE_enum(
     'scenario', 'OneByteRW', ['OneByteRW', 'ListConsistency',
-                              'SingleStreamThroughput', 'CleanupBucket'],
+                              'SingleStreamThroughput', 'CleanupBucket',
+                              'MultiStreamWrite', 'MultiStreamRead'],
     'The various scenarios to run. OneByteRW: read and write of single byte. '
     'ListConsistency: List-after-write and list-after-update consistency. '
     'SingleStreamThroughput: Throughput of single stream large object RW. '
-    'CleanupBucket: Cleans up everything in a given bucket.')
+    'CleanupBucket: Cleans up everything in a given bucket.'
+    'MultiStreamWrite: Write objects with many streams at once.'
+    'MultiStreamRead: Read objects with many streams at once.')
 
 flags.DEFINE_integer('iterations', 1, 'The number of iterations to run for the '
                      'particular test scenario. Currently only applicable to '
                      'the ListConsistency scenario, ignored in others.')
+
+flags.DEFINE_integer('objects_per_stream', 1000, 'The number of objects to '
+                     'read and write per stream in the MultiStreamThroughput '
+                     'scenario.')
+flags.DEFINE_string('object_sizes', 1, 'The size of the objects to use, as a '
+                    'distribution. Currently only applicable to the '
+                    'MultiStreamThroughput scenario, ignored in others. Ex: '
+                    '{1024: 100.0}, (1KiB 100% of the time), '
+                    '{1000: 50.0, 10000: 50.0} (1KB 50% of the time, 10KB 50% '
+                    'of the time)')
+flags.DEFINE_integer('num_streams', 1, 'The number of streams to use. Only '
+                     'applies to the MultiStreamThroughput scenario.',
+                     lower_bound=1)
+flags.DEFINE_string('objects_written_file', None, 'The path where the '
+                    'multistream write benchmark will save a list of the '
+                    'objects it wrote, and the multistream read benchmark will '
+                    'get a list of objects to read. If the scenario is '
+                    'MultiStreamWrite and this file exists, it will be '
+                    'deleted.')
+
+flags.DEFINE_float('start_time', None, 'The time (as a POSIX timestamp) '
+                   'to start the operation. Only applies to the '
+                   'MultiStreamRead and MultiStreamWrite scenarios.')
 
 STORAGE_TO_SCHEMA_DICT = {'GCS': 'gs', 'S3': 's3', 'AZURE': 'azure'}
 
@@ -117,6 +149,12 @@ LARGE_OBJECT_FAILURE_TOLERANCE = 0.1
 # A global variable initialized once for Azure Blob Service
 _AZURE_BLOB_SERVICE = None
 
+BYTES_PER_KILOBYTE = 1024
+
+# The multistream benchmarks log how many threads are still active
+# every THREAD_STATUS_LOG_INTERVAL seconds.
+THREAD_STATUS_LOG_INTERVAL = 10
+
 
 # When a storage provider fails more than a threshold number of requests, we
 # stop the benchmarking tests and raise a low availability error back to the
@@ -139,6 +177,41 @@ def _useBotoApi(storage_schema):
     return True
   else:
     return False
+
+
+class SizeDistributionIterator(object):
+  """Draw object sizes from a distribution.
+
+  Args:
+    dist: dict. The distribution to draw sizes from.
+  """
+
+  # IMPLEMENTATION LIMITATION: right now, this object only supports
+  # point distributions, which contain only a single size.
+
+  def __init__(self, dist):
+    if len(dist) != 1:
+      raise NotImplementedError(
+          'General distributions are not implemented yet.')
+
+    size, _ = dist.iteritems().next()
+    self.size = size
+
+  # this is required by the Python iterator protocol
+  def __iter__(self):
+    return self
+
+  def next(self):
+    return self.size
+
+
+def MaxSizeInDistribution(dist):
+  """Find the maximum object size in a distribution."""
+
+  if len(dist) != 1:
+    raise NotImplementedError('General distributions are not implemented yet.')
+
+  return long(dist.iterkeys().next())
 
 
 def PercentileCalculator(numbers):
@@ -244,6 +317,19 @@ def CleanupBucket(storage_schema):
     objects_to_cleanup = _ListObjects(storage_schema, FLAGS.bucket, prefix=None)
 
 
+def GenerateWritePayload(size):
+  payload_bytes = bytearray(size)
+  # don't use a for...range(100M), range(100M) will create a list of 100mm items
+  # with each item being the default object size of 30 bytes or so, it will lead
+  # to out of memory error.
+  for i in xrange(size):
+    payload_bytes[i] = ord(random.choice(string.letters))
+
+  payload_string = payload_bytes.decode('ascii')
+
+  return payload_bytes, payload_string
+
+
 def WriteObjects(storage_schema, bucket, object_prefix, count,
                  size, objects_written, latency_results=None,
                  bandwidth_results=None, host_to_connect=None):
@@ -266,57 +352,76 @@ def WriteObjects(storage_schema, bucket, object_prefix, count,
         successfully written.
     host_to_connect: An optional endpoint string to connect to.
   """
-  payload_bytes = bytearray(size)
-  # Use a while loop to fill up the byte array which is by default 100MB in size
-  # don't use a for...range(100M), range(100M) will create a list of 100mm items
-  # with each item being the default object size of 30 bytes or so, it will lead
-  # to out of memory error.
-  i = 0
-  while i < size:
-    payload_bytes[i] = ord(random.choice(string.letters))
-    i += 1
 
-  payload_string = payload_bytes.decode('ascii')
+  payload_bytes, payload_string = GenerateWritePayload(size)
 
-  for i in range(count):
+  for i in xrange(count):
     object_name = '%s_%d' % (object_prefix, i)
 
-    # Ready to go!
-    start_time = time.time()
-
-    # We write the object to storage provider and if successful we place the
-    # name of the object to the objects_written list. When a write fails, the
-    # object won't be placed into the objects_written list, and then it's up to
-    # the caller to decide if they want to tolerate the failure and accept
-    # the results, depending on test scenarios.
     try:
-      if _useBotoApi(storage_schema):
-        object_path = '%s/%s' % (bucket, object_name)
-        object_uri = boto.storage_uri(object_path, storage_schema)
-        if host_to_connect is not None:
-          object_uri.connect(host=host_to_connect)
-
-        object_uri.set_contents_from_string(payload_string)
-      else:
-        _AZURE_BLOB_SERVICE.put_block_blob_from_bytes(bucket, object_name,
-                                                      bytes(payload_bytes))
-
-      latency = time.time() - start_time
-
-      if latency_results is not None:
-        latency_results.append(latency)
-
-      if bandwidth_results is not None and latency > 0.0:
-        bandwidth_results.append(size / latency)
+      _, latency = WriteObjectFromBuffer(
+          storage_schema, bucket, object_name,
+          payload_bytes, payload_string, size,
+          host_to_connect=host_to_connect)
 
       objects_written.append(object_name)
-    except:
-      logging.exception('Caught exception while writing object %s.',
-                        object_name)
+      if latency_results is not None:
+        latency_results.append(latency)
+      if bandwidth_results is not None and latency > 0.0:
+        bandwidth_results.append(size / latency)
+    except Exception as e:
+      logging.info('Caught exception %s while writing object %s' %
+                   (e, object_name))
+
+
+def WriteObjectFromBuffer(storage_schema, bucket_name, object_name,
+                          payload_bytes, payload_string, size_to_write,
+                          host_to_connect=None):
+  """Write an object to a storage provider.
+
+  Exceptions are propagated to the caller, which can decide whether to
+  tolerate them or not.
+
+  Args:
+    storage_schema: The address schema identifying a storage. e.g., "gs"
+    bucket_name: Name of the bucket to write to.
+    object_name: Name of the object.
+    payload_bytes: A bytearray to transfer.
+    payload_string: A string version of payload_bytes.
+    size_to_write: The size of the objects to write, in bytes. If size is
+      less than the size of payload_{bytes,string}, then this will
+      transfer the prefix of payload_{bytes,string} of the desired size.
+    host_to_connect: An optional endpoint string to connect to.
+
+  Returns:
+    a tuple (start_time, latency).
+
+  """
+
+  # Ready to go!
+  start_time = time.time()
+
+  if _useBotoApi(storage_schema):
+    object_path = '%s/%s' % (bucket_name, object_name)
+    object_uri = boto.storage_uri(object_path, storage_schema)
+    if host_to_connect is not None:
+      object_uri.connect(host=host_to_connect)
+
+    payload_view = memoryview(str(payload_string))
+    object_uri.set_contents_from_string(payload_view[:size_to_write])
+  else:
+    payload_view = memoryview(payload_bytes)
+    _AZURE_BLOB_SERVICE.put_block_blob_from_bytes(
+        bucket_name, object_name, bytes(payload_view[:size_to_write]))
+
+  latency = time.time() - start_time
+
+  return start_time, latency
 
 
 def ReadObjects(storage_schema, bucket, objects_to_read, latency_results=None,
-                bandwidth_results=None, object_size=None, host_to_connect=None):
+                bandwidth_results=None, object_size=None,
+                start_times=None, host_to_connect=None):
   """Read a bunch of objects.
 
   Args:
@@ -326,21 +431,17 @@ def ReadObjects(storage_schema, bucket, objects_to_read, latency_results=None,
     latency_results: An optional list to receive latency results.
     bandwidth_results: An optional list to receive bandwidth results.
     object_size: Size of the object that will be read, used to calculate bw.
+    start_times: An optional list to receive start time results.
     host_to_connect: An optional endpoint string to connect to.
   """
+
   for object_name in objects_to_read:
-
-    start_time = time.time()
     try:
-      if _useBotoApi(storage_schema):
-        object_path = '%s/%s' % (bucket, object_name)
-        object_uri = boto.storage_uri(object_path, storage_schema)
-        object_uri.connect(host=host_to_connect)
-        object_uri.new_key().get_contents_as_string()
-      else:
-        _AZURE_BLOB_SERVICE.get_blob_to_bytes(bucket, object_name)
+      start_time, latency = ReadObject(storage_schema, bucket, object_name,
+                                       host_to_connect=host_to_connect)
 
-      latency = time.time() - start_time
+      if start_times is not None:
+        start_times.append(start_time)
 
       if latency_results is not None:
         latency_results.append(latency)
@@ -350,6 +451,38 @@ def ReadObjects(storage_schema, bucket, objects_to_read, latency_results=None,
         bandwidth_results.append(object_size / latency)
     except:
       logging.exception('Failed to read object %s', object_name)
+
+
+def ReadObject(storage_schema, bucket_name, object_name, host_to_connect=None):
+  """Read an object.
+
+  Exceptions are propagated to the caller, which can decide whether to
+  tolerate them or not.
+
+  Args:
+    storage_schema: The address schema identifying a storage. e.g., "gs"
+    bucket_name: Name of the bucket.
+    object_name: Name of the object.
+    host_to_connect: An optional endpoint string to connect to.
+
+  Returns:
+    A tuple (start_time, latency)
+  """
+
+  start_time = time.time()
+
+  if _useBotoApi(storage_schema):
+    object_path = '%s/%s' % (bucket_name, object_name)
+    object_uri = boto.storage_uri(object_path, storage_schema)
+    if host_to_connect is not None:
+      object_uri.connect(host=host_to_connect)
+    object_uri.new_key().get_contents_as_string()
+  else:
+    _AZURE_BLOB_SERVICE.get_blob_to_bytes(bucket_name, object_name)
+
+  latency = time.time() - start_time
+
+  return start_time, latency
 
 
 def DeleteObjectsConcurrently(storage_schema, per_thread_objects_to_delete,
@@ -516,6 +649,309 @@ def SingleStreamThroughputBenchmark(storage_schema, host_to_connect=None):
   finally:
     DeleteObjects(storage_schema, FLAGS.bucket, objects_written,
                   host_to_connect=host_to_connect)
+
+
+def RunThreadedWorkers(worker, worker_args, per_thread_args=None):
+  """Run a worker function in many threads, then gather and return the results.
+
+  Args:
+    worker: either WriteWorker or ReadWorker. The worker function to call.
+    worker_args: a tuple. The arguments to pass to the worker function. The
+      result queue and stream number will be appended as the last two arguments.
+    per_thread_args: if given, an array with length equal to the
+      number of threads. Thread number i will be passed
+      per_thread_args[i] after its regular arguments and before the
+      result queue and stream number.
+
+  Returns:
+    A list of the results returned by the workers.
+  """
+
+  result_queue = Queue.Queue()
+
+  logging.info('Creating %s threads', FLAGS.num_streams)
+  if per_thread_args is None:
+    threads = [threading.Thread(target=worker,
+                                args=worker_args + (result_queue, i))
+               for i in xrange(FLAGS.num_streams)]
+  else:
+    threads = [threading.Thread(target=worker,
+                                args=worker_args +
+                                (per_thread_args[i],) +
+                                (result_queue, i))
+               for i in xrange(FLAGS.num_streams)]
+  logging.info('Threads created. Starting threads.')
+  for thread in threads:
+    thread.start()
+  logging.info('Threads started.')
+  while True:
+    time.sleep(THREAD_STATUS_LOG_INTERVAL)
+    num_alive = sum((thread.isAlive() for thread in threads))
+    if num_alive == 0:
+      break
+    else:
+      logging.info('%s of %s threads are still working.',
+                   num_alive, FLAGS.num_streams)
+  logging.info('All threads complete.')
+
+  results = []
+
+  try:
+    while True:
+      res = result_queue.get_nowait()
+      results.append(res)
+  except Queue.Empty:
+    pass
+
+  return results
+
+
+def MultiStreamWrites(storage_schema, host_to_connect=None):
+  """Run multi-stream write benchmark.
+
+  Args:
+    storage_schema: a two-character string indicating the storage
+      type. Ex: 'gs', 's3'.
+    host_to_connect: if given, an endpoint URL to connect to.
+
+  This function writes objects to the storage backend, potentially
+  using multiple threads.
+
+  It doesn't return anything, but it outputs two sets of results in
+  two different ways. First, it writes a list of the names of all the
+  objects it has written with their sizes to
+  FLAGS.objects_written_file (if given). The format is
+
+  [[object_name_1, object_size_1],
+   [object_name_2, object_size_2],
+   ...]
+
+  Second, it writes records of the objects it wrote, along with timing
+  information, to sys.stdout. The format is
+
+  [{"operation": "upload", "start_time": start_time_1,
+    "latency": latency_1, "size": size_1, "stream_num": stream_num_1},
+   [{"operation": "upload", "start_time": start_time_2,
+    "latency": latency_2, "size": size_2, "stream_num": stream_num_2}
+   ...]
+
+  Both kinds of output are written as JSON, for easy serialization and
+  deserialization.
+
+  """
+
+  size_distribution = yaml.load(cStringIO.StringIO(FLAGS.object_sizes))
+
+  payload_bytes, payload_string = GenerateWritePayload(
+      MaxSizeInDistribution(size_distribution))
+
+  results = RunThreadedWorkers(
+      WriteWorker,
+      (storage_schema,
+       host_to_connect,
+       payload_bytes,
+       payload_string,
+       size_distribution,
+       FLAGS.objects_per_stream,
+       FLAGS.start_time))
+
+  # object_records is the data we leave on the VM for future reads. We
+  # need to pass data to the reader so it will know what object names
+  # it can read.
+  if FLAGS.objects_written_file is not None:
+    try:
+      object_records = []
+      for result in results:
+        for name, size in zip(result['object_names'], result['sizes']):
+          object_records.append([name, size])
+      if os.path.exists(FLAGS.objects_written_file):
+        os.remove(FLAGS.objects_written_file)
+      with open(FLAGS.objects_written_file, 'w') as out:
+        json.dump(object_records, out)
+    except Exception as ex:
+      # If we can't write our objects written, we still want to return
+      # the data we collected, so keep going.
+      logging.info('Got exception %s while trying to write objects written '
+                   'file.', ex.msg)
+
+  # operation_records is the data we send back to the controller.
+  operation_records = []
+  for result in results:
+    operation = result['operation']
+    stream_num = result['stream_num']
+    for start_time, latency, size in zip(result['start_times'],
+                                         result['latencies'],
+                                         result['sizes']):
+      operation_records.append({'operation': operation,
+                                'start_time': start_time,
+                                'latency': latency,
+                                'size': size,
+                                'stream_num': stream_num})
+
+  num_writes_requested = FLAGS.objects_per_stream * FLAGS.num_streams
+  min_writes_allowed = num_writes_requested * (1.0 - FAILURE_TOLERANCE)
+  if len(operation_records) < min_writes_allowed:
+    raise LowAvailabilityError(
+        'Wrote %s objects out of %s requested (%s requred)' %
+        (len(operation_records), num_writes_requested, min_writes_allowed))
+
+  json.dump(operation_records, sys.stdout, indent=0)
+
+
+def MultiStreamReads(storage_schema, host_to_connect=None):
+  """Run multi-stream read benchmark.
+
+  Args:
+    storage_schema: a two-character string indicating the storage
+      type. Ex: 'gs', 's3'.
+    host_to_connect: if given, an endpoint URL to connect to.
+
+  This function reads a list of object names and sizes from
+  FLAGS.objects_written_file (in the format written by
+  MultiStreamWrites and then reads the objects from the storage
+  backend, potentially using multiple threads.
+
+  It doesn't directly return anything, but it writes its results to
+  sys.stdout in the following format:
+
+  [{"operation": "download", "start_time": start_time_1,
+    "latency": latency_1, "size": size_1, "stream_num": stream_num_1},
+   {"operation": "download", "start_time": start_time_1,
+    "latency": latency_1, "size": size_1, "stream_num": stream_num_1},
+   ...]
+
+  """
+
+  # Read the object records that the MultiStreamWriter left for us.
+  if FLAGS.objects_written_file is None:
+    raise ValueError('The MultiStreamRead benchmark needs a list of object '
+                     'names to read from. Use '
+                     '--objects_written_file=<filename>.')
+  with open(FLAGS.objects_written_file, 'r') as object_file:
+    object_records = json.load(object_file)
+
+  num_workers = FLAGS.num_streams
+  objects_by_worker = [object_records[i::num_workers]
+                       for i in xrange(num_workers)]
+
+  results = RunThreadedWorkers(
+      ReadWorker,
+      (storage_schema,
+       host_to_connect,
+       FLAGS.start_time),
+      per_thread_args=objects_by_worker)
+
+  # send data back to the controller
+  operation_records = []
+  for result in results:
+    operation = result['operation']
+    stream_num = result['stream_num']
+    for start_time, latency, size in zip(result['start_times'],
+                                         result['latencies'],
+                                         result['sizes']):
+      operation_records.append({'operation': operation,
+                                'stream_num': stream_num,
+                                'start_time': start_time,
+                                'latency': latency,
+                                'size': size})
+
+  num_reads_requested = len(object_records)
+  min_reads_allowed = num_reads_requested * (1.0 - FAILURE_TOLERANCE)
+  if len(operation_records) < min_reads_allowed:
+    raise LowAvailabilityError(
+        'Read %s objects out of %s requested (%s requred)' %
+        (len(operation_records), num_reads_requested, min_reads_allowed))
+
+  json.dump(operation_records, sys.stdout, indent=0)
+
+
+def SleepUntilTime(when):
+  """Sleep until a given time.
+
+  Args:
+    when: float. The time to sleep to, as a POSIX timestamp.
+  """
+
+  now = time.time()
+  sleep_time = when - now
+  if sleep_time > 0.0:
+    time.sleep(sleep_time)
+  elif sleep_time == 0.0:
+    pass
+  else:
+    logging.info('Sleep time %s was too small', sleep_time)
+
+
+def WriteWorker(storage_schema, host_to_connect,
+                payload_bytes, payload_string,
+                size_distribution, num_objects,
+                start_time, result_queue, worker_num):
+  object_names = []
+  start_times = []
+  latencies = []
+  sizes = []
+
+  size_iterator = SizeDistributionIterator(size_distribution)
+  object_prefix = ('pkb_write_worker_%f_%s' % (time.time(), worker_num))
+
+  if start_time is not None:
+    SleepUntilTime(start_time)
+
+  for i in xrange(num_objects):
+    object_name = '%s_%d' % (object_prefix, i)
+    object_size = size_iterator.next()
+
+    try:
+      start_time, latency = WriteObjectFromBuffer(
+          storage_schema, FLAGS.bucket, object_name,
+          payload_bytes, payload_string, object_size,
+          host_to_connect=host_to_connect)
+
+      object_names.append(object_name)
+      start_times.append(start_time)
+      latencies.append(latency)
+      sizes.append(object_size)
+    except Exception as e:
+      logging.info('Worker %s caught exception %s while writing object %s' %
+                   (worker_num, e, object_name))
+
+  result_queue.put({'operation': 'upload',
+                    'object_names': object_names,
+                    'start_times': start_times,
+                    'latencies': latencies,
+                    'sizes': sizes,
+                    'stream_num': worker_num})
+
+
+def ReadWorker(storage_schema, host_to_connect,
+               start_time, object_records,
+               result_queue, worker_num):
+
+  start_times = []
+  latencies = []
+  sizes = []
+
+  if start_time is not None:
+    SleepUntilTime(start_time)
+
+  for name, size in object_records:
+    try:
+      start_time, latency = ReadObject(storage_schema, FLAGS.bucket,
+                                       name, host_to_connect=host_to_connect)
+
+      start_times.append(start_time)
+      latencies.append(latency)
+      sizes.append(size)
+    except Exception as e:
+      logging.info('Worker %s caught exception %s while reading object %s' %
+                   (worker_num, e, name))
+
+
+  result_queue.put({'operation': 'download',
+                    'start_times': start_times,
+                    'latencies': latencies,
+                    'sizes': sizes,
+                    'stream_num': worker_num})
 
 
 def OneByteRWBenchmark(storage_schema, host_to_connect=None):
@@ -809,6 +1245,10 @@ def Main(argv=sys.argv):
     return SingleStreamThroughputBenchmark(storage_schema, host_to_connect)
   elif FLAGS.scenario == 'CleanupBucket':
     return CleanupBucket(storage_schema)
+  elif FLAGS.scenario == 'MultiStreamWrite':
+    return MultiStreamWrites(storage_schema, host_to_connect)
+  elif FLAGS.scenario == 'MultiStreamRead':
+    return MultiStreamReads(storage_schema, host_to_connect)
 
 if __name__ == '__main__':
   sys.exit(Main())

--- a/perfkitbenchmarker/scripts/object_storage_api_tests.py
+++ b/perfkitbenchmarker/scripts/object_storage_api_tests.py
@@ -897,6 +897,8 @@ def WriteWorker(storage_schema, host_to_connect,
     object_name = '%s_%d' % (object_prefix, i)
     object_size = size_iterator.next()
 
+    # TODO: make use of object_size later when adding object size
+    # distribution support.
     try:
       start_time, latency = WriteObjectFromBuffer(
           storage_schema, FLAGS.bucket, object_name,

--- a/tests/flag_util_test.py
+++ b/tests/flag_util_test.py
@@ -173,6 +173,54 @@ class TestUnitsParser(unittest.TestCase):
       up.Parse('1m')
 
 
+class TestStringToBytes(unittest.TestCase):
+  def testValidString(self):
+    self.assertEqual(flag_util.StringToBytes('100KB'),
+                     100000)
+
+  def testUnparseableString(self):
+    with self.assertRaises(ValueError):
+      flag_util.StringToBytes('asdf')
+
+  def testBadUnits(self):
+    with self.assertRaises(ValueError):
+      flag_util.StringToBytes('100m')
+
+  def testNonIntegerBytes(self):
+    with self.assertRaises(ValueError):
+      flag_util.StringToBytes('1.5B')
+
+  def testNegativeBytes(self):
+    with self.assertRaises(ValueError):
+      flag_util.StringToBytes('-10KB')
+
+
+class TestStringToRawPct(unittest.TestCase):
+  def testValidPct(self):
+    self.assertEquals(flag_util.StringToRawPercent('50.5%'),
+                      50.5)
+
+  def testNullString(self):
+    with self.assertRaises(ValueError):
+      flag_util.StringToRawPercent('')
+
+  def testOneCharacterString(self):
+    with self.assertRaises(ValueError):
+      flag_util.StringToRawPercent('%')
+
+  def testNoPercentSign(self):
+    with self.assertRaises(ValueError):
+      flag_util.StringToRawPercent('100')
+
+  def testNegativePercent(self):
+    with self.assertRaises(ValueError):
+      flag_util.StringToRawPercent('-12%')
+
+  def testPercentAbove100(self):
+    with self.assertRaises(ValueError):
+      flag_util.StringToRawPercent('112%')
+
+
 class TestYAMLParser(unittest.TestCase):
 
   def setUp(self):

--- a/tests/object_storage_service_benchmark_test.py
+++ b/tests/object_storage_service_benchmark_test.py
@@ -1,0 +1,127 @@
+# Copyright 2016 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the object_storage_service benchmark."""
+
+import mock
+import unittest
+import time
+
+from perfkitbenchmarker import sample
+from perfkitbenchmarker.linux_benchmarks import object_storage_service_benchmark
+from tests import mock_flags
+
+
+class TestBuildCommands(unittest.TestCase):
+  def setUp(self):
+    mocked_flags = mock_flags.PatchTestCaseFlags(self)
+
+    mocked_flags.object_storage_scenario = 'api_multistream'
+    mocked_flags.object_storage_multistream_objects_per_stream = 100
+    mocked_flags.object_storage_object_sizes = {'1KB': '100%'}
+    mocked_flags.object_storage_multistream_num_streams = 10
+
+  def testBuildCommands(self):
+    vm = mock.MagicMock()
+    vm.RobustRemoteCommand = mock.MagicMock(return_value=('', ''))
+
+    with mock.patch(time.__name__ + '.time', return_value=1.0):
+      with mock.patch(object_storage_service_benchmark.__name__ +
+                      '._ParseMultiStreamResults'):
+        object_storage_service_benchmark.ApiBasedBenchmarks(
+            [], {}, vm, 'GCP', 'test_script.py', 'bucket')
+
+    self.assertEqual(
+        vm.RobustRemoteCommand.call_args_list[0],
+        mock.call('test_script.py --storage_provider=GCP --bucket=bucket '
+                  '--objects_per_stream=100 --object_sizes="{1000: 100.0}" '
+                  '--num_streams=10 --start_time=7.0 '
+                  '--objects_written_file=/tmp/pkb/pkb-objects-written '
+                  '--scenario=MultiStreamWrite',
+                  should_log=True))
+
+    self.assertEqual(
+        vm.RobustRemoteCommand.call_args_list[1],
+        mock.call('test_script.py --storage_provider=GCP --bucket=bucket '
+                  '--objects_per_stream=100 '
+                  '--num_streams=10 --start_time=7.0 '
+                  '--objects_written_file=/tmp/pkb/pkb-objects-written '
+                  '--scenario=MultiStreamRead',
+                  should_log=True))
+
+
+class TestParseMultiStreamResults(unittest.TestCase):
+  def setUp(self):
+    self.raw_result = """
+[{"latency": 0.1, "operation": "upload", "stream_num": 1, "start_time": 5.0, "size": 1},
+ {"latency": 0.1, "operation": "download", "stream_num": 1, "start_time": 10.0, "size": 1}]"""  # noqa: line too long
+
+  def testParseResults(self):
+    samples = object_storage_service_benchmark._ParseMultiStreamResults(
+        self.raw_result)
+
+    self.assertEqual(samples,
+                     [sample.Sample('Multi-stream upload latency',
+                                    0.1,
+                                    'sec',
+                                    {'stream_num': 1, 'object_size_b': 1},
+                                    5.0),
+                      sample.Sample('Multi-stream download latency',
+                                    0.1,
+                                    'sec',
+                                    {'stream_num': 1, 'object_size_b': 1},
+                                    10.0)])
+
+  def testKeepsBaseMetadata(self):
+    samples = object_storage_service_benchmark._ParseMultiStreamResults(
+        self.raw_result, metadata={'foo': 'bar'})
+    self.assertEqual(samples[0].metadata['foo'],
+                     'bar')
+
+
+class TestDistributionToBackendFormat(unittest.TestCase):
+  def testPointDistribution(self):
+    dist = {'100KB': '100%'}
+
+    self.assertEqual(
+        object_storage_service_benchmark._DistributionToBackendFormat(dist),
+        {100000: 100.0})
+
+  def testMultiplePointsDistribution(self):
+    dist = {'1B': '10%',
+            '2B': '20%',
+            '4B': '70%'}
+
+    self.assertEqual(
+        object_storage_service_benchmark._DistributionToBackendFormat(dist),
+        {1: 10.0,
+         2: 20.0,
+         4: 70.0})
+
+  def testAbbreviatedPointDistribution(self):
+    dist = '100KB'
+
+    self.assertEqual(
+        object_storage_service_benchmark._DistributionToBackendFormat(dist),
+        {100000: 100.0})
+
+  def testBadPercentages(self):
+    dist = {'1B': '50%'}
+
+    with self.assertRaises(ValueError):
+      object_storage_service_benchmark._DistributionToBackendFormat(dist)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tests/object_storage_service_benchmark_test.py
+++ b/tests/object_storage_service_benchmark_test.py
@@ -66,6 +66,13 @@ class TestProcessMultiStreamResults(unittest.TestCase):
 [{"latency": 0.1, "operation": "upload", "stream_num": 1, "start_time": 5.0, "size": 1},
  {"latency": 0.1, "operation": "upload", "stream_num": 1, "start_time": 10.0, "size": 1}]"""  # noqa: line too long
 
+    mocked_flags = mock_flags.PatchTestCaseFlags(self)
+    mocked_flags.object_storage_scenario = 'api_multistream'
+    mocked_flags.object_storage_multistream_objects_per_stream = 100
+    mocked_flags.object_storage_object_sizes = '1B'
+    mocked_flags.object_storage_multistream_num_streams = 10
+
+
   def testProcessResults(self):
     with mock.patch(object_storage_service_benchmark.__name__ +
                     '._AppendPercentilesToResults',
@@ -83,7 +90,9 @@ class TestProcessMultiStreamResults(unittest.TestCase):
       self.assertEqual(positional_args[2],
                        'Multi-stream upload latency')
       self.assertEqual(positional_args[3], 'sec')
-      self.assertEqual(positional_args[4], {'object_size_B': 1})
+      self.assertEqual(positional_args[4], {'object_size_B': 1,
+                                            'num_streams': 10,
+                                            'objects_per_stream': 100})
 
   def testKeepsBaseMetadata(self):
     results = []


### PR DESCRIPTION
Add the MultiStreamThroughput benchmark for object storage
services. This also requires splitting WriteObjects() in
scripts/object_storage_api_tests.py into two functions that work
together.