### PR TITLE
Default to latest gsutil version

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/object_storage_service_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/object_storage_service_benchmark.py
@@ -95,10 +95,7 @@ flags.DEFINE_string('boto_file_location', None,
 flags.DEFINE_string('azure_lib_version', None,
                     'Use a particular version of azure client lib, e.g.: 1.0.2')
 
-# TODO: set default to None (latest version) once
-# https://www.google.com/url?q=https://github.com/GoogleCloudPlatform/gsutil/issues/348
-# is resolved.
-flags.DEFINE_string('google_cloud_sdk_version', '96.0.0',
+flags.DEFINE_string('google_cloud_sdk_version', None,
                     'Use a particular version of the Google Cloud SDK, e.g.: '
                     '103.0.0')
 


### PR DESCRIPTION
Now that a GCS bug is resolved, resolve a PKB todo by defaulting to the
latest gsutil version.