### PR TITLE
gce_virtual_machine: Support user provided instance metadata

### DIFF
--- a/perfkitbenchmarker/flag_util.py
+++ b/perfkitbenchmarker/flag_util.py
@@ -364,3 +364,27 @@ def DEFINE_yaml(name, default, help, flag_values=flags.FLAGS, **kwargs):
   serializer = YAMLSerializer()
 
   flags.DEFINE(parser, name, default, help, flag_values, serializer, **kwargs)
+
+
+def ParseKeyValuePairs(strings):
+  """Parses colon separated key value pairs from a list of strings.
+
+  Pairs should be separated by a comma and key and value by a colon, e.g.,
+  ['k1:v1', 'k2:v2,k3:v3'].
+
+  Args:
+    strings: A list of strings.
+
+  Returns:
+    A dict populated with keys and values from the flag.
+  """
+  pairs = {}
+  for pair in [kv for s in strings for kv in s.split(',')]:
+    try:
+      key, value = pair.split(':')
+      pairs[key] = value
+    except ValueError:
+      logging.error('Bad key value pair format. Skipping "%s".', pair)
+      continue
+
+  return pairs

--- a/perfkitbenchmarker/providers/gcp/flags.py
+++ b/perfkitbenchmarker/providers/gcp/flags.py
@@ -35,3 +35,21 @@ flags.DEFINE_string(
     'https://cloud.google.com/sdk/gcloud/reference/compute/disks/create')
 flags.DEFINE_string('gce_network_name', None, 'The name of an already created '
                     'network to use instead of creating a new one.')
+flags.DEFINE_multistring(
+    'gcp_instance_metadata_from_file',
+    [],
+    'A colon separated key-value pair that will be added to the '
+    '"--metadata-from-file" flag of the gcloud cli (with the colon replaced by '
+    'the equal sign). Multiple key-value pairs may be specified by separating '
+    'each pair by commas. This option can be repeated multiple times. For '
+    'information about GCP instance metadata, see: --metadata-from-file from '
+    '`gcloud help compute instances create`.')
+flags.DEFINE_multistring(
+    'gcp_instance_metadata',
+    [],
+    'A colon separated key-value pair that will be added to the '
+    '"--metadata" flag of the gcloud cli (with the colon replaced by the equal '
+    'sign). Multiple key-value pairs may be specified by separating each pair '
+    'by commas. This option can be repeated multiple times. For information '
+    'about GCP instance metadata, see: --metadata from '
+    '`gcloud help compute instances create`.')

--- a/perfkitbenchmarker/publisher.py
+++ b/perfkitbenchmarker/publisher.py
@@ -29,6 +29,7 @@ import uuid
 from perfkitbenchmarker import disk
 from perfkitbenchmarker import events
 from perfkitbenchmarker import flags
+from perfkitbenchmarker import flag_util
 from perfkitbenchmarker import version
 from perfkitbenchmarker import vm_util
 
@@ -177,14 +178,8 @@ class DefaultMetadataProvider(MetadataProvider):
     # Flatten all user metadata into a single list (since each string in the
     # FLAGS.metadata can actually be several key-value pairs) and then iterate
     # over it.
-    for pair in [kv for item in FLAGS.metadata for kv in item.split(',')]:
-      try:
-        key, value = pair.split(':')
-        metadata[key] = value
-      except ValueError:
-        logging.error('Bad metadata flag format. Skipping "%s".', pair)
-        continue
-
+    parsed_metadata = flag_util.ParseKeyValuePairs(FLAGS.metadata)
+    metadata.update(parsed_metadata)
     return metadata
 
 


### PR DESCRIPTION
Two of the instance metadata keys that are particularly interesting are
'startup-script' and 'user-data', which are reserved by google-startup-script
and Cloud
Config(https://cloudinit.readthedocs.org/en/latest/topics/format.html#cloud-config-data)
to run user specified workloads at boot time. This can be a useful way to
measure VM boot time as a lot cloud workloads are started through some init
scripts, instead of SSH. Plus, sshd on GCP images is usually started at a
pretty late stage.

@voellm @skschneider @cmccoy