### PR TITLE
Factor object_storage_api_tests.py with separate backend objects

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/object_storage_service_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/object_storage_service_benchmark.py
@@ -177,6 +177,7 @@ LARGE_DATA_SIZE_IN_BYTES = 3 * 1024 * 1024 * 1024
 LARGE_DATA_SIZE_IN_MBITS = 8 * LARGE_DATA_SIZE_IN_BYTES / 1000 / 1000
 
 API_TEST_SCRIPT = 'object_storage_api_tests.py'
+API_TEST_SCRIPTS_DIR = 'object_storage_api_test_scripts'
 
 # Various constants to name the result metrics.
 THROUGHPUT_UNIT = 'Mbps'
@@ -1440,8 +1441,14 @@ def Prepare(benchmark_spec):
   file_path = data.ResourcePath(DATA_FILE)
   vms[0].PushFile(file_path, '%s/run/' % scratch_dir)
 
-  api_test_script_path = data.ResourcePath(API_TEST_SCRIPT)
-  vms[0].PushFile(api_test_script_path, '%s/run/' % scratch_dir)
+  api_test_scripts_path = data.ResourcePath(API_TEST_SCRIPTS_DIR)
+  logging.info('api_test_scripts_path: %s, %s',
+               API_TEST_SCRIPTS_DIR,
+               api_test_scripts_path)
+  for path in os.listdir(api_test_scripts_path):
+    logging.info('Uploading %s', path)
+    vms[0].PushFile('%s/%s' % (api_test_scripts_path, path),
+                    '%s/run/' % scratch_dir)
 
 
 def Run(benchmark_spec):

--- a/perfkitbenchmarker/scripts/object_storage_api_test_scripts/azure_service.py
+++ b/perfkitbenchmarker/scripts/object_storage_api_test_scripts/azure_service.py
@@ -1,0 +1,67 @@
+# Copyright 2016 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""An interface to the Azure Blob Storage API."""
+
+import logging
+import time
+
+import gflags as flags
+import azure.storage.blob
+
+import object_storage_interface
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_string('azure_account', None,
+                    'The name of the storage account for Azure.')
+
+flags.DEFINE_string('azure_key', None,
+                    'The key of the storage account for Azure.')
+
+
+class AzureService(object_storage_interface.ObjectStorageServiceBase):
+  def __init__(self):
+    if FLAGS.azure_key is None or FLAGS.azure_account is None:
+      raise ValueError('Must specify azure account and key.')
+    self.blobService = azure.storage.blob.BlobService(FLAGS.azure_account,
+                                                      FLAGS.azure_key)
+
+  def ListObjects(self, bucket, prefix):
+    return [obj.name
+            for obj in self.blobService.list_blobs(bucket, prefix=prefix)]
+
+  def DeleteObjects(self, bucket, objects_to_delete, objects_deleted=None):
+    for object_name in objects_to_delete:
+      try:
+        self.blobService.delete_blob(bucket, object_name)
+        if objects_deleted is not None:
+          objects_deleted.append(object_name)
+      except:
+        logging.exception('Caught exception while deleting object %s.',
+                          object_name)
+
+  def WriteObjectFromBuffer(self, bucket, object, stream, size):
+    stream.seek(0)
+    start_time = time.time()
+    self.blobService.put_block_blob_from_file(
+        bucket, object, stream, count=size)
+    latency = time.time() - start_time
+    return start_time, latency
+
+  def ReadObject(self, bucket, object):
+    start_time = time.time()
+    self.blobService.get_blob_to_bytes(bucket, object)
+    latency = time.time() - start_time
+    return start_time, latency

--- a/perfkitbenchmarker/scripts/object_storage_api_test_scripts/boto_service.py
+++ b/perfkitbenchmarker/scripts/object_storage_api_test_scripts/boto_service.py
@@ -1,0 +1,74 @@
+# Copyright 2016 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""An interface to boto-based object storage APIs."""
+
+import logging
+import time
+
+import boto
+
+import object_storage_interface
+
+
+class BotoService(object_storage_interface.ObjectStorageServiceBase):
+  def __init__(self, storage_schema, host_to_connect=None):
+    self.storage_schema = storage_schema
+    self.host_to_connect = host_to_connect
+
+  def _StorageURI(self, bucket, object=None):
+    """Return a storage_uri for the given resource.
+
+    Args:
+      bucket: the name of a bucket.
+      object: the name of an object, if given.
+
+    Returns: a storage_uri. If object is given, the uri will be for
+    the bucket-object combination. If object is not given, the uri
+    will be for the bucket.
+    """
+
+    if object is not None:
+      path = '%s/%s' % (bucket, object)
+    else:
+      path = bucket
+    storage_uri = boto.storage_uri(path, self.storage_schema)
+    if self.host_to_connect is not None:
+      storage_uri.connect(host=self.host_to_connect)
+    return storage_uri
+
+  def ListObjects(self, bucket, prefix):
+    bucket_uri = self._StorageURI(bucket)
+    return [obj.name for obj in bucket_uri.list_bucket(prefix=prefix)]
+
+  def DeleteObjects(self, bucket, objects_to_delete, objects_deleted=None):
+    for object_name in objects_to_delete:
+      try:
+        object_uri = self._StorageURI(bucket, object_name)
+        object_uri.delete_key()
+        if objects_deleted is not None:
+          objects_deleted.append(object_name)
+      except:
+        logging.exception('Caught exception while deleting object %s.',
+                          object_name)
+
+  # Not implementing WriteObjectFromBuffer because the implementation
+  # is different for GCS and S3.
+
+  def ReadObject(self, bucket, object):
+    start_time = time.time()
+    object_uri = self._StorageURI(bucket, object)
+    object_uri.new_key().get_contents_as_string()
+    latency = time.time() - start_time
+    return start_time, latency

--- a/perfkitbenchmarker/scripts/object_storage_api_test_scripts/gcs.py
+++ b/perfkitbenchmarker/scripts/object_storage_api_test_scripts/gcs.py
@@ -1,0 +1,40 @@
+# Copyright 2016 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""An interface to Google Cloud Storage, using the boto library."""
+
+import logging
+import time
+
+import gflags as flags
+
+import boto_service
+
+FLAGS = flags.FLAGS
+
+
+class GCSService(boto_service.BotoService):
+  def __init__(self):
+    # GCS does not use separate endpoints, so host_to_connect makes no sense.
+    if FLAGS.host is not None:
+      logging.warning('GCSService ignoring --host=%s', FLAGS.host)
+    super(GCSService, self).__init__('gs', host_to_connect=None)
+
+  def WriteObjectFromBuffer(self, bucket, object, stream, size):
+    stream.seek(0)
+    start_time = time.time()
+    object_uri = self._StorageURI(bucket, object)
+    object_uri.set_contents_from_file(stream, size=size)
+    latency = time.time() - start_time
+    return start_time, latency

--- a/perfkitbenchmarker/scripts/object_storage_api_test_scripts/object_storage_interface.py
+++ b/perfkitbenchmarker/scripts/object_storage_api_test_scripts/object_storage_interface.py
@@ -1,0 +1,103 @@
+# Copyright 2016 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The generic superclass for object storage API providers."""
+
+import abc
+
+
+class ObjectStorageServiceBase(object):
+  """Our interface to an object storage service."""
+
+  __metaclass__ = abc.ABCMeta
+
+  @abc.abstractmethod
+  def __init__(self):
+    """Create the service object."""
+
+    # __init__ takes no arguments because there are no universal
+    # arguments that apply to all services. Instead, each service
+    # should look at FLAGS, get the configuration it needs, and raise
+    # an exception if the flags are invalid for its particular
+    # service.
+
+    pass
+
+
+  @abc.abstractmethod
+  def ListObjects(self, bucket, prefix):
+    """List the objects in a bucket given a prefix.
+
+    Args:
+      bucket: the name of the bucket.
+      prefix: a prefix to list from.
+
+    Returns:
+      A list of object names.
+    """
+
+    pass
+
+
+  @abc.abstractmethod
+  def DeleteObjects(self, bucket, objects_to_delete, objects_deleted=None):
+    """Delete a list of objects.
+
+    Args:
+      bucket: the name of the bucket.
+      objects_to_delete: a list of names of objects to delete.
+      objects_deleted: if given, a list to record the objects that
+        have been successfully deleted.
+    """
+
+    pass
+
+
+  @abc.abstractmethod
+  def WriteObjectFromBuffer(self, bucket, object, stream, size):
+    """Write an object to a bucket.
+
+    Exceptions are propagated to the caller, which can decide whether
+    to tolerate them or not. This function will seek() to the
+    beginning of stream before sending.
+
+    Args:
+      bucket: the name of the bucket to write to.
+      object: the name of the object.
+      stream: a read()-able and seek()-able stream to transfer.
+      size: the number of bytes to transfer.
+
+    Returns:
+      a tuple of (start_time, latency).
+    """
+
+    pass
+
+
+  @abc.abstractmethod
+  def ReadObject(self, bucket, object):
+    """Read an object.
+
+    Exceptions are propagated to the caller, which can decide whether
+    to tolerate them or not.
+
+    Args:
+      bucket: the name of the bucket.
+      object: the name of the object.
+
+    Returns:
+      A tuple of (start_time, latency)
+    """
+
+    pass

--- a/perfkitbenchmarker/scripts/object_storage_api_test_scripts/s3.py
+++ b/perfkitbenchmarker/scripts/object_storage_api_test_scripts/s3.py
@@ -1,0 +1,46 @@
+# Copyright 2016 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""An interface to S3, using the boto library."""
+
+import logging
+import time
+
+import gflags as flags
+
+import boto_service
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_string('host', None, 'The hostname of the storage endpoint.')
+
+
+class S3Service(boto_service.BotoService):
+  def __init__(self):
+    if FLAGS.host is not None:
+      logging.info('Will use user-specified host endpoint: %s', FLAGS.host)
+    super(S3Service, self).__init__('s3', host_to_connect=FLAGS.host)
+
+  def WriteObjectFromBuffer(self, bucket, object, stream, size):
+    stream.seek(0)
+    start_time = time.time()
+    object_uri = self._StorageURI(bucket, object)
+    # We need to access the raw key object so we can set its storage
+    # class
+    key = object_uri.new_key()
+    if FLAGS.object_storage_class is not None:
+      key._set_storage_class(FLAGS.object_storage_class)
+    key.set_contents_from_file(stream, size=size)
+    latency = time.time() - start_time
+    return start_time, latency

--- a/perfkitbenchmarker/scripts/object_storage_api_test_scripts/validate_service.py
+++ b/perfkitbenchmarker/scripts/object_storage_api_test_scripts/validate_service.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+
+# Copyright 2016 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A script to validate ObjectStorageServiceBase implementations."""
+
+import cStringIO
+import logging
+import sys
+
+import gflags as flags
+
+import object_storage_api_tests
+
+FLAGS = flags.FLAGS
+
+
+def ValidateService(service):
+  object_names = ['object_' + str(i) for i in range(10)]
+  payload = object_storage_api_tests.GenerateWritePayload(100)
+  handle = cStringIO.StringIO(payload)
+
+  logging.info('Starting test.')
+
+  # Write objects
+  for name in object_names:
+    service.WriteObjectFromBuffer(FLAGS.bucket, name, handle, 100)
+
+  logging.info('Wrote 10 100B objects to %s.', FLAGS.bucket)
+
+  # Read the objects back
+  for name in object_names:
+    service.ReadObject(FLAGS.bucket, name)
+
+  logging.info('Read objects back.')
+
+  # List the objects
+  names = service.ListObjects(FLAGS.bucket, 'object_')
+  if sorted(names) != object_names:
+    logging.error('ListObjects returned %s, but should have returned %s',
+                  names, object_names)
+
+  logging.info('Listed object names.')
+
+  # Delete the objects
+  deleted = []
+  service.DeleteObjects(FLAGS.bucket, object_names, objects_deleted=deleted)
+  if sorted(deleted) != object_names:
+    logging.error('DeleteObjects returned %s, but should have returned %s',
+                  deleted, object_names)
+
+  logging.info('Deleted objects. Test is complete.')
+
+
+if __name__ == '__main__':
+  logging.basicConfig(level=logging.INFO)
+  FLAGS(sys.argv)
+
+  service = (
+      object_storage_api_tests._STORAGE_TO_SERVICE_DICT[FLAGS.storage_provider]())  # noqa
+  ValidateService(service)

--- a/perfkitbenchmarker/scripts/object_storage_api_tests.py
+++ b/perfkitbenchmarker/scripts/object_storage_api_tests.py
@@ -279,6 +279,8 @@ class ObjectStorageBackend(object):
     # an exception if the flags are invalid for its particular
     # provider.
 
+    pass
+
 
   @abc.abstractmethod
   def ListObjects(self, bucket, prefix):

--- a/script-tests/integration/object_storage_worker_integration_tests.py
+++ b/script-tests/integration/object_storage_worker_integration_tests.py
@@ -83,7 +83,13 @@ class TestScenarios(unittest.TestCase):
   """
 
   def setUp(self):
-    object_storage_api_tests.FLAGS([])
+    self.FLAGS = object_storage_api_tests.FLAGS
+    self.FLAGS([])
+    self.objects_written_file = self.FLAGS.objects_written_file
+    self.FLAGS.objects_written_file = '/tmp/objects-written'
+
+  def tearDown(self):
+    self.FLAGS.objects_written_file = self.objects_written_file
 
   def testOneByteRW(self):
     object_storage_api_tests.OneByteRWBenchmark(MockObjectStorageBackend())
@@ -99,11 +105,14 @@ class TestScenarios(unittest.TestCase):
   def testCleanupBucket(self):
     object_storage_api_tests.CleanupBucket(MockObjectStorageBackend())
 
-  def testMultiStreamWrite(self):
-    object_storage_api_tests.MultiStreamWrites(MockObjectStorageBackend())
+  def testMultiStreamWriteAndRead(self):
+    backend = MockObjectStorageBackend()
 
-  # Can't test MultiStreamRead this way because it depends on a file
-  # with a list of objects written by MultiStreamWrites.
+    # Have to sequence MultiStreamWrites and MultiStreamReads because
+    # MultiStreamReads will read from the objects_written_file that
+    # MultiStreamWrites generates.
+    object_storage_api_tests.MultiStreamWrites(backend)
+    object_storage_api_tests.MultiStreamReads(backend)
 
   def testTestBackend(self):
     object_storage_api_tests.TestBackend(MockObjectStorageBackend())

--- a/script-tests/integration/object_storage_worker_integration_tests.py
+++ b/script-tests/integration/object_storage_worker_integration_tests.py
@@ -1,0 +1,114 @@
+# Copyright 2016 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for the object_storage_service benchmark worker process."""
+
+import time
+import unittest
+
+import object_storage_api_tests
+
+
+class MockObjectStorageBackend(object_storage_api_tests.ObjectStorageBackend):
+  def __init__(self):
+    self.bucket = None
+    self.objects = {}
+
+  def _CheckBucket(self, bucket):
+    """Make sure that we are only passed one bucket name.
+
+    Args:
+      bucket: the name of a bucket.
+
+    Raises: ValueError, if this object has been passed a different
+    bucket name previously.
+    """
+
+    if self.bucket is None:
+      self.bucket = bucket
+    elif self.bucket != bucket:
+      raise ValueError(
+          'MockObjectStorageBackend passed two bucket names: %s and %s' %
+          (self.bucket, bucket))
+
+  def ListObjects(self, bucket, prefix):
+    self._CheckBucket(bucket)
+
+    return [value
+            for name, value in self.objects.iteritems()
+            if name.startswith(prefix)]
+
+  def DeleteObjects(self, bucket, objects_to_delete, objects_deleted=None):
+    self._CheckBucket(bucket)
+
+    for name in objects_to_delete:
+      if name in self.objects:
+        del self.objects[name]
+        if objects_deleted is not None:
+          objects_deleted.append(name)
+
+  def WriteObjectFromBuffer(self, bucket, object, stream, size):
+    self._CheckBucket(bucket)
+
+    stream.seek(0)
+    self.objects[object] = stream.read(size)
+
+    return time.time(), 0.001
+
+  def ReadObject(self, bucket, object):
+    self._CheckBucket(bucket)
+
+    self.objects[object]
+
+    return time.time(), 0.001
+
+
+class TestScenarios(unittest.TestCase):
+  """Test that the benchmark scenarios complete.
+
+  Specifically, given a correctly operating backend
+  (MockObjectStorageBackend), verify that every scenario except
+  MultiStreamRead runs to completion without raising an exception.
+  """
+
+  def setUp(self):
+    object_storage_api_tests.FLAGS([])
+
+  def testOneByteRW(self):
+    object_storage_api_tests.OneByteRWBenchmark(MockObjectStorageBackend())
+
+  def testListConsistency(self):
+    object_storage_api_tests.ListConsistencyBenchmark(
+        MockObjectStorageBackend())
+
+  def testSingleStreamThroughput(self):
+    object_storage_api_tests.SingleStreamThroughputBenchmark(
+        MockObjectStorageBackend())
+
+  def testCleanupBucket(self):
+    object_storage_api_tests.CleanupBucket(MockObjectStorageBackend())
+
+  def testMultiStreamWrite(self):
+    object_storage_api_tests.MultiStreamWrites(MockObjectStorageBackend())
+
+  # Can't test MultiStreamRead this way because it depends on a file
+  # with a list of objects written by MultiStreamWrites.
+
+  def testTestBackend(self):
+    object_storage_api_tests.TestBackend(MockObjectStorageBackend())
+
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tests/linux_benchmarks/object_storage_service_benchmark_test.py
+++ b/tests/linux_benchmarks/object_storage_service_benchmark_test.py
@@ -31,6 +31,7 @@ class TestGenerateJobFileString(unittest.TestCase):
   def testRunCountTest(self):
     with mock.patch('os.path.isfile', return_value=True),\
         mock.patch(PKB + '.data.ResourcePath', return_value=['a', 'b']),\
+        mock.patch('os.listdir', return_value=[]),\
         mock.patch(MOD_PATH + '.S3StorageBenchmark.Prepare') as Prepare,\
         mock.patch(MOD_PATH
                    + '.S3StorageBenchmark.Run') as Run, mock.patch(

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,11 @@ deps =
 setenv =
     PERFKIT_INTEGRATION = 1
 
+[testenv:scripttests-integration]
+commands = nosetests {toxinidir}/script-tests/integration
+setenv = 
+  PYTHONPATH = {toxinidir}/perfkitbenchmarker/scripts:{env:PYTHONPATH:}
+
 [flake8]
 ignore = E111,E129,E303
 max-line-length = 80

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ deps =
 [testenv:scripttests]
 commands = nosetests {toxinidir}/script-tests []
 setenv = 
-  PYTHONPATH = {toxinidir}/perfkitbenchmarker/scripts:{env:PYTHONPATH:}
+  PYTHONPATH = {toxinidir}/perfkitbenchmarker/scripts:{toxinidir}/perfkitbenchmarker/scripts/object_storage_api_test_scripts:{env:PYTHONPATH:}
 
 [testenv:flake8]
 skip_install = True
@@ -38,7 +38,7 @@ setenv =
 [testenv:scripttests-integration]
 commands = nosetests {toxinidir}/script-tests/integration
 setenv = 
-  PYTHONPATH = {toxinidir}/perfkitbenchmarker/scripts:{env:PYTHONPATH:}
+  PYTHONPATH = {toxinidir}/perfkitbenchmarker/scripts:{toxinidir}/perfkitbenchmarker/scripts/object_storage_api_test_scripts:{env:PYTHONPATH:}
 
 [flake8]
 ignore = E111,E129,E303


### PR DESCRIPTION
Move the code for each object storage provider in
object_storage_api_tests.py to a separate per-provider "backend" object,
and update the benchmarks to work with this system. Add a new
TestBackend scenario for testing these backends (clearly marked as for
debugging only in the docstring). Also take the opportunity to improve
testing of the benchmarks, by implementing a mock backend and adding
some integration tests that use it.