### PR TITLE
Initial commit of spark benchmark framework

### DIFF
--- a/perfkitbenchmarker/configs/benchmark_config_spec.py
+++ b/perfkitbenchmarker/configs/benchmark_config_spec.py
@@ -28,6 +28,7 @@ from perfkitbenchmarker import flags
 from perfkitbenchmarker import os_types
 from perfkitbenchmarker import providers
 from perfkitbenchmarker import static_virtual_machine
+from perfkitbenchmarker import spark_service
 from perfkitbenchmarker import virtual_machine
 from perfkitbenchmarker.configs import option_decoders
 from perfkitbenchmarker.configs import spec
@@ -163,6 +164,73 @@ class _StaticVmListDecoder(option_decoders.ListDecoder):
         default=list, item_decoder=_StaticVmDecoder(), **kwargs)
 
 
+class _SparkServiceSpec(spec.BaseSpec):
+  """Configurable options of an Apache Spark Service.
+
+  We may add more options here, such as disk specs, as necessary.
+
+  Attributes:
+    spark_service_type: string.  pkb_managed or managed_service
+    num_workers: number of workers.
+    machine_type: machine type to use.
+    cloud: cloud to use.
+    project: project to use.
+  """
+
+  def __init__(self, component_full_name, flag_values=None, **kwargs):
+    super(_SparkServiceSpec, self).__init__(component_full_name,
+                                            flag_values=flag_values,
+                                            **kwargs)
+
+  @classmethod
+  def _GetOptionDecoderConstructions(cls):
+    """Gets decoder classes and constructor args for each configurable option.
+
+    Returns:
+      dict. Maps option name string to a (ConfigOptionDecoder class, dict) pair.
+      The pair specifies a decoder class and its __init__() keyword arguments
+      to construct in order to decode the named option.
+    """
+    result = super(_SparkServiceSpec, cls)._GetOptionDecoderConstructions()
+    result.update({
+        'static_cluster_name': (option_decoders.StringDecoder,
+                                {'default': None, 'none_ok': True}),
+        'spark_service_type': (option_decoders.EnumDecoder, {
+            'default': spark_service.PROVIDER_MANAGED,
+            'valid_values': [spark_service.PROVIDER_MANAGED,
+                             spark_service.PKB_MANAGED]}),
+        'num_workers': (option_decoders.IntDecoder, {
+            'default': 3, 'min': 1}),
+        'cloud': (option_decoders.EnumDecoder, {
+            'valid_values': providers.VALID_CLOUDS}),
+        'project': (option_decoders.StringDecoder, {'default': None,
+                                                    'none_ok': True}),
+        'machine_type': (option_decoders.StringDecoder, {'default': None,
+                                                         'none_ok': True})})
+    return result
+
+  @classmethod
+  def _ApplyFlags(cls, config_values, flag_values):
+    """Modifies config options based on runtime flag values.
+
+    Can be overridden by derived classes to add support for specific flags.
+
+    Args:
+      config_values: dict mapping config option names to provided values. May
+          be modified by this function.
+      flag_values: flags.FlagValues. Runtime flags that may override the
+          provided config values.
+    """
+    super(_SparkServiceSpec, cls)._ApplyFlags(config_values, flag_values)
+    if flag_values['cloud'].present or 'cloud' not in config_values:
+      config_values['cloud'] = flag_values.cloud
+    if flag_values['project'].present or 'project' not in config_values:
+      config_values['project'] = flag_values.project
+    if flag_values['spark_static_cluster_name'].present:
+      config_values['static_cluster_name'] = (
+          flag_values.spark_static_cluster_name)
+
+
 class _VmGroupSpec(spec.BaseSpec):
   """Configurable options of a VM group.
 
@@ -286,6 +354,33 @@ class _VmGroupsDecoder(option_decoders.TypeVerifier):
     return result
 
 
+class _SparkServiceDecoder(option_decoders.TypeVerifier):
+  """Validates the spark_service dictionary of a benchmark config object."""
+  def __init__(self, **kwargs):
+    super(_SparkServiceDecoder, self).__init__(valid_types=(dict,), **kwargs)
+
+  def Decode(self, value, component_full_name, flag_values):
+    """Verifies spark_service dictionary of a benchmark config object.
+
+    Args:
+      value: dict Spark Service config dictionary
+      component_full_name: string.  Fully qualified name of the configurable
+      component containing the config option.
+      flag_values: flags.FlagValues.  Runtime flag values to be propagated to
+        BaseSpec constructors.
+    Returns:
+      _SparkServiceSpec Build from the config passed in in value.
+    Raises:
+      errors.Config.InvalidateValue upon invalid input value.
+    """
+    spark_service_config = super(_SparkServiceDecoder, self).Decode(
+        value, component_full_name, flag_values)
+    result = _SparkServiceSpec(self._GetOptionFullName(component_full_name),
+                               flag_values, **spark_service_config)
+    return result
+
+
+
 class BenchmarkConfigSpec(spec.BaseSpec):
   """Configurable options of a benchmark run.
 
@@ -316,7 +411,8 @@ class BenchmarkConfigSpec(spec.BaseSpec):
       for group_name, group_spec in sorted(self.vm_groups.iteritems()):
         if group_spec.os_type not in expected_os_types:
           mismatched_os_types.append('{0}.vm_groups[{1}].os_type: {2}'.format(
-              component_full_name, repr(group_name), repr(group_spec.os_type)))
+              component_full_name, repr(group_name),
+              repr(group_spec.os_type)))
       if mismatched_os_types:
         raise errors.Config.InvalidValue(
             'VM groups in {0} may only have the following OS types: {1}. The '
@@ -341,7 +437,8 @@ class BenchmarkConfigSpec(spec.BaseSpec):
     result.update({
         'description': (option_decoders.StringDecoder, {'default': None}),
         'flags': (_FlagsDecoder, {}),
-        'vm_groups': (_VmGroupsDecoder, {})})
+        'vm_groups': (_VmGroupsDecoder, {'default': {}}),
+        'spark_service': (_SparkServiceDecoder, {'default': None})})
     return result
 
   def _DecodeAndInit(self, component_full_name, config, decoders, flag_values):

--- a/perfkitbenchmarker/errors.py
+++ b/perfkitbenchmarker/errors.py
@@ -177,7 +177,7 @@ class Config(object):
 
 
 class Juju(object):
-  """Errors related to the Juju OS_TYPE"""
+  """Errors related to the Juju OS_TYPE."""
   class TimeoutException(Error):
     pass
 

--- a/perfkitbenchmarker/linux_benchmarks/cloudsuite_graph_analytics_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/cloudsuite_graph_analytics_benchmark.py
@@ -48,7 +48,7 @@ cloudsuite_graph_analytics:
 
 
 def GetConfig(user_config):
-  """ Reads the config file and overwrites vm_count with num_vms"""
+  """Reads the config file and overwrites vm_count with num_vms."""
 
   config = configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
   if FLAGS['num_vms'].present:

--- a/perfkitbenchmarker/linux_benchmarks/mysql_service_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/mysql_service_benchmark.py
@@ -141,7 +141,7 @@ class DBStatusQueryError(Exception):
 
 
 def _GenerateRandomPassword():
-  """ Generates a random password to be used by the DB instance.
+  """Generates a random password to be used by the DB instance.
   Args:
     None
   Returns:
@@ -285,7 +285,7 @@ def _GetSysbenchCommandPrefix(os_type):
 
 
 def _IssueSysbenchCommand(vm, duration):
-  """ Issues a sysbench run command given a vm and a duration.
+  """Issues a sysbench run command given a vm and a duration.
 
       Does nothing if duration is <= 0
 
@@ -330,7 +330,7 @@ def _IssueSysbenchCommand(vm, duration):
 
 
 def _RunSysbench(vm, metadata):
-  """ Runs the Sysbench OLTP test.
+  """Runs the Sysbench OLTP test.
 
   The test is run on the DB instance as indicated by the vm.db_instance_address.
 
@@ -678,7 +678,7 @@ class GoogleCloudSQLBenchmark(object):
   """MySQL benchmark based on the Google Cloud SQL service."""
 
   def Prepare(self, vm):
-    """Prepares the DB and everything for the provider GCP (Cloud SQL)
+    """Prepares the DB and everything for the provider GCP (Cloud SQL).
 
     Args:
       vm: The VM to be used as the test client

--- a/perfkitbenchmarker/linux_benchmarks/spark_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/spark_benchmark.py
@@ -1,0 +1,104 @@
+# Copyright 2014 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Runs a jar using a cluster that supports Apache Spark.
+
+This benchmark takes a jarfile and class name, and runs that class
+using an Apache Spark cluster.  The Apache Spark cluster can be one
+supplied by a cloud provider, such as Google's Dataproc.
+
+By default, it runs SparkPi.
+
+It records how long the job takes to run.
+
+For more on Apache Spark, see: http://spark.apache.org/
+"""
+
+import datetime
+import logging
+
+from perfkitbenchmarker import configs
+from perfkitbenchmarker import sample
+from perfkitbenchmarker import flags
+
+
+
+BENCHMARK_NAME = 'spark'
+BENCHMARK_CONFIG = """
+spark:
+  description: Run a jar on a spark cluster.
+  spark_service:
+    spark_service_type: managed
+    num_workers: 4
+"""
+
+# This points to a file on the spark cluster.
+DEFAULT_JARFILE = 'file:///usr/lib/spark/lib/spark-examples.jar'
+DEFAULT_CLASSNAME = 'org.apache.spark.examples.SparkPi'
+
+flags.DEFINE_string('spark_jarfile', DEFAULT_JARFILE,
+                    'Jarfile to submit.')
+flags.DEFINE_string('spark_classname', DEFAULT_CLASSNAME,
+                    'Classname to be used')
+flags.DEFINE_string('spark_static_cluster_name', None,
+                    'If set, the name of the Spark cluster, assumed to be '
+                    'ready.')
+
+FLAGS = flags.FLAGS
+
+
+def GetConfig(user_config):
+  return configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
+
+
+def Prepare(benchmark_spec):
+  pass
+
+
+def Run(benchmark_spec):
+  """Executes the given jar on the specified Spark cluster.
+
+  Args:
+    benchmark_spec: The benchmark specification. Contains all data that is
+        required to run the benchmark.
+
+  Returns:
+    A list of sample.Sample objects.
+  """
+  spark_cluster = benchmark_spec.spark_service
+  jar_start = datetime.datetime.now()
+  stdout, stderr, retcode = spark_cluster.SubmitJob(FLAGS.spark_jarfile,
+                                                    FLAGS.spark_classname)
+  logging.info('Jar result is ' + stdout)
+  jar_end = datetime.datetime.now()
+
+  metadata = spark_cluster.GetMetadata().update(
+      {'jarfile': FLAGS.spark_jarfile, 'class': FLAGS.spark_classname})
+
+  results = []
+  results.append(sample.Sample('jar_time',
+                               (jar_end - jar_start).total_seconds(),
+                               'seconds', metadata))
+
+  if not spark_cluster.user_managed:
+    create_time = (spark_cluster.create_end_time -
+                   spark_cluster.create_start_time)
+    results.append(sample.Sample('cluster_create_time', create_time, 'seconds',
+                                 metadata))
+
+  return results
+
+
+def Cleanup(benchmark_spec):
+  pass

--- a/perfkitbenchmarker/linux_virtual_machine.py
+++ b/perfkitbenchmarker/linux_virtual_machine.py
@@ -566,7 +566,7 @@ class BaseLinuxMixin(virtual_machine.BaseOsMixin):
       self.RemoteCommand('pkill -9 sysbench')
 
   def PrepareBackgroundWorkload(self):
-    """Install packages needed for the background workload """
+    """Install packages needed for the background workload."""
     if self.background_cpu_threads:
       self.Install('sysbench')
     if self.background_network_mbits_per_sec:

--- a/perfkitbenchmarker/pkb.py
+++ b/perfkitbenchmarker/pkb.py
@@ -75,6 +75,7 @@ from perfkitbenchmarker import linux_benchmarks
 from perfkitbenchmarker import log_util
 from perfkitbenchmarker import os_types
 from perfkitbenchmarker import requirements
+from perfkitbenchmarker import spark_service
 from perfkitbenchmarker import stages
 from perfkitbenchmarker import static_virtual_machine
 from perfkitbenchmarker import timing_util
@@ -176,6 +177,9 @@ flags.DEFINE_bool(
 flags.DEFINE_boolean(
     'ignore_package_requirements', False,
     'Disables Python package requirement runtime checks.')
+flags.DEFINE_enum('spark_service_type', None,
+                  [spark_service.PKB_MANAGED, spark_service.PROVIDER_MANAGED],
+                  'Type of spark service to use')
 
 
 # Support for using a proxy in the cloud environment.
@@ -316,6 +320,7 @@ def DoProvisionPhase(name, spec, timer):
   """
   logging.info('Provisioning resources for benchmark %s', name)
   spec.ConstructVirtualMachines()
+  spec.ConstructSparkService()
   # Pickle the spec before we try to create anything so we can clean
   # everything up on a second run if something goes wrong.
   spec.PickleSpec()
@@ -624,7 +629,7 @@ def _GenerateBenchmarkDocumentation():
                            windows_benchmarks.BENCHMARKS):
     benchmark_config = configs.LoadMinimalConfig(
         benchmark_module.BENCHMARK_CONFIG, benchmark_module.BENCHMARK_NAME)
-    vm_groups = benchmark_config['vm_groups']
+    vm_groups = benchmark_config.get('vm_groups', {})
     total_vm_count = 0
     vm_str = ''
     scratch_disk_str = ''
@@ -636,7 +641,6 @@ def _GenerateBenchmarkDocumentation():
         total_vm_count += group_vm_count
       if group.get('disk_spec'):
         scratch_disk_str = ' with scratch volume(s)'
-
 
     name = benchmark_module.BENCHMARK_NAME
     if benchmark_module in windows_benchmarks.BENCHMARKS:

--- a/perfkitbenchmarker/provider_info.py
+++ b/perfkitbenchmarker/provider_info.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Module containing class for provider data
+"""Module containing class for provider data.
 
 This contains the BaseProviderInfo class which is
 used for IsBenchmarkSupported
@@ -23,12 +23,12 @@ _PROVIDER_INFO_REGISTRY = {}
 
 
 def GetProviderInfoClass(cloud):
-  """Returns the provider info class corresponding to the cloud"""
+  """Returns the provider info class corresponding to the cloud."""
   return _PROVIDER_INFO_REGISTRY.get(cloud, BaseProviderInfo)
 
 
 class AutoRegisterProviderInfoMeta(type):
-  """Metaclass which allows ProviderInfos to automatically be registered"""
+  """Metaclass which allows ProviderInfos to automatically be registered."""
 
   def __init__(cls, name, bases, dct):
     super(AutoRegisterProviderInfoMeta, cls).__init__(name, bases, dct)
@@ -37,7 +37,7 @@ class AutoRegisterProviderInfoMeta(type):
 
 
 class BaseProviderInfo():
-  """Class that holds provider-related data ."""
+  """Class that holds provider-related data."""
   __metaclass__ = AutoRegisterProviderInfoMeta
 
   CLOUD = None

--- a/perfkitbenchmarker/providers/gcp/gcp_dataproc.py
+++ b/perfkitbenchmarker/providers/gcp/gcp_dataproc.py
@@ -1,0 +1,80 @@
+# Copyright 2016 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Module containing class for GCP's spark service.
+
+Spark clusters can be created and deleted.
+"""
+
+import logging
+
+from perfkitbenchmarker import flags
+from perfkitbenchmarker import providers
+from perfkitbenchmarker import spark_service
+from perfkitbenchmarker.providers.gcp import util
+
+
+FLAGS = flags.FLAGS
+
+
+class GcpDataproc(spark_service.BaseSparkService):
+  """Object representing a GCP Dataproc cluster.
+
+  Attributes:
+    name: Cluster name.
+    num_nodes: Number of nodes in the cluster.
+    project: Enclosing project for the cluster.
+    zone: zone of the cluster.
+  """
+
+  CLOUD = providers.GCP
+  SERVICE_NAME = 'dataproc'
+
+  def _Create(self):
+    """Creates the cluster."""
+    cmd = util.GcloudCommand(self, 'dataproc', 'clusters', 'create',
+                             self.name)
+    if self.project is not None:
+      cmd.flags['project'] = self.project
+    cmd.flags['num-workers'] = self.num_workers
+    if self.machine_type:
+      cmd.flags['worker-machine-type'] = self.machine_type
+      cmd.flags['master-machine-type'] = self.machine_type
+    cmd.Issue()
+
+  def _Delete(self):
+    """Deletes the cluster."""
+    cmd = util.GcloudCommand(self, 'dataproc', 'clusters', 'delete',
+                             self.name)
+    cmd.Issue()
+
+  def _Exists(self):
+    """Check to see whether the cluster exists."""
+    cmd = util.GcloudCommand(self, 'dataproc', 'clusters', 'describe',
+                             self.name)
+    stdout, stderr, retcode = cmd.Issue()
+    return retcode == 0
+
+  def SubmitJob(self, jarfile, classname):
+    cmd = util.GcloudCommand(self, 'dataproc', 'jobs', 'submit', 'spark')
+    cmd.flags['cluster'] = self.name
+    cmd.flags['jar'] = jarfile
+    cmd.flags['class'] = classname
+    stdout, stderr, retcode = cmd.Issue()
+    if retcode != 0:
+      logging.error('Submit job returned code %s STDOUT: %s STDERR: %s',
+                    retcode, stdout, stderr)
+    return stdout, stderr, retcode
+
+  def SetClusterProperty(self):
+    pass

--- a/perfkitbenchmarker/providers/gcp/provider_info.py
+++ b/perfkitbenchmarker/providers/gcp/provider_info.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" Provider info for Google Cloud Platform
-
-"""
+""" Provider info for Google Cloud Platform."""
 
 from perfkitbenchmarker import providers
 from perfkitbenchmarker import provider_info

--- a/perfkitbenchmarker/resource.py
+++ b/perfkitbenchmarker/resource.py
@@ -27,13 +27,19 @@ from perfkitbenchmarker import vm_util
 
 
 class BaseResource(object):
-  """An object representing a cloud resource."""
+  """An object representing a cloud resource.
+
+  Attributes:
+    created: True if the resource has been created.
+    pkb_managed: Whether the resource is managed (created and deleted) by PKB.
+  """
 
   __metaclass__ = abc.ABCMeta
 
-  def __init__(self):
+  def __init__(self, user_managed=False):
     super(BaseResource, self).__init__()
-    self.created = False
+    self.created = user_managed
+    self.user_managed = user_managed
 
     # Creation and deletion time information
     # that we may make use of later.
@@ -126,11 +132,15 @@ class BaseResource(object):
 
   def Create(self):
     """Creates a resource and its dependencies."""
+    if self.user_managed:
+      return
     self._CreateDependencies()
     self._CreateResource()
     self._PostCreate()
 
   def Delete(self):
     """Deletes a resource and its dependencies."""
+    if self.user_managed:
+      return
     self._DeleteResource()
     self._DeleteDependencies()

--- a/perfkitbenchmarker/sample.py
+++ b/perfkitbenchmarker/sample.py
@@ -21,7 +21,7 @@ _SAMPLE_FIELDS = 'metric', 'value', 'unit', 'metadata', 'timestamp'
 
 
 def PercentileCalculator(numbers, percentiles=PERCENTILES_LIST):
-  """Computes percentiles, stddev and mean on a set of numbers
+  """Computes percentiles, stddev and mean on a set of numbers.
 
   Args:
     numbers: The set of numbers to compute percentiles for. Can be a

--- a/perfkitbenchmarker/spark_service.py
+++ b/perfkitbenchmarker/spark_service.py
@@ -1,0 +1,129 @@
+# Copyright 2016 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Benchmarking support for Apache Spark services.
+
+In order to benchmark Apache Spark services such as Google Cloud
+Platform's Dataproc or Amazon's EMR, we create a BaseSparkService
+class.  Classes to wrap each provider's Apache Spark Service are
+in the provider directory as a subclass of BaseSparkService.
+
+Also in this module is a PkbSparkService, which builds a Spark
+cluster by creating VMs and installing the necessary software.
+
+For more on Apache Spark: http://spark.apache.org/
+"""
+
+import abc
+
+from perfkitbenchmarker import flags
+from perfkitbenchmarker import resource
+
+FLAGS = flags.FLAGS
+
+# Cloud to use for pkb-created Spark service.
+PKB_MANAGED = 'pkb_managed'
+PROVIDER_MANAGED = 'managed'
+
+# This is used for error messages.
+
+_SPARK_SERVICE_REGISTRY = {}
+
+
+def GetSparkServiceClass(cloud, service_type):
+  """Get the Spark class corresponding to 'cloud'."""
+  if service_type == PKB_MANAGED:
+    return _SPARK_SERVICE_REGISTRY.get(service_type)
+  elif cloud in _SPARK_SERVICE_REGISTRY:
+    return _SPARK_SERVICE_REGISTRY.get(cloud)
+  else:
+    raise Exception('No Spark service found for {0}'.format(cloud))
+
+
+class AutoRegisterSparkServiceMeta(abc.ABCMeta):
+  """Metaclass which allows SparkServices to register."""
+
+  def __init__(cls, name, bases, dct):
+    if hasattr(cls, 'CLOUD'):
+      if cls.CLOUD is None:
+        raise Exception('BaseSparkService subclasses must have a CLOUD'
+                        'attribute.')
+      else:
+        _SPARK_SERVICE_REGISTRY[cls.CLOUD] = cls
+    super(AutoRegisterSparkServiceMeta, cls).__init__(name, bases, dct)
+
+
+
+class BaseSparkService(resource.BaseResource):
+  """Object representing a Spark Service."""
+
+  __metaclass__ = AutoRegisterSparkServiceMeta
+
+  def __init__(self, name, static_cluster, spark_service_spec):
+    super(BaseSparkService, self).__init__(user_managed=static_cluster)
+    self.name = name
+    self.num_workers = spark_service_spec.num_workers
+    self.machine_type = spark_service_spec.machine_type
+    self.project = spark_service_spec.project
+
+  @abc.abstractmethod
+  def SubmitJob(self, job_jar, class_name):
+    """Submit a job to the spark service.
+
+    What this returns is not currently defined.  Platforms have their
+    own output from job submission, but users will typically want to
+    access the output from the job itself.
+    """
+    # TODO(hildrum) determine what the return value from this will be
+    # and provide a way to access the job's output
+    pass
+
+  def GetMetadata(self):
+    """Return a dictionary of the metadata for this cluster."""
+    return {'spark_service': self.SERVICE_NAME,
+            'num_workers': self.num_workers,
+            'machine_type': self.machine_type,
+            'spark_cluster_name': self.name}
+
+
+
+class PkbSparkService(BaseSparkService):
+  """A Spark service created from vms.
+
+  This class will create a Spark service by creating VMs and installing
+  the necessary software.  (Similar to how the hbase benchmark currently
+  runs.  It should work across all or almost all providers.
+  """
+
+  CLOUD = PKB_MANAGED
+  SERVICE_NAME = 'pkb-managed'
+
+  def __init__(self, name, static_cluster, spark_service_spec):
+    super(PkbSparkService, self).__init__(name, static_cluster,
+                                          spark_service_spec)
+    self.vms = []
+
+  def _Create(self):
+    """Create an Apache Spark cluster."""
+    raise NotImplementedError()
+
+  def _Delete(self):
+    """Delete the vms."""
+    for vm in self.vms:
+      vm.Delete()
+
+  # TODO(hildrum) actually implement this.
+  def SubmitJob(self, jar_file, class_name):
+    """Submit the jar file."""
+    raise NotImplementedError()

--- a/perfkitbenchmarker/virtual_machine.py
+++ b/perfkitbenchmarker/virtual_machine.py
@@ -578,16 +578,16 @@ class BaseOsMixin(object):
     raise NotImplementedError()
 
   def StartBackgroundWorkload(self):
-    """Start the background workload"""
+    """Start the background workload."""
     if self.background_cpu_threads or self.background_network_mbits_per_sec:
       raise NotImplementedError()
 
   def StopBackgroundWorkload(self):
-    """Stop the background workoad"""
+    """Stop the background workoad."""
     if self.background_cpu_threads or self.background_network_mbits_per_sec:
       raise NotImplementedError()
 
   def PrepareBackgroundWorkload(self):
-    """Prepare for the background workload"""
+    """Prepare for the background workload."""
     if self.background_cpu_threads or self.background_network_mbits_per_sec:
       raise NotImplementedError()

--- a/tests/spark_service_test.py
+++ b/tests/spark_service_test.py
@@ -1,0 +1,107 @@
+# Copyright 2015 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for perfkitbenchmarker.benchmark_spec."""
+
+import unittest
+
+from perfkitbenchmarker import benchmark_spec
+from perfkitbenchmarker import configs
+from perfkitbenchmarker import context
+from perfkitbenchmarker import flags
+from perfkitbenchmarker import os_types
+from perfkitbenchmarker import pkb
+from perfkitbenchmarker import providers
+from perfkitbenchmarker import spark_service
+from perfkitbenchmarker.configs import benchmark_config_spec
+from perfkitbenchmarker.providers.gcp import gcp_dataproc
+from tests import mock_flags
+
+
+FLAGS = flags.FLAGS
+
+NAME = 'name'
+UID = 'name0'
+DATAPROC_CONFIG = """
+name:
+  spark_service:
+    spark_service_type: managed
+    machine_type: n1-standard-4
+    num_workers: 4
+"""
+
+PKB_MANAGED_CONFIG = """
+name:
+  spark_service:
+    spark_service_type: pkb_managed
+    num_workers: 5
+"""
+
+
+class _BenchmarkSpecTestCase(unittest.TestCase):
+
+  def setUp(self):
+    self._mocked_flags = mock_flags.MockFlags()
+    self._mocked_flags.cloud = providers.GCP
+    self._mocked_flags.os_type = os_types.DEBIAN
+    self.addCleanup(context.SetThreadBenchmarkSpec, None)
+
+  def _CreateBenchmarkSpecFromYaml(self, yaml_string, benchmark_name=NAME):
+    config = configs.LoadConfig(yaml_string, {}, benchmark_name)
+    return self._CreateBenchmarkSpecFromConfigDict(config, benchmark_name)
+
+  def _CreateBenchmarkSpecFromConfigDict(self, config_dict, benchmark_name):
+    config_spec = benchmark_config_spec.BenchmarkConfigSpec(
+        benchmark_name, flag_values=self._mocked_flags, **config_dict)
+    return benchmark_spec.BenchmarkSpec(config_spec, benchmark_name, UID)
+
+
+class ConstructSparkServiceTestCase(_BenchmarkSpecTestCase):
+
+  def setUp(self):
+    super(ConstructSparkServiceTestCase, self).setUp()
+    pkb._InitializeRunUri()
+
+  def testDataprocConfig(self):
+    spec = self._CreateBenchmarkSpecFromYaml(DATAPROC_CONFIG)
+    spec.ConstructVirtualMachines()
+    spec.ConstructSparkService()
+    self.assertTrue(hasattr(spec, 'spark_service'))
+    self.assertTrue(spec.spark_service is not None)
+    self.assertEqual(len(spec.vms), 0)
+    self.assertEqual(spec.config.spark_service.num_workers, 4,
+                     str(spec.config.spark_service.__dict__))
+    self.assertEqual(spec.config.spark_service.spark_service_type,
+                     spark_service.PROVIDER_MANAGED)
+    self.assertEqual(spec.config.spark_service.machine_type, 'n1-standard-4',
+                     str(spec.config.spark_service.__dict__))
+    self.assertTrue(isinstance(spec.spark_service,
+                               gcp_dataproc.GcpDataproc))
+
+  def testPkbManaged(self):
+    spec = self._CreateBenchmarkSpecFromYaml(PKB_MANAGED_CONFIG)
+    self.assertEqual(spec.config.spark_service.num_workers, 5,
+                     str(spec.config.spark_service.__dict__))
+    self.assertEqual(spec.config.spark_service.spark_service_type,
+                     spark_service.PKB_MANAGED)
+
+    spec.ConstructVirtualMachines()
+    self.assertEqual(len(spec.vms), 0)
+    spec.ConstructSparkService()
+    self.assertEqual(spec.spark_service.num_workers, 5)
+    self.assertTrue(isinstance(spec.spark_service,
+                               spark_service.PkbSparkService))
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
Initial commit of framework to run Spark Service benchmarks.  This contains a BaseSparkService class, a GCP implementation (using Dataproc), and a simple run-this-jar benchmark.

Not included in this pull request, but to be included later:
* Support for arguments to the jar to be run.
* PKB created spark clusters.
* Amazon EMR spark cluster.
* A way to access the output of the spark job.  