### PR TITLE
Support object storage classes

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/object_storage_service_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/object_storage_service_benchmark.py
@@ -59,6 +59,9 @@ flags.DEFINE_string('object_storage_region', None,
 flags.DEFINE_string('object_storage_gcs_multiregion', None,
                     'Storage multiregion for GCS in object storage benchmark.')
 
+flags.DEFINE_string('object_storage_storage_class', None,
+                    'Storage class to use in object storage benchmark.')
+
 flags.DEFINE_enum('object_storage_scenario', 'all',
                   ['all', 'cli', 'api_data', 'api_namespace',
                    'api_multistream'],
@@ -471,6 +474,8 @@ def ApiBasedBenchmarks(results, metadata, vm, storage, test_script_path,
         cmd_parts += [azure_command_suffix]
       if host_to_connect is not None:
         cmd_parts += ['--host', host_to_connect]
+      if FLAGS.object_storage_storage_class is not None:
+        cmd_parts += ['--storage_class', FLAGS.object_storage_storage_class]
 
       return ' '.join(cmd_parts)
 
@@ -1076,6 +1081,8 @@ class GoogleCloudStorageBenchmark(object):
     make_bucket_command = '%s mb' % vm.gsutil_path
     if FLAGS.object_storage_gcs_multiregion:
       make_bucket_command += ' -l %s' % FLAGS.object_storage_gcs_multiregion
+    if FLAGS.object_storage_storage_class:
+      make_bucket_command += ' -c %s' % FLAGS.object_storage_storage_class
     make_bucket_command += ' gs://%s' % vm.bucket_name
     vm.RemoteCommand(make_bucket_command)
 

--- a/perfkitbenchmarker/linux_benchmarks/object_storage_service_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/object_storage_service_benchmark.py
@@ -475,7 +475,8 @@ def ApiBasedBenchmarks(results, metadata, vm, storage, test_script_path,
       if host_to_connect is not None:
         cmd_parts += ['--host', host_to_connect]
       if FLAGS.object_storage_storage_class is not None:
-        cmd_parts += ['--storage_class', FLAGS.object_storage_storage_class]
+        cmd_parts += ['--object_storage_class',
+                      FLAGS.object_storage_storage_class]
 
       return ' '.join(cmd_parts)
 
@@ -1081,7 +1082,7 @@ class GoogleCloudStorageBenchmark(object):
     make_bucket_command = '%s mb' % vm.gsutil_path
     if FLAGS.object_storage_gcs_multiregion:
       make_bucket_command += ' -l %s' % FLAGS.object_storage_gcs_multiregion
-    if FLAGS.object_storage_storage_class:
+    if FLAGS.object_storage_storage_class is not None:
       make_bucket_command += ' -c %s' % FLAGS.object_storage_storage_class
     make_bucket_command += ' gs://%s' % vm.bucket_name
     vm.RemoteCommand(make_bucket_command)

--- a/perfkitbenchmarker/scripts/object_storage_api_tests.py
+++ b/perfkitbenchmarker/scripts/object_storage_api_tests.py
@@ -100,9 +100,10 @@ flags.DEFINE_float('start_time', None, 'The time (as a POSIX timestamp) '
                    'to start the operation. Only applies to the '
                    'MultiStreamRead and MultiStreamWrite scenarios.')
 
-flags.DEFINE_string('storage_class', None, 'The storage class to use for '
-                    'uploads. Currently only applicable to AWS, ignored by '
-                    'other providers.')
+flags.DEFINE_string('object_storage_class', None, 'The storage class to use '
+                    'for uploads. Currently only applicable to AWS. For other '
+                    'providers, storage class is determined by the bucket, '
+                    'which is passed in by the --bucket parameter.')
 
 STORAGE_TO_SCHEMA_DICT = {'GCS': 'gs', 'S3': 's3', 'AZURE': 'azure'}
 
@@ -443,12 +444,12 @@ def WriteObjectFromBuffer(storage_schema, bucket_name, object_name,
     if host_to_connect is not None:
       object_uri.connect(host=host_to_connect)
 
-    if FLAGS.storage_class and storage_schema == 's3':
+    if FLAGS.object_storage_class and storage_schema == 's3':
       # We need to use a lower-level upload method when using an S3
       # storage class because we need access to the key object so we
       # can set its storage class.
       key = object_uri.new_key()
-      key._set_storage_class(FLAGS.storage_class)
+      key._set_storage_class(FLAGS.object_storage_class)
       key.set_contents_from_file(stream, size=size)
     else:
       object_uri.set_contents_from_file(stream, size=size)


### PR DESCRIPTION
Add --object_storage_storage_class flag, which lets users of the object
storage benchmark choose the storage class of their objects.