### PR TITLE
Fix error about failing to build collectd

### DIFF
--- a/perfkitbenchmarker/data/build_collectd.sh.j2
+++ b/perfkitbenchmarker/data/build_collectd.sh.j2
@@ -32,9 +32,12 @@ function install_deps_debian() {
   export DEBIAN_FRONTEND=noninteractive
   sudo aptitude install -q -y \
     autoconf \
+    automake \
     bison \
     flex \
     libtool \
+    libtool-ltdl \
+    libltdl-dev \
     pkg-config \
     build-essential
 }


### PR DESCRIPTION
Install dependencies pkg for building collectd for ubuntu image. The patch is to fix issue https://github.com/GoogleCloudPlatform/PerfKitBenchmarker/issues/1082