### PR TITLE
Fix spurious -Wmaybe-uninitialized error in silo

### DIFF
--- a/perfkitbenchmarker/linux_packages/silo.py
+++ b/perfkitbenchmarker/linux_packages/silo.py
@@ -36,8 +36,13 @@ def _Install(vm):
   # This is due to a failing clone command when executing behind a proxy.
   # Replacing the protocol to https instead of git fixes the issue.
   vm.RemoteCommand('git config --global url."https://".insteadOf git://')
-  vm.RemoteCommand('cd {0} && MODE=perf DEBUG=0 CHECK_INVARIANTS=0 make\
-          -j{1} dbtest'.format(SILO_DIR, nthreads))
+  # Disable -Wmaybe-uninitialized errors when GCC has the option to workaround
+  # a spurious error in masstree.
+  cxx = '"g++ -std=gnu++0x \
+          $(echo | gcc -Wmaybe-uninitialized -E - >/dev/null 2>&1 && \
+            echo -Wno-error=maybe-uninitialized)"'
+  vm.RemoteCommand('cd {0} && CXX={2} MODE=perf DEBUG=0 CHECK_INVARIANTS=0 make\
+          -j{1} dbtest'.format(SILO_DIR, nthreads, cxx))
 
 
 def YumInstall(vm):


### PR DESCRIPTION
The silo package fails to build with g++ 4.9.2 because of a 'maybe
uninitialized' error:

  Makefile:197: recipe for target 'out-perf.masstree/json.o' failed
  STDERR: Warning: Permanently added '127.0.0.1' (ECDSA) to the list of known hosts.
  Cloning into 'masstree'...
  make[1]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
  masstree/json.cc: In member function void lcdf::Json::hard_unparse(lcdf::StringAccum&, const lcdf::Json::unparse_manipulator&, int) const:
  masstree/json.cc:636:28: error: upx may be used uninitialized in this function [-Werror=maybe-uninitialized]
                   sa << upx[1];
                              ^
  masstree/json.cc:642:2: error: expanded may be used uninitialized in this function [-Werror=maybe-uninitialized]
    if (expanded)
    ^
  cc1plus: all warnings being treated as errors
  make: *** [out-perf.masstree/json.o] Error 1

This patch disables errors on this warning.