### PR TITLE
Don't request SSH verbose output when --log_level=debug

### DIFF
--- a/perfkitbenchmarker/vm_util.py
+++ b/perfkitbenchmarker/vm_util.py
@@ -75,8 +75,6 @@ flags.DEFINE_integer('background_network_mbits_per_sec', None,
                      'Number of megabits per second of background '
                      'network traffic to generate during the run phase '
                      'of the benchmark')
-flags.DEFINE_boolean('verbose_ssh', False,
-                     'Request verbose output from SSH commands run by PKB.')
 
 
 class IpAddressSubset(object):
@@ -184,8 +182,6 @@ def GetSshOptions(ssh_key_filename):
       '-i', ssh_key_filename
   ]
   options.extend(FLAGS.ssh_options)
-  if FLAGS.verbose_ssh:
-    options.append('-v')
 
   return options
 

--- a/perfkitbenchmarker/vm_util.py
+++ b/perfkitbenchmarker/vm_util.py
@@ -75,6 +75,8 @@ flags.DEFINE_integer('background_network_mbits_per_sec', None,
                      'Number of megabits per second of background '
                      'network traffic to generate during the run phase '
                      'of the benchmark')
+flags.DEFINE_boolean('verbose_ssh', False,
+                     'Request verbose output from SSH commands run by PKB.')
 
 
 class IpAddressSubset(object):
@@ -182,7 +184,7 @@ def GetSshOptions(ssh_key_filename):
       '-i', ssh_key_filename
   ]
   options.extend(FLAGS.ssh_options)
-  if FLAGS.log_level == 'debug':
+  if FLAGS.verbose_ssh:
     options.append('-v')
 
   return options


### PR DESCRIPTION
PKB's current behavior is to request verbose SSH output (via "ssh -v") whenever --log_level=debug. However, verbose SSH output is *very* verbose. And the problem is frequently not SSH, meaning you have to dig through lots and lots of SSH logs looking for the rare bit of actual PKB debug output to investigate a problem.

This PR adds a --verbose_ssh flag that enables verbose SSH output, and disables
verbose SSH output when --log_level=debug but the verbose_ssh flag is
not set.

I tested by running the fio benchmark with --log_level=debug with and without --verbose_ssh. The output was as expected.