### PR TITLE
Object storage multistream write

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/object_storage_service_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/object_storage_service_benchmark.py
@@ -811,7 +811,7 @@ def _RunMultiStreamProcesses(vms, command_builder, cmd_args,
 
   output = [None] * num_streams
 
-  def _StartMultiStreamProcess(proc_idx):
+  def RunOneProcess(proc_idx):
     vm_idx = proc_idx // streams_per_vm
     logging.info('Running on VM %s.', vm_idx)
     cmd = command_builder.BuildCommand(
@@ -821,7 +821,7 @@ def _RunMultiStreamProcesses(vms, command_builder, cmd_args,
 
   # Each process has a thread managing it.
   threads = [
-      threading.Thread(target=_StartMultiStreamProcess, args=(i,))
+      threading.Thread(target=RunOneProcess, args=(i,))
       for i in xrange(num_streams)]
   for thread in threads:
     thread.start()

--- a/perfkitbenchmarker/linux_benchmarks/object_storage_service_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/object_storage_service_benchmark.py
@@ -868,23 +868,23 @@ def _MultiStreamOneWay(results, metadata, vms, command_builder,
   logging.info('Start time is %s', start_time)
 
   cmd_args = [
-    '--bucket=%s' % bucket_name,
-    '--objects_per_stream=%s' % (
-      FLAGS.object_storage_multistream_objects_per_stream),
-    '--num_streams=1',
-    '--start_time=%s' % start_time,
-    '--objects_written_file=%s' % objects_written_file]
-  
+      '--bucket=%s' % bucket_name,
+      '--objects_per_stream=%s' % (
+          FLAGS.object_storage_multistream_objects_per_stream),
+      '--num_streams=1',
+      '--start_time=%s' % start_time,
+      '--objects_written_file=%s' % objects_written_file]
+
   if operation == 'upload':
     cmd_args += [
-      '--object_sizes="%s"' % size_distribution,
-      '--object_naming_scheme=%s' % FLAGS.object_storage_object_naming_scheme,
-      '--scenario=MultiStreamWrite']
+        '--object_sizes="%s"' % size_distribution,
+        '--object_naming_scheme=%s' % FLAGS.object_storage_object_naming_scheme,
+        '--scenario=MultiStreamWrite']
   elif operation == 'download':
     cmd_args += ['--scenario=MultiStreamRead']
   else:
     raise Exception('Value of operation must be \'upload\' or \'download\'.'
-                    'Value is: \''+operation+'\'')
+                    'Value is: \'' + operation + '\'')
 
   output = _RunMultiStreamProcesses(vms, command_builder, cmd_args,
                                     streams_per_vm, num_streams)

--- a/perfkitbenchmarker/linux_benchmarks/object_storage_service_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/object_storage_service_benchmark.py
@@ -1229,10 +1229,12 @@ def Run(benchmark_spec):
       benchmark(results, metadata, vms[0], command_builder,
                 service, buckets[0], regional_bucket_name)
 
-  # MultiStreamRW and MultiStreamWrite are the only benchmarks that support multiple VMs, so
-  # they have a slightly different calling convention than the others.
+  # MultiStreamRW and MultiStreamWrite are the only benchmarks that support
+  # multiple VMs, so they have a slightly different calling convention than the
+  # others.
   for name, benchmark in [('api_multistream', MultiStreamRWBenchmark),
-                          ('api_multistream_writes', MultiStreamWriteBenchmark)]:
+                          ('api_multistream_writes',
+                           MultiStreamWriteBenchmark)]:
     if FLAGS.object_storage_scenario in {name, 'all'}:
       benchmark(results, metadata, vms, command_builder,
                 service, buckets[0], regional_bucket_name)

--- a/tests/linux_benchmarks/object_storage_service_benchmark_test.py
+++ b/tests/linux_benchmarks/object_storage_service_benchmark_test.py
@@ -44,17 +44,17 @@ class TestBuildCommands(unittest.TestCase):
         with mock.patch(object_storage_service_benchmark.__name__ +
                         '.LoadWorkerOutput', return_value=(None, None, None)):
           object_storage_service_benchmark.MultiStreamRWBenchmark(
-              [], {}, [vm], command_builder, None, 'bucket', 'regional-bucket')
+              [], {}, [vm], command_builder, 'bucket')
 
     self.assertEqual(
         command_builder.BuildCommand.call_args_list[0],
         mock.call(['--bucket=bucket',
                    '--objects_per_stream=100',
-                   '--object_sizes="{1000: 100.0}"',
                    '--num_streams=1',
                    '--start_time=16.1',
-                   '--object_naming_scheme=sequential_by_stream',
                    '--objects_written_file=/tmp/pkb/pkb-objects-written',
+                   '--object_sizes="{1000: 100.0}"',
+                   '--object_naming_scheme=sequential_by_stream',
                    '--scenario=MultiStreamWrite',
                    '--stream_num_start=0']))
 


### PR DESCRIPTION
Added a api_multistream_writes scenario to object_storage_service benchmark where only write latency and throughput is measured (no reads).

Summary:
- Copy and paste MultiStreamRWBenchmark into MultiStreamWriteBenchmark. Remove the bottom section that did the reads.
- Refactor out the now-redundant nested _RunMultiStreamProcesses and _StartMultiStreamProcess closures.
- Nest _StartMultiStreamProcess under _RunMultiStreamProcess so that fewer parameters need to be passed to it.
- Refactor out the now-redundant redundant multistream writes code into a separate _MultiStreamWrites function.