### PR TITLE
rackspace: Fix missing flags bug

### DIFF
--- a/perfkitbenchmarker/providers/rackspace/rackspace_network.py
+++ b/perfkitbenchmarker/providers/rackspace/rackspace_network.py
@@ -301,13 +301,12 @@ class RackspaceFirewall(network.BaseFirewall):
     self._lock = threading.Lock()  # Guards security-group creation/deletion
     self.firewall_rules = {}
 
-
   def AllowPort(self, vm, port, to_port=None, source_range=None):
-    if FLAGS.use_security_group:
-      # At Rackspace all ports are open by default
-      # TODO(meteorfox) Implement security groups support
+    # At Rackspace all ports are open by default
+    # TODO(meteorfox) Implement security groups support
+    if FLAGS.rackspace_use_security_group:
       raise NotImplementedError()
 
   def DisallowAllPorts(self):
-    if FLAGS.use_security_group:
+    if FLAGS.rackspace_use_security_group:
       raise NotImplementedError()

--- a/perfkitbenchmarker/providers/rackspace/rackspace_virtual_machine.py
+++ b/perfkitbenchmarker/providers/rackspace/rackspace_virtual_machine.py
@@ -263,7 +263,7 @@ class RackspaceVirtualMachine(virtual_machine.BaseVirtualMachine):
     create_cmd.flags['name'] = self.name
     create_cmd.flags['keypair'] = self.name
     create_cmd.flags['flavor-id'] = self.machine_type
-    if FLAGS.boot_from_cbs_volume:
+    if FLAGS.rackspace_boot_from_cbs_volume:
       blk_flag = RenderBlockDeviceTemplate(self.image, REMOTE_BOOT_DISK_SIZE_GB)
       create_cmd.flags['block-device'] = blk_flag
     else:


### PR DESCRIPTION
After the rename for use_security_group and boot_from_cbs_volume, their
references were not updated causing fatal failure with flags not being defined.

Addresses Issue #902 