### PR TITLE
fio: Bump Git tag to fio-2.7

### DIFF
--- a/perfkitbenchmarker/linux_packages/fio.py
+++ b/perfkitbenchmarker/linux_packages/fio.py
@@ -23,7 +23,7 @@ from perfkitbenchmarker import vm_util
 
 FIO_DIR = '%s/fio' % vm_util.VM_TMP_DIR
 GIT_REPO = 'http://git.kernel.dk/fio.git'
-GIT_TAG = 'fio-2.2.10'
+GIT_TAG = 'fio-2.7'
 FIO_PATH = FIO_DIR + '/fio'
 FIO_CMD_PREFIX = '%s --output-format=json' % FIO_PATH
 SECTION_REGEX = r'\[(\w+)\]\n([\w\d\n=*$/]+)'


### PR DESCRIPTION
On modern Linux kernels  fio-2.2.10 fails to build from
source due to missing a header file stdint.h that used to be included in
mtd-user.h. fio-2.7 tag includes the fix for this issue.

For more info on the bug see:
https://github.com/axboe/fio/commit/d7bb6180f831091c468e5aa749b142efd5eddda4

Addresses issue #1094 