### PR TITLE
Turn off selinux for mongodb.

### DIFF
--- a/perfkitbenchmarker/linux_packages/mongodb_server.py
+++ b/perfkitbenchmarker/linux_packages/mongodb_server.py
@@ -18,6 +18,7 @@
 
 def YumInstall(vm):
   """Installs the mongodb package on the VM."""
+  vm.RemoteCommand('sudo setenforce 0')
   mongodb_repo = (
       '[mongodb]\nname=MongoDB Repository\nbaseurl='
       'http://downloads-distro.mongodb.org/repo/redhat/os/x86_64/\n'


### PR DESCRIPTION
With selinux on, mongodb does not start:

```
2016-03-09 10:22:14,276 browbeat Thread-19 mongodb_ycsb(1/1) INFO     Ran ssh -A -p 22 cloud-user@x.x.x.x -2 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -o PreferredAuthentications=publickey -o PasswordAuthentication=no -o ConnectTimeout=5 -o GSSAPIAuthentication=no -o ServerAliveInterval=30 -o ServerAliveCountMax=10 -i /tmp/perfkitbenchmarker/run_browbeat/perfkitbenchmarker_keyfile sudo service mongod restart. Got return code (1).
STDOUT: Restarting mongod (via systemctl):  [FAILED]

STDERR: Warning: Permanently added 'x.x.x.x' (ECDSA) to the list of known hosts.
Job for mongod.service failed because the control process exited with error code. See "systemctl status mongod.service" and "journalctl -xe" for details.

2016-03-09 10:22:14,282 browbeat MainThread mongodb_ycsb(1/1) ERROR    Exception occurred while calling <lambda>(<functools.partial object at 0x335d998>):
Traceback (most recent call last):
  File "/home/stack/perfkit-venv/PerfKitBenchmarker/perfkitbenchmarker/vm_util.py", line 245, in _ExecuteThreadCall
    queue.put(ThreadCallResult(call_id, target(*args, **kwargs), None))
  File "/home/stack/perfkit-venv/PerfKitBenchmarker/perfkitbenchmarker/linux_benchmarks/mongodb_ycsb_benchmark.py", line 98, in <lambda>
    vm_util.RunThreaded((lambda f: f()), server_partials + client_partials)
  File "/home/stack/perfkit-venv/PerfKitBenchmarker/perfkitbenchmarker/linux_benchmarks/mongodb_ycsb_benchmark.py", line 73, in _PrepareServer
    vm.GetServiceName('mongodb_server'))
  File "/home/stack/perfkit-venv/PerfKitBenchmarker/perfkitbenchmarker/linux_virtual_machine.py", line 313, in RemoteCommand
    suppress_warning, timeout)
  File "/home/stack/perfkit-venv/PerfKitBenchmarker/perfkitbenchmarker/linux_virtual_machine.py", line 374, in RemoteHostCommand
    raise errors.VirtualMachine.RemoteCommandError(error_text)
RemoteCommandError: Got non-zero return code (1) executing sudo service mongod restart
```

I would prefer to not to have to turn off selinux, however to get this benchmark running in the mean time on centos and rhel based virtual machines we can turn off selinux on the machine that contains mongodb.