### PR TITLE
Add Retry decorator for WaitForBootCompletion method.

### DIFF
--- a/perfkitbenchmarker/providers/openstack/os_virtual_machine.py
+++ b/perfkitbenchmarker/providers/openstack/os_virtual_machine.py
@@ -178,12 +178,8 @@ class OpenStackVirtualMachine(virtual_machine.BaseVirtualMachine):
         except NotFound:
             return False
 
+    @vm_util.Retry(poll_interval=5, log_errors=False)
     def WaitForBootCompletion(self):
-        # Do one longer sleep, then check at shorter intervals.
-        if self.boot_wait_time is None:
-          self.boot_wait_time = 15
-        time.sleep(self.boot_wait_time)
-        self.boot_wait_time = 5
         resp, _ = self.RemoteCommand('hostname', retries=1)
         if self.bootable_time is None:
             self.bootable_time = time.time()


### PR DESCRIPTION
The decorator @vm_util.Retry(log_errors=False, poll_interval=1) was missing
in v1.4.0 for some reason. The code exit on the first get hostname attempt
while VM still booting up.

resolves #982
@meteorfox @hildrum 