### PR TITLE
Add support for AWS EMR spark clusters

### DIFF
--- a/perfkitbenchmarker/benchmark_spec.py
+++ b/perfkitbenchmarker/benchmark_spec.py
@@ -237,17 +237,10 @@ class BenchmarkSpec(object):
 
     providers.LoadProvider(self.config.spark_service.cloud)
     spark_service_spec = self.config.spark_service
-    service_type = spark_service_spec.spark_service_type
+    service_type = spark_service_spec.service_type
     spark_service_class = spark_service.GetSparkServiceClass(
         spark_service_spec.cloud, service_type)
-    if self.config.spark_service.static_cluster_name:
-      name = self.config.spark_service.static_cluster_name
-      static_cluster = True
-    else:
-      name = 'pkb-' + FLAGS.run_uri
-      static_cluster = False
-    self.spark_service = spark_service_class(name, static_cluster,
-                                             spark_service_spec)
+    self.spark_service = spark_service_class(spark_service_spec)
 
   def Prepare(self):
     targets = [(vm.PrepareBackgroundWorkload, (), {}) for vm in self.vms]

--- a/perfkitbenchmarker/configs/benchmark_config_spec.py
+++ b/perfkitbenchmarker/configs/benchmark_config_spec.py
@@ -199,7 +199,7 @@ class _SparkServiceSpec(spec.BaseSpec):
     result = super(_SparkServiceSpec, cls)._GetOptionDecoderConstructions()
     result.update({
         'static_cluster_id': (option_decoders.StringDecoder,
-                                {'default': None, 'none_ok': True}),
+                              {'default': None, 'none_ok': True}),
         'service_type': (option_decoders.EnumDecoder, {
             'default': spark_service.PROVIDER_MANAGED,
             'valid_values': [spark_service.PROVIDER_MANAGED,

--- a/perfkitbenchmarker/configs/benchmark_config_spec.py
+++ b/perfkitbenchmarker/configs/benchmark_config_spec.py
@@ -168,9 +168,14 @@ class _SparkServiceSpec(spec.BaseSpec):
   """Configurable options of an Apache Spark Service.
 
   We may add more options here, such as disk specs, as necessary.
+  When there are flags for these attributes, the convention is that
+  the flag is prefixed with spark.  For example, the static_cluster_id
+  is overriden by the flag spark_static_cluster_id
 
   Attributes:
-    spark_service_type: string.  pkb_managed or managed_service
+    service_type: string.  pkb_managed or managed_service
+    static_cluster_id: if user has created a cluster, the id of the
+      cluster.
     num_workers: number of workers.
     machine_type: machine type to use.
     cloud: cloud to use.
@@ -193,9 +198,9 @@ class _SparkServiceSpec(spec.BaseSpec):
     """
     result = super(_SparkServiceSpec, cls)._GetOptionDecoderConstructions()
     result.update({
-        'static_cluster_name': (option_decoders.StringDecoder,
+        'static_cluster_id': (option_decoders.StringDecoder,
                                 {'default': None, 'none_ok': True}),
-        'spark_service_type': (option_decoders.EnumDecoder, {
+        'service_type': (option_decoders.EnumDecoder, {
             'default': spark_service.PROVIDER_MANAGED,
             'valid_values': [spark_service.PROVIDER_MANAGED,
                              spark_service.PKB_MANAGED]}),
@@ -226,9 +231,9 @@ class _SparkServiceSpec(spec.BaseSpec):
       config_values['cloud'] = flag_values.cloud
     if flag_values['project'].present or 'project' not in config_values:
       config_values['project'] = flag_values.project
-    if flag_values['spark_static_cluster_name'].present:
-      config_values['static_cluster_name'] = (
-          flag_values.spark_static_cluster_name)
+    if flag_values['spark_static_cluster_id'].present:
+      config_values['static_cluster_id'] = (
+          flag_values.spark_static_cluster_id)
 
 
 class _VmGroupSpec(spec.BaseSpec):

--- a/perfkitbenchmarker/linux_benchmarks/spark_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/spark_benchmark.py
@@ -26,7 +26,6 @@ For more on Apache Spark, see: http://spark.apache.org/
 """
 
 import datetime
-import logging
 
 from perfkitbenchmarker import configs
 from perfkitbenchmarker import sample
@@ -77,6 +76,9 @@ def Run(benchmark_spec):
   jar_start = datetime.datetime.now()
   success = spark_cluster.SubmitJob(FLAGS.spark_jarfile,
                                     FLAGS.spark_classname)
+  if not success:
+    raise Exception('Class {0} from jar {1} did not run'.format(
+        FLAGS.spark_classname, FLAGS.spark_jarfile))
   jar_end = datetime.datetime.now()
 
   metadata = spark_cluster.GetMetadata().update(

--- a/perfkitbenchmarker/linux_benchmarks/spark_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/spark_benchmark.py
@@ -39,7 +39,7 @@ BENCHMARK_CONFIG = """
 spark:
   description: Run a jar on a spark cluster.
   spark_service:
-    spark_service_type: managed
+    service_type: managed
     num_workers: 4
 """
 
@@ -51,9 +51,6 @@ flags.DEFINE_string('spark_jarfile', DEFAULT_JARFILE,
                     'Jarfile to submit.')
 flags.DEFINE_string('spark_classname', DEFAULT_CLASSNAME,
                     'Classname to be used')
-flags.DEFINE_string('spark_static_cluster_name', None,
-                    'If set, the name of the Spark cluster, assumed to be '
-                    'ready.')
 
 FLAGS = flags.FLAGS
 
@@ -78,9 +75,8 @@ def Run(benchmark_spec):
   """
   spark_cluster = benchmark_spec.spark_service
   jar_start = datetime.datetime.now()
-  stdout, stderr, retcode = spark_cluster.SubmitJob(FLAGS.spark_jarfile,
-                                                    FLAGS.spark_classname)
-  logging.info('Jar result is ' + stdout)
+  success = spark_cluster.SubmitJob(FLAGS.spark_jarfile,
+                                    FLAGS.spark_classname)
   jar_end = datetime.datetime.now()
 
   metadata = spark_cluster.GetMetadata().update(

--- a/perfkitbenchmarker/providers/aws/aws_emr.py
+++ b/perfkitbenchmarker/providers/aws/aws_emr.py
@@ -53,8 +53,6 @@ class AwsEMR(spark_service.BaseSparkService):
 
   CLOUD = providers.AWS
   SERVICE_NAME = 'emr'
-  debug = True
-
 
   def __init__(self, spark_service_spec):
     super(AwsEMR, self).__init__(spark_service_spec)

--- a/perfkitbenchmarker/providers/aws/aws_emr.py
+++ b/perfkitbenchmarker/providers/aws/aws_emr.py
@@ -1,0 +1,144 @@
+# Copyright 2016 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Module containing class for AWS's spark service.
+
+Spark clusters can be created and deleted.
+"""
+
+import json
+import logging
+
+from perfkitbenchmarker import flags
+from perfkitbenchmarker import providers
+from perfkitbenchmarker import spark_service
+from perfkitbenchmarker import vm_util
+import time
+import util
+
+
+FLAGS = flags.FLAGS
+
+DEFAULT_MACHINE_TYPE = 'm1.large'
+RELEASE_LABEL = 'emr-4.5.0'
+READY_CHECK_SLEEP = 30
+READY_CHECK_TRIES = 60
+READY_STATE = 'WAITING'
+
+JOB_WAIT_SLEEP = 30
+
+DELETED_STATES = ['TERMINATING', 'TERMINATED_WITH_ERRORS', 'TERMINATED']
+
+class AwsEMR(spark_service.BaseSparkService):
+  """Object representing a AWS EMR cluster.
+
+  Attributes:
+    cluster_id: Cluster identifier, set in superclass.
+    num_workers: Number of works, set in superclass.
+    machine_type: Machine type to use.
+    project: Enclosing project for the cluster.
+    cmd_prefix: emr prefix, including region
+  """
+
+  CLOUD = providers.AWS
+  SERVICE_NAME = 'emr'
+  debug = True
+
+
+  def __init__(self, spark_service_spec):
+    super(AwsEMR, self).__init__(spark_service_spec)
+    # TODO(hildrum) use availability zone when appropriate
+    if self.machine_type is None:
+      self.machine_type = DEFAULT_MACHINE_TYPE
+    self.cmd_prefix = util.AWS_PREFIX + ['emr']
+    if FLAGS.zones:
+      region = util.GetRegionFromZone(FLAGS.zones[0])
+      self.cmd_prefix += ['--region', region]
+
+  def _Create(self):
+    """Creates the cluster."""
+    name = 'pkb_' + FLAGS.run_uri
+    # we need to store the cluster id.
+    cmd = self.cmd_prefix + ['create-cluster',
+        '--name', name, '--release-label', RELEASE_LABEL,
+        '--use-default-roles',
+        '--instance-count', str(self.num_workers),
+        '--instance-type', self.machine_type,
+        '--application', 'Name=SPARK']
+    stdout, _, _ = vm_util.IssueCommand(cmd)
+    result = json.loads(stdout)
+    self.cluster_id = result['ClusterId']
+    logging.info('Cluster created with id %s', self.cluster_id)
+
+  def _Delete(self):
+    """Deletes the cluster."""
+    cmd = self.cmd_prefix + ['terminate-clusters', '--cluster-ids', self.cluster_id]
+    vm_util.IssueCommand(cmd)
+
+  def _Exists(self):
+    """Check to see whether the cluster exists."""
+    cmd = self.cmd_prefix + ['describe-cluster',
+                             '--cluster-id', self.cluster_id]
+    stdout, _, rc = vm_util.IssueCommand(cmd)
+    if rc != 0:
+      return False
+    result = json.loads(stdout)
+    if result['Cluster']['Status']['State'] in DELETED_STATES:
+      return False
+    else:
+      return True
+
+  def _WaitUntilReady(self):
+    """Check to see if the cluster is ready."""
+    cmd = self.cmd_prefix + ['describe-cluster', '--cluster-id', self.cluster_id]
+    tries = 0
+    while tries < READY_CHECK_TRIES:
+      tries += 1
+      stdout , _, rc = vm_util.IssueCommand(cmd)
+      result = json.loads(stdout)
+      if result['Cluster']['Status']['State'] == READY_STATE:
+        return True
+      time.sleep(READY_CHECK_SLEEP)
+    return False
+
+  def _SetClusterIdFromName():
+    self.cluster_id = None
+
+  def SubmitJob(self, jarfile, classname, job_poll_interval=JOB_WAIT_SLEEP):
+    arg_list = ['--class', classname, jarfile]
+    arg_string = '[' + ','.join(arg_list) + ']'
+    step_list = ['Type=Spark', 'Args='+arg_string]
+    step_string = ','.join(step_list)
+    cmd = self.cmd_prefix + ['add-steps', '--cluster-id',
+                             self.cluster_id, '--steps', step_string]
+    stdout, _, _ = vm_util.IssueCommand(cmd)
+    result = json.loads(stdout)
+    step_id = result['StepIds'][0]
+    # Now, we wait for the step to be completed.
+    while True:
+      cmd = self.cmd_prefix + ['describe-step', '--cluster-id',
+                               self.cluster_id, '--step-id', step_id]
+
+      stdout, _, _ = vm_util.IssueCommand(cmd)
+      result = json.loads(stdout)
+      state = result['Step']['Status']['State']
+      if state == "COMPLETED":
+        return True
+      elif state == "FAILED":
+        return False
+      else:
+        logging.info('Waiting %s seconds for job to finish', job_poll_interval)
+        time.sleep(job_poll_interval)
+
+  def SetClusterProperty(self):
+    pass

--- a/perfkitbenchmarker/providers/gcp/gcp_dataproc.py
+++ b/perfkitbenchmarker/providers/gcp/gcp_dataproc.py
@@ -16,8 +16,6 @@
 Spark clusters can be created and deleted.
 """
 
-import logging
-
 from perfkitbenchmarker import flags
 from perfkitbenchmarker import providers
 from perfkitbenchmarker import spark_service

--- a/perfkitbenchmarker/resource.py
+++ b/perfkitbenchmarker/resource.py
@@ -20,6 +20,7 @@ reliably.
 """
 
 import abc
+import logging
 import time
 
 from perfkitbenchmarker import errors
@@ -71,6 +72,18 @@ class BaseResource(object):
     exceptions.
     """
     raise NotImplementedError()
+
+  def _WaitUntilReady(self):
+    """Return true if the underlying resource is ready.
+
+    Supplying this method is optional.  Use it when a resource can exist
+    without being ready.  If the subclass does not implement
+    it then it just returns true.
+
+    Returns:
+      True if the resource was ready in time, False if the wait timed out.
+    """
+    return True
 
   def _PostCreate(self):
     """Method that will be called once after _CreateReource is called.
@@ -136,6 +149,9 @@ class BaseResource(object):
       return
     self._CreateDependencies()
     self._CreateResource()
+    ready = self._WaitUntilReady()
+    if not ready:
+      raise Exception('Wait for resource to be read timed out, giving up')
     self._PostCreate()
 
   def Delete(self):

--- a/perfkitbenchmarker/resource.py
+++ b/perfkitbenchmarker/resource.py
@@ -20,7 +20,6 @@ reliably.
 """
 
 import abc
-import logging
 import time
 
 from perfkitbenchmarker import errors

--- a/perfkitbenchmarker/spark_service.py
+++ b/perfkitbenchmarker/spark_service.py
@@ -30,7 +30,11 @@ import abc
 from perfkitbenchmarker import flags
 from perfkitbenchmarker import resource
 
-FLAGS = flags.FLAGS
+
+flags.DEFINE_string('spark_static_cluster_id', None,
+                    'If set, the name of the Spark cluster, assumed to be '
+                    'ready.')
+
 
 # Cloud to use for pkb-created Spark service.
 PKB_MANAGED = 'pkb_managed'
@@ -70,20 +74,35 @@ class BaseSparkService(resource.BaseResource):
 
   __metaclass__ = AutoRegisterSparkServiceMeta
 
-  def __init__(self, name, static_cluster, spark_service_spec):
-    super(BaseSparkService, self).__init__(user_managed=static_cluster)
-    self.name = name
+  def __init__(self, spark_service_spec):
+    """Initialize the Apache Spark Service object.
+
+    Args:
+      spark_service_spec: spec of the spark service.
+    """
+    is_user_managed = spark_service_spec.static_cluster_id is not None
+    super(BaseSparkService, self).__init__(user_managed=is_user_managed)
+    self.spec = spark_service_spec
+    self.cluster_id = spark_service_spec.static_cluster_id
     self.num_workers = spark_service_spec.num_workers
     self.machine_type = spark_service_spec.machine_type
     self.project = spark_service_spec.project
 
   @abc.abstractmethod
-  def SubmitJob(self, job_jar, class_name):
+  def SubmitJob(self, job_jar, class_name, job_poll_interval=None):
     """Submit a job to the spark service.
 
-    What this returns is not currently defined.  Platforms have their
-    own output from job submission, but users will typically want to
-    access the output from the job itself.
+    Submits a job and waits for it to complete.
+
+    Args:
+      job_jar: Jar file to execute.
+      class_name: Name of the main class.
+      job_poll_interval: integer saying how often to poll for job
+        completion.  Not used by providers for which submit job is a
+        synchronous operations.
+
+    Returns:
+      True if the job submission was successful, false otherwise.
     """
     # TODO(hildrum) determine what the return value from this will be
     # and provide a way to access the job's output
@@ -94,7 +113,7 @@ class BaseSparkService(resource.BaseResource):
     return {'spark_service': self.SERVICE_NAME,
             'num_workers': self.num_workers,
             'machine_type': self.machine_type,
-            'spark_cluster_name': self.name}
+            'spark_cluster_id': self.cluster_id}
 
 
 
@@ -109,9 +128,8 @@ class PkbSparkService(BaseSparkService):
   CLOUD = PKB_MANAGED
   SERVICE_NAME = 'pkb-managed'
 
-  def __init__(self, name, static_cluster, spark_service_spec):
-    super(PkbSparkService, self).__init__(name, static_cluster,
-                                          spark_service_spec)
+  def __init__(self, spark_service_spec):
+    super(PkbSparkService, self).__init__(spark_service_spec)
     self.vms = []
 
   def _Create(self):

--- a/perfkitbenchmarker/spark_service.py
+++ b/perfkitbenchmarker/spark_service.py
@@ -99,7 +99,7 @@ class BaseSparkService(resource.BaseResource):
       class_name: Name of the main class.
       job_poll_interval: integer saying how often to poll for job
         completion.  Not used by providers for which submit job is a
-        synchronous operations.
+        synchronous operation.
 
     Returns:
       True if the job submission was successful, false otherwise.


### PR DESCRIPTION
Next pull request related to issue #1010.

Adds support for AWS EMR spark clusters.  

This inspired a couple of other changes.  
* I added an optional _WaitUntilReady to `resource.py`.  This is called after the resource exists and should wait and return True when the resource is ready to be used.     
* The spec attributed named for spark clusters called `static_cluster_name` was renamed to `static_cluster_id` to better match up with the distinction EMR makes between names and ids.    
* Also, to be consistent with the spark spec attribute `static_cluster_id` and the flag `spark_static_cluster_id`, I renamed the spark spec attribute `spark_service_type` to just `service_type`.  

@ehankland, PTAL.