### PR TITLE
[datastore_ycsb] Support overriding vm_count in benchmark specs

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/cloud_datastore_ycsb_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/cloud_datastore_ycsb_benchmark.py
@@ -68,7 +68,10 @@ flags.DEFINE_string('google_datastore_debug',
 
 
 def GetConfig(user_config):
-    return configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
+    config = configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
+    if FLAGS['num_vms'].present:
+        config['vm_groups']['default']['vm_count'] = FLAGS.num_vms
+    return config
 
 
 def CheckPrerequisites():

--- a/perfkitbenchmarker/linux_benchmarks/cloud_datastore_ycsb_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/cloud_datastore_ycsb_benchmark.py
@@ -69,8 +69,8 @@ flags.DEFINE_string('google_datastore_debug',
 
 def GetConfig(user_config):
     config = configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
-    if FLAGS['num_vms'].present:
-        config['vm_groups']['default']['vm_count'] = FLAGS.num_vms
+    if FLAGS['ycsb_client_vms'].present:
+        config['vm_groups']['default']['vm_count'] = FLAGS.ycsb_client_vms
     return config
 
 


### PR DESCRIPTION
The previous implementation cannot override `vm_count` field in `BENCHMARK_CONFIG`. Not sure why.
Took this snippet from other benchmarks, explicitly overriding `vm_count`.