### PR TITLE
Update speccpu2006 benchmark to support iso file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ In its current release these are the benchmarks that are executed:
   - `ping`: No license needed.
   - `silo`: MIT License
   - `scimark2`: [public domain](http://math.nist.gov/scimark2/credits.html)
-  - `speccpu2006`: [Spec CPU2006](http://www.spec.org/cpu2006/)
+  - `speccpu2006`: [SPEC CPU2006](http://www.spec.org/cpu2006/)
   - `sysbench_oltp`: [GPL v2](https://github.com/akopytov/sysbench)
   - [`tomcat`](https://github.com/apache/tomcat):
     [Apache v2](https://github.com/apache/tomcat/blob/trunk/LICENSE)
@@ -76,9 +76,27 @@ Some of the benchmarks invoked require Java. You must also agree with the follow
 Benchmarker users must manually download the CoreMark tarball from their website and save it under the
 `perfkitbenchmarker/data` folder (e.g. `~/PerfKitBenchmarker/perfkitbenchmarker/data/coremark_v1.0.tgz`)
 
-[SpecCPU2006](https://www.spec.org/cpu2006/) benchmark setup cannot be automated. SPEC requires users to purchase a license and agree with their terms and conditions.
-PerfKit Benchmarker users must manually download SpecCPU2006 tarball from their website and save it under
-the `perfkitbenchmarker/data` folder (e.g. `~/PerfKitBenchmarker/perfkitbenchmarker/data/cpu2006v1.2.tgz`)
+[SPEC CPU2006](https://www.spec.org/cpu2006/) benchmark setup cannot be
+automated. SPEC requires that users purchase a license and agree with their
+terms and conditions. PerfKit Benchmarker users must manually download
+`cpu2006-1.2.iso` from the SPEC website, save it under the
+`perfkitbenchmarker/data` folder (e.g.
+`~/PerfKitBenchmarker/perfkitbenchmarker/data/cpu2006-1.2.iso`), and also
+supply a runspec cfg file (e.g.
+`~/PerfKitBenchmarker/perfkitbenchmarker/data/linux64-x64-gcc47.cfg`).
+Alternately, PerfKit Benchmarker can accept a tar file that can be generated
+with the following steps:
+
+* Extract the contents of `cpu2006-1.2.iso` into a directory named `cpu2006`
+* Run `cpu2006/install.sh`
+* Copy the cfg file into `cpu2006/config`
+* Create a tar file containing the `cpu2006` directory, and place it under the
+  `perfkitbenchmarker/data` folder (e.g.
+  `~/PerfKitBenchmarker/perfkitbenchmarker/data/cpu2006v1.2.tgz`).
+
+PerfKit Benchmarker will use the tar file if it is present. Otherwise, it will
+search for the iso and cfg files.
+
 
 Installing PerfKit Benchmarker and Prerequisites
 ================================================

--- a/tests/linux_benchmarks/speccpu2006_benchmark_test.py
+++ b/tests/linux_benchmarks/speccpu2006_benchmark_test.py
@@ -234,22 +234,23 @@ class Speccpu2006BenchmarkTestCase(unittest.TestCase,
 
     vm = DummyVM()
 
-    samples = speccpu2006_benchmark.ExtractScore(TEST_OUTPUT_SPECINT, vm, False)
+    samples = speccpu2006_benchmark._ExtractScore(TEST_OUTPUT_SPECINT, vm,
+                                                  False)
     self.assertSampleListsEqualUpToTimestamp(samples, EXPECTED_RESULT_SPECINT)
 
-    samples = speccpu2006_benchmark.ExtractScore(TEST_OUTPUT_SPECFP, vm, False)
+    samples = speccpu2006_benchmark._ExtractScore(TEST_OUTPUT_SPECFP, vm, False)
     self.assertSampleListsEqualUpToTimestamp(samples, EXPECTED_RESULT_SPECFP)
 
     # By default, incomplete results result in error.
     with self.assertRaises(errors.Benchmarks.RunError):
-      samples = speccpu2006_benchmark.ExtractScore(TEST_OUTPUT_BAD1, vm, False)
+      samples = speccpu2006_benchmark._ExtractScore(TEST_OUTPUT_BAD1, vm, False)
 
     with self.assertRaises(errors.Benchmarks.RunError):
-      samples = speccpu2006_benchmark.ExtractScore(TEST_OUTPUT_BAD2, vm, False)
+      samples = speccpu2006_benchmark._ExtractScore(TEST_OUTPUT_BAD2, vm, False)
 
     # Now use keep_partial_results
-    samples = speccpu2006_benchmark.ExtractScore(TEST_OUTPUT_BAD1, vm, True)
+    samples = speccpu2006_benchmark._ExtractScore(TEST_OUTPUT_BAD1, vm, True)
     self.assertSampleListsEqualUpToTimestamp(samples, EXPECTED_RESULT_BAD1)
 
-    samples = speccpu2006_benchmark.ExtractScore(TEST_OUTPUT_BAD2, vm, True)
+    samples = speccpu2006_benchmark._ExtractScore(TEST_OUTPUT_BAD2, vm, True)
     self.assertSampleListsEqualUpToTimestamp(samples, EXPECTED_RESULT_BAD2)


### PR DESCRIPTION
Additionally, update flags and log messages to match the new behavior
and to standardize to "SPEC CPU2006" spelling.