### PR TITLE
Fix deprecated comment in pkb.py

### DIFF
--- a/perfkitbenchmarker/pkb.py
+++ b/perfkitbenchmarker/pkb.py
@@ -16,7 +16,7 @@
 
 All benchmarks in PerfKitBenchmarker export the following interface:
 
-GetInfo: this returns, the name of the benchmark, the number of machines
+GetConfig: this returns, the name of the benchmark, the number of machines
          required to run one instance of the benchmark, a detailed description
          of the benchmark, and if the benchmark requires a scratch disk.
 Prepare: this function takes a list of VMs as an input parameter. The benchmark


### PR DESCRIPTION
The `GetInfo` interface exposed by benchmark module has changed to `GetConfig`. Thus need to change the pydoc in `pkb.py`