### PR TITLE
OpenStack: Deprecate openstack_volume_size

### DIFF
--- a/perfkitbenchmarker/providers/openstack/flags.py
+++ b/perfkitbenchmarker/providers/openstack/flags.py
@@ -62,8 +62,8 @@ flags.DEFINE_boolean('openstack_boot_from_volume', False,
                      'Boot from volume instead of an image')
 
 flags.DEFINE_integer('openstack_volume_size', None,
-                     'DEPRECATED: Use data_disk_size'
-                     'Size of the volume (GB)')
+                     '(DEPRECATED: Use data_disk_size) '
+                     'Size of the volume (GB).')
 
 flags.DEFINE_string('openstack_image_username', 'ubuntu',
                     'Ssh username for cloud image')

--- a/perfkitbenchmarker/providers/openstack/flags.py
+++ b/perfkitbenchmarker/providers/openstack/flags.py
@@ -62,6 +62,7 @@ flags.DEFINE_boolean('openstack_boot_from_volume', False,
                      'Boot from volume instead of an image')
 
 flags.DEFINE_integer('openstack_volume_size', None,
+                     'DEPRECATED: Use data_disk_size'
                      'Size of the volume (GB)')
 
 flags.DEFINE_string('openstack_image_username', 'ubuntu',

--- a/perfkitbenchmarker/providers/openstack/os_disk.py
+++ b/perfkitbenchmarker/providers/openstack/os_disk.py
@@ -30,7 +30,8 @@ def CreateVolume(resource, name):
   """Creates a remote (Cinder) block volume."""
   vol_cmd = os_utils.OpenStackCLICommand(resource, 'volume', 'create', name)
   vol_cmd.flags['availability-zone'] = resource.zone
-  if 'openstack_volume_size' in vol_cmd.flags.keys():
+  if 'openstack_volume_size' in vol_cmd.flags.keys() and \
+          'data_disk_size' not in vol_cmd.flags.keys():
     vol_cmd.flags['data_disk_size'] = vol_cmd.flags.get('openstack_volume_size')
   vol_cmd.flags['size'] = (vol_cmd.flags.get('data_disk_size') or
                            REMOTE_VOLUME_DEFAULT_SIZE_GB)
@@ -44,7 +45,8 @@ def CreateBootVolume(resource, name, image):
   vol_cmd = os_utils.OpenStackCLICommand(resource, 'volume', 'create', name)
   vol_cmd.flags['availability-zone'] = resource.zone
   vol_cmd.flags['image'] = image
-  if 'openstack_volume_size' in vol_cmd.flags.keys():
+  if 'openstack_volume_size' in vol_cmd.flags.keys() and \
+          'data_disk_size' not in vol_cmd.flags.keys():
     vol_cmd.flags['data_disk_size'] = vol_cmd.flags.get('openstack_volume_size')
   vol_cmd.flags['size'] = (vol_cmd.flags.get('data_disk_size') or
                            GetImageMinDiskSize(resource, image))

--- a/perfkitbenchmarker/providers/openstack/os_disk.py
+++ b/perfkitbenchmarker/providers/openstack/os_disk.py
@@ -31,6 +31,7 @@ def CreateVolume(resource, name):
   vol_cmd = os_utils.OpenStackCLICommand(resource, 'volume', 'create', name)
   vol_cmd.flags['availability-zone'] = resource.zone
   vol_cmd.flags['size'] = (FLAGS.openstack_volume_size or
+                           vol_cmd.flags.get('data_disk_size') or
                            REMOTE_VOLUME_DEFAULT_SIZE_GB)
   stdout, _, _ = vol_cmd.Issue()
   vol_resp = json.loads(stdout)
@@ -43,6 +44,7 @@ def CreateBootVolume(resource, name, image):
   vol_cmd.flags['availability-zone'] = resource.zone
   vol_cmd.flags['image'] = image
   vol_cmd.flags['size'] = (FLAGS.openstack_volume_size or
+                           vol_cmd.flags.get('data_disk_size') or
                            GetImageMinDiskSize(resource, image))
   stdout, _, _ = vol_cmd.Issue()
   vol_resp = json.loads(stdout)

--- a/perfkitbenchmarker/providers/openstack/os_disk.py
+++ b/perfkitbenchmarker/providers/openstack/os_disk.py
@@ -30,8 +30,9 @@ def CreateVolume(resource, name):
   """Creates a remote (Cinder) block volume."""
   vol_cmd = os_utils.OpenStackCLICommand(resource, 'volume', 'create', name)
   vol_cmd.flags['availability-zone'] = resource.zone
-  vol_cmd.flags['size'] = (FLAGS.openstack_volume_size or
-                           vol_cmd.flags.get('data_disk_size') or
+  if 'openstack_volume_size' in vol_cmd.flags.keys():
+    vol_cmd.flags['data_disk_size'] = vol_cmd.flags.get('openstack_volume_size')
+  vol_cmd.flags['size'] = (vol_cmd.flags.get('data_disk_size') or
                            REMOTE_VOLUME_DEFAULT_SIZE_GB)
   stdout, _, _ = vol_cmd.Issue()
   vol_resp = json.loads(stdout)
@@ -43,8 +44,9 @@ def CreateBootVolume(resource, name, image):
   vol_cmd = os_utils.OpenStackCLICommand(resource, 'volume', 'create', name)
   vol_cmd.flags['availability-zone'] = resource.zone
   vol_cmd.flags['image'] = image
-  vol_cmd.flags['size'] = (FLAGS.openstack_volume_size or
-                           vol_cmd.flags.get('data_disk_size') or
+  if 'openstack_volume_size' in vol_cmd.flags.keys():
+    vol_cmd.flags['data_disk_size'] = vol_cmd.flags.get('openstack_volume_size')
+  vol_cmd.flags['size'] = (vol_cmd.flags.get('data_disk_size') or
                            GetImageMinDiskSize(resource, image))
   stdout, _, _ = vol_cmd.Issue()
   vol_resp = json.loads(stdout)


### PR DESCRIPTION
So as to standardize flags as with other providers, 'data_disk_size'
flag should be used instead of openstack_volume_size.  So as not to
break users' scenarios, openstack_volume_size will still be included
and used but if it is not set, data_disk_size will be used before
using the default.