### PR TITLE
Netperf

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
@@ -189,6 +189,18 @@ def _ParseNetperfOutput(stdout, metadata, benchmark_name,
   # Don't modify the metadata dict that was passed in
   metadata = metadata.copy()
 
+  # Extract stats from stdout
+  # Sample output:
+  #
+  # "MIGRATED TCP REQUEST/RESPONSE TEST from 0.0.0.0 (0.0.0.0) port 20001
+  # AF_INET to 104.154.50.86 () port 20001 AF_INET : +/-2.500% @ 99% conf.
+  # : first burst 0",\n
+  # Throughput,Throughput Units,Throughput Confidence Width (%),
+  # Confidence Iterations Run,Stddev Latency Microseconds,
+  # 50th Percentile Latency Microseconds,90th Percentile Latency Microseconds,
+  # 99th Percentile Latency Microseconds,Minimum Latency Microseconds,
+  # Maximum Latency Microseconds\n
+  # 1405.50,Trans/s,2.522,4,783.80,683,735,841,600,900\n
   fp = io.StringIO(stdout)
   # "-o" flag above specifies CSV output, but there is one extra header line:
   banner = next(fp)

--- a/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
@@ -80,7 +80,6 @@ TRANSACTIONS_PER_SECOND = 'transactions_per_second'
 PORT_START = 20000
 
 REMOTE_SCRIPTS_DIR = 'netperf_test_scripts'
-REMOTE_SCRIPT_FILES = ['netperf_test.py']
 REMOTE_SCRIPT = 'netperf_test.py'
 
 PERCENTILES = [50, 90, 99]
@@ -123,15 +122,16 @@ def Prepare(benchmark_spec):
   vms[0].Install('pip')
   vms[0].RemoteCommand('sudo pip install python-gflags==2.0')
 
-  # Copy remote test script to client
+  # Create a scratch directory for the remote test script
   scratch_dir = vms[0].GetScratchDir()
   vms[0].RemoteCommand('sudo mkdir -p %s/run/' % scratch_dir)
   vms[0].RemoteCommand('sudo chmod 777 %s/run/' % scratch_dir)
-  for file_name in REMOTE_SCRIPT_FILES:
-    path = data.ResourcePath(os.path.join(REMOTE_SCRIPTS_DIR, file_name))
-    logging.info('Uploading %s to %s', path, vms[0])
-    vms[0].PushFile(path, '%s/run/' % scratch_dir)
-    vms[0].RemoteCommand('sudo chmod 777 %s/run/%s' % (scratch_dir, file_name))
+  # Copy remote test script to client
+  path = data.ResourcePath(os.path.join(REMOTE_SCRIPTS_DIR, REMOTE_SCRIPT))
+  logging.info('Uploading %s to %s', path, vms[0])
+  vms[0].PushFile(path, '%s/run/' % scratch_dir)
+  vms[0].RemoteCommand('sudo chmod 777 %s/run/%s' %
+                       (scratch_dir, REMOTE_SCRIPT))
 
 
 def _HistogramStatsCalculator(histogram, percentiles=PERCENTILES):

--- a/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
@@ -118,7 +118,6 @@ def Prepare(benchmark_spec):
                        port_end=PORT_START + num_streams * 2 - 1,
                        netserver_path=netperf.NETSERVER_PATH)
   vms[1].RemoteCommand(netserver_cmd)
-  # vms[1].RemoteCommand('%s -p %s' % (netperf.NETSERVER_PATH, COMMAND_PORT))
 
   # Install some stuff on the client vm
   vms[0].Install('pip')

--- a/perfkitbenchmarker/network.py
+++ b/perfkitbenchmarker/network.py
@@ -51,12 +51,14 @@ class BaseFirewall(object):
         benchmark_spec.firewalls[key] = cls()
       return benchmark_spec.firewalls[key]
 
-  def AllowPort(self, vm, port):
+  def AllowPort(self, vm, start_port, end_port=None):
     """Opens a port on the firewall.
 
     Args:
       vm: The BaseVirtualMachine object to open the port for.
-      port: The local port to open.
+      start_port: The first local port in a range of ports to open.
+      end_port: The last port in a range of ports to open. If None, only
+        start_port will be opened.
     """
     pass
 

--- a/perfkitbenchmarker/scripts/netperf_test_scripts/netperf_test.py
+++ b/perfkitbenchmarker/scripts/netperf_test_scripts/netperf_test.py
@@ -47,10 +47,10 @@ def Main(argv=sys.argv):
   assert(num_streams >= 1)
   assert(port_start)
 
-  stdouts = [None for _ in range(num_streams)]
-  stderrs = [None for _ in range(num_streams)]
-  return_codes = [None for _ in range(num_streams)]
-  processes = [None for _ in range(num_streams)]
+  stdouts = [None] * len(num_streams)
+  stderrs = [None] * len(num_streams)
+  return_codes = [None] * len(num_streams)
+  processes = [None] * len(num_streams)
 
   # Start all of the netperf processes
   for i in range(num_streams):

--- a/perfkitbenchmarker/scripts/netperf_test_scripts/netperf_test.py
+++ b/perfkitbenchmarker/scripts/netperf_test_scripts/netperf_test.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright 2014 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import json
 import logging
 import subprocess

--- a/perfkitbenchmarker/scripts/netperf_test_scripts/netperf_test.py
+++ b/perfkitbenchmarker/scripts/netperf_test_scripts/netperf_test.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+
+import io
+import json
+import subprocess
+import sys
+import gflags as flags
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_integer('num_streams', 1, 'Number of netperf processes to run')
+
+flags.DEFINE_string('netperf_cmd', None,
+                    'netperf command to run')
+
+def Main(argv=sys.argv):
+  # Parse command-line flags
+  try:
+    argv = FLAGS(argv)
+  except flags.FlagsError as e:
+    logging.error('%s\nUsage: %s ARGS\n%s', e, sys.argv[0], FLAGS)
+    sys.exit(1)
+
+  netperf_cmd = FLAGS.netperf_cmd
+  num_streams = FLAGS.num_streams
+
+  assert(netperf_cmd)
+  assert(num_streams >= 1)
+
+  stdouts = [None for _ in range(num_streams)]
+  stderrs = [None for _ in range(num_streams)]
+  return_codes = [None for _ in range(num_streams)]
+  processes = [None for _ in range(num_streams)]
+
+  # Start all of the netperf processes
+  for i in range(num_streams):
+    processes[i] = subprocess.Popen(netperf_cmd, stdout=subprocess.PIPE,
+                                    stderr=subprocess.PIPE, shell=True)
+  # Wait for all of the netperf processes to finish and save their return codes
+  for i, process in enumerate(processes):
+    stdouts[i], stderrs[i] = process.communicate()
+    return_codes[i] = process.returncode
+  # Dump the stdouts, stderrs, and return_codes to stdout in json form
+  print(json.dumps((stdouts, stderrs, return_codes)))
+
+if __name__ == '__main__':
+  sys.exit(Main())

--- a/perfkitbenchmarker/scripts/netperf_test_scripts/netperf_test.py
+++ b/perfkitbenchmarker/scripts/netperf_test_scripts/netperf_test.py
@@ -47,10 +47,10 @@ def Main(argv=sys.argv):
   assert(num_streams >= 1)
   assert(port_start)
 
-  stdouts = [None] * len(num_streams)
-  stderrs = [None] * len(num_streams)
-  return_codes = [None] * len(num_streams)
-  processes = [None] * len(num_streams)
+  stdouts = [None] * num_streams
+  stderrs = [None] * num_streams
+  return_codes = [None] * num_streams
+  processes = [None] * num_streams
 
   # Start all of the netperf processes
   for i in range(num_streams):

--- a/perfkitbenchmarker/scripts/netperf_test_scripts/netperf_test.py
+++ b/perfkitbenchmarker/scripts/netperf_test_scripts/netperf_test.py
@@ -42,7 +42,7 @@ def Main(argv=sys.argv):
   for i in range(num_streams):
     command_port = port_start + i * 2
     data_port = port_start + i * 2 + 1
-    cmd = netperf_cmd + (' -p %s -P %s' % (command_port, data_port))
+    cmd = netperf_cmd.format(command_port=command_port, data_port=data_port)
     processes[i] = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                                     stderr=subprocess.PIPE, shell=True)
   # Wait for all of the netperf processes to finish and save their return codes

--- a/perfkitbenchmarker/virtual_machine.py
+++ b/perfkitbenchmarker/virtual_machine.py
@@ -285,10 +285,10 @@ class BaseVirtualMachine(resource.BaseResource):
     """Returns a list of local disks on the VM."""
     return []
 
-  def AllowPort(self, port):
+  def AllowPort(self, start_port, end_port=None):
     """Opens the port on the firewall corresponding to the VM if one exists."""
     if self.firewall:
-      self.firewall.AllowPort(self, port)
+      self.firewall.AllowPort(self, start_port, end_port)
 
   def AllowRemoteAccessPorts(self):
     """Allow all ports in self.remote_access_ports."""

--- a/tests/linux_benchmarks/netperf_benchmark_test.py
+++ b/tests/linux_benchmarks/netperf_benchmark_test.py
@@ -50,6 +50,18 @@ class NetperfBenchmarkTestCase(unittest.TestCase):
     self.should_run_external.return_value = run_external
     self.should_run_internal.return_value = run_internal
 
+  def testHistogramStatsCalculator(self):
+    histogram = {1: 5, 2: 10, 5: 5}
+    stats = netperf_benchmark._HistogramStatsCalculator(
+        histogram, [0, 20, 30, 74, 80, 100])
+    self.assertEqual(stats['p0'], 1)
+    self.assertEqual(stats['p20'], 1)
+    self.assertEqual(stats['p30'], 2)
+    self.assertEqual(stats['p74'], 2)
+    self.assertEqual(stats['p80'], 5)
+    self.assertEqual(stats['p100'], 5)
+    self.assertTrue(stats['stddev'] - 1.538 <= 0.001)
+
   def testExternalAndInternal(self):
     self._ConfigureIpTypes()
     vm_spec = mock.MagicMock(spec=benchmark_spec.BenchmarkSpec)

--- a/tests/linux_benchmarks/netperf_benchmark_test.py
+++ b/tests/linux_benchmarks/netperf_benchmark_test.py
@@ -64,9 +64,6 @@ class NetperfBenchmarkTestCase(unittest.TestCase):
     self.assertEqual(stats['p100'], 5)
     self.assertTrue(abs(stats['stddev'] - 1.538) <= 0.001)
 
-  def testParseNetperfOutput(self):
-    pass
-
   def testExternalAndInternal(self):
     self._ConfigureIpTypes()
     vm_spec = mock.MagicMock(spec=benchmark_spec.BenchmarkSpec)
@@ -108,7 +105,19 @@ class NetperfBenchmarkTestCase(unittest.TestCase):
          ('TCP_CRR_Latency_max', 2500.0, 'us'),
          ('TCP_CRR_Latency_stddev', 551.07, 'us'),
          ('TCP_STREAM_Throughput', 1187.94, mbps),
-         ('TCP_STREAM_Throughput', 1973.37, mbps),
+         ('TCP_STREAM_Latency_p50', 2.0, 'us'),
+         ('TCP_STREAM_Latency_p90', 6.0, 'us'),
+         ('TCP_STREAM_Latency_p99', 3374.0, 'us'),
+         ('TCP_STREAM_Latency_min', 1.0, 'us'),
+         ('TCP_STREAM_Latency_max', 3500.0, 'us'),
+         ('TCP_STREAM_Latency_stddev', 1084.37, 'us'),
+         ('TCP_STREAM_Throughput', 1973.37, 'Mbits/sec'),
+         ('TCP_STREAM_Latency_p50', 2.0, 'us'),
+         ('TCP_STREAM_Latency_p90', 4.0, 'us'),
+         ('TCP_STREAM_Latency_p99', 20.0, 'us'),
+         ('TCP_STREAM_Latency_min', 1.0, 'us'),
+         ('TCP_STREAM_Latency_max', 30.0, 'us'),
+         ('TCP_STREAM_Latency_stddev', 694.1, 'us'),
          ('UDP_RR_Transaction_Rate', 1359.71, tps),
          ('UDP_RR_Latency_p50', 700.0, 'us'),
          ('UDP_RR_Latency_p90', 757.0, 'us'),
@@ -127,10 +136,7 @@ class NetperfBenchmarkTestCase(unittest.TestCase):
 
     external_meta = {'ip_type': 'external'}
     internal_meta = {'ip_type': 'internal'}
-    expected_meta = (([external_meta] * 7 + [internal_meta] * 7) * 2 +
-                     [external_meta, internal_meta] +
-                     [external_meta] * 7 +
-                     [internal_meta] * 7)
+    expected_meta = (([external_meta] * 7 + [internal_meta] * 7) * 4)
 
     for i, meta in enumerate(expected_meta):
       self.assertIsInstance(result[i][3], dict)

--- a/tests/linux_benchmarks/netperf_benchmark_test.py
+++ b/tests/linux_benchmarks/netperf_benchmark_test.py
@@ -35,7 +35,9 @@ class NetperfBenchmarkTestCase(unittest.TestCase):
                         'netperf_results.json')
 
     with open(path) as fp:
-      self.expected_stdout = ['\n'.join(i) for i in json.load(fp)]
+      stdouts = ['\n'.join(i) for i in json.load(fp)]
+      self.expected_stdout = [json.dumps(([stdout], [''], [0]))
+                              for stdout in stdouts]
 
     p = mock.patch(vm_util.__name__ + '.ShouldRunOnExternalIpAddress')
     self.should_run_external = p.start()
@@ -60,7 +62,10 @@ class NetperfBenchmarkTestCase(unittest.TestCase):
     self.assertEqual(stats['p74'], 2)
     self.assertEqual(stats['p80'], 5)
     self.assertEqual(stats['p100'], 5)
-    self.assertTrue(stats['stddev'] - 1.538 <= 0.001)
+    self.assertTrue(abs(stats['stddev'] - 1.538) <= 0.001)
+
+  def testParseNetperfOutput(self):
+    pass
 
   def testExternalAndInternal(self):
     self._ConfigureIpTypes()


### PR DESCRIPTION
Multithreaded netperf benchmark. Launches a bunch of netperf servers and clients (1:1). Added a `--netperf_num_streams` flag to specify the number of threads. Netperf clients are now launched from a script that gets copied over to the client VMs. The servers are launched with a bash for-loop in the prepare phase.

@yuyantingzero @ehankland @cwilkes PTAL