### PR TITLE
Add specific version requirement for colorama.

### DIFF
--- a/requirements-aws.txt
+++ b/requirements-aws.txt
@@ -15,3 +15,4 @@
 # Additional requirements (beyond those in requirements.txt) for running
 # PerfKitBenchmarker on AWS.
 awscli
+colorama==0.3.3


### PR DESCRIPTION
awscli and colorlog both take a dependency on colorama. However,
awscli has specific version requirements that may be ignored when
installing both requirements.txt and aws-requirements.txt unless
otherwise specified.