### PR TITLE
Add percentiles option to PercentilesCalculator

### DIFF
--- a/perfkitbenchmarker/sample.py
+++ b/perfkitbenchmarker/sample.py
@@ -25,7 +25,8 @@ def PercentileCalculator(numbers, percentiles=PERCENTILES_LIST):
 
   Args:
     numbers: The set of numbers to compute percentiles for.
-    percentiles: If given, a list of percentiles to compute.
+    percentiles: If given, a list of percentiles to compute. Can be
+      floats, ints or longs.
 
   Returns:
     A dictionary of percentiles.
@@ -35,10 +36,12 @@ def PercentileCalculator(numbers, percentiles=PERCENTILES_LIST):
   total = sum(numbers_sorted)
   result = {}
   for percentile in percentiles:
+    if percentile < 0.0 or percentile > 100.0:
+      raise ValueError('Invalid percentile %s' % percentile)
+
     percentile_string = 'p%s' % str(percentile)
     index = int(count * float(percentile) / 100.0)
-    if index == count:
-      index = count - 1
+    index = min(index, count - 1)  # Correction to handle 100th percentile.
     result[percentile_string] = numbers_sorted[index]
 
   if count > 0:

--- a/perfkitbenchmarker/sample.py
+++ b/perfkitbenchmarker/sample.py
@@ -20,11 +20,12 @@ PERCENTILES_LIST = [0.1, 1, 5, 10, 50, 90, 95, 99, 99.9]
 _SAMPLE_FIELDS = 'metric', 'value', 'unit', 'metadata', 'timestamp'
 
 
-def PercentileCalculator(numbers):
+def PercentileCalculator(numbers, percentiles=PERCENTILES_LIST):
   """Computes percentiles, stddev and mean on a set of numbers
 
   Args:
     numbers: The set of numbers to compute percentiles for.
+    percentiles: If given, a list of percentiles to compute.
 
   Returns:
     A dictionary of percentiles.
@@ -33,10 +34,12 @@ def PercentileCalculator(numbers):
   count = len(numbers_sorted)
   total = sum(numbers_sorted)
   result = {}
-  for percentile in PERCENTILES_LIST:
+  for percentile in percentiles:
     percentile_string = 'p%s' % str(percentile)
-    result[percentile_string] = numbers_sorted[
-        int(count * float(percentile) / 100)]
+    index = int(count * float(percentile) / 100.0)
+    if index == count:
+      index = count - 1
+    result[percentile_string] = numbers_sorted[index]
 
   if count > 0:
     average = total / float(count)

--- a/perfkitbenchmarker/sample.py
+++ b/perfkitbenchmarker/sample.py
@@ -30,7 +30,15 @@ def PercentileCalculator(numbers, percentiles=PERCENTILES_LIST):
 
   Returns:
     A dictionary of percentiles.
+
+  Raises:
+    ValueError, if numbers is empty or if a percentile is outside of
+    [0, 100].
   """
+
+  if not numbers:
+    raise ValueError("Can't compute percentiles of empty list.")
+
   numbers_sorted = sorted(numbers)
   count = len(numbers_sorted)
   total = sum(numbers_sorted)
@@ -44,14 +52,13 @@ def PercentileCalculator(numbers, percentiles=PERCENTILES_LIST):
     index = min(index, count - 1)  # Correction to handle 100th percentile.
     result[percentile_string] = numbers_sorted[index]
 
-  if count > 0:
-    average = total / float(count)
-    result['average'] = average
-    if count > 1:
-      total_of_squares = sum([(i - average) ** 2 for i in numbers])
-      result['stddev'] = (total_of_squares / (count - 1)) ** 0.5
-    else:
-      result['stddev'] = 0
+  average = total / float(count)
+  result['average'] = average
+  if count > 1:
+    total_of_squares = sum([(i - average) ** 2 for i in numbers])
+    result['stddev'] = (total_of_squares / (count - 1)) ** 0.5
+  else:
+    result['stddev'] = 0
 
   return result
 

--- a/tests/sample_test.py
+++ b/tests/sample_test.py
@@ -28,3 +28,19 @@ class SampleTestCase(unittest.TestCase):
     instance = sample.Sample(metric='Test', value=1.0, unit='Mbps',
                              metadata=metadata.copy())
     self.assertDictEqual(metadata, instance.metadata)
+
+
+class TestPercentileCalculator(unittest.TestCase):
+  def testPercentileCalculator(self):
+    numbers = range(0, 1001)
+    percentiles = sample.PercentileCalculator(numbers,
+                                              percentiles=[0, 1, 99.9, 100])
+
+    self.assertEqual(percentiles['p0'], 0)
+    self.assertEqual(percentiles['p1'], 10)
+    self.assertEqual(percentiles['p99.9'], 999)
+    self.assertEqual(percentiles['p100'], 1000)
+    self.assertEqual(percentiles['average'], 500)
+
+    # 4 percentiles we requested, plus average and stddev
+    self.assertEqual(len(percentiles), 6)

--- a/tests/sample_test.py
+++ b/tests/sample_test.py
@@ -44,3 +44,15 @@ class TestPercentileCalculator(unittest.TestCase):
 
     # 4 percentiles we requested, plus average and stddev
     self.assertEqual(len(percentiles), 6)
+
+  def testNoNumbers(self):
+    with self.assertRaises(ValueError):
+      sample.PercentileCalculator([], percentiles=[0, 1, 99])
+
+  def testOutOfRangePercentile(self):
+    with self.assertRaises(ValueError):
+      sample.PercentileCalculator([3], percentiles=[-1])
+
+  def testWrongTypePercentile(self):
+    with self.assertRaises(ValueError):
+      sample.PercentileCalculator([3], percentiles=["a"])


### PR DESCRIPTION
Let the user specify which percentiles to compute. Also adds a test for
the PercentilesCalculator and fixes a bug revealed by the test.