### PR TITLE
Add GCP Region Names API

### DIFF
--- a/perfkitbenchmarker/providers/gcp/util.py
+++ b/perfkitbenchmarker/providers/gcp/util.py
@@ -113,3 +113,61 @@ class GcloudCommand(object):
     if hasattr(resource, 'zone'):
       self.flags['zone'] = resource.zone
     self.additional_flags.extend(FLAGS.additional_gcloud_flags or ())
+
+
+class GCPLocation(object):
+  """A GCP location.
+
+  This class may represent a zone, region, or continent.
+  """
+
+  MULTIREGION = 'multiregion'
+  REGION = 'region'
+  ZONE = 'zone'
+
+  def __init__(self, name):
+    parts = name.split('-')
+    if len(parts) == 0 or len(parts) > 3:
+      raise ValueError('%s is not a valid GCP Location' % name)
+
+    self._multiregion = parts[0]
+    self._region = parts[1] if len(parts) > 1 else None
+    self._zone = parts[2] if len(parts) > 2 else None
+
+  def asMultiRegion(self):
+    return self._multiregion
+
+  def asRegion(self):
+    if self._region is not None:
+      return '%s-%s' % (self._multiregion, self._region)
+    else:
+      raise ValueError('Location %s has no region' % self)
+
+  def asZone(self):
+    if self._zone is not None:
+      return '%s-%s-%s' % (self._multiregion, self._region, self._zone)
+    else:
+      raise ValueError('Location %s has no region' % self)
+
+  def kind(self):
+    if self._zone is not None:
+      return self.ZONE
+    elif self._region is not None:
+      return self.REGION
+    else:
+      return self.MULTIREGION
+
+  def asGCSMultiRegion(self):
+    if self._multiregion == 'europe':
+      return 'eu'
+    else:
+      return self._multiregion
+
+  def __str__(self):
+    val = self._multiregion
+    if self._region is not None:
+      val = val + '-' + self._region
+      if self._zone is not None:
+        val = val + '-' + self._zone
+
+    return val

--- a/tests/gcp_location_test.py
+++ b/tests/gcp_location_test.py
@@ -1,0 +1,64 @@
+# Copyright 2016 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the GCPLocation class."""
+
+
+import unittest
+
+from perfkitbenchmarker.providers.gcp import util
+
+
+class GCPLocationTest(unittest.TestCase):
+  def testAsMultiRegion(self):
+    loc = util.GCPLocation('us')
+
+    self.assertEquals(loc.asMultiRegion(), 'us')
+    with self.assertRaises(ValueError):
+      loc.asRegion()
+    with self.assertRaises(ValueError):
+      loc.asZone()
+
+    self.assertEquals(str(loc), 'us')
+    self.assertEquals(loc.kind(), util.GCPLocation.MULTIREGION)
+
+  def testAsRegion(self):
+    loc = util.GCPLocation('europe-west1')
+
+    self.assertEquals(loc.asMultiRegion(), 'europe')
+    self.assertEquals(loc.asRegion(), 'europe-west1')
+    with self.assertRaises(ValueError):
+      loc.asZone()
+
+    self.assertEquals(str(loc), 'europe-west1')
+    self.assertEquals(loc.kind(), util.GCPLocation.REGION)
+
+  def testAsZone(self):
+    loc = util.GCPLocation('asia-east1-a')
+
+    self.assertEquals(loc.asMultiRegion(), 'asia')
+    self.assertEquals(loc.asRegion(), 'asia-east1')
+    self.assertEquals(loc.asZone(), 'asia-east1-a')
+
+    self.assertEquals(str(loc), 'asia-east1-a')
+    self.assertEquals(loc.kind(), util.GCPLocation.ZONE)
+
+  def testAsGCSContinent(self):
+    loc = util.GCPLocation('europe-west1-b')
+
+    self.assertEquals(loc.asGCSMultiRegion(), 'eu')
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
A simple API to pull out the parts of a GCP zone, region, or
multi-region location name.