### PR TITLE
Add Object Size Distributions

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/object_storage_service_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/object_storage_service_benchmark.py
@@ -352,16 +352,12 @@ def _ProcessMultiStreamResults(raw_result, operation, sizes,
       FLAGS.object_storage_multistream_objects_per_stream)
 
   overall_metadata = metadata.copy()
-  # I would love to publish the full distribution in the metadata, but
-  # I'm afraid that including a complex value like a dictionary in
-  # metadata that is otherwise simple Python objects would break
-  # parsers. Also, we'd need to implement a custom serializer unless
-  # we wanted regular expression parsing of metadata to depend on
-  # Python's hash function. I add 'object_size_B':'distribution' for
-  # the full results because the metadata for the per-object-size
-  # values will include the 'object_size_B' field, and searching can
-  # be easier when all the records you care about have the same
-  # metadata fields.
+  # Don't publish the full distribution in the metadata because doing
+  # so might break regexp-based parsers that assume that all metadata
+  # values are simple Python objects. However, do add an
+  # 'object_size_B' metadata field even for the full results because
+  # searching metadata is easier when all records with the same metric
+  # name have the same set of metadata fields.
   overall_metadata['object_size_B'] = 'distribution'
   logging.info('Processing %s multi-stream %s results for the full '
                'distribution.', len(records), operation)

--- a/perfkitbenchmarker/scripts/object_storage_api_tests.py
+++ b/perfkitbenchmarker/scripts/object_storage_api_tests.py
@@ -198,8 +198,12 @@ class SizeDistributionIterator(object):
     self.sizes = []
     self.cutoffs = []
 
+    # Sorting the (size, percent change) pairs by size makes for a
+    # nicer interface and also simplifies unit testing.
+    sorted_dist = sorted(dist.iteritems(), key=lambda x: x[0])
+
     total_percent = 0.0
-    for size, percent in dist.iteritems():
+    for size, percent in sorted_dist:
       total_percent += percent
       self.sizes.append(size)
       self.cutoffs.append(total_percent)

--- a/perfkitbenchmarker/scripts/object_storage_api_tests.py
+++ b/perfkitbenchmarker/scripts/object_storage_api_tests.py
@@ -187,32 +187,55 @@ class SizeDistributionIterator(object):
     dist: dict. The distribution to draw sizes from.
   """
 
-  # IMPLEMENTATION LIMITATION: right now, this object only supports
-  # point distributions, which contain only a single size.
-
   def __init__(self, dist):
-    if len(dist) != 1:
-      raise NotImplementedError(
-          'General distributions are not implemented yet.')
+    # This class chooses random numbers by using random.random() to
+    # pick a float in [0.0, 100.0), then converting that into a choice
+    # from our distribution. The data structure is two lists, sizes
+    # and cutoffs. If the random number is in the range [cutoffs[i-1],
+    # cutoffs[i]), then the random choice is sizes[i]. Cutoffs has an
+    # implied starting element 0.0, and its last element must be
+    # 100.0.
+    self.sizes = []
+    self.cutoffs = []
 
-    size, _ = dist.iteritems().next()
-    self.size = size
+    total_percent = 0.0
+    for size, percent in dist.iteritems():
+      total_percent += percent
+      self.sizes.append(size)
+      self.cutoffs.append(total_percent)
+
+    # I considered storing probabilities instead of percents, but I'm
+    # afraid that there is an edge case where the probability
+    # corresponding to a percent doesn't have a terminating binary
+    # representation and then the total percent is less than 1.0 even
+    # though the percentages add up to 100. I can't prove that this
+    # happens, but storing percentages seems safer.
+    assert total_percent == 100.0
 
   # this is required by the Python iterator protocol
   def __iter__(self):
     return self
 
   def next(self):
+    val = random.random() * 100.0
+
+    # binary search has a lower asymptotic complexity than linear
+    # scanning, but thanks to caches and sequential access, I suspect
+    # linear scanning will be faster for any realistic distribution.
+    for i in xrange(len(self.sizes)):
+      if self.cutoffs[i] > val:
+        return self.sizes[i]
+
+    raise AssertionError("Random percent %s didn't match percent cutoff list %s"
+                         % (val, self.cutoffs))
+
     return self.size
 
 
 def MaxSizeInDistribution(dist):
   """Find the maximum object size in a distribution."""
 
-  if len(dist) != 1:
-    raise NotImplementedError('General distributions are not implemented yet.')
-
-  return long(dist.iterkeys().next())
+  return max(dist.iterkeys())
 
 
 def PercentileCalculator(numbers):
@@ -319,6 +342,15 @@ def CleanupBucket(storage_schema):
 
 
 def GenerateWritePayload(size):
+  """Generate random data for use with WriteObjectFromBuffer.
+
+  Args:
+    size: the amount of data needed, in bytes.
+
+  Returns:
+    A string of the length requested, filled with random data.
+  """
+
   payload_bytes = bytearray(size)
   # don't use a for...range(100M), range(100M) will create a list of 100mm items
   # with each item being the default object size of 30 bytes or so, it will lead
@@ -326,9 +358,7 @@ def GenerateWritePayload(size):
   for i in xrange(size):
     payload_bytes[i] = ord(random.choice(string.letters))
 
-  payload_string = payload_bytes.decode('ascii')
-
-  return payload_bytes, payload_string
+  return payload_bytes.decode('ascii')
 
 
 def WriteObjects(storage_schema, bucket, object_prefix, count,
@@ -354,7 +384,8 @@ def WriteObjects(storage_schema, bucket, object_prefix, count,
     host_to_connect: An optional endpoint string to connect to.
   """
 
-  payload_bytes, payload_string = GenerateWritePayload(size)
+  payload = GenerateWritePayload(size)
+  handle = cStringIO.StringIO(payload)
 
   for i in xrange(count):
     object_name = '%s_%d' % (object_prefix, i)
@@ -362,7 +393,7 @@ def WriteObjects(storage_schema, bucket, object_prefix, count,
     try:
       _, latency = WriteObjectFromBuffer(
           storage_schema, bucket, object_name,
-          payload_bytes, payload_string,
+          handle, size,
           host_to_connect=host_to_connect)
 
       objects_written.append(object_name)
@@ -370,14 +401,14 @@ def WriteObjects(storage_schema, bucket, object_prefix, count,
         latency_results.append(latency)
       if bandwidth_results is not None and latency > 0.0:
         bandwidth_results.append(size / latency)
+      handle.seek(0)
     except Exception as e:
       logging.info('Caught exception %s while writing object %s' %
                    (e, object_name))
 
 
 def WriteObjectFromBuffer(storage_schema, bucket_name, object_name,
-                          payload_bytes, payload_string,
-                          host_to_connect=None):
+                          stream, size, host_to_connect=None):
   """Write an object to a storage provider.
 
   Exceptions are propagated to the caller, which can decide whether to
@@ -387,8 +418,8 @@ def WriteObjectFromBuffer(storage_schema, bucket_name, object_name,
     storage_schema: The address schema identifying a storage. e.g., "gs"
     bucket_name: Name of the bucket to write to.
     object_name: Name of the object.
-    payload_bytes: A bytearray to transfer.
-    payload_string: A string version of payload_bytes.
+    stream: A read()-able stream to transfer.
+    size: The number of bytes to transfer.
     host_to_connect: An optional endpoint string to connect to.
 
   Returns:
@@ -405,10 +436,10 @@ def WriteObjectFromBuffer(storage_schema, bucket_name, object_name,
     if host_to_connect is not None:
       object_uri.connect(host=host_to_connect)
 
-    object_uri.set_contents_from_string(payload_string)
+    object_uri.set_contents_from_file(stream, size=size)
   else:
-    _AZURE_BLOB_SERVICE.put_block_blob_from_bytes(
-        bucket_name, object_name, bytes(payload_bytes))
+    _AZURE_BLOB_SERVICE.put_block_blob_from_file(
+        bucket_name, object_name, stream, count=size)
 
   latency = time.time() - start_time
 
@@ -736,17 +767,15 @@ def MultiStreamWrites(storage_schema, host_to_connect=None):
 
   """
 
-  size_distribution = yaml.load(cStringIO.StringIO(FLAGS.object_sizes))
+  size_distribution = yaml.load(FLAGS.object_sizes)
 
-  payload_bytes, payload_string = GenerateWritePayload(
-      MaxSizeInDistribution(size_distribution))
+  payload = GenerateWritePayload(MaxSizeInDistribution(size_distribution))
 
   results = RunThreadedWorkers(
       WriteWorker,
       (storage_schema,
        host_to_connect,
-       payload_bytes,
-       payload_string,
+       payload,
        size_distribution,
        FLAGS.objects_per_stream,
        FLAGS.start_time))
@@ -879,9 +908,22 @@ def SleepUntilTime(when):
 
 
 def WriteWorker(storage_schema, host_to_connect,
-                payload_bytes, payload_string,
-                size_distribution, num_objects,
+                payload, size_distribution, num_objects,
                 start_time, result_queue, worker_num):
+  """Upload objects for the multi-stream writes benchmark.
+
+  Args:
+    storage_schema: a two-character string indicating the storage
+      type. Ex: 'gs', 's3'.
+    host_to_connect: if given, an endpoint URL to connect to.
+    payload: a string. The bytes to upload.
+    size_distribution: the distribution of object sizes to use.
+    num_objects: the number of objects to upload.
+    start_time: a POSIX timestamp. When to start uploading.
+    result_queue: a Queue.Queue to record results in.
+    worker_num: the thread number of this worker.
+  """
+
   object_names = []
   start_times = []
   latencies = []
@@ -890,6 +932,8 @@ def WriteWorker(storage_schema, host_to_connect,
   size_iterator = SizeDistributionIterator(size_distribution)
   object_prefix = ('pkb_write_worker_%f_%s' % (time.time(), worker_num))
 
+  payload_handle = cStringIO.StringIO(payload)
+
   if start_time is not None:
     SleepUntilTime(start_time)
 
@@ -897,18 +941,18 @@ def WriteWorker(storage_schema, host_to_connect,
     object_name = '%s_%d' % (object_prefix, i)
     object_size = size_iterator.next()
 
-    # TODO: make use of object_size later when adding object size
-    # distribution support.
     try:
       start_time, latency = WriteObjectFromBuffer(
           storage_schema, FLAGS.bucket, object_name,
-          payload_bytes, payload_string,
+          payload_handle, object_size,
           host_to_connect=host_to_connect)
 
       object_names.append(object_name)
       start_times.append(start_time)
       latencies.append(latency)
       sizes.append(object_size)
+
+      payload_handle.seek(0)
     except Exception as e:
       logging.info('Worker %s caught exception %s while writing object %s' %
                    (worker_num, e, object_name))

--- a/script-tests/object_storage_worker_tests.py
+++ b/script-tests/object_storage_worker_tests.py
@@ -40,10 +40,7 @@ class TestSizeDistributionIterator(unittest.TestCase):
     with mock.patch(random.__name__ + '.random') as rand:
       rand.side_effect = [0.2, 0.7, 0.2]
       values = list(itertools.islice(iter, 3))
-      # We should draw either 1, 10, 1 or 10, 1, 10, but which one
-      # depends on Python's hash function, and I don't want this test
-      # to depend on that.
-      self.assertTrue(values == [1, 10, 1] or values == [10, 1, 10])
+      self.assertTrue(values == [1, 10, 1])
 
   def testNonTerminatingBinaryPercent(self):
     # 20/100 = 1/5 does not terminate in binary
@@ -54,7 +51,7 @@ class TestSizeDistributionIterator(unittest.TestCase):
       rand.side_effect = [0.1, 0.9]
       values = list(itertools.islice(iter, 2))
 
-      self.assertTrue(values == [1, 10] or values == [10, 1])
+      self.assertTrue(values == [1, 10])
 
 
 class TestMaxSizeInDistribution(unittest.TestCase):

--- a/script-tests/object_storage_worker_tests.py
+++ b/script-tests/object_storage_worker_tests.py
@@ -15,28 +15,58 @@
 """Tests for the object_storage_service benchmark worker process."""
 
 import itertools
+import random
 import unittest
+
+import mock
 
 import object_storage_api_tests
 
 
 class TestSizeDistributionIterator(unittest.TestCase):
   def testPointDistribution(self):
-    dist = {}
-    dist[10] = 100.0
+    dist = {10: 100.0}
 
     iter = object_storage_api_tests.SizeDistributionIterator(dist)
 
-    lst = list(itertools.islice(iter, 5))
+    values = list(itertools.islice(iter, 5))
 
-    self.assertEqual(lst, [10, 10, 10, 10, 10])
+    self.assertEqual(values, [10, 10, 10, 10, 10])
+
+  def testTwoElementDistribution(self):
+    dist = {1: 50.0, 10: 50.0}
+    iter = object_storage_api_tests.SizeDistributionIterator(dist)
+
+    with mock.patch(random.__name__ + '.random') as rand:
+      rand.side_effect = [0.2, 0.7, 0.2]
+      values = list(itertools.islice(iter, 3))
+      # We should draw either 1, 10, 1 or 10, 1, 10, but which one
+      # depends on Python's hash function, and I don't want this test
+      # to depend on that.
+      self.assertTrue(values == [1, 10, 1] or values == [10, 1, 10])
+
+  def testNonTerminatingBinaryPercent(self):
+    # 20/100 = 1/5 does not terminate in binary
+    dist = {1: 20.0, 10: 80.0}
+    iter = object_storage_api_tests.SizeDistributionIterator(dist)
+
+    with mock.patch(random.__name__ + '.random') as rand:
+      rand.side_effect = [0.1, 0.9]
+      values = list(itertools.islice(iter, 2))
+
+      self.assertTrue(values == [1, 10] or values == [10, 1])
 
 
 class TestMaxSizeInDistribution(unittest.TestCase):
   def testPointDistribution(self):
-    dist = {}
+    dist = {10: 100.0}
     dist[10] = 100.0
 
+    self.assertEqual(object_storage_api_tests.MaxSizeInDistribution(dist),
+                     10)
+
+  def testTwoElementDistribution(self):
+    dist = {1: 50.0, 10: 50.0}
     self.assertEqual(object_storage_api_tests.MaxSizeInDistribution(dist),
                      10)
 


### PR DESCRIPTION
Add object size distribution support to the api_multistream scenario of
the object_storage_service benchmark. Also introduce a
SizeDistributionIterator class to provide general support for
distributions, and change the object storage upload mechanism from
strings to streams to allow use of APIs that make distribution support
easier.