### PR TITLE
Cloud bigtable

### DIFF
--- a/perfkitbenchmarker/data/cloudbigtable/hbase-site.xml.j2
+++ b/perfkitbenchmarker/data/cloudbigtable/hbase-site.xml.j2
@@ -9,7 +9,7 @@
   </property>
   <property>
     <name>hbase.client.connection.impl</name>
-    <value>com.google.cloud.bigtable.hbase1_1.BigtableConnection</value>
+    <value>com.google.cloud.bigtable.hbase{{ hbase_version }}.BigtableConnection</value>
   </property>
   <property>
     <name>google.bigtable.project.id</name>

--- a/perfkitbenchmarker/linux_packages/hbase.py
+++ b/perfkitbenchmarker/linux_packages/hbase.py
@@ -25,6 +25,7 @@ from perfkitbenchmarker import data
 from perfkitbenchmarker import vm_util
 from perfkitbenchmarker.linux_packages import hadoop
 
+
 HBASE_VERSION = '1.1.4'
 HBASE_URL = ('http://www.us.apache.org/dist/hbase/{0}/'
              'hbase-{0}-bin.tar.gz').format(HBASE_VERSION)

--- a/perfkitbenchmarker/pkb.py
+++ b/perfkitbenchmarker/pkb.py
@@ -355,17 +355,17 @@ def RunBenchmark(benchmark, collector, sequence_number, total_benchmarks,
       benchmark_name, sequence_number, total_benchmarks)
   log_context = log_util.GetThreadLogContext()
   with log_context.ExtendLabel(label_extension):
-    # Optional prerequisite checking.
-    check_prereqs = getattr(benchmark, 'CheckPrerequisites', None)
-    if check_prereqs:
-      try:
-        check_prereqs()
-      except:
-        logging.exception('Prerequisite check failed for %s', benchmark_name)
-        raise
 
     spec = _GetBenchmarkSpec(benchmark_config, benchmark_name, benchmark_uid)
     with spec.RedirectGlobalFlags():
+      # Optional prerequisite checking.
+      check_prereqs = getattr(benchmark, 'CheckPrerequisites', None)
+      if check_prereqs:
+        try:
+          check_prereqs()
+        except:
+          logging.exception('Prerequisite check failed for %s', benchmark_name)
+          raise
       end_to_end_timer = timing_util.IntervalTimer()
       detailed_timer = timing_util.IntervalTimer()
       try:


### PR DESCRIPTION
Add the necessary scopes to the benchmark configuration for the `cloud_bigtable_ycsb` benchmark; for this to work, also needed to move the CheckPrerequisites step to after the flags from benchmark configs have been applied.  

Also, have the cloud_bigtable_ycsb pick up the hbase version from the hbase package.  