### PR TITLE
Install openssl for the object storage benchmark

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/object_storage_service_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/object_storage_service_benchmark.py
@@ -1422,6 +1422,7 @@ def Prepare(benchmark_spec):
   if FLAGS.azure_lib_version is not None:
     azure_version_string = '==%s' % FLAGS.azure_lib_version
   vms[0].RemoteCommand('sudo pip install azure%s' % azure_version_string)
+  vms[0].Install('openssl')
   vms[0].Install('gcs_boto_plugin')
 
   OBJECT_STORAGE_BENCHMARK_DICTIONARY[FLAGS.storage].Prepare(vms[0])


### PR DESCRIPTION
This lets the benchmark run on debian 8.