### PR TITLE
Add 'ap-northeast-2' to the S3 regions table

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/object_storage_service_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/object_storage_service_benchmark.py
@@ -231,6 +231,7 @@ AWS_S3_REGION_TO_ENDPOINT_TABLE = {
     'ap-southeast-1': 's3-ap-southeast-1',
     'ap-southeast-2': 's3-ap-southeast-2',
     'ap-northeast-1': 's3-ap-northeast-1',
+    'ap-northeast-2': 's3-ap-northeast-2',
     'sa-east-1': 's3-sa-east-1'
 }
 AWS_S3_ENDPOINT_SUFFIX = '.amazonaws.com'


### PR DESCRIPTION
The object storage benchmark needs to know what endpoint to use for each S3 region it benchmarks. AWS seems to have added the 'ap-northeast-2' region since I originally
created the S3 endpoints table, so this patch adds it to the table.

The table is an ongoing maintenance burden, but it's relatively small, so we can handle it. However, I wanted to mention that the long-term solution is moving to a model where we tell the SDK the location of our bucket and it chooses the endpoint itself, which should happen when we move to boto3. This PR should be considered a short-term fix until that happens.