### PR TITLE
Don't require version of gcs-oauth2-boto-plugin

### DIFF
--- a/perfkitbenchmarker/linux_packages/gcs_boto_plugin.py
+++ b/perfkitbenchmarker/linux_packages/gcs_boto_plugin.py
@@ -19,7 +19,7 @@
 def _Install(vm):
   """Installs the iperf package on the VM."""
   vm.Install('pip')
-  vm.RemoteCommand('sudo pip install gcs-oauth2-boto-plugin==1.8')
+  vm.RemoteCommand('sudo pip install gcs-oauth2-boto-plugin')
 
 
 def YumInstall(vm):


### PR DESCRIPTION
The 1.8 version we used to require is not compatible with the latest
oauth2client, and using the most recent version causes no problems.