### PR TITLE
Add Cloud Datastore benchmark

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/cloud_datastore_ycsb_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/cloud_datastore_ycsb_benchmark.py
@@ -21,7 +21,7 @@ cloud_datastore_ycsb:
       Configure the number of VMs via --num-vms.
   vm_groups:
     default:
-      vm_spec: n1-standard-4
+      vm_spec: *default_single_core
       vm_count: null'''
 
 YCSB_BINDING_TAR_URL = 'https://github.com/brianfrankcooper/YCSB/releases/download/0.9.0/ycsb-googledatastore-binding-0.9.0.tar.gz'
@@ -38,6 +38,10 @@ flags.DEFINE_string('google_datastore_serviceAccount',
 flags.DEFINE_string('google_datastore_datasetId',
                     None,
                     'The project ID that has Cloud Datastore service')
+flags.DEFINE_string('google_datastore_debug',
+                    'false',
+                    'The logging level when running YCSB')
+
 
 
 def GetConfig(user_config):
@@ -49,7 +53,8 @@ def CheckPrerequisites():
     # we should always make sure valid credential flags are set.
     if not (FLAGS.google_datastore_keyfile and FLAGS.google_datastore_serviceAccount):
         raise ValueError("'google_datastore_keyfile' and 'google_datastore_serviceAccount' must be set")
-
+    if not FLAGS.google_datastore_datasetId:
+        raise ValueError("'google_datastore_datasetId' must be set ")
 
 def Prepare(benchmark_spec):
     benchmark_spec.always_call_cleanup = True
@@ -59,10 +64,19 @@ def Prepare(benchmark_spec):
 
 
 def Run(benchmark_spec):
+    vms = benchmark_spec.vms
     executor = ycsb.YCSBExecutor('googledatastore')
+    run_kwargs = {
+            'threads': 4,
+            'googledatastore.datasetId': FLAGS.google_datastore_datasetId,
+            'googledatastore.privateKeyFile': PRIVATE_KEYFILE_DIR,
+            'googledatastore.serviceAccountEmail': FLAGS.google_datastore_serviceAccount,
+            'googledatastore.debug': FLAGS.google_datastore_debug,
+            }
+    load_kwargs = run_kwargs.copy()
     # TODO: support more flags, like thread, operationcount, recordcount, etc.
-    if not FLAGS['ycsb_preload_threads'].present:
-      load_kwargs['threads'] = 32
+    if FLAGS['ycsb_preload_threads'].present:
+      load_kwargs['threads'] = FLAGS['ycsb_preload_threads']
     samples = list(executor.LoadAndRun(vms,
                                        load_kwargs=load_kwargs,
                                        run_kwargs=run_kwargs))
@@ -76,9 +90,10 @@ def Cleanup(benchmark_spec):
 
 def _Install(vm):
     # Override YCSB_TAR_URL so that we only need to download the binding we need.
+    default_ycsb_tar_url = ycsb.YCSB_TAR_URL
     ycsb.YCSB_TAR_URL = YCSB_BINDING_TAR_URL
     vm.Install('ycsb')
-    vm.Install('curl')
-    
+    ycsb.YCSB_TAR_URL = default_ycsb_tar_url
+
     # Copy private key file to VM
     vm.RemoteCopy(FLAGS.google_datastore_keyfile, PRIVATE_KEYFILE_DIR)

--- a/perfkitbenchmarker/linux_benchmarks/cloud_datastore_ycsb_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/cloud_datastore_ycsb_benchmark.py
@@ -75,11 +75,11 @@ def CheckPrerequisites():
     # Before YCSB Cloud Datastore supports Application Default Credential,
     # we should always make sure valid credential flags are set.
     if not FLAGS.google_datastore_keyfile:
-        raise ValueError("'google_datastore_keyfile' must be set")
+        raise ValueError('"google_datastore_keyfile" must be set')
     if not FLAGS.google_datastore_serviceAccount:
-        raise ValueError("'google_datastore_serviceAccount' must be set")
+        raise ValueError('"google_datastore_serviceAccount" must be set')
     if not FLAGS.google_datastore_datasetId:
-        raise ValueError("'google_datastore_datasetId' must be set ")
+        raise ValueError('"google_datastore_datasetId" must be set ')
 
 
 def Prepare(benchmark_spec):
@@ -121,7 +121,6 @@ def Cleanup(benchmark_spec):
     # TODO: support automatic cleanup.
     logging.warning(
         "For now, we can only manually delete all the entries via GCP portal.")
-    return
 
 
 def _Install(vm):

--- a/perfkitbenchmarker/linux_benchmarks/cloud_datastore_ycsb_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/cloud_datastore_ycsb_benchmark.py
@@ -1,0 +1,84 @@
+import json
+import logging
+import os
+import pipes
+import posixpath
+import re
+import subprocess
+
+from perfkitbenchmarker import configs
+from perfkitbenchmarker import data
+from perfkitbenchmarker import flags
+from perfkitbenchmarker import vm_util
+from perfkitbenchmarker.linux_packages import ycsb
+
+
+BENCHMARK_NAME = 'cloud_datastore_ycsb'
+BENCHMARK_CONFIG = '''
+cloud_datastore_ycsb:
+  description: >
+      Run YCSB agains Google Cloud Datastore.
+      Configure the number of VMs via --num-vms.
+  vm_groups:
+    default:
+      vm_spec: n1-standard-4
+      vm_count: null'''
+
+YCSB_BINDING_TAR_URL = 'https://github.com/brianfrankcooper/YCSB/releases/download/0.9.0/ycsb-googledatastore-binding-0.9.0.tar.gz'
+YCSB_BINDING_LIB_DIR = posixpath.join(ycsb.YCSB_DIR, 'lib')
+PRIVATE_KEYFILE_DIR = '/tmp/key.p12'
+
+FLAGS = flags.FLAGS
+flags.DEFINE_string('google_datastore_keyfile',
+                    None,
+                    'The path to Google API P12 private key file')
+flags.DEFINE_string('google_datastore_serviceAccount',
+                    None,
+                    'The service account email associated with datastore private key file')
+flags.DEFINE_string('google_datastore_datasetId',
+                    None,
+                    'The project ID that has Cloud Datastore service')
+
+
+def GetConfig(user_config):
+    return configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
+
+
+def CheckPrerequisites():
+    # Before YCSB Cloud Datastore supports accessing Application Default Credential,
+    # we should always make sure valid credential flags are set.
+    if not (FLAGS.google_datastore_keyfile and FLAGS.google_datastore_serviceAccount):
+        raise ValueError("'google_datastore_keyfile' and 'google_datastore_serviceAccount' must be set")
+
+
+def Prepare(benchmark_spec):
+    benchmark_spec.always_call_cleanup = True
+    vms = benchmark_spec.vms
+    # Install required packages and copy credential files
+    vm_util.RunThreaded(_Install, vms)
+
+
+def Run(benchmark_spec):
+    executor = ycsb.YCSBExecutor('googledatastore')
+    # TODO: support more flags, like thread, operationcount, recordcount, etc.
+    if not FLAGS['ycsb_preload_threads'].present:
+      load_kwargs['threads'] = 32
+    samples = list(executor.LoadAndRun(vms,
+                                       load_kwargs=load_kwargs,
+                                       run_kwargs=run_kwargs))
+    return samples
+
+
+def Cleanup(benchmark_spec):
+    # For now, we can only manually delete all the entries via GCP portal.
+    return
+
+
+def _Install(vm):
+    # Override YCSB_TAR_URL so that we only need to download the binding we need.
+    ycsb.YCSB_TAR_URL = YCSB_BINDING_TAR_URL
+    vm.Install('ycsb')
+    vm.Install('curl')
+    
+    # Copy private key file to VM
+    vm.RemoteCopy(FLAGS.google_datastore_keyfile, PRIVATE_KEYFILE_DIR)

--- a/perfkitbenchmarker/linux_benchmarks/cloud_datastore_ycsb_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/cloud_datastore_ycsb_benchmark.py
@@ -58,10 +58,18 @@ def CheckPrerequisites():
 
 def Prepare(benchmark_spec):
     benchmark_spec.always_call_cleanup = True
+    default_ycsb_tar_url = ycsb.YCSB_TAR_URL
     vms = benchmark_spec.vms
+    
+    # TODO: this is a hacky way to override the tar url, need to figure some other ways.
+    # Override YCSB_TAR_URL so that we only need to download the binding we need.
+    ycsb.YCSB_TAR_URL = YCSB_BINDING_TAR_URL
+    
     # Install required packages and copy credential files
     vm_util.RunThreaded(_Install, vms)
-
+    
+    # Restore YCSB_TAR_URL
+    ycsb.YCSB_TAR_URL = default_ycsb_tar_url
 
 def Run(benchmark_spec):
     vms = benchmark_spec.vms
@@ -89,11 +97,7 @@ def Cleanup(benchmark_spec):
 
 
 def _Install(vm):
-    # Override YCSB_TAR_URL so that we only need to download the binding we need.
-    default_ycsb_tar_url = ycsb.YCSB_TAR_URL
-    ycsb.YCSB_TAR_URL = YCSB_BINDING_TAR_URL
     vm.Install('ycsb')
-    ycsb.YCSB_TAR_URL = default_ycsb_tar_url
 
     # Copy private key file to VM
     vm.RemoteCopy(FLAGS.google_datastore_keyfile, PRIVATE_KEYFILE_DIR)

--- a/perfkitbenchmarker/linux_benchmarks/cloud_datastore_ycsb_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/cloud_datastore_ycsb_benchmark.py
@@ -1,13 +1,6 @@
-import json
-import logging
-import os
-import pipes
 import posixpath
-import re
-import subprocess
 
 from perfkitbenchmarker import configs
-from perfkitbenchmarker import data
 from perfkitbenchmarker import flags
 from perfkitbenchmarker import vm_util
 from perfkitbenchmarker.linux_packages import ycsb
@@ -24,7 +17,9 @@ cloud_datastore_ycsb:
       vm_spec: *default_single_core
       vm_count: null'''
 
-YCSB_BINDING_TAR_URL = 'https://github.com/brianfrankcooper/YCSB/releases/download/0.9.0/ycsb-googledatastore-binding-0.9.0.tar.gz'
+YCSB_BINDING_TAR_URL = ('https://github.com/brianfrankcooper/YCSB/releases'
+                        '/download/0.9.0/'
+                        'ycsb-googledatastore-binding-0.9.0.tar.gz')
 YCSB_BINDING_LIB_DIR = posixpath.join(ycsb.YCSB_DIR, 'lib')
 PRIVATE_KEYFILE_DIR = '/tmp/key.p12'
 
@@ -34,7 +29,8 @@ flags.DEFINE_string('google_datastore_keyfile',
                     'The path to Google API P12 private key file')
 flags.DEFINE_string('google_datastore_serviceAccount',
                     None,
-                    'The service account email associated with datastore private key file')
+                    'The service account email associated with'
+                    'datastore private key file')
 flags.DEFINE_string('google_datastore_datasetId',
                     None,
                     'The project ID that has Cloud Datastore service')
@@ -43,48 +39,52 @@ flags.DEFINE_string('google_datastore_debug',
                     'The logging level when running YCSB')
 
 
-
 def GetConfig(user_config):
     return configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
 
 
 def CheckPrerequisites():
-    # Before YCSB Cloud Datastore supports accessing Application Default Credential,
+    # Before YCSB Cloud Datastore supports Application Default Credential,
     # we should always make sure valid credential flags are set.
-    if not (FLAGS.google_datastore_keyfile and FLAGS.google_datastore_serviceAccount):
-        raise ValueError("'google_datastore_keyfile' and 'google_datastore_serviceAccount' must be set")
+    if not FLAGS.google_datastore_keyfile:
+        raise ValueError("'google_datastore_keyfile' must be set")
+    if not FLAGS.google_datastore_serviceAccount:
+        raise ValueError("'google_datastore_serviceAccount' must be set")
     if not FLAGS.google_datastore_datasetId:
         raise ValueError("'google_datastore_datasetId' must be set ")
+
 
 def Prepare(benchmark_spec):
     benchmark_spec.always_call_cleanup = True
     default_ycsb_tar_url = ycsb.YCSB_TAR_URL
     vms = benchmark_spec.vms
-    
-    # TODO: this is a hacky way to override the tar url, need to figure some other ways.
-    # Override YCSB_TAR_URL so that we only need to download the binding we need.
+
+    # TODO: figure out a less hacky way to override.
+    # Override so that we only need to download the required binding.
     ycsb.YCSB_TAR_URL = YCSB_BINDING_TAR_URL
-    
+
     # Install required packages and copy credential files
     vm_util.RunThreaded(_Install, vms)
-    
+
     # Restore YCSB_TAR_URL
     ycsb.YCSB_TAR_URL = default_ycsb_tar_url
+
 
 def Run(benchmark_spec):
     vms = benchmark_spec.vms
     executor = ycsb.YCSBExecutor('googledatastore')
     run_kwargs = {
-            'threads': 4,
-            'googledatastore.datasetId': FLAGS.google_datastore_datasetId,
-            'googledatastore.privateKeyFile': PRIVATE_KEYFILE_DIR,
-            'googledatastore.serviceAccountEmail': FLAGS.google_datastore_serviceAccount,
+        'threads': 4,
+        'googledatastore.datasetId': FLAGS.google_datastore_datasetId,
+        'googledatastore.privateKeyFile': PRIVATE_KEYFILE_DIR,
+        'googledatastore.serviceAccountEmail':
+        FLAGS.google_datastore_serviceAccount,
             'googledatastore.debug': FLAGS.google_datastore_debug,
-            }
+    }
     load_kwargs = run_kwargs.copy()
     # TODO: support more flags, like thread, operationcount, recordcount, etc.
     if FLAGS['ycsb_preload_threads'].present:
-      load_kwargs['threads'] = FLAGS['ycsb_preload_threads']
+        load_kwargs['threads'] = FLAGS['ycsb_preload_threads']
     samples = list(executor.LoadAndRun(vms,
                                        load_kwargs=load_kwargs,
                                        run_kwargs=run_kwargs))

--- a/perfkitbenchmarker/linux_benchmarks/cloud_datastore_ycsb_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/cloud_datastore_ycsb_benchmark.py
@@ -1,4 +1,32 @@
+# Copyright 2015 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Run YCSB benchmark against Google Cloud Datastore
+
+Before running this benchmark, you have to download your P12
+service account private key file to local machine, and pass the path
+via 'google_datastore_keyfile' parameters to PKB.
+
+Service Account email associated with the key file is also needed to
+pass to PKB.
+
+By default, this benchmark provision 1 single-CPU VM and spawn 1 thread
+to test Datastore.
+"""
+
 import posixpath
+import logging
 
 from perfkitbenchmarker import configs
 from perfkitbenchmarker import flags
@@ -7,7 +35,7 @@ from perfkitbenchmarker.linux_packages import ycsb
 
 
 BENCHMARK_NAME = 'cloud_datastore_ycsb'
-BENCHMARK_CONFIG = '''
+BENCHMARK_CONFIG = """
 cloud_datastore_ycsb:
   description: >
       Run YCSB agains Google Cloud Datastore.
@@ -15,7 +43,7 @@ cloud_datastore_ycsb:
   vm_groups:
     default:
       vm_spec: *default_single_core
-      vm_count: null'''
+      vm_count: 1"""
 
 YCSB_BINDING_TAR_URL = ('https://github.com/brianfrankcooper/YCSB/releases'
                         '/download/0.9.0/'
@@ -74,15 +102,13 @@ def Run(benchmark_spec):
     vms = benchmark_spec.vms
     executor = ycsb.YCSBExecutor('googledatastore')
     run_kwargs = {
-        'threads': 4,
         'googledatastore.datasetId': FLAGS.google_datastore_datasetId,
         'googledatastore.privateKeyFile': PRIVATE_KEYFILE_DIR,
         'googledatastore.serviceAccountEmail':
-        FLAGS.google_datastore_serviceAccount,
-            'googledatastore.debug': FLAGS.google_datastore_debug,
+            FLAGS.google_datastore_serviceAccount,
+        'googledatastore.debug': FLAGS.google_datastore_debug,
     }
     load_kwargs = run_kwargs.copy()
-    # TODO: support more flags, like thread, operationcount, recordcount, etc.
     if FLAGS['ycsb_preload_threads'].present:
         load_kwargs['threads'] = FLAGS['ycsb_preload_threads']
     samples = list(executor.LoadAndRun(vms,
@@ -92,7 +118,9 @@ def Run(benchmark_spec):
 
 
 def Cleanup(benchmark_spec):
-    # For now, we can only manually delete all the entries via GCP portal.
+    # TODO: support automatic cleanup.
+    logging.warning(
+        "For now, we can only manually delete all the entries via GCP portal.")
     return
 
 

--- a/perfkitbenchmarker/linux_packages/ycsb.py
+++ b/perfkitbenchmarker/linux_packages/ycsb.py
@@ -198,6 +198,9 @@ def ParseResults(ycsb_result_string, data_type='histogram'):
         indicates that 530 ops took between 0ms and 1ms, and 1 took between
         19ms and 20ms. Empty bins are not reported.
   """
+
+  # TODO: YCSB 0.9.0 output client and command line string to stderr, so
+  # we need to support it in the future.
   lines = []
   client_string = 'YCSB'
   command_line = 'unknown'

--- a/perfkitbenchmarker/linux_packages/ycsb.py
+++ b/perfkitbenchmarker/linux_packages/ycsb.py
@@ -203,7 +203,11 @@ def ParseResults(ycsb_result_string, data_type='histogram'):
   command_line = 'unknown'
   fp = io.BytesIO(ycsb_result_string)
   result_string = next(fp).strip()
-  while not result_string.startswith('YCSB Client 0.') and not result_string.startswith('[OVERALL]'):
+
+  def IsHeadOfResults(line):
+      return line.startswith('YCSB Client 0.') or line.startswith('[OVERALL]')
+
+  while not IsHeadOfResults(result_string):
     result_string = next(fp).strip()
 
   if result_string.startswith('YCSB Client 0.'):
@@ -211,12 +215,11 @@ def ParseResults(ycsb_result_string, data_type='histogram'):
     command_line = next(fp).strip()
     if not command_line.startswith('Command line:'):
       raise IOError('Unexpected second line: {0}'.format(command_line))
-  if result_string.startswith('[OVERALL]'): # YCSB > 0.7.0 dosen't ouput YCSB version and command lines.
+  elif result_string.startswith('[OVERALL]'):  # YCSB > 0.7.0.
     lines.append(result_string)
   else:
     # Received unexpected header
     raise IOError('Unexpected header: {0}'.format(client_string))
-    
 
   # Some databases print additional output to stdout.
   # YCSB results start with [<OPERATION_NAME>];


### PR DESCRIPTION
Support running YCSB against Cloud Datastore.

Few things to notice here:

1. This benchmark overrides `ycsb.YCSB_TAR_URL` before installing required packages on VMs. This allows us to download only necessary YCSB bindings instead of the whole package.
2. Support parsing results that are returned by YCSB > 0.7.0. Latest YCSB no longer output the client line and command line in the output result.