### PR TITLE
Add back support for python-gflags version 2.

### DIFF
--- a/perfkitbenchmarker/__init__.py
+++ b/perfkitbenchmarker/__init__.py
@@ -13,4 +13,7 @@
 # limitations under the License.
 
 import gflags as flags  # NOQA
-from gflags import validators as flags_validators  # NOQA
+try:
+  from gflags import validators as flags_validators  # NOQA
+except ImportError:
+  from gflags import gflags_validators as flags_validators  # NOQA


### PR DESCRIPTION
Keep support for the older version until we have a full release that
supports the new one.