### PR TITLE
Add EPEL Repo to Silo Installation

### DIFF
--- a/perfkitbenchmarker/linux_packages/silo.py
+++ b/perfkitbenchmarker/linux_packages/silo.py
@@ -42,6 +42,7 @@ def _Install(vm):
 
 def YumInstall(vm):
   """Installs the Silo package on the VM."""
+  vm.InstallEpelRepo()
   vm.InstallPackages(YUM_PACKAGES)
   _Install(vm)
 


### PR DESCRIPTION
This allows jemalloc-devel to be installed and thus complete Silo install
for RHEL based instances.
