### PR TITLE
Upgrade to Pint 0.7

### DIFF
--- a/perfkitbenchmarker/__init__.py
+++ b/perfkitbenchmarker/__init__.py
@@ -21,28 +21,21 @@ import pint
 # we create it here.
 UNIT_REGISTRY = pint.UnitRegistry()
 
-# Pint 0.6 uses 'Bo' as the abbreviation for a byte. We want to use
-# 'B', like the rest of the world.
-UNIT_REGISTRY.define('byte = 8 * bit = B')
-
 # Apparently the prefix kilo- is supposed to be abbreviated with a
 # lower-case k. However, everyone uses the upper-case K, and would be
 # very surprised to find out that 'KB' is not a valid unit.
 UNIT_REGISTRY.define('K- = 1000')
 
 
-# The Pint documentation suggests serializing Quantities as
-# strings. If we don't supply any serializers, using --run_stage to
-# separate prepare and run phases of a benchmark can fail for any
-# benchmark that has a units flag where the default value is not
-# overridden, because the default value will have been serialized with
-# a different UnitRegistry than the one in the run phase.
+# The Pint documentation suggests serializing Quantities as tuples. We
+# supply serializers to make sure that Quantities are unpickled with
+# our UnitRegistry, where we have added the K- unit.
 def _PickleQuantity(q):
-  return _UnPickleQuantity, (str(q),)
+  return _UnPickleQuantity, (q.to_tuple(),)
 
 
 def _UnPickleQuantity(inp):
-  return UNIT_REGISTRY.parse_expression(inp)
+  return UNIT_REGISTRY.Quantity.from_tuple(inp)
 
 
 copy_reg.pickle(UNIT_REGISTRY.Quantity, _PickleQuantity)

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,4 @@ colorlog[windows]==2.6.0
 blinker>=1.3
 futures>=3.0.3
 PyYAML==3.11
-pint>=0.6
+pint>=0.7

--- a/tests/pint_pickle_test.py
+++ b/tests/pint_pickle_test.py
@@ -25,7 +25,7 @@ import perfkitbenchmarker
 class TestPintPickling(unittest.TestCase):
 
   def testSameUnitRegistry(self):
-    q_prepickle = perfkitbenchmarker.UNIT_REGISTRY.second
+    q_prepickle = 1.0 * perfkitbenchmarker.UNIT_REGISTRY.second
     q_pickled = pickle.dumps(q_prepickle)
     q_postpickle = pickle.loads(q_pickled)
 
@@ -36,26 +36,28 @@ class TestPintPickling(unittest.TestCase):
     # need all of your Quantities to point to the same UnitRegistry
     # object, and when we close and reopen PKB, we create a new
     # UnitRegistry. So to test it, we create a new UnitRegistry.
-    q_prepickle = perfkitbenchmarker.UNIT_REGISTRY.second
+    q_prepickle = 1.0 * perfkitbenchmarker.UNIT_REGISTRY.second
     q_pickled = pickle.dumps(q_prepickle)
 
     perfkitbenchmarker.UNIT_REGISTRY = pint.UnitRegistry()
 
     q_postpickle = pickle.loads(q_pickled)
 
-    with self.assertRaises(TypeError):
-      # We're checking that Pint can't convert the q_prepickle to the
-      # same units as q_postpickle, even though the units are both
-      # seconds, because they come from different UnitRegistries. For
-      # some reason the self.assertNotEqual check doesn't catch this.
-      q_prepickle.to(q_postpickle)
-
-    new_second = perfkitbenchmarker.UNIT_REGISTRY.second
+    new_second = 1.0 * perfkitbenchmarker.UNIT_REGISTRY.second
     self.assertEqual(q_postpickle, new_second)
     # This next line checks that q_postpickle is in the same "Pint
     # universe" as new_second, because we can convert q_postpickle to
     # the units of new_second.
     q_postpickle.to(new_second)
+
+  def testKB(self):
+    # Make sure we can pickle and unpickle quantities with the unit we
+    # defined ourselves.
+    q_prepickle = perfkitbenchmarker.UNIT_REGISTRY.parse_expression('1KB')
+    q_pickled = pickle.dumps(q_prepickle)
+    q_postpickle = pickle.loads(q_pickled)
+
+    self.assertEqual(q_prepickle, q_postpickle)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Now that Pint 0.7 has been released, change our code to fix some
incompatibilities with 0.7 and require pint>=0.7 in requirements.txt.