### PR TITLE
Fix Azure CLI version check.

### DIFF
--- a/perfkitbenchmarker/events.py
+++ b/perfkitbenchmarker/events.py
@@ -33,6 +33,11 @@ parsed, temporary directory initialized, run_uri set).
 Sender: None
 Payload: parsed_flags, the parsed FLAGS object.""")
 
+provider_imported = _events.signal('provider-imported', doc="""
+Signal sent after a cloud provider's modules have been imported.
+
+Sender: string. Cloud provider name chosen from providers.VALID_CLOUDS.""")
+
 
 RUN_PHASE = 'run'
 

--- a/perfkitbenchmarker/import_util.py
+++ b/perfkitbenchmarker/import_util.py
@@ -38,19 +38,3 @@ def LoadModulesForPath(path, package_prefix=None):
   for _, modname, ispkg in module_iter:
     if not ispkg:
       yield importlib.import_module(modname)
-
-
-def LoadModulesWithName(path, package_prefix, name):
-  """Load all modules with 'name'.
-
-  Args:
-    path: Path containing python modules.
-    package_prefix: Prefix (e.g., package name) to prefix all modules.
-      'path' and 'package_prefix' will be joined with a '.'.
-    name: The name of the modules to load.
-  """
-  prefix = package_prefix + '.'
-  module_iter = pkgutil.walk_packages(path, prefix=prefix)
-  for _, modname, ispkg in module_iter:
-    if not ispkg and modname.split('.')[-1] == name:
-      importlib.import_module(modname)

--- a/tests/providers/azure/__init__.py
+++ b/tests/providers/azure/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014 PerfKitBenchmarker Authors. All rights reserved.
+# Copyright 2016 PerfKitBenchmarker Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/providers/azure/util_test.py
+++ b/tests/providers/azure/util_test.py
@@ -1,0 +1,51 @@
+# Copyright 2016 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for perfkitbenchmarker.providers.azure.util."""
+
+import unittest
+
+import mock
+
+from perfkitbenchmarker import providers
+from perfkitbenchmarker.providers.azure import util
+
+
+class CheckAzureVersionTestCase(unittest.TestCase):
+
+  def setUp(self):
+    p = mock.patch.object(providers, '_imported_providers', new=set())
+    p.start()
+    self.addCleanup(p.stop)
+
+  def testNotCalledUponFlagImport(self):
+    self.assertFalse(providers._imported_providers)
+    with mock.patch.object(util, '_CheckAzureVersion') as mocked_function:
+      providers.LoadProviderFlags([providers.AZURE])
+      mocked_function.assert_not_called()
+
+  def testCalledUponFullImport(self):
+    self.assertFalse(providers._imported_providers)
+    with mock.patch.object(util, '_CheckAzureVersion') as mocked_function:
+      providers.LoadProvider(providers.AZURE)
+      mocked_function.assert_called_once_with()
+
+  def testAzureNotPresent(self):
+    self.assertFalse(providers._imported_providers)
+    with mock.patch.object(util.vm_util, 'IssueCommand', side_effect=OSError):
+      with self.assertRaises(SystemExit):
+        providers.LoadProvider(providers.AZURE)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tests/providers_test.py
+++ b/tests/providers_test.py
@@ -26,9 +26,17 @@ from tests import mock_flags
 
 class LoadProvidersTestCase(unittest.TestCase):
 
-  def testLoadAllProviders(self):
-    for cloud in providers.VALID_CLOUDS:
-      providers.LoadProvider(cloud)
+  def setUp(self):
+    p = mock.patch.object(providers, '_imported_providers', new=set())
+    p.start()
+    self.addCleanup(p.stop)
+
+  def testImportAllProviders(self):
+    # Test that all modules can be imported successfully, but mock out the call
+    # to provider_imported event handlers.
+    with mock.patch.object(providers.events.provider_imported, 'send'):
+      for cloud in providers.VALID_CLOUDS:
+        providers.LoadProvider(cloud)
 
   def testLoadInvalidProvider(self):
     with self.assertRaises(ImportError):


### PR DESCRIPTION
Related to #521

Previous behavior:
- Upon PKB initialization, providers packages were imported recursively
  (including `providers/azure/__init__.py`, its dependency `util.py`, and
  potentially other subpackages like `providers/azure/subpkg/__init__.py`)
- `CheckAzureVersion` was registered as a handler for the event
  `initialization_complete`, which was sent prior to dynamically loading
  providers, so `CheckAzureVersion` was never called.
- Missing Azure CLI error was suppressed.

New behavior:
- Upon PKB initialization, only `providers/azure/__init__.py` and
  `providers/azure/flags.py` are imported.
- `CheckAzureVersion` is registered as a handler for the new event,
  `provider_imported`, which is called at the end of `LoadProvider`.
- Missing Azure CLI error triggers a graceful exit.