### PR TITLE
Fix cloudsuite_web_serving benchmark

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/cloudsuite_web_serving_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/cloudsuite_web_serving_benchmark.py
@@ -89,7 +89,8 @@ def Prepare(benchmark_spec):
     vm.RemoteCommand('sudo docker pull cloudsuite/web-serving:web_server')
     vm.RemoteCommand('sudo docker pull cloudsuite/web-serving:memcached_server')
     vm.RemoteCommand('sudo docker run -dt --net host --name web_server '
-                     'cloudsuite/web-serving:web_server /etc/bootstrap.sh')
+                     'cloudsuite/web-serving:web_server '
+                     '/etc/bootstrap.sh mysql_server memcache_server')
     vm.RemoteCommand('sudo docker run -dt --net host --name memcache_server '
                      'cloudsuite/web-serving:memcached_server')
 
@@ -97,7 +98,7 @@ def Prepare(benchmark_spec):
     PrepareCommon(vm)
     vm.RemoteCommand('sudo docker pull cloudsuite/web-serving:db_server')
     vm.RemoteCommand('sudo docker run -dt --net host --name mysql_server '
-                     'cloudsuite/web-serving:db_server')
+                     'cloudsuite/web-serving:db_server web_server')
 
   def PrepareClient(vm):
     PrepareCommon(vm)


### PR DESCRIPTION
The cloudsuite commit ("Fix web-serving login problem (#70)"), added a
mandatory $WEB_SERVER_IP parameter to the
cloudsuite/web-serving:db_server image:

https://github.com/ParsaLab/cloudsuite/commit/41d417234e719083ae5edcb657f7cde7f3c8fbc5

Without the parameter, the db_server container fails at startup
with the error message "Web server IP is a mandatory parameter."

This commit also explicitly sets the two optional parameters to
cloudsuite/web-serving:web_server image as a defence against another
backwards-incompatible change like this.

Note that this commit doesn't fix the intermittent failure reported in
issue #696.