### PR TITLE
Improve Azure CLI version check.

### DIFF
--- a/perfkitbenchmarker/providers/azure/__init__.py
+++ b/perfkitbenchmarker/providers/azure/__init__.py
@@ -11,3 +11,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+EXPECTED_CLI_VERSION = '0.9.9'

--- a/perfkitbenchmarker/providers/azure/flags.py
+++ b/perfkitbenchmarker/providers/azure/flags.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 from perfkitbenchmarker import flags
+from perfkitbenchmarker.providers import azure
+
 
 NONE = 'None'
 READ_ONLY = 'ReadOnly'
@@ -38,3 +40,8 @@ flags.DEFINE_enum(
     'information. To use remote ssd scratch disks, you must use PLRS. If you '
     'use PLRS, you must use the DS series of machines, or else VM creation '
     'will fail.')
+
+flags.DEFINE_boolean(
+    'azure_ignore_cli_version', False,
+    'Unless set, PKB will require a specific version (%s) of the Azure CLI in '
+    'order to execute benchmarks using Azure VMs.' % azure.EXPECTED_CLI_VERSION)

--- a/perfkitbenchmarker/providers/azure/util.py
+++ b/perfkitbenchmarker/providers/azure/util.py
@@ -15,33 +15,71 @@
 """Utilities for working with Azure resources."""
 
 import logging
+import os
 import sys
 
 from perfkitbenchmarker import events
+from perfkitbenchmarker import flags
 from perfkitbenchmarker import providers
 from perfkitbenchmarker import vm_util
+from perfkitbenchmarker.providers import azure
+
 
 AZURE_PATH = 'azure'
-EXPECTED_VERSION = '0.9.9'
+
+FLAGS = flags.FLAGS
+
+_CLI_INSTALL_CMD = 'npm install -g azure-cli@%s' % azure.EXPECTED_CLI_VERSION
 
 
 def _CheckAzureVersion():
-  """Warns the user if the Azure CLI isn't the expected version."""
+  """Checks the version of the installed Azure CLI.
+
+  Exits the process if the version cannot be checked, or if the installed CLI
+  version does not match the expected version.
+
+  If the user provides the --azure_ignore_cli_version flag, a mismatched CLI
+  version will result in a warning, but execution will continue.
+  """
   version_cmd = [AZURE_PATH, '-v']
   try:
-    stdout, _, _ = vm_util.IssueCommand(version_cmd)
+    stdout, _, retcode = vm_util.IssueCommand(version_cmd)
   except OSError:
-    err_msg = ('Unable to execute the Azure CLI. See log for more details. See '
-               'README.md for information about how to set up PKB for Azure.')
+    err_msg = (
+        'Unable to execute the Azure CLI. See the log file for more details. '
+        'This failure may indicate that the Azure CLI is not installed. '
+        'Execute the following command to install the Azure CLI:{sep}'
+        '{install_cmd}{sep}See README.md for more information about how to set '
+        'up PerfKit Benchmarker for Azure.'.format(install_cmd=_CLI_INSTALL_CMD,
+                                                   sep=os.linesep))
     logging.debug(err_msg, exc_info=True)
     sys.exit(err_msg)
+
+  if retcode:
+    logging.error(
+        'Failed to get the Azure CLI version. This failure may indicate that '
+        'the installed version of the Azure CLI is out of date. Execute the '
+        'following command to install the recommended version of the Azure '
+        'CLI:%s%s', os.linesep, _CLI_INSTALL_CMD)
+    sys.exit(retcode)
+
   version = stdout.strip()
-  if version != EXPECTED_VERSION:
-    logging.warning('The version of the Azure CLI (%s) does not match the '
-                    'expected version (%s). This may result in '
-                    'incompatibilities which will cause commands to fail. '
-                    'Please install the reccomended version to ensure '
-                    'compatibility.', version, EXPECTED_VERSION)
+  if version != azure.EXPECTED_CLI_VERSION:
+    err_msg = (
+        'The version of the installed Azure CLI ({installed}) does not match '
+        'the expected version ({expected}). This may result in '
+        'incompatibilities that can cause commands to fail. To ensure '
+        'compatibility, install the recommended version of the CLI by '
+        'executing the following command:{sep}{install_cmd}'.format(
+            expected=azure.EXPECTED_CLI_VERSION, install_cmd=_CLI_INSTALL_CMD,
+            installed=version, sep=os.linesep))
+    if FLAGS.azure_ignore_cli_version:
+      logging.warning(err_msg)
+    else:
+      logging.error(
+          '%s%sTo bypass this CLI version check, run PerfKit Benchmarker with '
+          'the --azure_ignore_cli_version flag.', err_msg, os.linesep)
+      sys.exit(1)
 
 
 def _HandleProviderImported(sender):


### PR DESCRIPTION
Add or expand error messages for when `azure -v` fails or returns an
incorrect version. Exit PKB unless the version is correct or the
user specifies --azure_ignore_cli_version.

Addresses #521.