### PR TITLE
ContainerizedDebianMixin: don't run container commands as sudo

### DIFF
--- a/perfkitbenchmarker/linux_virtual_machine.py
+++ b/perfkitbenchmarker/linux_virtual_machine.py
@@ -876,6 +876,11 @@ class ContainerizedDebianMixin(DebianMixin):
     # Escapes bash sequences
     command = command.replace("'", r"'\''")
 
+    # The base image, ubuntu-latest, doesn't have 'sudo'. Also 'sudo' is not
+    # needed because the container starts as root.
+    if command.startswith('sudo '):
+      command = command[5:]
+
     logging.info('Docker running: %s' % command)
     command = "sudo docker exec %s bash -c '%s'" % (self.docker_id, command)
     return self.RemoteHostCommand(command, should_log, retries,


### PR DESCRIPTION
The base Docker image for `ContainerizedDebianMixin`: `ubuntu:latest`, doesn't
seem to have `sudo` installed. Also, since the container starts as `root`, the
container commands don't require `sudo` anyway. The base class, `DebianMixin`
may still need `sudo` though as the install commands are run on the host
machine, so the change is limited to the override in the
`ContainerizedDebianMixin` class.

Without this fix, the following fails with a `sudo not found` error:

```
$ ./pkb.py --image gci-dev-55-8820-0-0 --image_project google-containers \
  --os_type ubuntu_container --benchmarks cluster_boot

Ran ssh -A -p 22 perfkit@104.197.65.25 -2 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -o PreferredAuthentications=publickey -o PasswordAuthentication=no -o ConnectTimeout=5 -o GSSAPIAuthentication=no -o ServerAliveInterval=30 -o ServerAliveCountMax=10 -i /usr/local/google/tmp/perfkitbenchmarker/run_5156e942/perfkitbenchmarker_keyfile sudo docker exec daa96f24036d0a6fa5a1ddb4e72bec7393911c35d5a79a0a0a3ec1830620e912 bash -c 'sudo apt-get update'. Got return code (127).
STDOUT:
STDERR: Warning: Permanently added '104.197.65.25' (RSA) to the list of known hosts.
bash: sudo: command not found
```

This patch fixes it. Passed `hooks/check-everything`.

@ehankland Can you review?

cc/ @Amey-D