### PR TITLE
Use the BigQuery Streaming API

### DIFF
--- a/perfkitbenchmarker/publisher.py
+++ b/perfkitbenchmarker/publisher.py
@@ -486,8 +486,7 @@ class BigQueryPublisher(SamplePublisher):
                          self._credentials_file,
                          '--service_account_private_key_file=' +
                          self.service_account_private_key_file])
-      load_cmd.extend(['load',
-                       '--source_format=NEWLINE_DELIMITED_JSON',
+      load_cmd.extend(['insert',
                        self.bigquery_table,
                        tf.name])
       vm_util.IssueRetryableCommand(load_cmd)

--- a/tests/publisher_test.py
+++ b/tests/publisher_test.py
@@ -126,8 +126,7 @@ class BigQueryPublisherTestCase(unittest.TestCase):
     instance.PublishSamples(self.samples)
     self.mock_vm_util.IssueRetryableCommand.assert_called_once_with(
         ['bq',
-         'load',
-         '--source_format=NEWLINE_DELIMITED_JSON',
+         'insert',
          self.table,
          mock.ANY])
 


### PR DESCRIPTION
When using a BigQuery Table publisher, do 'bq insert' rather than 'bq
load', which will use the BigQuery streaming API rather than the bulk
load API.