### PR TITLE
Netperf thinktime flag

### DIFF
--- a/perfkitbenchmarker/data/netlib.patch
+++ b/perfkitbenchmarker/data/netlib.patch
@@ -1,6 +1,19 @@
---- src/netlib.c        2012-06-19 20:32:29.000000000 +0000
-+++ src/new_netlib.c    2016-08-13 01:34:03.787253999 +0000
-@@ -4288,9 +4288,8 @@
+diff -u -r netperf-2.6.0/src/netlib.c netperf-2.6.0-patch/src/netlib.c
+--- netperf-2.6.0/src/netlib.c	2012-06-19 13:32:29.000000000 -0700
++++ netperf-2.6.0-patch/src/netlib.c	2016-10-25 15:27:57.567600872 -0700
+@@ -234,6 +234,11 @@
+ char local_data_port[10];
+ char remote_data_port[10];
+ 
++// See comment in netlib.h
++uint32_t think_time = 0;
++uint32_t think_time_array_size = 0;
++float think_time_shuffle_ratio = 0.f;
++
+ char *local_data_address=NULL;
+ char *remote_data_address=NULL;
+ 
+@@ -4288,9 +4293,8 @@
    for(i = 0; i < 10; i++){
      sum = 0;
      for (j = i * base; j <  (i + 1) * base; j++) {
@@ -11,3 +24,202 @@
    }
    fprintf(where,"\n");
  }
+diff -u -r netperf-2.6.0/src/netlib.h netperf-2.6.0-patch/src/netlib.h
+--- netperf-2.6.0/src/netlib.h	2012-06-19 13:46:47.000000000 -0700
++++ netperf-2.6.0-patch/src/netlib.h	2016-10-25 15:27:20.011688139 -0700
+@@ -458,6 +458,11 @@
+ extern char local_data_port[10];
+ extern char remote_data_port[10];
+ 
++// Time in microseconds to do pointless work after each request received
++extern uint32_t think_time;
++extern uint32_t think_time_array_size;
++extern float think_time_shuffle_ratio;
++
+ extern char *local_data_address;
+ extern char *remote_data_address;
+ 
+diff -u -r netperf-2.6.0/src/nettest_bsd.c netperf-2.6.0-patch/src/nettest_bsd.c
+--- netperf-2.6.0/src/nettest_bsd.c	2012-06-19 13:32:47.000000000 -0700
++++ netperf-2.6.0-patch/src/nettest_bsd.c	2016-10-19 15:49:52.513244546 -0700
+@@ -8426,7 +8426,6 @@
+ void
+ recv_tcp_rr()
+ {
+-
+   struct ring_elt *send_ring;
+   struct ring_elt *recv_ring;
+ 
+diff -u -r netperf-2.6.0/src/nettest_bsd.h netperf-2.6.0-patch/src/nettest_bsd.h
+--- netperf-2.6.0/src/nettest_bsd.h	2012-06-19 13:47:09.000000000 -0700
++++ netperf-2.6.0-patch/src/nettest_bsd.h	2016-10-25 15:40:54.721791660 -0700
+@@ -66,6 +66,10 @@
+ 
+   int32_t    test_length;    /* how long is the test? */
+ 
++  uint32_t   think_time;               /* how long to pointlessly think on each request */
++  uint32_t   think_time_array_size;    /* size of pointer chase array for think_time work */
++  float      think_time_shuffle_ratio; /* how much of the pointer chase array to shuffle */
++
+   uint32_t   so_rcvavoid;    /* avoid copies on recv? */
+   uint32_t   so_sndavoid;    /* avoid copies on send? */
+   uint32_t   send_dirty_count; /* bytes to dirty before calling send */
+diff -u -r netperf-2.6.0/src/nettest_omni.c netperf-2.6.0-patch/src/nettest_omni.c
+--- netperf-2.6.0/src/nettest_omni.c	2012-06-19 13:33:48.000000000 -0700
++++ netperf-2.6.0-patch/src/nettest_omni.c	2016-10-27 17:22:31.537180976 -0700
+@@ -3759,6 +3759,10 @@
+       omni_request->socket_prio            = remote_socket_prio;
+       omni_request->socket_tos             = remote_socket_tos;
+ 
++      omni_request->think_time = think_time;
++      omni_request->think_time_array_size = think_time_array_size;
++      omni_request->think_time_shuffle_ratio = think_time_shuffle_ratio;
++
+       /* we have no else clauses here because we previously set flags
+ 	 to zero above raj 20090803 */
+       if (rem_nodelay)
+@@ -4932,6 +4936,11 @@
+ 	  omni_request->cong_control,
+ 	  sizeof(local_cong_control_req));
+ 
++  // Extract think_time parameters
++  think_time = omni_request->think_time;
++  think_time_array_size = omni_request->think_time_array_size;
++  think_time_shuffle_ratio = omni_request->think_time_shuffle_ratio;
++
+   /* based on what we have been told by the remote netperf, we want to
+      setup our endpoint for the "data connection" and let the remote
+      netperf know the situation. */
+@@ -5240,6 +5249,82 @@
+   addrlen = sizeof(peeraddr_in);
+   memset(&peeraddr_in,0,sizeof(peeraddr_in));
+ 
++
++  uint32_t* pointer_chase_array;
++  uint32_t* pointer_chase_inverse; // map pointers to their current index in the array
++  // Keep track of the current traversal order. We double buffer because we use the old ordering
++  // to calculate the new ordering after every swap.
++  uint32_t* pointer_chase_order; 
++  uint32_t* pointer_chase_order_tmp; 
++  if (think_time > 0 && think_time_array_size > 0) {
++    // Create a big array for our pointer chase
++    pointer_chase_array = malloc(sizeof(uint32_t) * think_time_array_size);
++    pointer_chase_inverse = malloc(sizeof(uint32_t) * think_time_array_size);
++    pointer_chase_order = malloc(sizeof(uint32_t) * think_time_array_size);
++    pointer_chase_order_tmp = malloc(sizeof(uint32_t) * think_time_array_size);
++    // Make each slot in the array point to the next slot
++    int i;
++    for (i = 0; i < think_time_array_size; i++) {
++      pointer_chase_array[i] = (i + 1) % think_time_array_size;
++      pointer_chase_inverse[i] = (think_time_array_size - 1 + i) % think_time_array_size;
++      pointer_chase_order[i] = (i + 1) % think_time_array_size;
++      pointer_chase_order_tmp[i] = (i + 1) % think_time_array_size;
++    }
++    // Shuffle some of the array
++    uint32_t swaps = 0;
++    const uint32_t to_swap = think_time_array_size * think_time_shuffle_ratio / 2.f;
++    while (swaps < to_swap) {
++      // Generate two random indices, a and b, where a < b < len-1
++      uint32_t a = rand() % (think_time_array_size - 1);
++      uint32_t b = (rand() % (think_time_array_size - 2 - a)) + a + 1;
++      // Generate two random indices, c and d, where a < c <= b and b < d < len
++      uint32_t c = (rand() % (b - a)) + a + 1;
++      uint32_t d = rand() % (think_time_array_size - 1 - b) + b + 1;
++      uint32_t tmp;
++      // In pointer_chase_array
++      // Swap a and b
++      uint32_t array_a = pointer_chase_inverse[pointer_chase_order[a]];
++      uint32_t array_b = pointer_chase_inverse[pointer_chase_order[b]];
++      uint32_t array_c = pointer_chase_inverse[pointer_chase_order[c]];
++      uint32_t array_d = pointer_chase_inverse[pointer_chase_order[d]];
++      tmp = pointer_chase_array[array_a];
++      pointer_chase_array[array_a] =
++        pointer_chase_array[array_b];
++      pointer_chase_array[array_b] = tmp;
++      // Swap c and d
++      tmp = pointer_chase_array[array_c];
++      pointer_chase_array[array_c] =
++        pointer_chase_array[array_d];
++      pointer_chase_array[array_d] = tmp;
++      // Fix pointer_chase_inverse
++      pointer_chase_inverse[pointer_chase_array[array_a]] = array_a;
++      pointer_chase_inverse[pointer_chase_array[array_b]] = array_b;
++      pointer_chase_inverse[pointer_chase_array[array_c]] = array_c;
++      pointer_chase_inverse[pointer_chase_array[array_d]] = array_d;
++      // Calculate the new traversal order
++      // Copy the beginning
++      memcpy(&pointer_chase_order_tmp[0], &pointer_chase_order[0], a*sizeof(uint32_t));
++      // Copy the middle sections
++      unsigned int cur_index = a;
++      memcpy(&pointer_chase_order_tmp[cur_index], &pointer_chase_order[b], (d - b)*sizeof(uint32_t));
++      cur_index += (d - b);
++      memcpy(&pointer_chase_order_tmp[cur_index], &pointer_chase_order[c], (b - c)*sizeof(uint32_t));
++      cur_index += (b - c);
++      memcpy(&pointer_chase_order_tmp[cur_index], &pointer_chase_order[a], (c - a)*sizeof(uint32_t));
++      // Copy the end
++      memcpy(&pointer_chase_order_tmp[d], &pointer_chase_order[d], (think_time_array_size - d)*sizeof(uint32_t));
++      // Swap our order buffers
++      uint32_t* tmp_order = pointer_chase_order_tmp;
++      pointer_chase_order_tmp = pointer_chase_order;
++      pointer_chase_order = tmp_order;
++      swaps++;
++    }
++    free(pointer_chase_inverse);
++    free(pointer_chase_order);
++    free(pointer_chase_order_tmp);
++    fprintf(where, "Finished creating pointer chase array\n");
++  }
++
+   /* Now it's time to start receiving data on the connection. We will */
+   /* first grab the apropriate counters and then start grabbing. */
+ 
+@@ -5409,6 +5494,15 @@
+       recv_ring = recv_ring->next;
+     }
+ 
++    if (think_time > 0) {
++        // Do think time here before we send the response
++        clock_t think_start = clock();
++        uint32_t cur_index = 0;
++        while (clock() - think_start < ((float)think_time) * (((float)CLOCKS_PER_SEC) / 1000000.f)) {
++            cur_index = pointer_chase_array[cur_index];
++        }
++    }
++
+     /* if we should try to send something, then by all means, let us
+        try to send something. */
+     if ((omni_request->direction & NETPERF_XMIT) &&
+@@ -5522,6 +5616,10 @@
+     }
+   }
+ 
++  if (think_time > 0) {
++      free(pointer_chase_array);
++  }
++
+   /* The current iteration loop now exits due to timeout or unit count
+      being  reached */
+   stop_timer();
+@@ -6895,7 +6993,7 @@
+ 
+ {
+ 
+-#define OMNI_ARGS "b:cCd:DG:hH:kK:l:L:m:M:nNoOp:P:r:R:s:S:t:T:u:Vw:W:46"
++#define OMNI_ARGS "b:cCd:DG:hH:kK:l:L:m:M:nNoOp:P:r:R:s:S:t:T:U:u:Vw:W:46"
+ 
+   extern char	*optarg;	  /* pointer to option string	*/
+ 
+@@ -7218,6 +7316,13 @@
+       test_uuid[sizeof(test_uuid) - 1] = 0;
+       have_uuid = 1;
+       break;
++    case 'U':
++      break_args(optarg, arg1, arg2);
++      break_args(optarg+strlen(arg1)+1, arg2, arg3);
++      think_time = convert(arg1);
++      think_time_array_size = convert(arg2);
++      think_time_shuffle_ratio = atof(arg3);
++      break;
+     case 'W':
+       /* set the "width" of the user space data */
+       /* buffer. This will be the number of */

--- a/perfkitbenchmarker/data/netlib.patch
+++ b/perfkitbenchmarker/data/netlib.patch
@@ -1,6 +1,6 @@
 diff -u -r netperf-2.6.0/src/netlib.c netperf-2.6.0-patch/src/netlib.c
 --- netperf-2.6.0/src/netlib.c	2012-06-19 13:32:29.000000000 -0700
-+++ netperf-2.6.0-patch/src/netlib.c	2016-10-25 15:27:57.567600872 -0700
++++ netperf-2.6.0-patch/src/netlib.c	2016-11-02 11:09:56.426738496 -0700
 @@ -234,6 +234,11 @@
  char local_data_port[10];
  char remote_data_port[10];
@@ -8,7 +8,7 @@ diff -u -r netperf-2.6.0/src/netlib.c netperf-2.6.0-patch/src/netlib.c
 +// See comment in netlib.h
 +uint32_t think_time = 0;
 +uint32_t think_time_array_size = 0;
-+float think_time_shuffle_ratio = 0.f;
++uint32_t think_time_run_length = 0;
 +
  char *local_data_address=NULL;
  char *remote_data_address=NULL;
@@ -26,7 +26,7 @@ diff -u -r netperf-2.6.0/src/netlib.c netperf-2.6.0-patch/src/netlib.c
  }
 diff -u -r netperf-2.6.0/src/netlib.h netperf-2.6.0-patch/src/netlib.h
 --- netperf-2.6.0/src/netlib.h	2012-06-19 13:46:47.000000000 -0700
-+++ netperf-2.6.0-patch/src/netlib.h	2016-10-25 15:27:20.011688139 -0700
++++ netperf-2.6.0-patch/src/netlib.h	2016-11-02 10:56:38.460630189 -0700
 @@ -458,6 +458,11 @@
  extern char local_data_port[10];
  extern char remote_data_port[10];
@@ -34,7 +34,7 @@ diff -u -r netperf-2.6.0/src/netlib.h netperf-2.6.0-patch/src/netlib.h
 +// Time in microseconds to do pointless work after each request received
 +extern uint32_t think_time;
 +extern uint32_t think_time_array_size;
-+extern float think_time_shuffle_ratio;
++extern float think_time_run_length;
 +
  extern char *local_data_address;
  extern char *remote_data_address;
@@ -52,28 +52,28 @@ diff -u -r netperf-2.6.0/src/nettest_bsd.c netperf-2.6.0-patch/src/nettest_bsd.c
  
 diff -u -r netperf-2.6.0/src/nettest_bsd.h netperf-2.6.0-patch/src/nettest_bsd.h
 --- netperf-2.6.0/src/nettest_bsd.h	2012-06-19 13:47:09.000000000 -0700
-+++ netperf-2.6.0-patch/src/nettest_bsd.h	2016-10-25 15:40:54.721791660 -0700
++++ netperf-2.6.0-patch/src/nettest_bsd.h	2016-11-02 11:10:13.542697954 -0700
 @@ -66,6 +66,10 @@
  
    int32_t    test_length;    /* how long is the test? */
  
 +  uint32_t   think_time;               /* how long to pointlessly think on each request */
 +  uint32_t   think_time_array_size;    /* size of pointer chase array for think_time work */
-+  float      think_time_shuffle_ratio; /* how much of the pointer chase array to shuffle */
++  uint32_t   think_time_run_length; /* the number of contiguous elements in the think time array to sum */
 +
    uint32_t   so_rcvavoid;    /* avoid copies on recv? */
    uint32_t   so_sndavoid;    /* avoid copies on send? */
    uint32_t   send_dirty_count; /* bytes to dirty before calling send */
 diff -u -r netperf-2.6.0/src/nettest_omni.c netperf-2.6.0-patch/src/nettest_omni.c
 --- netperf-2.6.0/src/nettest_omni.c	2012-06-19 13:33:48.000000000 -0700
-+++ netperf-2.6.0-patch/src/nettest_omni.c	2016-10-27 17:22:31.537180976 -0700
++++ netperf-2.6.0-patch/src/nettest_omni.c	2016-11-02 11:04:58.939443126 -0700
 @@ -3759,6 +3759,10 @@
        omni_request->socket_prio            = remote_socket_prio;
        omni_request->socket_tos             = remote_socket_tos;
  
 +      omni_request->think_time = think_time;
 +      omni_request->think_time_array_size = think_time_array_size;
-+      omni_request->think_time_shuffle_ratio = think_time_shuffle_ratio;
++      omni_request->think_time_run_length = think_time_run_length;
 +
        /* we have no else clauses here because we previously set flags
  	 to zero above raj 20090803 */
@@ -85,122 +85,59 @@ diff -u -r netperf-2.6.0/src/nettest_omni.c netperf-2.6.0-patch/src/nettest_omni
 +  // Extract think_time parameters
 +  think_time = omni_request->think_time;
 +  think_time_array_size = omni_request->think_time_array_size;
-+  think_time_shuffle_ratio = omni_request->think_time_shuffle_ratio;
++  think_time_run_length = omni_request->think_time_run_length;
 +
    /* based on what we have been told by the remote netperf, we want to
       setup our endpoint for the "data connection" and let the remote
       netperf know the situation. */
-@@ -5240,6 +5249,82 @@
+@@ -5240,6 +5249,16 @@
    addrlen = sizeof(peeraddr_in);
    memset(&peeraddr_in,0,sizeof(peeraddr_in));
  
 +
-+  uint32_t* pointer_chase_array;
-+  uint32_t* pointer_chase_inverse; // map pointers to their current index in the array
-+  // Keep track of the current traversal order. We double buffer because we use the old ordering
-+  // to calculate the new ordering after every swap.
-+  uint32_t* pointer_chase_order; 
-+  uint32_t* pointer_chase_order_tmp; 
++  uint32_t* think_time_array;
 +  if (think_time > 0 && think_time_array_size > 0) {
-+    // Create a big array for our pointer chase
-+    pointer_chase_array = malloc(sizeof(uint32_t) * think_time_array_size);
-+    pointer_chase_inverse = malloc(sizeof(uint32_t) * think_time_array_size);
-+    pointer_chase_order = malloc(sizeof(uint32_t) * think_time_array_size);
-+    pointer_chase_order_tmp = malloc(sizeof(uint32_t) * think_time_array_size);
-+    // Make each slot in the array point to the next slot
-+    int i;
-+    for (i = 0; i < think_time_array_size; i++) {
-+      pointer_chase_array[i] = (i + 1) % think_time_array_size;
-+      pointer_chase_inverse[i] = (think_time_array_size - 1 + i) % think_time_array_size;
-+      pointer_chase_order[i] = (i + 1) % think_time_array_size;
-+      pointer_chase_order_tmp[i] = (i + 1) % think_time_array_size;
-+    }
-+    // Shuffle some of the array
-+    uint32_t swaps = 0;
-+    const uint32_t to_swap = think_time_array_size * think_time_shuffle_ratio / 2.f;
-+    while (swaps < to_swap) {
-+      // Generate two random indices, a and b, where a < b < len-1
-+      uint32_t a = rand() % (think_time_array_size - 1);
-+      uint32_t b = (rand() % (think_time_array_size - 2 - a)) + a + 1;
-+      // Generate two random indices, c and d, where a < c <= b and b < d < len
-+      uint32_t c = (rand() % (b - a)) + a + 1;
-+      uint32_t d = rand() % (think_time_array_size - 1 - b) + b + 1;
-+      uint32_t tmp;
-+      // In pointer_chase_array
-+      // Swap a and b
-+      uint32_t array_a = pointer_chase_inverse[pointer_chase_order[a]];
-+      uint32_t array_b = pointer_chase_inverse[pointer_chase_order[b]];
-+      uint32_t array_c = pointer_chase_inverse[pointer_chase_order[c]];
-+      uint32_t array_d = pointer_chase_inverse[pointer_chase_order[d]];
-+      tmp = pointer_chase_array[array_a];
-+      pointer_chase_array[array_a] =
-+        pointer_chase_array[array_b];
-+      pointer_chase_array[array_b] = tmp;
-+      // Swap c and d
-+      tmp = pointer_chase_array[array_c];
-+      pointer_chase_array[array_c] =
-+        pointer_chase_array[array_d];
-+      pointer_chase_array[array_d] = tmp;
-+      // Fix pointer_chase_inverse
-+      pointer_chase_inverse[pointer_chase_array[array_a]] = array_a;
-+      pointer_chase_inverse[pointer_chase_array[array_b]] = array_b;
-+      pointer_chase_inverse[pointer_chase_array[array_c]] = array_c;
-+      pointer_chase_inverse[pointer_chase_array[array_d]] = array_d;
-+      // Calculate the new traversal order
-+      // Copy the beginning
-+      memcpy(&pointer_chase_order_tmp[0], &pointer_chase_order[0], a*sizeof(uint32_t));
-+      // Copy the middle sections
-+      unsigned int cur_index = a;
-+      memcpy(&pointer_chase_order_tmp[cur_index], &pointer_chase_order[b], (d - b)*sizeof(uint32_t));
-+      cur_index += (d - b);
-+      memcpy(&pointer_chase_order_tmp[cur_index], &pointer_chase_order[c], (b - c)*sizeof(uint32_t));
-+      cur_index += (b - c);
-+      memcpy(&pointer_chase_order_tmp[cur_index], &pointer_chase_order[a], (c - a)*sizeof(uint32_t));
-+      // Copy the end
-+      memcpy(&pointer_chase_order_tmp[d], &pointer_chase_order[d], (think_time_array_size - d)*sizeof(uint32_t));
-+      // Swap our order buffers
-+      uint32_t* tmp_order = pointer_chase_order_tmp;
-+      pointer_chase_order_tmp = pointer_chase_order;
-+      pointer_chase_order = tmp_order;
-+      swaps++;
-+    }
-+    free(pointer_chase_inverse);
-+    free(pointer_chase_order);
-+    free(pointer_chase_order_tmp);
-+    fprintf(where, "Finished creating pointer chase array\n");
++    // Create a big array to randomly traverse
++    // Don't bother intializing elements - we're just going to pointlessly sum things to force the CPU to read
++    // memory locations and do work. It should just be filled with random numbers anyway
++    think_time_array = malloc(sizeof(uint32_t) * think_time_array_size);
++    fprintf(where, "Finished creating think time array\n");
 +  }
 +
    /* Now it's time to start receiving data on the connection. We will */
    /* first grab the apropriate counters and then start grabbing. */
  
-@@ -5409,6 +5494,15 @@
+@@ -5409,6 +5428,18 @@
        recv_ring = recv_ring->next;
      }
  
 +    if (think_time > 0) {
-+        // Do think time here before we send the response
-+        clock_t think_start = clock();
-+        uint32_t cur_index = 0;
-+        while (clock() - think_start < ((float)think_time) * (((float)CLOCKS_PER_SEC) / 1000000.f)) {
-+            cur_index = pointer_chase_array[cur_index];
-+        }
++      // Do think time here before we send the response
++      clock_t think_start = clock();
++      uint32_t sum = 0;
++      while (clock() - think_start < ((float)think_time) * (((float)CLOCKS_PER_SEC) / 1000000.f)) {
++        uint32_t i;
++        uint32_t run_start = rand() % think_time_array_size;
++        for (i = run_start; i < think_time_run_length; i++)
++          sum = think_time_array[i];
++      }
 +    }
 +
      /* if we should try to send something, then by all means, let us
         try to send something. */
      if ((omni_request->direction & NETPERF_XMIT) &&
-@@ -5522,6 +5616,10 @@
+@@ -5522,6 +5553,10 @@
      }
    }
  
 +  if (think_time > 0) {
-+      free(pointer_chase_array);
++      free(think_time_array);
 +  }
 +
    /* The current iteration loop now exits due to timeout or unit count
       being  reached */
    stop_timer();
-@@ -6895,7 +6993,7 @@
+@@ -6895,7 +6930,7 @@
  
  {
  
@@ -209,7 +146,7 @@ diff -u -r netperf-2.6.0/src/nettest_omni.c netperf-2.6.0-patch/src/nettest_omni
  
    extern char	*optarg;	  /* pointer to option string	*/
  
-@@ -7218,6 +7316,13 @@
+@@ -7218,6 +7253,13 @@
        test_uuid[sizeof(test_uuid) - 1] = 0;
        have_uuid = 1;
        break;
@@ -218,7 +155,7 @@ diff -u -r netperf-2.6.0/src/nettest_omni.c netperf-2.6.0-patch/src/nettest_omni
 +      break_args(optarg+strlen(arg1)+1, arg2, arg3);
 +      think_time = convert(arg1);
 +      think_time_array_size = convert(arg2);
-+      think_time_shuffle_ratio = atof(arg3);
++      think_time_run_length = atof(arg3);
 +      break;
      case 'W':
        /* set the "width" of the user space data */

--- a/perfkitbenchmarker/flag_util.py
+++ b/perfkitbenchmarker/flag_util.py
@@ -213,15 +213,17 @@ class FlagDictSubstitution(object):
     """
     self._flags = flag_values
     self._substitute = substitute
+    self._flag_dict_func_name = (
+        '_flags' if hasattr(self._flags, '_flags') else 'FlagDict')
 
   def __enter__(self):
     """Begins the flag substitution."""
-    self._original_flagdict = self._flags.FlagDict
-    self._flags.__dict__['FlagDict'] = self._substitute
+    self._original_flagdict = getattr(self._flags, self._flag_dict_func_name)
+    self._flags.__dict__[self._flag_dict_func_name] = self._substitute
 
   def __exit__(self, *unused_args, **unused_kwargs):
     """Stops the flag substitution."""
-    self._flags.__dict__['FlagDict'] = self._original_flagdict
+    self._flags.__dict__[self._flag_dict_func_name] = self._original_flagdict
 
 
 class UnitsParser(flags.ArgumentParser):

--- a/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
@@ -58,8 +58,8 @@ flags.DEFINE_integer('netperf_thinktime', 0,
 flags.DEFINE_integer('netperf_thinktime_array_size', 0,
                      'The size of the array to traverse for thinktime.')
 flags.DEFINE_integer('netperf_thinktime_run_length', 0,
-                   'The number of contiguous numbers to sum at a time in the '
-                   'thinktime array.')
+                     'The number of contiguous numbers to sum at a time in the '
+                     'thinktime array.')
 
 ALL_BENCHMARKS = ['TCP_RR', 'TCP_CRR', 'TCP_STREAM', 'UDP_RR']
 flags.DEFINE_list('netperf_benchmarks', ALL_BENCHMARKS,

--- a/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
@@ -53,6 +53,8 @@ flags.DEFINE_bool('netperf_enable_histograms', True,
 flag_util.DEFINE_integerlist('netperf_num_streams', flag_util.IntegerList([1]),
                              'Number of netperf processes to run. Netperf '
                              'will run once for each value in the list.')
+flags.DEFINE_integer('netperf_thinktime', 0,
+                     'Time in microseconds to do work for each request.')
 
 ALL_BENCHMARKS = ['TCP_RR', 'TCP_CRR', 'TCP_STREAM', 'UDP_RR']
 flags.DEFINE_list('netperf_benchmarks', ALL_BENCHMARKS,
@@ -200,14 +202,19 @@ def _ParseNetperfOutput(stdout, metadata, benchmark_name,
   # 99th Percentile Latency Microseconds,Minimum Latency Microseconds,
   # Maximum Latency Microseconds\n
   # 1405.50,Trans/s,2.522,4,783.80,683,735,841,600,900\n
-  fp = io.StringIO(stdout)
-  # "-o" flag above specifies CSV output, but there is one extra header line:
-  banner = next(fp)
-  assert banner.startswith('MIGRATED'), stdout
-  r = csv.DictReader(fp)
-  results = next(r)
-  logging.info('Netperf Results: %s', results)
-  assert 'Throughput' in results
+  try:
+    fp = io.StringIO(stdout)
+    # "-o" flag above specifies CSV output, but there is one extra header line:
+    banner = next(fp)
+    assert banner.startswith('MIGRATED'), stdout
+    r = csv.DictReader(fp)
+    results = next(r)
+    logging.info('Netperf Results: %s', results)
+    assert 'Throughput' in results
+  except:
+    logging.info('Netperf ERROR: Failed to parse stdout. STDOUT: %s' %
+                 stdout)
+    return None
 
   # Update the metadata with some additional infos
   meta_keys = [('Confidence Iterations Run', 'confidence_iter'),
@@ -288,6 +295,7 @@ def RunNetperf(vm, benchmark_name, server_ip, num_streams):
                  '-t {benchmark_name} -H {server_ip} -l {length} {confidence}'
                  ' -- '
                  '-P ,{{data_port}} '
+                 '-U {thinktime} '
                  '-o THROUGHPUT,THROUGHPUT_UNITS,P50_LATENCY,P90_LATENCY,'
                  'P99_LATENCY,STDDEV_LATENCY,'
                  'MIN_LATENCY,MAX_LATENCY,'
@@ -296,6 +304,7 @@ def RunNetperf(vm, benchmark_name, server_ip, num_streams):
                      benchmark_name=benchmark_name,
                      server_ip=server_ip,
                      length=FLAGS.netperf_test_length,
+                     thinktime=FLAGS.netperf_thinktime,
                      confidence=confidence, verbosity=verbosity)
 
   # Run all of the netperf processes and collect their stdout
@@ -318,7 +327,15 @@ def RunNetperf(vm, benchmark_name, server_ip, num_streams):
                                        enable_latency_histograms)
                    for stdout in stdouts]
 
-  if len(parsed_output) == 1:
+  # Filter out failed netperf runs
+  parsed_output = [out for out in parsed_output if out is not None]
+
+  logging.info('%s out of %s netperf threads succeeded',
+               len(parsed_output), num_streams)
+
+  if len(parsed_output) == 0:
+    raise Exception('All netperf threads failed')
+  elif len(parsed_output) == 1:
     # Only 1 netperf thread
     throughput_sample, latency_samples, histogram = parsed_output[0]
     return [throughput_sample] + latency_samples
@@ -341,8 +358,7 @@ def RunNetperf(vm, benchmark_name, server_ip, num_streams):
     throughput_stats['min'] = min(throughputs)
     throughput_stats['max'] = max(throughputs)
     # Calculate aggregate throughput
-    assert num_streams, len(throughputs)
-    throughput_stats['total'] = throughput_stats['average'] * num_streams
+    throughput_stats['total'] = throughput_stats['average'] * len(throughputs)
     # Create samples for throughput stats
     for stat, value in throughput_stats.items():
       samples.append(

--- a/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
@@ -55,6 +55,10 @@ flag_util.DEFINE_integerlist('netperf_num_streams', flag_util.IntegerList([1]),
                              'will run once for each value in the list.')
 flags.DEFINE_integer('netperf_thinktime', 0,
                      'Time in microseconds to do work for each request.')
+flags.DEFINE_integer('netperf_thinktime_array_size', 0,
+                     'The size of the array to traverse for thinktime.')
+flags.DEFINE_float('netperf_thinktime_shuffle', 0.0,
+                     'The fraction of the thinktime array to shuffle.')
 
 ALL_BENCHMARKS = ['TCP_RR', 'TCP_CRR', 'TCP_STREAM', 'UDP_RR']
 flags.DEFINE_list('netperf_benchmarks', ALL_BENCHMARKS,
@@ -295,7 +299,7 @@ def RunNetperf(vm, benchmark_name, server_ip, num_streams):
                  '-t {benchmark_name} -H {server_ip} -l {length} {confidence}'
                  ' -- '
                  '-P ,{{data_port}} '
-                 '-U {thinktime} '
+                 '-U {thinktime},{thinktime_array_size},{thinktime_shuffle} '
                  '-o THROUGHPUT,THROUGHPUT_UNITS,P50_LATENCY,P90_LATENCY,'
                  'P99_LATENCY,STDDEV_LATENCY,'
                  'MIN_LATENCY,MAX_LATENCY,'
@@ -305,6 +309,8 @@ def RunNetperf(vm, benchmark_name, server_ip, num_streams):
                      server_ip=server_ip,
                      length=FLAGS.netperf_test_length,
                      thinktime=FLAGS.netperf_thinktime,
+                     thinktime_array_size=FLAGS.netperf_thinktime_array_size,
+                     thinktime_shuffle=FLAGS.netperf_thinktime_shuffle,
                      confidence=confidence, verbosity=verbosity)
 
   # Run all of the netperf processes and collect their stdout

--- a/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
@@ -57,8 +57,9 @@ flags.DEFINE_integer('netperf_thinktime', 0,
                      'Time in microseconds to do work for each request.')
 flags.DEFINE_integer('netperf_thinktime_array_size', 0,
                      'The size of the array to traverse for thinktime.')
-flags.DEFINE_float('netperf_thinktime_shuffle', 0.0,
-                   'The fraction of the thinktime array to shuffle.')
+flags.DEFINE_integer('netperf_thinktime_run_length', 0,
+                   'The number of contiguous numbers to sum at a time in the '
+                   'thinktime array.')
 
 ALL_BENCHMARKS = ['TCP_RR', 'TCP_CRR', 'TCP_STREAM', 'UDP_RR']
 flags.DEFINE_list('netperf_benchmarks', ALL_BENCHMARKS,
@@ -299,7 +300,7 @@ def RunNetperf(vm, benchmark_name, server_ip, num_streams):
                  '-t {benchmark_name} -H {server_ip} -l {length} {confidence}'
                  ' -- '
                  '-P ,{{data_port}} '
-                 '-U {thinktime},{thinktime_array_size},{thinktime_shuffle} '
+                 '-U {thinktime},{thinktime_array_size},{thinktime_run_length} '
                  '-o THROUGHPUT,THROUGHPUT_UNITS,P50_LATENCY,P90_LATENCY,'
                  'P99_LATENCY,STDDEV_LATENCY,'
                  'MIN_LATENCY,MAX_LATENCY,'
@@ -310,7 +311,7 @@ def RunNetperf(vm, benchmark_name, server_ip, num_streams):
                      length=FLAGS.netperf_test_length,
                      thinktime=FLAGS.netperf_thinktime,
                      thinktime_array_size=FLAGS.netperf_thinktime_array_size,
-                     thinktime_shuffle=FLAGS.netperf_thinktime_shuffle,
+                     thinktime_run_length=FLAGS.netperf_thinktime_run_length,
                      confidence=confidence, verbosity=verbosity)
 
   # Run all of the netperf processes and collect their stdout

--- a/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
@@ -58,7 +58,7 @@ flags.DEFINE_integer('netperf_thinktime', 0,
 flags.DEFINE_integer('netperf_thinktime_array_size', 0,
                      'The size of the array to traverse for thinktime.')
 flags.DEFINE_float('netperf_thinktime_shuffle', 0.0,
-                     'The fraction of the thinktime array to shuffle.')
+                   'The fraction of the thinktime array to shuffle.')
 
 ALL_BENCHMARKS = ['TCP_RR', 'TCP_CRR', 'TCP_STREAM', 'UDP_RR']
 flags.DEFINE_list('netperf_benchmarks', ALL_BENCHMARKS,

--- a/perfkitbenchmarker/linux_packages/netperf.py
+++ b/perfkitbenchmarker/linux_packages/netperf.py
@@ -49,7 +49,7 @@ def _Install(vm):
   # Modify netperf to print out all buckets in its histogram rather than
   # aggregating.
   vm.PushDataFile('netlib.patch', NETLIB_PATCH)
-  vm.RemoteCommand('cd %s && patch -p0 netlib.c netlib.patch' %
+  vm.RemoteCommand('cd %s && patch -p2 < netlib.patch' %
                    NETPERF_SRC_DIR)
   vm.RemoteCommand('cd %s && CFLAGS=-DHIST_NUM_OF_BUCKET=%s '
                    './configure --enable-histogram=yes '

--- a/perfkitbenchmarker/linux_packages/ycsb.py
+++ b/perfkitbenchmarker/linux_packages/ycsb.py
@@ -74,6 +74,9 @@ AGGREGATE_OPERATORS = {
     'Return=-1': operator.add,
     'Return=-2': operator.add,
     'Return=-3': operator.add,
+    'Return=OK': operator.add,
+    'Return=ERROR': operator.add,
+    'LatencyVariance(ms)': None,
     'AverageLatency(ms)': None,  # Requires both average and # of ops.
     'Throughput(ops/sec)': operator.add,
     '95thPercentileLatency(ms)': None,  # Calculated across clients.

--- a/tests/linux_benchmarks/netperf_benchmark_test.py
+++ b/tests/linux_benchmarks/netperf_benchmark_test.py
@@ -105,19 +105,7 @@ class NetperfBenchmarkTestCase(unittest.TestCase):
          ('TCP_CRR_Latency_max', 2500.0, 'us'),
          ('TCP_CRR_Latency_stddev', 551.07, 'us'),
          ('TCP_STREAM_Throughput', 1187.94, mbps),
-         ('TCP_STREAM_Latency_p50', 2.0, 'us'),
-         ('TCP_STREAM_Latency_p90', 6.0, 'us'),
-         ('TCP_STREAM_Latency_p99', 3374.0, 'us'),
-         ('TCP_STREAM_Latency_min', 1.0, 'us'),
-         ('TCP_STREAM_Latency_max', 3500.0, 'us'),
-         ('TCP_STREAM_Latency_stddev', 1084.37, 'us'),
          ('TCP_STREAM_Throughput', 1973.37, 'Mbits/sec'),
-         ('TCP_STREAM_Latency_p50', 2.0, 'us'),
-         ('TCP_STREAM_Latency_p90', 4.0, 'us'),
-         ('TCP_STREAM_Latency_p99', 20.0, 'us'),
-         ('TCP_STREAM_Latency_min', 1.0, 'us'),
-         ('TCP_STREAM_Latency_max', 30.0, 'us'),
-         ('TCP_STREAM_Latency_stddev', 694.1, 'us'),
          ('UDP_RR_Transaction_Rate', 1359.71, tps),
          ('UDP_RR_Latency_p50', 700.0, 'us'),
          ('UDP_RR_Latency_p90', 757.0, 'us'),
@@ -136,7 +124,10 @@ class NetperfBenchmarkTestCase(unittest.TestCase):
 
     external_meta = {'ip_type': 'external'}
     internal_meta = {'ip_type': 'internal'}
-    expected_meta = (([external_meta] * 7 + [internal_meta] * 7) * 4)
+    expected_meta = (([external_meta] * 7 + [internal_meta] * 7) * 2 +
+                     [external_meta, internal_meta] +
+                     [external_meta] * 7 +
+                     [internal_meta] * 7)
 
     for i, meta in enumerate(expected_meta):
       self.assertIsInstance(result[i][3], dict)


### PR DESCRIPTION
Patched netperf to include a "think time" flag, which, if specified, makes netserver traverse an array of configurable size in a random order. You can also specify what fraction of the array to shuffle.

One issue with this patch is that the system I've devised to ensure that all elements in the array get traversed no matter how we shuffle it is pretty slow. Specifically, it's O(n*m), where n is the size of the array and m is the number of swaps to perform. This puts a practical limit on how large our arrays can be. Shuffling a 1GB array takes an obscene amount of time. I'll look into finding a faster way to shuffle properly in the future.
