### PR TITLE
Add --sysctl and --set_files

### DIFF
--- a/perfkitbenchmarker/linux_virtual_machine.py
+++ b/perfkitbenchmarker/linux_virtual_machine.py
@@ -232,9 +232,9 @@ class BaseLinuxMixin(virtual_machine.BaseOsMixin):
     def ConfigureSubtree(subtree):
       for name, value in subtree.iteritems():
         path_components.append(name)
-        if isinstance(value, basestring):
+        if not isinstance(value, dict):
           self.RemoteCommand('echo "%s" | sudo tee %s' %
-                             (value, posixpath.join(*path_components)))
+                             (str(value), posixpath.join(*path_components)))
         else:
           ConfigureSubtree(value)
         path_components.pop()

--- a/perfkitbenchmarker/linux_virtual_machine.py
+++ b/perfkitbenchmarker/linux_virtual_machine.py
@@ -230,7 +230,8 @@ class BaseLinuxMixin(virtual_machine.BaseOsMixin):
   def DoSysctls(self):
     """Apply --sysctl to the VM."""
 
-    self.RemoteCommand('sudo sysctl -w %s' % (' '.join(FLAGS.sysctl),))
+    if FLAGS.sysctl:
+      self.RemoteCommand('sudo sysctl -w %s' % (' '.join(FLAGS.sysctl),))
 
   @vm_util.Retry(log_errors=False, poll_interval=1)
   def WaitForBootCompletion(self):

--- a/perfkitbenchmarker/linux_virtual_machine.py
+++ b/perfkitbenchmarker/linux_virtual_machine.py
@@ -234,7 +234,7 @@ class BaseLinuxMixin(virtual_machine.BaseOsMixin):
         path_components.append(name)
         if not isinstance(value, dict):
           self.RemoteCommand('echo "%s" | sudo tee %s' %
-                             (str(value), posixpath.join(*path_components)))
+                             (value, posixpath.join(*path_components)))
         else:
           ConfigureSubtree(value)
         path_components.pop()

--- a/perfkitbenchmarker/publisher.py
+++ b/perfkitbenchmarker/publisher.py
@@ -185,8 +185,8 @@ class DefaultMetadataProvider(MetadataProvider):
           for key, value in data_disk.metadata.iteritems():
             metadata[name_prefix + 'data_disk_0_' + key] = value
 
-    metadata['procfs_config'] = str(FLAGS.procfs_config)
-    metadata['sysfs_config'] = str(FLAGS.sysfs_config)
+    metadata['set_files'] = ','.join(FLAGS.set_files)
+    metadata['sysctl'] = ','.join(FLAGS.sysctl)
 
     # Flatten all user metadata into a single list (since each string in the
     # FLAGS.metadata can actually be several key-value pairs) and then iterate

--- a/perfkitbenchmarker/publisher.py
+++ b/perfkitbenchmarker/publisher.py
@@ -185,8 +185,10 @@ class DefaultMetadataProvider(MetadataProvider):
           for key, value in data_disk.metadata.iteritems():
             metadata[name_prefix + 'data_disk_0_' + key] = value
 
-    metadata['set_files'] = ','.join(FLAGS.set_files)
-    metadata['sysctl'] = ','.join(FLAGS.sysctl)
+    if FLAGS.set_files:
+      metadata['set_files'] = ','.join(FLAGS.set_files)
+    if FLAGS.sysctl:
+      metadata['sysctl'] = ','.join(FLAGS.sysctl)
 
     # Flatten all user metadata into a single list (since each string in the
     # FLAGS.metadata can actually be several key-value pairs) and then iterate

--- a/perfkitbenchmarker/publisher.py
+++ b/perfkitbenchmarker/publisher.py
@@ -185,6 +185,9 @@ class DefaultMetadataProvider(MetadataProvider):
           for key, value in data_disk.metadata.iteritems():
             metadata[name_prefix + 'data_disk_0_' + key] = value
 
+    metadata['procfs_config'] = str(FLAGS.procfs_config)
+    metadata['sysfs_config'] = str(FLAGS.sysfs_config)
+
     # Flatten all user metadata into a single list (since each string in the
     # FLAGS.metadata can actually be several key-value pairs) and then iterate
     # over it.

--- a/tests/linux_virtual_machine_test.py
+++ b/tests/linux_virtual_machine_test.py
@@ -1,0 +1,96 @@
+# Copyright 2016 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for linux_virtual_machine.py"""
+
+import unittest
+
+import mock
+
+from perfkitbenchmarker import linux_virtual_machine
+from tests import mock_flags
+
+
+# Need to provide implementations for all of the abstract methods in
+# order to instantiate linux_virtual_machine.BaseLinuxMixin.
+class LinuxVM(linux_virtual_machine.BaseLinuxMixin):
+  def Install(self):
+    pass
+
+  def Uninstall(self):
+    pass
+
+
+class TestConfigureVMKernel(unittest.TestCase):
+  def setUp(self):
+    self.mocked_flags = mock_flags.PatchTestCaseFlags(self)
+
+  def testConfigureVMKernel(self):
+    vm = LinuxVM()
+
+    self.mocked_flags.procfs_config = {'sys': {'vm':
+                                          {'dirty_background_ratio': '10'}}}
+    self.mocked_flags.sysfs_config = {}
+    with mock.patch.object(vm, 'RemoteCommand') as remote_command:
+      vm.ConfigureVMKernel()
+
+    self.assertEqual(remote_command.call_args_list,
+                     [mock.call('echo "10" | sudo tee '
+                                '/proc/sys/vm/dirty_background_ratio')])
+
+  def testConvertToString(self):
+    vm = LinuxVM()
+
+    self.mocked_flags.procfs_config = {'sys': {'vm':
+                                          {'dirty_background_ratio': 10}}}
+    self.mocked_flags.sysfs_config = {}
+    with mock.patch.object(vm, 'RemoteCommand') as remote_command:
+      vm.ConfigureVMKernel()
+
+    self.assertEqual(remote_command.call_args_list,
+                     [mock.call('echo "10" | sudo tee '
+                                '/proc/sys/vm/dirty_background_ratio')])
+
+  def testMultipleFiles(self):
+    vm = LinuxVM()
+
+    self.mocked_flags.procfs_config = {'sys': {'vm':
+                                               {'dirty_background_ratio': 10,
+                                                'dirty_ratio': 50}}}
+    self.mocked_flags.sysfs_config = {}
+    with mock.patch.object(vm, 'RemoteCommand') as remote_command:
+      vm.ConfigureVMKernel()
+
+    self.assertEqual(remote_command.call_args_list,
+                     [mock.call('echo "10" | sudo tee '
+                                '/proc/sys/vm/dirty_background_ratio'),
+                      mock.call('echo "50" | sudo tee '
+                                '/proc/sys/vm/dirty_ratio')])
+
+  def testSysfs(self):
+    vm = LinuxVM()
+
+    self.mocked_flags.procfs_config = {}
+    self.mocked_flags.sysfs_config = {'kernel': {'mm': {'transparent_hugepage':
+                                                        {'enabled': 'always'}}}}
+    with mock.patch.object(vm, 'RemoteCommand') as remote_command:
+      vm.ConfigureVMKernel()
+
+    self.assertEqual(remote_command.call_args_list,
+                     [mock.call('echo "always" | sudo tee '
+                                '/sys/kernel/mm/transparent_hugepage/enabled')])
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tests/linux_virtual_machine_test.py
+++ b/tests/linux_virtual_machine_test.py
@@ -87,6 +87,18 @@ class TestSysctl(unittest.TestCase):
         [mock.call('sudo sysctl -w vm.dirty_background_ratio=10 '
                    'vm.dirty_ratio=25')])
 
+  def testNoSysctl(self):
+    self.mocked_flags = mock_flags.PatchTestCaseFlags(self)
+    self.mocked_flags.sysctl = []
+    vm = LinuxVM()
+
+    with mock.patch.object(vm, 'RemoteCommand') as remote_command:
+      vm.DoSysctls()
+
+    self.assertEqual(
+        remote_command.call_args_list,
+        [])
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/tests/publisher_test.py
+++ b/tests/publisher_test.py
@@ -273,9 +273,7 @@ class DefaultMetadataProviderTestCase(unittest.TestCase):
                          'image': self.mock_vm.image,
                          'vm_count': 1,
                          'num_striped_disks': 1,
-                         'hostnames': 'Hostname',
-                         'sysctl': '',
-                         'set_files': ''}
+                         'hostnames': 'Hostname'}
 
   def _RunTest(self, spec, expected, input_metadata=None):
     input_metadata = input_metadata or {}

--- a/tests/publisher_test.py
+++ b/tests/publisher_test.py
@@ -237,7 +237,9 @@ class DefaultMetadataProviderTestCase(unittest.TestCase):
     p = mock.patch(publisher.__name__ + '.FLAGS')
     self.mock_flags = p.start()
     self.mock_flags.configure_mock(metadata=[],
-                                   num_striped_disks=1)
+                                   num_striped_disks=1,
+                                   procfs_config={},
+                                   sysfs_config={})
     self.addCleanup(p.stop)
 
     self.maxDiff = None
@@ -271,7 +273,9 @@ class DefaultMetadataProviderTestCase(unittest.TestCase):
                          'image': self.mock_vm.image,
                          'vm_count': 1,
                          'num_striped_disks': 1,
-                         'hostnames': 'Hostname'}
+                         'hostnames': 'Hostname',
+                         'procfs_config': '{}',
+                         'sysfs_config': '{}'}
 
   def _RunTest(self, spec, expected, input_metadata=None):
     input_metadata = input_metadata or {}

--- a/tests/publisher_test.py
+++ b/tests/publisher_test.py
@@ -238,8 +238,8 @@ class DefaultMetadataProviderTestCase(unittest.TestCase):
     self.mock_flags = p.start()
     self.mock_flags.configure_mock(metadata=[],
                                    num_striped_disks=1,
-                                   procfs_config={},
-                                   sysfs_config={})
+                                   sysctl=[],
+                                   set_files=[])
     self.addCleanup(p.stop)
 
     self.maxDiff = None
@@ -274,8 +274,8 @@ class DefaultMetadataProviderTestCase(unittest.TestCase):
                          'vm_count': 1,
                          'num_striped_disks': 1,
                          'hostnames': 'Hostname',
-                         'procfs_config': '{}',
-                         'sysfs_config': '{}'}
+                         'sysctl': '',
+                         'set_files': ''}
 
   def _RunTest(self, spec, expected, input_metadata=None):
     input_metadata = input_metadata or {}


### PR DESCRIPTION
These new flags let users configure guest Linux kernels, via setting
options in procfs and sysfs. Also record the configuration in the output
and update some tests.