### PR TITLE
Change check-lint.sh to invoke flake8 via tox.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ setenv =
 [testenv:flake8]
 skip_install = True
 usedevelop = True
-commands = flake8 perfkitbenchmarker tests script-tests pkb.py
+commands = flake8 {posargs:perfkitbenchmarker tests script-tests pkb.py}
 deps =
     flake8==2.4.1
     pep8==1.5.7


### PR DESCRIPTION
Prevents complaints raised by newer versions of flake8/pep8.