### PR TITLE
netperf aggregate throughput stat

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
@@ -340,6 +340,8 @@ def RunNetperf(vm, benchmark_name, server_ip, num_streams):
     throughput_stats = sample.PercentileCalculator(throughputs, [50, 90, 99])
     throughput_stats['min'] = min(throughputs)
     throughput_stats['max'] = max(throughputs)
+    # Calculate aggregate throughput
+    throughput_stats['total'] = throughput_stats['average'] * num_streams
     # Create samples for throughput stats
     for stat, value in throughput_stats.items():
       samples.append(

--- a/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
@@ -341,6 +341,7 @@ def RunNetperf(vm, benchmark_name, server_ip, num_streams):
     throughput_stats['min'] = min(throughputs)
     throughput_stats['max'] = max(throughputs)
     # Calculate aggregate throughput
+    assert num_streams, len(throughputs)
     throughput_stats['total'] = throughput_stats['average'] * num_streams
     # Create samples for throughput stats
     for stat, value in throughput_stats.items():


### PR DESCRIPTION
Add up all the throughputs. TODO evaluate whether we ramp ups and ramp downs are distorting this at all. Just wanted to get this in before 1.8.0.