### PR TITLE
Release 1.6

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,27 @@
+# 1.6.0
+
+New features:
+* Apache Spark benchmark (GH-1014,GH-1011)
+* Cloudsuite dataserving benchmark (thanks @ustiugov, GH-930)
+
+Enhancements:
+* Optionally publish VM hostnames in metadata (GH-1020)
+* Control which netperf benchmarks are run via flag (GH-1029)
+* Netperf benchmark reports min and max latency (GH-1013)
+* Add multichase to the google benchmark set (GH-1018)
+* Update Cloudsuite web serving benchmark (thanks @ivonindza, @GH-998)
+* Object storage updates (GH-987)
+* Repeat Run stage (GH-1032)
+
+Bugfixes and maintenance updates:
+* Fix path to cassandra-cli (thanks @adamisrael, GH-1006)
+* Update ycsb version; affects cloud_bigtable_ycsb_benchmark, hbase_ycsb
+  (GH-1021, GH-1025, GH-1031)
+  * Use latest gsutil version (GH-1012)
+  * Remove duplicate requirements files (GH-975)
+  * Update openblas version (GH-1003)
+  * Background workload refactor (GH-1033)
+
 # 1.5.0
 
 New features:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,10 +17,10 @@ Bugfixes and maintenance updates:
 * Fix path to cassandra-cli (thanks @adamisrael, GH-1006)
 * Update ycsb version; affects cloud_bigtable_ycsb_benchmark, hbase_ycsb
   (GH-1021, GH-1025, GH-1031)
-  * Use latest gsutil version (GH-1012)
-  * Remove duplicate requirements files (GH-975)
-  * Update openblas version (GH-1003)
-  * Background workload refactor (GH-1033)
+* Use latest gsutil version (GH-1012)
+* Remove duplicate requirements files (GH-975)
+* Update openblas version (GH-1003)
+* Background workload refactor (GH-1033)
 
 # 1.5.0
 

--- a/perfkitbenchmarker/background_workload.py
+++ b/perfkitbenchmarker/background_workload.py
@@ -1,0 +1,130 @@
+# Copyright 2016 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module containing classes for background workloads."""
+
+from perfkitbenchmarker import os_types
+from perfkitbenchmarker import vm_util
+
+BACKGROUND_WORKLOADS = []
+
+BACKGROUND_IPERF_PORT = 20001
+BACKGROUND_IPERF_SECONDS = 2147483647
+
+
+class AutoRegisterBackgroundWorkloadMeta(type):
+  """Metaclass which allows BackgroundWorkloads to be auto-registered."""
+
+  def __init__(cls, name, bases, dct):
+    super(AutoRegisterBackgroundWorkloadMeta, cls).__init__(name, bases, dct)
+    BACKGROUND_WORKLOADS.append(cls)
+
+
+class BaseBackgroundWorkload(object):
+  """Baseclass for background workloads."""
+  __metaclass__ = AutoRegisterBackgroundWorkloadMeta
+
+  EXCLUDED_OS_TYPES = []
+
+  @staticmethod
+  def IsEnabled(vm):
+    """Returns true if this background workload is enabled on this VM."""
+    return False
+
+  @staticmethod
+  def Prepare(vm):
+    """Prepares the background workload on this VM."""
+    pass
+
+  @staticmethod
+  def Start(vm):
+    """Starts the background workload on this VM."""
+    pass
+
+  @staticmethod
+  def Stop(vm):
+    """Stops the background workload on this VM."""
+    pass
+
+
+class CpuWorkload(BaseBackgroundWorkload):
+  """Workload that runs sysbench in the background."""
+
+  EXCLUDED_OS_TYPES = os_types.WINDOWS_OS_TYPES
+
+  @staticmethod
+  def IsEnabled(vm):
+    """Returns true if this background workload is enabled on this VM."""
+    return bool(vm.background_cpu_threads)
+
+  @staticmethod
+  def Prepare(vm):
+    """Prepares the background workload on this VM."""
+    vm.Install('sysbench')
+
+  @staticmethod
+  def Start(vm):
+    """Starts the background workload on this VM."""
+    vm.RemoteCommand(
+        'nohup sysbench --num-threads=%s --test=cpu --cpu-max-prime=10000000 '
+        'run 1> /dev/null 2> /dev/null &' % vm.background_cpu_threads)
+
+  @staticmethod
+  def Stop(vm):
+    """Stops the background workload on this VM."""
+    vm.RemoteCommand('pkill -9 sysbench')
+
+
+class NetworkWorkload(BaseBackgroundWorkload):
+  """Workload that runs iperf in the background."""
+
+  EXCLUDED_OS_TYPES = os_types.WINDOWS_OS_TYPES
+
+  @staticmethod
+  def IsEnabled(vm):
+    """Returns true if this background workload is enabled on this VM."""
+    return bool(vm.background_network_mbits_per_sec)
+
+  @staticmethod
+  def Prepare(vm):
+    """Prepares the background workload on this VM."""
+    vm.Install('iperf')
+
+  @staticmethod
+  def Start(vm):
+    """Starts the background workload on this VM."""
+    vm.AllowPort(BACKGROUND_IPERF_PORT)
+    vm.RemoteCommand('nohup iperf --server --port %s &> /dev/null &' %
+                     BACKGROUND_IPERF_PORT)
+    stdout, _ = vm.RemoteCommand('pgrep iperf -n')
+    vm.server_pid = stdout.strip()
+
+    if vm.background_network_ip_type == vm_util.IpAddressSubset.EXTERNAL:
+      ip_address = vm.ip_address
+    else:
+      ip_address = vm.internal_ip
+    iperf_cmd = ('nohup iperf --client %s --port %s --time %s -u -b %sM '
+                 '&> /dev/null &' % (ip_address, BACKGROUND_IPERF_PORT,
+                                     BACKGROUND_IPERF_SECONDS,
+                                     vm.background_network_mbits_per_sec))
+
+    vm.RemoteCommand(iperf_cmd)
+    stdout, _ = vm.RemoteCommand('pgrep iperf -n')
+    vm.client_pid = stdout.strip()
+
+  @staticmethod
+  def Stop(vm):
+    """Stops the background workload on this VM."""
+    vm.RemoteCommand('kill -9 ' + vm.client_pid)
+    vm.RemoteCommand('kill -9 ' + vm.server_pid)

--- a/perfkitbenchmarker/linux_packages/ycsb.py
+++ b/perfkitbenchmarker/linux_packages/ycsb.py
@@ -515,6 +515,7 @@ class YCSBExecutor(object):
     for parameter, value in parameters.iteritems():
       command.extend(('-p', '{0}={1}'.format(parameter, value)))
 
+    command.append('-p measurementtype=histogram')
     return 'cd %s; %s' % (YCSB_DIR, ' '.join(command))
 
   @property

--- a/perfkitbenchmarker/linux_virtual_machine.py
+++ b/perfkitbenchmarker/linux_virtual_machine.py
@@ -58,9 +58,6 @@ REMOTE_KEY_PATH = '.ssh/id_rsa'
 CONTAINER_MOUNT_DIR = '/mnt'
 CONTAINER_WORK_DIR = '/root'
 
-BACKGROUND_IPERF_PORT = 20001
-BACKGROUND_IPERF_SECONDS = 2147483647
-
 # This pair of scripts used for executing long-running commands, which will be
 # resilient in the face of SSH connection errors.
 # EXECUTE_COMMAND runs a command, streaming stdout / stderr to a file, then
@@ -564,47 +561,6 @@ class BaseLinuxMixin(virtual_machine.BaseOsMixin):
       if time.time() < end_time:
         time.sleep(end_time - time.time())
       self.RemoteCommand('pkill -9 sysbench')
-
-  def PrepareBackgroundWorkload(self):
-    """Install packages needed for the background workload."""
-    if self.background_cpu_threads:
-      self.Install('sysbench')
-    if self.background_network_mbits_per_sec:
-      self.Install('iperf')
-
-  def StartBackgroundWorkload(self):
-    """Starts the blackground workload."""
-    if self.background_cpu_threads:
-      self.RemoteCommand(
-          'nohup sysbench --num-threads=%s --test=cpu --cpu-max-prime=10000000 '
-          'run 1> /dev/null 2> /dev/null &' % self.background_cpu_threads)
-    if self.background_network_mbits_per_sec:
-      self.AllowPort(BACKGROUND_IPERF_PORT)
-      self.RemoteCommand('nohup iperf --server --port %s &> /dev/null &' %
-                         BACKGROUND_IPERF_PORT)
-      stdout, _ = self.RemoteCommand('pgrep iperf -n')
-      self.server_pid = stdout.strip()
-
-      if self.background_network_ip_type == vm_util.IpAddressSubset.EXTERNAL:
-        ip_address = self.ip_address
-      else:
-        ip_address = self.internal_ip
-      iperf_cmd = ('nohup iperf --client %s --port %s --time %s -u -b %sM '
-                   '&> /dev/null &' % (ip_address, BACKGROUND_IPERF_PORT,
-                                       BACKGROUND_IPERF_SECONDS,
-                                       self.background_network_mbits_per_sec))
-
-      self.RemoteCommand(iperf_cmd)
-      stdout, _ = self.RemoteCommand('pgrep iperf -n')
-      self.client_pid = stdout.strip()
-
-  def StopBackgroundWorkload(self):
-    """Stops the background workload."""
-    if self.background_cpu_threads:
-      self.RemoteCommand('pkill -9 sysbench')
-    if self.background_network_mbits_per_sec:
-      self.RemoteCommand('kill -9 ' + self.client_pid)
-      self.RemoteCommand('kill -9 ' + self.server_pid)
 
 
 class RhelMixin(BaseLinuxMixin):

--- a/perfkitbenchmarker/publisher.py
+++ b/perfkitbenchmarker/publisher.py
@@ -621,3 +621,4 @@ class SampleCollector(object):
     """Publish samples via all registered publishers."""
     for publisher in self.publishers:
       publisher.PublishSamples(self.samples)
+    self.samples = []

--- a/perfkitbenchmarker/virtual_machine.py
+++ b/perfkitbenchmarker/virtual_machine.py
@@ -24,6 +24,7 @@ import threading
 
 import jinja2
 
+from perfkitbenchmarker import background_workload
 from perfkitbenchmarker import data
 from perfkitbenchmarker import disk
 from perfkitbenchmarker import errors
@@ -579,15 +580,24 @@ class BaseOsMixin(object):
 
   def StartBackgroundWorkload(self):
     """Start the background workload."""
-    if self.background_cpu_threads or self.background_network_mbits_per_sec:
-      raise NotImplementedError()
+    for workload in background_workload.BACKGROUND_WORKLOADS:
+      if workload.IsEnabled(self):
+        if self.OS_TYPE in workload.EXCLUDED_OS_TYPES:
+          raise NotImplementedError()
+        workload.Start(self)
 
   def StopBackgroundWorkload(self):
     """Stop the background workoad."""
-    if self.background_cpu_threads or self.background_network_mbits_per_sec:
-      raise NotImplementedError()
+    for workload in background_workload.BACKGROUND_WORKLOADS:
+      if workload.IsEnabled(self):
+        if self.OS_TYPE in workload.EXCLUDED_OS_TYPES:
+          raise NotImplementedError()
+        workload.Stop(self)
 
   def PrepareBackgroundWorkload(self):
     """Prepare for the background workload."""
-    if self.background_cpu_threads or self.background_network_mbits_per_sec:
-      raise NotImplementedError()
+    for workload in background_workload.BACKGROUND_WORKLOADS:
+      if workload.IsEnabled(self):
+        if self.OS_TYPE in workload.EXCLUDED_OS_TYPES:
+          raise NotImplementedError()
+        workload.Prepare(self)


### PR DESCRIPTION
New features:
* Apache Spark benchmark (GH-1014,GH-1011)
* Cloudsuite dataserving benchmark (thanks @ustiugov, GH-930)

Enhancements:
* Optionally publish VM hostnames in metadata (GH-1020)
* Control which netperf benchmarks are run via flag (GH-1029)
* Netperf benchmark reports min and max latency (GH-1013)
* Add multichase to the google benchmark set (GH-1018)
* Update Cloudsuite web serving benchmark (thanks @ivonindza, @GH-998)
* Object storage updates (GH-987)
* Repeat Run stage (GH-1032)

Bugfixes and maintenance updates:
* Fix path to cassandra-cli (thanks @adamisrael, GH-1006)
* Update ycsb version; affects cloud_bigtable_ycsb_benchmark, hbase_ycsb
  (GH-1021, GH-1025, GH-1031)
* Use latest gsutil version (GH-1012)
* Remove duplicate requirements files (GH-975)
* Update openblas version (GH-1003)
* Background workload refactor (GH-1033)
