### PR TITLE
Minor fixes in flag descriptions

### DIFF
--- a/perfkitbenchmarker/benchmark_spec.py
+++ b/perfkitbenchmarker/benchmark_spec.py
@@ -61,18 +61,18 @@ flags.DEFINE_enum('cloud', providers.GCP,
                   providers.VALID_CLOUDS,
                   'Name of the cloud to use.')
 flags.DEFINE_string('scratch_dir', None,
-                    'Base name for all scratch disk directories in the VM.'
-                    'Upon creation, these directories will have numbers'
+                    'Base name for all scratch disk directories in the VM. '
+                    'Upon creation, these directories will have numbers '
                     'appended to them (for example /scratch0, /scratch1, etc).')
 flags.DEFINE_enum('benchmark_compatibility_checking', SUPPORTED,
                   [SUPPORTED, NOT_EXCLUDED, SKIP_CHECK],
                   'Method used to check compatibility between the benchmark '
                   ' and the cloud.  ' + SUPPORTED + ' runs the benchmark only'
                   ' if the cloud provider has declared it supported. ' +
-                  NOT_EXCLUDED + ' runs the benchmark unless it has been '
-                  ' declared not supported by the could provider. ' +
+                  NOT_EXCLUDED + ' runs the benchmark unless it has been'
+                  ' declared not supported by the cloud provider. ' +
                   SKIP_CHECK + ' does not do the compatibility'
-                  ' check. The default is ' + SUPPORTED)
+                  ' check.')
 
 
 class BenchmarkSpec(object):

--- a/perfkitbenchmarker/configs/__init__.py
+++ b/perfkitbenchmarker/configs/__init__.py
@@ -83,7 +83,7 @@ flags.DEFINE_multistring(
     'the user config (specified via --benchmark_config_file_path), so it has '
     'a higher priority than that config. The value of the flag should be '
     'fully.qualified.key=value (e.g. --config_override=cluster_boot.vm_groups.'
-    'default.vm_count=4). This flag can be repeated.')
+    'default.vm_count=4).')
 
 
 def _LoadUserConfig(path):

--- a/perfkitbenchmarker/data/__init__.py
+++ b/perfkitbenchmarker/data/__init__.py
@@ -37,7 +37,7 @@ FLAGS = flags.FLAGS
 flags.DEFINE_multistring('data_search_paths', ['.'],
                          'Additional paths to search for data files. '
                          'These paths will be searched prior to using files '
-                         'bundled with PerfKitBenchmarker')
+                         'bundled with PerfKitBenchmarker.')
 
 _RESOURCES = 'resources'
 

--- a/perfkitbenchmarker/publisher.py
+++ b/perfkitbenchmarker/publisher.py
@@ -94,8 +94,7 @@ flags.DEFINE_multistring(
     [],
     'A colon separated key-value pair that will be added to the labels field '
     'of all samples as metadata. Multiple key-value pairs may be specified '
-    'by separating each pair by commas. This option can be repeated multiple '
-    'times.')
+    'by separating each pair by commas.')
 
 DEFAULT_JSON_OUTPUT_NAME = 'perfkitbenchmarker_results.json'
 DEFAULT_CREDENTIALS_JSON = 'credentials.json'


### PR DESCRIPTION
Was reading flags, founds some stuff.  Flag types that are multistream automatically get a `repeat this option to specify a list of values`, so there's no need for the description itself to say how to repeat the flag.