### PR TITLE
Only upload the files needed for the API testing script

### DIFF
--- a/perfkitbenchmarker/object_storage_service.py
+++ b/perfkitbenchmarker/object_storage_service.py
@@ -211,6 +211,17 @@ class ObjectStorageService(object):
 
     return []
 
+  @classmethod
+  def APIScriptFiles(cls):
+    """Files to upload for the API test script.
+
+    Returns:
+      A list of file names. These files will be uploaded to the remote
+      VM if this service's API is being benchmarked.
+    """
+
+    return []
+
 
 def FindCredentialFile(default_location):
   """Return the path to the credential file."""

--- a/perfkitbenchmarker/providers/aws/s3.py
+++ b/perfkitbenchmarker/providers/aws/s3.py
@@ -95,3 +95,7 @@ class S3Service(object_storage_service.ObjectStorageService):
   def APIScriptArgs(self):
     hostname = AWS_S3_REGION_TO_ENDPOINT_TABLE[self.region]
     return ['--host=' + hostname + AWS_S3_ENDPOINT_SUFFIX]
+
+  @classmethod
+  def APIScriptFiles(cls):
+    return ['boto_service.py', 's3.py']

--- a/perfkitbenchmarker/providers/azure/azure_blob_storage.py
+++ b/perfkitbenchmarker/providers/azure/azure_blob_storage.py
@@ -120,3 +120,7 @@ class AzureBlobStorageService(object_storage_service.ObjectStorageService):
   def APIScriptArgs(self):
     return ['--azure_account=%s' % self.storage_account,
             '--azure_key=%s' % self.azure_key]
+
+  @classmethod
+  def APIScriptFiles(cls):
+    return ['azure_service.py']

--- a/perfkitbenchmarker/providers/gcp/gcs.py
+++ b/perfkitbenchmarker/providers/gcp/gcs.py
@@ -147,3 +147,7 @@ class GoogleCloudStorageService(object_storage_service.ObjectStorageService):
                 linux_packages.GetPipPackageVersion(vm, 'boto')}
 
     return metadata
+
+  @classmethod
+  def APIScriptFiles(cls):
+    return ['boto_service.py', 'gcs.py']


### PR DESCRIPTION
In the object storage benchmark, only upload the API test files for the
provider under test, not for all providers.