### PR TITLE
[jdbc_ycsb] Support YCSB JDBC benchmark

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/jdbc_ycsb_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/jdbc_ycsb_benchmark.py
@@ -45,7 +45,7 @@ jdbc_ycsb:
     default:
       vm_spec: *default_single_core
       vm_count: 1"""
-YCSB_VERSION = '0.9.0'
+
 YCSB_BINDING_LIB_DIR = posixpath.join(ycsb.YCSB_DIR, 'jdbc-binding', 'lib')
 CREATE_TABLE_SQL = ("CREATE TABLE usertable "
                     "(YCSB_KEY VARCHAR(255) PRIMARY KEY, "
@@ -75,8 +75,10 @@ flags.DEFINE_string('db_driver_path',
 
 
 def GetConfig(user_config):
-    return configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
-
+    config = configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
+    if FLAGS['ycsb_client_vms'].present:
+        config['vm_groups']['default']['vm_count'] = FLAGS.ycsb_client_vms
+    return config
 
 def CheckPrerequisites():
     # Before YCSB Cloud Datastore supports Application Default Credential,

--- a/perfkitbenchmarker/linux_benchmarks/jdbc_ycsb_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/jdbc_ycsb_benchmark.py
@@ -147,8 +147,6 @@ def Run(benchmark_spec):
 def Cleanup(benchmark_spec):
     # support automatic cleanup.
     ExecuteSql(benchmark_spec.vms[0], DROP_TABLE_SQL)
-    #logging.warning(
-    #    "For now, we can only manually drop the table.")
 
 
 def _Install(vm):

--- a/perfkitbenchmarker/linux_benchmarks/jdbc_ycsb_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/jdbc_ycsb_benchmark.py
@@ -26,7 +26,6 @@ Tested against Azure SQL database.
 """
 
 import posixpath
-import logging
 
 from perfkitbenchmarker import configs
 from perfkitbenchmarker import errors
@@ -80,6 +79,7 @@ def GetConfig(user_config):
         config['vm_groups']['default']['vm_count'] = FLAGS.ycsb_client_vms
     return config
 
+
 def CheckPrerequisites():
     # Before YCSB Cloud Datastore supports Application Default Credential,
     # we should always make sure valid credential flags are set.
@@ -109,17 +109,17 @@ def Prepare(benchmark_spec):
 
 def ExecuteSql(vm, sql):
     db_args = (
-            ' -p db.driver={0}'
-            ' -p db.url="{1}"'
-            ' -p db.user={2}'
-            ' -p db.passwd={3}').format(
-                                        FLAGS.db_driver,
-                                        FLAGS.db_url,
-                                        FLAGS.db_user,
-                                        FLAGS.db_passwd)
+        ' -p db.driver={0}'
+        ' -p db.url="{1}"'
+        ' -p db.user={2}'
+        ' -p db.passwd={3}').format(
+        FLAGS.db_driver,
+        FLAGS.db_url,
+        FLAGS.db_user,
+        FLAGS.db_passwd)
 
     exec_cmd = 'java -cp "{0}/*" com.yahoo.ycsb.db.JdbcDBCli -c "{1}" ' \
-                .format(YCSB_BINDING_LIB_DIR, sql)
+        .format(YCSB_BINDING_LIB_DIR, sql)
     stdout, stderr = vm.RobustRemoteCommand(exec_cmd + db_args)
 
     if 'successfully executed' not in stdout and not stderr:
@@ -151,6 +151,6 @@ def Cleanup(benchmark_spec):
 
 def _Install(vm):
     vm.Install('ycsb')
-    
+
     # Copy driver jar to VM.
     vm.RemoteCopy(FLAGS.db_driver_path, YCSB_BINDING_LIB_DIR)

--- a/perfkitbenchmarker/linux_benchmarks/jdbc_ycsb_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/jdbc_ycsb_benchmark.py
@@ -1,0 +1,156 @@
+# Copyright 2015 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Run YCSB benchmark against managed SQL databases that support JDBC.
+
+This benchmark does not provision VMs for the corresponding SQL database
+cluster. The only VM group is client group that sends requests to specified
+DB.
+
+Before running this benchmark, you have to manually create `usertable` as
+specified in YCSB JDBC binding.
+
+Tested against Azure SQL database.
+
+"""
+
+import posixpath
+import logging
+
+from perfkitbenchmarker import configs
+from perfkitbenchmarker import errors
+from perfkitbenchmarker import flags
+from perfkitbenchmarker import vm_util
+from perfkitbenchmarker.linux_packages import ycsb
+
+
+BENCHMARK_NAME = 'jdbc_ycsb'
+BENCHMARK_CONFIG = """
+jdbc_ycsb:
+  description: >
+      Run YCSB against relational databases that support JDBC.
+      Configure the number of VMs via --num-vms.
+  vm_groups:
+    default:
+      vm_spec: *default_single_core
+      vm_count: 1"""
+YCSB_VERSION = '0.9.0'
+YCSB_BINDING_LIB_DIR = posixpath.join(ycsb.YCSB_DIR, 'jdbc-binding', 'lib')
+CREATE_TABLE_SQL = ("CREATE TABLE usertable "
+                    "(YCSB_KEY VARCHAR(255) PRIMARY KEY, "
+                    "FIELD0 TEXT, FIELD1 TEXT, "
+                    "FIELD2 TEXT, FIELD3 TEXT, "
+                    "FIELD4 TEXT, FIELD5 TEXT, "
+                    "FIELD6 TEXT, FIELD7 TEXT, "
+                    "FIELD8 TEXT, FIELD9 TEXT);")
+DROP_TABLE_SQL = "DROP TABLE IF EXISTS usertable;"
+
+FLAGS = flags.FLAGS
+flags.DEFINE_string('db_driver',
+                    None,
+                    'The class of JDBC driver that connects to DB.')
+flags.DEFINE_string('db_url',
+                    None,
+                    'The URL that is used to connect to DB')
+flags.DEFINE_string('db_user',
+                    None,
+                    'The username of target DB.')
+flags.DEFINE_string('db_passwd',
+                    None,
+                    'The password of specified DB user.')
+flags.DEFINE_string('db_driver_path',
+                    None,
+                    'The path to JDBC driver jar file on local machine.')
+
+
+def GetConfig(user_config):
+    return configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
+
+
+def CheckPrerequisites():
+    # Before YCSB Cloud Datastore supports Application Default Credential,
+    # we should always make sure valid credential flags are set.
+    if not FLAGS.db_driver:
+        raise ValueError('"db_driver" must be set')
+    if not FLAGS.db_driver_path:
+        raise ValueError('"db_driver_path" must be set')
+    if not FLAGS.db_url:
+        raise ValueError('"db_url" must be set')
+    if not FLAGS.db_user:
+        raise ValueError('"db_user" must be set ')
+    if not FLAGS.db_passwd:
+        raise ValueError('"db_passwd" must be set ')
+
+
+def Prepare(benchmark_spec):
+    benchmark_spec.always_call_cleanup = True
+    vms = benchmark_spec.vms
+
+    # Install required packages and copy credential files.
+    vm_util.RunThreaded(_Install, vms)
+
+    # Create benchmark table.
+    ExecuteSql(vms[0], DROP_TABLE_SQL)
+    ExecuteSql(vms[0], CREATE_TABLE_SQL)
+
+
+def ExecuteSql(vm, sql):
+    db_args = (
+            ' -p db.driver={0}'
+            ' -p db.url="{1}"'
+            ' -p db.user={2}'
+            ' -p db.passwd={3}').format(
+                                        FLAGS.db_driver,
+                                        FLAGS.db_url,
+                                        FLAGS.db_user,
+                                        FLAGS.db_passwd)
+
+    exec_cmd = 'java -cp "{0}/*" com.yahoo.ycsb.db.JdbcDBCli -c "{1}" ' \
+                .format(YCSB_BINDING_LIB_DIR, sql)
+    stdout, stderr = vm.RobustRemoteCommand(exec_cmd + db_args)
+
+    if 'successfully executed' not in stdout and not stderr:
+        raise errors.VirtualMachine.RemoteCommandError(stderr)
+
+
+def Run(benchmark_spec):
+    vms = benchmark_spec.vms
+    executor = ycsb.YCSBExecutor('jdbc')
+    run_kwargs = {
+        'db.driver': FLAGS.db_driver,
+        'db.url': '"%s"' % FLAGS.db_url,
+        'db.user': FLAGS.db_user,
+        'db.passwd': FLAGS.db_passwd,
+    }
+    load_kwargs = run_kwargs.copy()
+    if FLAGS['ycsb_preload_threads'].present:
+        load_kwargs['threads'] = FLAGS['ycsb_preload_threads']
+    samples = list(executor.LoadAndRun(vms,
+                                       load_kwargs=load_kwargs,
+                                       run_kwargs=run_kwargs))
+    return samples
+
+
+def Cleanup(benchmark_spec):
+    # support automatic cleanup.
+    ExecuteSql(benchmark_spec.vms[0], DROP_TABLE_SQL)
+    #logging.warning(
+    #    "For now, we can only manually drop the table.")
+
+
+def _Install(vm):
+    vm.Install('ycsb')
+    
+    # Copy driver jar to VM.
+    vm.RemoteCopy(FLAGS.db_driver_path, YCSB_BINDING_LIB_DIR)

--- a/perfkitbenchmarker/linux_benchmarks/jdbc_ycsb_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/jdbc_ycsb_benchmark.py
@@ -78,6 +78,7 @@ flags.DEFINE_integer('jdbc_ycsb_fetch_size',
                      10,
                      'The JDBC fetch size hinted to driver')
 
+
 def GetConfig(user_config):
     config = configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
     if FLAGS['ycsb_client_vms'].present:


### PR DESCRIPTION
Add YCSB benchmark against JDBC-supported databases.

This benchmark takes care of creating and dropping test table.

Have to specify the path to jdbc driver jar to run the benchmark.