### PR TITLE
Use temp files for Popen stdout and stderr in IssueCommand.

### DIFF
--- a/tests/vm_util_test.py
+++ b/tests/vm_util_test.py
@@ -263,7 +263,7 @@ class IssueCommandTestCase(unittest.TestCase):
 
   def testNoTimeout_ExceptionRaised(self):
     with mock.patch('subprocess.Popen', spec=subprocess.Popen) as mock_popen:
-      mock_popen.return_value.communicate.side_effect = KeyboardInterrupt()
+      mock_popen.return_value.wait.side_effect = KeyboardInterrupt()
       with self.assertRaises(KeyboardInterrupt):
         vm_util.IssueCommand(['sleep', '2s'], timeout=None)
     self.assertFalse(HaveSleepSubprocess())


### PR DESCRIPTION
Avoids issue of limited pipe size.
Addresses #860.