### PR TITLE
side-by-side improvements

### DIFF
--- a/tools/side-by-side/side_by_side.html.j2
+++ b/tools/side-by-side/side_by_side.html.j2
@@ -112,6 +112,9 @@
 
          if (left && right) {
            rel = right.value / left.value;
+	   if (right.value == left.value) {
+	     rel = 1
+	   }
            tooltip.push('Relative value: ' + String(rel) + '\n');
            if (rel < 1) {
              style = 'fill-color: #ef8a62';
@@ -255,9 +258,14 @@
                 {% set pct_diff = ((head_sample.value - base_sample.value) / base_sample.value * 100) -%}
                 {% set relative_diff = '{0:.3f}'.format(head_sample.value / base_sample.value) %}
                 {% else -%}
-                {% set pct_diff = infinity -%}
-                {% set relative_diff = "&infin;" %}
-                {% endif -%}
+		  {% if base_sample.value == head_sample.value -%}
+		    {% set pct_diff = 0 -%}
+		    {% set relative_diff = '{0:.3f}'.format(1) -%}
+		  {% else -%}
+                    {% set pct_diff = infinity -%}
+                    {% set relative_diff = "&infin;" %}
+                  {% endif -%}
+		{% endif -%}
                 <td>{{ head_sample.value - base_sample.value }}</td>
                 <td class="{{ class_for_percent_diff(pct_diff) }}">
                   {%- if class_for_percent_diff(pct_diff) %}

--- a/tools/side-by-side/side_by_side.py
+++ b/tools/side-by-side/side_by_side.py
@@ -233,8 +233,10 @@ def _MatchSamples(base_samples, head_samples):
       result.extend(zip(base_samples[base_begin:base_end],
                         head_samples[head_begin:head_end]))
     elif opcode == 'replace':
-      result.extend(itertools.izip_longest(base_samples[base_begin:base_end],
-                                           head_samples[head_begin:head_end]))
+      result.extend(zip(base_samples[base_begin:base_end],
+                        [None] * (base_end - base_begin)))
+      result.extend(zip([None] * (head_end - head_begin),
+                        head_samples[head_begin:head_end]))
     elif opcode == 'delete':
       result.extend(zip(base_samples[base_begin:base_end],
                         [None] * (base_end - base_begin)))


### PR DESCRIPTION
* When the base and the head are both zero, report the relative difference as 1 and the percent difference as 0.
Old:
![image](https://cloud.githubusercontent.com/assets/5419652/16505350/6059501c-3ed1-11e6-8136-07f5a244e380.png)
New:
![image](https://cloud.githubusercontent.com/assets/5419652/16505332/487c6326-3ed1-11e6-99ef-21668f23b66d.png)

* Force metrics to be the same rather than just being in a similar place in the sequence.  
Before:
![image](https://cloud.githubusercontent.com/assets/5419652/16505383/8b3794d8-3ed1-11e6-8cd8-01f603e2e94b.png)

After:
![image](https://cloud.githubusercontent.com/assets/5419652/16505439/d5bffcb6-3ed1-11e6-9520-666b5480b713.png)
