### PR TITLE
[openjdk7] Support Ubuntu 16.04

### DIFF
--- a/perfkitbenchmarker/linux_packages/openjdk7.py
+++ b/perfkitbenchmarker/linux_packages/openjdk7.py
@@ -27,6 +27,7 @@ def YumInstall(vm):
   """Installs the OpenJDK7 package on the VM."""
   vm.InstallPackages('java-1.7.0-openjdk-devel')
 
+
 @vm_util.Retry(max_retries=1)
 def AptInstall(vm):
   """Installs the OpenJDK7 package on the VM."""
@@ -39,8 +40,8 @@ def AptInstall(vm):
       UpdateAptRepo(vm)
       raise e
 
+
 def UpdateAptRepo(vm):
     logging.info('Adding openjdk repo.')
     vm.RemoteCommand('sudo add-apt-repository -y ppa:openjdk-r/ppa')
     vm.RemoteCommand('sudo apt-get update')
-


### PR DESCRIPTION
Quick fix for #1038 .

Solution based on [Install openjdk-7-jdk on Ubuntu16.04](http://askubuntu.com/questions/761127/ubuntu-16-04-and-openjdk-7).