### PR TITLE
Change bg tests to patch and verify call counts for each VM separately.

### DIFF
--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -25,6 +25,7 @@
 -rrequirements-cloudstack.txt
 
 # Test requirements
+contextlib2>=0.5.1
 mock>=1.0.1
 nose>=1.3
 flake8>=2.1.0


### PR DESCRIPTION
MagicMock.call_count is unreliable in multithreaded environments.
Rather than patching the class's methods, patch each VM's methods.
Addresses #948.