### PR TITLE
Fix publisher bug when disk_size is None

### DIFF
--- a/perfkitbenchmarker/publisher.py
+++ b/perfkitbenchmarker/publisher.py
@@ -154,20 +154,22 @@ class DefaultMetadataProvider(MetadataProvider):
 
       if vm.scratch_disks:
         data_disk = vm.scratch_disks[0]
+        disk_type = data_disk.disk_type
+        disk_size = data_disk.disk_size
+        num_stripes = data_disk.num_striped_disks
         # Legacy metadata keys
-        metadata[name_prefix + 'scratch_disk_type'] = data_disk.disk_type
-        metadata[name_prefix + 'scratch_disk_size'] = data_disk.disk_size
+        metadata[name_prefix + 'scratch_disk_type'] = disk_type
+        metadata[name_prefix + 'scratch_disk_size'] = disk_size
         metadata[name_prefix + 'num_striped_disks'] = (
             data_disk.num_striped_disks)
         if getattr(data_disk, 'iops', None) is not None:
           metadata[name_prefix + 'scratch_disk_iops'] = data_disk.iops
           metadata[name_prefix + 'aws_provisioned_iops'] = data_disk.iops
         # Modern metadata keys
-        metadata[name_prefix + 'data_disk_0_type'] = data_disk.disk_type
+        metadata[name_prefix + 'data_disk_0_type'] = disk_type
         metadata[name_prefix + 'data_disk_0_size'] = (
-            data_disk.disk_size * data_disk.num_striped_disks)
-        metadata[name_prefix + 'data_disk_0_num_stripes'] = (
-            data_disk.num_striped_disks)
+            disk_size * num_stripes if disk_size else disk_size)
+        metadata[name_prefix + 'data_disk_0_num_stripes'] = num_stripes
         if getattr(data_disk, 'metadata', None) is not None:
           if disk.LEGACY_DISK_TYPE in data_disk.metadata:
             metadata[name_prefix + 'scratch_disk_type'] = (

--- a/tests/publisher_test.py
+++ b/tests/publisher_test.py
@@ -191,6 +191,12 @@ class SampleCollectorTestCase(unittest.TestCase):
     self.benchmark = 'test!'
     self.benchmark_spec = mock.MagicMock()
 
+    p = mock.patch(publisher.__name__ + '.FLAGS')
+    self.mock_flags = p.start()
+    self.addCleanup(p.stop)
+
+    self.mock_flags.product_name = 'PerfKitBenchmarker'
+
   def _VerifyResult(self, contains_metadata=True):
     self.assertEqual(1, len(self.instance.samples))
     collector_sample = self.instance.samples[0]
@@ -291,6 +297,19 @@ class DefaultMetadataProviderTestCase(unittest.TestCase):
     expected.update(scratch_disk_size=20,
                     scratch_disk_type='disk-type',
                     data_disk_0_size=20,
+                    data_disk_0_type='disk-type',
+                    data_disk_0_num_stripes=1)
+    self._RunTest(self.mock_spec, expected)
+
+  def testAddMetadata_DiskSizeNone(self):
+    # This situation can happen with static VMs
+    self.mock_disk.configure_mock(disk_type='disk-type',
+                                  disk_size=None)
+    self.mock_vm.configure_mock(scratch_disks=[self.mock_disk])
+    expected = self.default_meta.copy()
+    expected.update(scratch_disk_size=None,
+                    scratch_disk_type='disk-type',
+                    data_disk_0_size=None,
                     data_disk_0_type='disk-type',
                     data_disk_0_num_stripes=1)
     self._RunTest(self.mock_spec, expected)


### PR DESCRIPTION
This situation can happen when using static VMs. Also fix an unrelated
bug in the SampleCollectorTestCase that was causing our tests to fail.