### PR TITLE
Use posixpath in MongoDB YCSB benchmark

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/mongodb_ycsb_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/mongodb_ycsb_benchmark.py
@@ -22,7 +22,7 @@ YCSB homepage: https://github.com/brianfrankcooper/YCSB/wiki
 """
 
 import functools
-import os
+import posixpath
 
 from perfkitbenchmarker import configs
 from perfkitbenchmarker import flags
@@ -57,7 +57,7 @@ def GetConfig(user_config):
 
 
 def _GetDataDir(vm):
-  return os.path.join(vm.GetScratchDir(), 'mongodb-data')
+  return posixpath.join(vm.GetScratchDir(), 'mongodb-data')
 
 
 def _PrepareServer(vm):


### PR DESCRIPTION
The benchmark incorrectly uses os.path when it should use posixpath. Fix
this bug.

In addition to the unit tests, I have verified that I can actually run a MongoDB benchmark with this patch.