### PR TITLE
[ycsb] Upgrade YCSB to 0.9.0 and support latest logging format.

### DIFF
--- a/perfkitbenchmarker/linux_packages/ycsb.py
+++ b/perfkitbenchmarker/linux_packages/ycsb.py
@@ -55,7 +55,7 @@ from perfkitbenchmarker import vm_util
 
 FLAGS = flags.FLAGS
 
-YCSB_VERSION = '0.7.0'
+YCSB_VERSION = '0.9.0'
 YCSB_TAR_URL = ('https://github.com/brianfrankcooper/YCSB/releases/'
                 'download/{0}/ycsb-{0}.tar.gz').format(YCSB_VERSION)
 YCSB_DIR = posixpath.join(vm_util.VM_TMP_DIR, 'ycsb')
@@ -627,8 +627,11 @@ class YCSBExecutor(object):
       param, value = pv.split('=', 1)
       kwargs[param] = value
     command = self._BuildCommand('run', **kwargs)
-    stdout, _ = vm.RobustRemoteCommand(command)
-    return ParseResults(str(stdout))
+    # YCSB version greater than 0.7.0 output some of the
+    # info we need to stderr. So we have to combine these 2
+    # output to get expected results.
+    stdout, stderr = vm.RobustRemoteCommand(command)
+    return ParseResults(str(stderr + stdout))
 
   def _RunThreaded(self, vms, **kwargs):
     """Run a single workload using `vms`."""


### PR DESCRIPTION
YCSB 0.9.0 output results and log to `stdout` and `stderr`.

Previously we only parse stdout log to get the info we care about, but with YCSB 0.9.0, that is not the case anymore. We need to combine both log files to get all the info.