### PR TITLE
Auto detect package versions

### DIFF
--- a/perfkitbenchmarker/linux_packages/hadoop.py
+++ b/perfkitbenchmarker/linux_packages/hadoop.py
@@ -69,7 +69,11 @@ def YumInstall(vm):
 
 def AptInstall(vm):
   """Installs Hadoop on the VM."""
-  vm.InstallPackages('libsnappy1 libsnappy-dev')
+  libsnappy = 'libsnappy1'
+  if not vm.HasPackage(libsnappy):
+    # libsnappy's name on ubuntu16.04 is libsnappy1v5. Let's try that instead.
+    libsnappy = 'libsnappy1v5'
+  vm.InstallPackages('%s libsnappy-dev' % libsnappy)
   _Install(vm)
 
 

--- a/perfkitbenchmarker/linux_packages/openjdk.py
+++ b/perfkitbenchmarker/linux_packages/openjdk.py
@@ -21,17 +21,26 @@ FLAGS = flags.FLAGS
 
 JAVA_HOME = '/usr'
 
-flags.DEFINE_string('openjdk_version', '7', 'Version of openjdk to use. '
-                    'You must use this flag to specify version 8 for '
-                    'ubuntu 1604 and other operating systems where '
-                    'openjdk7 is not installable by default')
+flags.DEFINE_string('openjdk_version', None, 'Version of openjdk to use. '
+                    'By default, the version of openjdk is automatically '
+                    'detected.')
+
+
+def _OpenJdkPackage(vm, format_string):
+  version = FLAGS.openjdk_version
+  if version is None:
+    if vm.HasPackage(format_string.format('7')):
+      version = '7'
+    else:
+      version = '8'
+  return format_string.format(version)
 
 
 def YumInstall(vm):
   """Installs the OpenJDK package on the VM."""
-  vm.InstallPackages('java-1.{0}.0-openjdk-devel'.format(FLAGS.openjdk_version))
+  vm.InstallPackages(_OpenJdkPackage(vm, 'java-1.{0}.0-openjdk-devel'))
 
 
 def AptInstall(vm):
   """Installs the OpenJDK package on the VM."""
-  vm.InstallPackages('openjdk-{0}-jdk'.format(FLAGS.openjdk_version))
+  vm.InstallPackages(_OpenJdkPackage(vm, 'openjdk-{0}-jdk'))

--- a/perfkitbenchmarker/linux_virtual_machine.py
+++ b/perfkitbenchmarker/linux_virtual_machine.py
@@ -450,9 +450,7 @@ class BaseLinuxMixin(virtual_machine.BaseOsMixin):
     Raises:
       AuthError: If the VM cannot access its peer.
     """
-    try:
-      self.RemoteCommand('ssh %s hostname' % peer.internal_ip)
-    except errors.VirtualMachine.RemoteCommandError:
+    if not self.TryRemoteCommand('ssh %s hostname' % peer.internal_ip):
       raise errors.VirtualMachine.AuthError(
           'Authentication check failed. If you are running with Static VMs, '
           'please make sure that %s can ssh into %s without supplying any '
@@ -517,11 +515,7 @@ class BaseLinuxMixin(virtual_machine.BaseOsMixin):
 
   def _TestReachable(self, ip):
     """Returns True if the VM can reach the ip address and False otherwise."""
-    try:
-      self.RemoteCommand('ping -c 1 %s' % ip)
-    except errors.VirtualMachine.RemoteCommandError:
-      return False
-    return True
+    return self.TryRemoteCommand('ping -c 1 %s' % ip)
 
   def SetupLocalDisks(self):
     """Performs Linux specific setup of local disks."""

--- a/perfkitbenchmarker/linux_virtual_machine.py
+++ b/perfkitbenchmarker/linux_virtual_machine.py
@@ -640,6 +640,11 @@ class RhelMixin(BaseLinuxMixin):
         vm_util.VM_TMP_DIR,
         ignore_failure=True)
 
+  def HasPackage(self, package):
+    """Returns True iff the package is available for installation."""
+    return self.TryRemoteCommand('sudo yum info %s' % package,
+                                 suppress_warning=True)
+
   def InstallPackages(self, packages):
     """Installs packages using the yum package manager."""
     self.RemoteCommand('sudo yum install -y %s' % packages)
@@ -741,6 +746,11 @@ class DebianMixin(BaseLinuxMixin):
         'sudo dpkg --set-selections < %s/dpkg_selections' % vm_util.VM_TMP_DIR)
     self.RemoteCommand('sudo DEBIAN_FRONTEND=\'noninteractive\' '
                        'apt-get --purge -y dselect-upgrade')
+
+  def HasPackage(self, package):
+    """Returns True iff the package is available for installation."""
+    return self.TryRemoteCommand('apt-get install --just-print %s' % package,
+                                 suppress_warning=True)
 
   @vm_util.Retry()
   def InstallPackages(self, packages):

--- a/perfkitbenchmarker/virtual_machine.py
+++ b/perfkitbenchmarker/virtual_machine.py
@@ -374,6 +374,16 @@ class BaseOsMixin(object):
     """
     raise NotImplementedError()
 
+  def TryRemoteCommand(self, command, **kwargs):
+    """Runs a remote command and returns True iff it succeeded."""
+    try:
+      self.RemoteCommand(command, **kwargs)
+      return True
+    except errors.VirtualMachine.RemoteCommandError:
+      return False
+    except:
+      raise
+
   @abc.abstractmethod
   def RemoteCopy(self, file_path, remote_path='', copy_to=True):
     """Copies a file to or from the VM.

--- a/perfkitbenchmarker/windows_virtual_machine.py
+++ b/perfkitbenchmarker/windows_virtual_machine.py
@@ -218,11 +218,7 @@ class WindowsMixin(virtual_machine.BaseOsMixin):
 
   def _TestReachable(self, ip):
     """Returns True if the VM can reach the ip address and False otherwise."""
-    try:
-      self.RemoteCommand('ping -n 1 %s' % ip)
-    except errors.VirtualMachine.RemoteCommandError:
-      return False
-    return True
+    return self.TryRemoteCommand('ping -n 1 %s' % ip)
 
   def DownloadFile(self, url, dest):
     """Downloads the content at the url to the specified destination."""


### PR DESCRIPTION
Automatically detect the right versions of openjdk and libsnappy. This obviates the --openjdk_version flag. Also makes hadoop installation on ubuntu-16.04 work.