### PR TITLE
Handle unset PYTHONPATH in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ deps =
 [testenv:scripttests]
 commands = nosetests {toxinidir}/script-tests []
 setenv = 
-  PYTHONPATH = {toxinidir}/perfkitbenchmarker/scripts:{env:PYTHONPATH}
+  PYTHONPATH = {toxinidir}/perfkitbenchmarker/scripts:{env:PYTHONPATH:}
 
 [testenv:flake8]
 skip_install = True


### PR DESCRIPTION
Provide default value so Tox won't error when PYTHONPATH is unset.