### PR TITLE
obey flag overrides for static vm specs

### DIFF
--- a/perfkitbenchmarker/configs/benchmark_config_spec.py
+++ b/perfkitbenchmarker/configs/benchmark_config_spec.py
@@ -153,7 +153,8 @@ class _StaticVmDecoder(option_decoders.TypeVerifier):
     input_dict = super(_StaticVmDecoder, self).Decode(
         value, component_full_name, flag_values)
     return static_virtual_machine.StaticVmSpec(
-        self._GetOptionFullName(component_full_name), **input_dict)
+        self._GetOptionFullName(component_full_name), flag_values=flag_values,
+        **input_dict)
 
 
 class _StaticVmListDecoder(option_decoders.ListDecoder):

--- a/perfkitbenchmarker/static_virtual_machine.py
+++ b/perfkitbenchmarker/static_virtual_machine.py
@@ -84,7 +84,8 @@ class StaticVmSpec(virtual_machine.BaseVmSpec):
     self.tag = tag
     self.disk_specs = [
         disk.BaseDiskSpec(
-            '{0}.disk_specs[{1}]'.format(component_full_name, i), **disk_spec)
+            '{0}.disk_specs[{1}]'.format(component_full_name, i),
+            flag_values=kwargs.get('flag_values'), **disk_spec)
         for i, disk_spec in enumerate(disk_specs or ())]
 
 

--- a/tests/configs/benchmark_config_spec_test.py
+++ b/tests/configs/benchmark_config_spec_test.py
@@ -173,6 +173,22 @@ class StaticVmDecoderTestCase(unittest.TestCase):
     self.assertIsInstance(result, static_virtual_machine.StaticVmSpec)
     self.assertEqual(result.ssh_port, 111)
 
+  def testVmSpecFlag(self):
+    flags = mock_flags.MockFlags()
+    flags['install_packages'].value = False
+    flags['install_packages'].present = True
+    result = self._decoder.Decode({}, _COMPONENT, flags)
+    self.assertFalse(result.install_packages)
+
+  def testDiskSpecFlag(self):
+    flags = mock_flags.MockFlags()
+    flags['scratch_dir'].value = '/path/from/flag'
+    flags['scratch_dir'].present = True
+    result = self._decoder.Decode(
+        {'disk_specs': [{'mount_point': '/path/from/spec'}]},
+        _COMPONENT, flags)
+    self.assertEqual(result.disk_specs[0].mount_point, '/path/from/flag')
+
 
 class StaticVmListDecoderTestCase(unittest.TestCase):
 


### PR DESCRIPTION
Flag overrides weren't being obeyed for static VM specs (and their
children). For example, setting --install_packages=False on the
command line didn't prevent packages from being installed on static
VMs.
