### PR TITLE
openstack: Add support for optional floating ip pool

### DIFF
--- a/perfkitbenchmarker/providers/openstack/flags.py
+++ b/perfkitbenchmarker/providers/openstack/flags.py
@@ -52,9 +52,9 @@ flags.DEFINE_string('openstack_private_network', 'private',
                     'Name of OpenStack private network.')
 
 flags.DEFINE_string('openstack_network', 'private',
-                    'Name of OpenStack network. Network provides '
+                    'Name of OpenStack network. This network provides '
                     'automatically allocated fixed-IP addresses to attached '
-                    'instances. Typically, network is used for internal '
+                    'instances. Typically, this network is used for internal '
                     'communication between instances. '
                     'If openstack_floating_ip_pool is not '
                     'set then this network will be used to communicate with '
@@ -64,8 +64,8 @@ flags.DEFINE_string('openstack_floating_ip_pool', None,
                     'Name of OpenStack floating IP-address pool. If set, '
                     'a floating-ip address from this pool will be associated'
                     'to each instance and will be used for communicating '
-                    'with it. An internally routable network must be set as '
-                    'well using the openstack_network flag.')
+                    'with it. To use this flag, an internally routable network '
+                    'must also be specified via the openstack_network flag.')
 
 flags.DEFINE_boolean('openstack_config_drive', False,
                      'Add possibilities to get metadata from external drive')

--- a/perfkitbenchmarker/providers/openstack/flags.py
+++ b/perfkitbenchmarker/providers/openstack/flags.py
@@ -44,10 +44,28 @@ flags.DEFINE_string('openstack_nova_endpoint_type',
                     'defaults to $NOVA_ENDPOINT_TYPE.')
 
 flags.DEFINE_string('openstack_public_network', None,
-                    'Name of OpenStack public network')
+                    '(DEPRECATED: Use openstack_floating_ip_pool) '
+                    'Name of OpenStack public network.')
 
 flags.DEFINE_string('openstack_private_network', 'private',
-                    'Name of OpenStack private network')
+                    '(DEPRECATED: Use openstack_network) '
+                    'Name of OpenStack private network.')
+
+flags.DEFINE_string('openstack_network', 'private',
+                    'Name of OpenStack network. Network provides '
+                    'automatically allocated fixed-IP addresses to attached '
+                    'instances. Typically, network is used for internal '
+                    'communication between instances. '
+                    'If openstack_floating_ip_pool is not '
+                    'set then this network will be used to communicate with '
+                    'the instance.')
+
+flags.DEFINE_string('openstack_floating_ip_pool', None,
+                    'Name of OpenStack floating IP-address pool. If set, '
+                    'a floating-ip address from this pool will be associated'
+                    'to each instance and will be used for communicating '
+                    'with it. An internally routable network must be set as '
+                    'well using the openstack_network flag.')
 
 flags.DEFINE_boolean('openstack_config_drive', False,
                      'Add possibilities to get metadata from external drive')

--- a/perfkitbenchmarker/providers/openstack/os_virtual_machine.py
+++ b/perfkitbenchmarker/providers/openstack/os_virtual_machine.py
@@ -17,6 +17,7 @@ import threading
 import time
 
 from perfkitbenchmarker import virtual_machine, linux_virtual_machine
+from perfkitbenchmarker import errors
 from perfkitbenchmarker import flags
 from perfkitbenchmarker import vm_util
 from perfkitbenchmarker import providers
@@ -54,21 +55,47 @@ class OpenStackVirtualMachine(virtual_machine.BaseVirtualMachine):
                                                FLAGS.run_uri)
         self.client = os_utils.NovaClient()
         self.public_network = os_network.OpenStackPublicNetwork(
-            FLAGS.openstack_public_network
+            FLAGS.openstack_floating_ip_pool
         )
         self.id = None
         self.pk = None
         self.user_name = FLAGS.openstack_image_username
         self.boot_wait_time = None
         self.image = self.image or self.DEFAULT_IMAGE
+        self.public_net = None
+        self.private_net = None
+        self.floating_ip = None
 
     def _Create(self):
         image = self.client.images.findall(name=self.image)[0]
         flavor = self.client.flavors.findall(name=self.machine_type)[0]
 
-        network = self.client.networks.find(
-            label=FLAGS.openstack_private_network)
-        nics = [{'net-id': network.id}]
+        # FIXME(meteofox): Remove --openstack_public_network and
+        # --openstack_private_network once depreciation time has expired
+        self.floating_ip_pool_name = (FLAGS.openstack_floating_ip_pool or
+                                      FLAGS.openstack_public_network)
+        self.network_name = (FLAGS.openstack_network or
+                             FLAGS.openstack_private_network)
+
+        if self.network_name:
+            self.private_net = self.client.networks.find(
+                label=self.network_name)
+        if self.floating_ip_pool_name:
+            self.public_net = self.client.networks.find(
+                label=self.floating_ip_pool_name)
+
+        if self.public_net is None and self.private_net is None:
+            raise errors.Error(
+                'Cannot build instance without a network. Make sure to set '
+                'either just --openstack_network or both --openstack_network '
+                'and --openstack_private_network flags.')
+        elif self.private_net is None and self.public_net:
+            raise errors.Error(
+                'Cannot allocate floating IP address without an internally '
+                'routable network. Make sure --openstack_network flag is set.')
+
+        nics = [{'net-id': self.private_net.id}]
+
         image_id = image.id
         boot_from_vol = []
         scheduler_hints = None
@@ -84,7 +111,6 @@ class OpenStackVirtualMachine(virtual_machine.BaseVirtualMachine):
             scheduler_hints = {'group': group.id}
 
         if FLAGS.openstack_boot_from_volume:
-
             if FLAGS.openstack_volume_size:
                 volume_size = FLAGS.openstack_volume_size
             else:
@@ -120,18 +146,22 @@ class OpenStackVirtualMachine(virtual_machine.BaseVirtualMachine):
             instance = self.client.servers.get(self.id)
             status = instance.status
 
+        assert self.private_net is not None  # Previously checked, must be true.
+        self.internal_ip = instance.networks[self.network_name][0]
+        self.ip_address = self.internal_ip
+        if self.public_net:
+            self.floating_ip = self._AllocateFloatingIP(instance)
+            self.ip_address = self.floating_ip.ip
+
+    def _AllocateFloatingIP(self, instance):
         with self._floating_ip_lock:
-            self.floating_ip = self.public_network.get_or_create()
-            instance.add_floating_ip(self.floating_ip)
-            logging.info('floating-ip associated: {}'.format(
-                self.floating_ip.ip))
-
-        while not self.public_network.is_attached(self.floating_ip):
+            floating_ip = self.public_network.get_or_create()
+            instance.add_floating_ip(floating_ip)
+            logging.info(
+                'floating-ip associated: {}'.format(floating_ip.ip))
+        while not self.public_network.is_attached(floating_ip):
             time.sleep(1)
-
-        self.ip_address = self.floating_ip.ip
-        self.internal_ip = instance.networks[
-            FLAGS.openstack_private_network][0]
+        return floating_ip
 
     @os_utils.retry_authorization(max_retries=4)
     def _Delete(self):
@@ -142,7 +172,8 @@ class OpenStackVirtualMachine(virtual_machine.BaseVirtualMachine):
         except NotFound:
             logging.info('Instance not found, may have been already deleted')
 
-        self.public_network.release(self.floating_ip)
+        if self.floating_ip:
+            self.public_network.release(self.floating_ip)
 
     @os_utils.retry_authorization(max_retries=4)
     def _Exists(self):


### PR DESCRIPTION
Tested on OpenStack Kilo.

Nova API version:

Id   | Status    | Updated | Min Version | Version 
------|------------|-------------|------------------|------------
v2.0 | SUPPORTED | 2011-01-21T11:33:21Z |             |         
v2.1 | CURRENT   | 2013-07-23T11:33:21Z | 2.1         | 2.3     

Tested the following combinations:

```bash
# --openstack_network defaults 'private'
./pkb.py --cloud=OpenStack --machine_type=m1.medium --image='Ubuntu 14.04' \
         --openstack_floating_ip_pool=public --benchmarks=netperf
```

```bash
# Explicit flags
./pkb.py --cloud=OpenStack --machine_type=m1.medium --image='Ubuntu 14.04' \
         --openstack_floating_ip_pool=public --openstack_network=service \
         --benchmarks=netperf
```

```bash
# No floating IP pool
./pkb.py --cloud=OpenStack --machine_type=m1.medium --image='Ubuntu 14.04'  \
         --openstack_network=service --benchmarks=netperf
```
