### PR TITLE
Fix path to `cassandra-cli` when running benchmark from upstream repo

### DIFF
--- a/perfkitbenchmarker/linux_packages/cassandra.py
+++ b/perfkitbenchmarker/linux_packages/cassandra.py
@@ -214,10 +214,10 @@ def _StartCassandraIfNotRunning(vm):
 def GetCassandraCliPath(vm):
   if vm.OS_TYPE == os_types.JUJU:
     # Replace the stock CASSANDRA_CLI so that it uses the binary
-    # installed by the cassandra-stress charm.
+    # installed by the cassandra charm.
     return '/usr/bin/cassandra-cli'
 
-  return posixpath.join(CASSANDRA_DIR, 'tools', 'bin',
+  return posixpath.join(CASSANDRA_DIR, 'bin',
                         'cassandra-cli')
 
 


### PR DESCRIPTION
This fixes a bug I introduced in a previous PR, which would cause the cassandra benchmarks to fail when run from non-Juju os_types.