### PR TITLE
More flexible handling of java version

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/scimark2_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/scimark2_benchmark.py
@@ -81,7 +81,7 @@ def Prepare(benchmark_spec):
   logging.info('Preparing SciMark2 on %s', vm)
   vm.Install('build_tools')
   vm.Install('wget')
-  vm.Install('openjdk7')
+  vm.Install('openjdk')
   vm.InstallPackages('unzip')
   cmds = [
       'rm -rf {0} && mkdir {0}'.format(SCIMARK2_PATH),

--- a/perfkitbenchmarker/linux_packages/cassandra.py
+++ b/perfkitbenchmarker/linux_packages/cassandra.py
@@ -69,7 +69,7 @@ def _Install(vm):
   """Installs Cassandra from a tarball."""
   vm.Install('ant')
   vm.Install('build_tools')
-  vm.Install('openjdk7')
+  vm.Install('openjdk')
   vm.Install('curl')
   vm.RemoteCommand(
       'cd {0}; git clone {1}; cd {2}; git checkout {3}; {4}/bin/ant'.format(

--- a/perfkitbenchmarker/linux_packages/faban.py
+++ b/perfkitbenchmarker/linux_packages/faban.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2016 PerfKitBenchmarker Authors. All rights reserved.
+# Copyright 2016 PerfKitBenchmarker Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/perfkitbenchmarker/linux_packages/faban.py
+++ b/perfkitbenchmarker/linux_packages/faban.py
@@ -1,4 +1,4 @@
-# Copyright 2015 PerfKitBenchmarker Authors. All rights reserved.
+# Copyright 2015-2016 PerfKitBenchmarker Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ import time
 import posixpath
 
 from perfkitbenchmarker import vm_util
-from perfkitbenchmarker.linux_packages.openjdk7 import JAVA_HOME
+from perfkitbenchmarker.linux_packages.openjdk import JAVA_HOME
 
 FABAN_HOME_DIR = posixpath.join(vm_util.VM_TMP_DIR, 'faban')
 
@@ -30,7 +30,7 @@ FABAN_PORT = 9980
 
 def _Install(vm):
   """Installs the Faban on the VM."""
-  vm.Install('openjdk7')
+  vm.Install('openjdk')
   vm.Install('ant')
   vm.RemoteCommand('cd {0} && '
                    'wget {2} && '

--- a/perfkitbenchmarker/linux_packages/hadoop.py
+++ b/perfkitbenchmarker/linux_packages/hadoop.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2016 PerfKitBenchmarker Authors. All rights reserved.
+# Copyright 2016 PerfKitBenchmarker Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/perfkitbenchmarker/linux_packages/hadoop.py
+++ b/perfkitbenchmarker/linux_packages/hadoop.py
@@ -1,4 +1,4 @@
-# Copyright 2015 PerfKitBenchmarker Authors. All rights reserved.
+# Copyright 2015-2016 PerfKitBenchmarker Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ def CheckPrerequisites():
 
 
 def _Install(vm):
-  vm.Install('openjdk7')
+  vm.Install('openjdk')
   vm.Install('curl')
   vm.RemoteCommand(('mkdir {0} && curl -L {1} | '
                     'tar -C {0} --strip-components=1 -xzf -').format(

--- a/perfkitbenchmarker/linux_packages/maven.py
+++ b/perfkitbenchmarker/linux_packages/maven.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2016 PerfKitBenchmarker Authors. All rights reserved.
+# Copyright 2016 PerfKitBenchmarker Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/perfkitbenchmarker/linux_packages/maven.py
+++ b/perfkitbenchmarker/linux_packages/maven.py
@@ -1,4 +1,4 @@
-# Copyright 2014 PerfKitBenchmarker Authors. All rights reserved.
+# Copyright 2014-2016 PerfKitBenchmarker Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ MVN_DIR = '%s/apache-maven-3.3.9' % vm_util.VM_TMP_DIR
 
 def _Install(vm):
   """Installs the maven package on the VM."""
-  vm.Install('openjdk7')
+  vm.Install('openjdk')
   vm.Install('wget')
   vm.RemoteCommand('wget %s -P %s' % (MVN_URL, vm_util.VM_TMP_DIR))
   vm.RemoteCommand('cd %s && tar xvzf %s' % (vm_util.VM_TMP_DIR, MVN_TAR))

--- a/perfkitbenchmarker/linux_packages/openjdk.py
+++ b/perfkitbenchmarker/linux_packages/openjdk.py
@@ -23,6 +23,7 @@ JAVA_HOME = '/usr'
 
 flags.DEFINE_string('openjdk_version', '7', 'Version of openjdk to use.')
 
+
 def YumInstall(vm):
   """Installs the OpenJDK package on the VM."""
   vm.InstallPackages('java-1.{0}.0-openjdk-devel'.format(FLAGS.openjdk_version))

--- a/perfkitbenchmarker/linux_packages/openjdk.py
+++ b/perfkitbenchmarker/linux_packages/openjdk.py
@@ -13,16 +13,21 @@
 # limitations under the License.
 
 
-"""Module containing OpenJDK7 installation and cleanup functions."""
+"""Module containing OpenJDK installation and cleanup functions."""
+
+from perfkitbenchmarker import flags
+
+FLAGS = flags.FLAGS
 
 JAVA_HOME = '/usr'
 
+flags.DEFINE_string('openjdk_version', '7', 'Version of openjdk to use.')
 
 def YumInstall(vm):
-  """Installs the OpenJDK7 package on the VM."""
-  vm.InstallPackages('java-1.7.0-openjdk-devel')
+  """Installs the OpenJDK package on the VM."""
+  vm.InstallPackages('java-1.{0}.0-openjdk-devel'.format(FLAGS.openjdk_version))
 
 
 def AptInstall(vm):
-  """Installs the OpenJDK7 package on the VM."""
-  vm.InstallPackages('openjdk-7-jdk')
+  """Installs the OpenJDK package on the VM."""
+  vm.InstallPackages('openjdk-{0}-jdk'.format(FLAGS.openjdk_version))

--- a/perfkitbenchmarker/linux_packages/openjdk.py
+++ b/perfkitbenchmarker/linux_packages/openjdk.py
@@ -21,7 +21,10 @@ FLAGS = flags.FLAGS
 
 JAVA_HOME = '/usr'
 
-flags.DEFINE_string('openjdk_version', '7', 'Version of openjdk to use.')
+flags.DEFINE_string('openjdk_version', '7', 'Version of openjdk to use. '
+                    'You must use this flag to specify version 8 for '
+                    'ubuntu 1604 and other operating systems where '
+                    'openjdk7 is not installable by default')
 
 
 def YumInstall(vm):

--- a/perfkitbenchmarker/linux_packages/solr.py
+++ b/perfkitbenchmarker/linux_packages/solr.py
@@ -1,4 +1,4 @@
-# Copyright 2015 PerfKitBenchmarker Authors. All rights reserved.
+# Copyright 2015-2016 PerfKitBenchmarker Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ SOLR_TAR_URL = ('archive.apache.org/dist/lucene/solr/5.2.1/solr-5.2.1.tgz')
 
 def _Install(vm):
   """Installs the Apache Solr on the VM."""
-  vm.Install('openjdk7')
+  vm.Install('openjdk')
   vm.RobustRemoteCommand('cd {0} && '
                          'wget -O solr.tar.gz {2} && '
                          'tar -zxf solr.tar.gz'.format(

--- a/perfkitbenchmarker/linux_packages/solr.py
+++ b/perfkitbenchmarker/linux_packages/solr.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2016 PerfKitBenchmarker Authors. All rights reserved.
+# Copyright 2016 PerfKitBenchmarker Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/perfkitbenchmarker/linux_packages/tomcat.py
+++ b/perfkitbenchmarker/linux_packages/tomcat.py
@@ -1,4 +1,4 @@
-# Copyright 2015 PerfKitBenchmarker Authors. All rights reserved.
+# Copyright 2015-2016 PerfKitBenchmarker Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ _TOMCAT_PROTOCOL = 'org.apache.coyote.http11.Http11Nio2Protocol'
 
 
 def _Install(vm):
-  vm.Install('openjdk7')
+  vm.Install('openjdk')
   vm.Install('curl')
   vm.RemoteCommand(
       ('mkdir -p {0} && curl -L {1} | '

--- a/perfkitbenchmarker/linux_packages/tomcat.py
+++ b/perfkitbenchmarker/linux_packages/tomcat.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2016 PerfKitBenchmarker Authors. All rights reserved.
+# Copyright 2016 PerfKitBenchmarker Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/perfkitbenchmarker/linux_packages/ycsb.py
+++ b/perfkitbenchmarker/linux_packages/ycsb.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2016 PerfKitBenchmarker Authors. All rights reserved.
+# Copyright 2016 PerfKitBenchmarker Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/perfkitbenchmarker/linux_packages/ycsb.py
+++ b/perfkitbenchmarker/linux_packages/ycsb.py
@@ -1,4 +1,4 @@
-# Copyright 2015 PerfKitBenchmarker Authors. All rights reserved.
+# Copyright 2015-2016 PerfKitBenchmarker Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -144,7 +144,7 @@ def CheckPrerequisites():
 
 def _Install(vm):
   """Installs the YCSB package on the VM."""
-  vm.Install('openjdk7')
+  vm.Install('openjdk')
   vm.Install('curl')
   vm.RemoteCommand(('mkdir -p {0} && curl -L {1} | '
                     'tar -C {0} --strip-components=1 -xzf -').format(


### PR DESCRIPTION
Allow the java version used to be specified as a command line flag.  Addresses issue #1038; may make PR #1050 obsolete.

With this change, you can use `--openjdk_version=8` to specify java 8 when running with ubuntu1604.