### PR TITLE
Fix bug during cleanup phase of object_storage_service benchmark

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/object_storage_service_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/object_storage_service_benchmark.py
@@ -1107,7 +1107,7 @@ def PrepareVM(vm, service):
 
 def CleanupVM(vm):
   vm.RemoteCommand('/usr/bin/yes | sudo pip uninstall python-gflags')
-  vm.RemoteCommand('rm -rf /tmp/run/')
+  vm.RemoteCommand('sudo rm -rf /tmp/run/')
   objects_written_file = posixpath.join(vm_util.VM_TMP_DIR,
                                         OBJECTS_WRITTEN_FILE)
   vm.RemoteCommand('rm -f %s' % objects_written_file)


### PR DESCRIPTION
`/tmp/run` folder is created with `sudo`, and we were trying to delete it without sudo. I'm not sure whether root permissions are actually needed to create/work within `/tmp`.