### PR TITLE
Persist package installation across reboots

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/mysql_service_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/mysql_service_benchmark.py
@@ -35,11 +35,11 @@ import uuid
 from perfkitbenchmarker import providers
 from perfkitbenchmarker import configs
 from perfkitbenchmarker import flags
-from perfkitbenchmarker import os_types
 from perfkitbenchmarker import sample
 from perfkitbenchmarker import vm_util
 from perfkitbenchmarker.providers.aws import aws_network
 from perfkitbenchmarker.providers.aws import util
+from perfkitbenchmarker.linux_packages import sysbench05plus
 
 FLAGS = flags.FLAGS
 flags.DEFINE_enum(
@@ -113,7 +113,6 @@ MYSQL_ROOT_USER = 'root'
 MYSQL_ROOT_PASSWORD_PREFIX = 'Perfkit8'
 MYSQL_PORT = '3306'
 
-NORMAL_SYSBENCH_PATH_PREFIX = '/usr'
 PREPARE_SCRIPT_PATH = '/share/doc/sysbench/tests/db/parallel_prepare.lua'
 OLTP_SCRIPT_PATH = '/share/doc/sysbench/tests/db/oltp.lua'
 
@@ -268,22 +267,6 @@ def ParseSysbenchOutput(sysbench_output, results, metadata):
         metadata))
 
 
-def _GetSysbenchCommandPrefix(os_type):
-  """Determines the prefix for a sysbench command based on the operating system.
-
-  Args:
-    os_type: string. Operating system of the machine on which the sysbench
-        command will be executed. Chosen from os_types.ALL.
-
-  Returns:
-    A string representing the sysbench command prefix.
-  """
-  if os_type == os_types.RHEL:
-    return vm_util.VM_TMP_DIR
-  else:
-    return NORMAL_SYSBENCH_PATH_PREFIX
-
-
 def _IssueSysbenchCommand(vm, duration):
   """Issues a sysbench run command given a vm and a duration.
 
@@ -298,7 +281,7 @@ def _IssueSysbenchCommand(vm, duration):
   """
   stdout = ''
   stderr = ''
-  oltp_script_path = _GetSysbenchCommandPrefix(vm.OS_TYPE) + OLTP_SCRIPT_PATH
+  oltp_script_path = sysbench05plus.PathPrefix(vm) + OLTP_SCRIPT_PATH
   if duration > 0:
     run_cmd_tokens = ['sysbench',
                       '--test=%s' % oltp_script_path,
@@ -362,8 +345,7 @@ def _RunSysbench(vm, metadata):
   # Provision the Sysbench test based on the input flags (load data into DB)
   # Could take a long time if the data to be loaded is large.
   data_load_start_time = time.time()
-  prepare_script_path = (_GetSysbenchCommandPrefix(vm.OS_TYPE) +
-                         PREPARE_SCRIPT_PATH)
+  prepare_script_path = sysbench05plus.PathPrefix(vm) + PREPARE_SCRIPT_PATH
   data_load_cmd_tokens = ['sysbench',
                           '--test=%s' % prepare_script_path,
                           '--mysql_svc_oltp_tables_count=%d' %

--- a/perfkitbenchmarker/linux_packages/__init__.py
+++ b/perfkitbenchmarker/linux_packages/__init__.py
@@ -21,11 +21,12 @@ package manager (e.g. YumInstall(vm) and AptInstall(vm)).
 They may also define functions that return the path to a configuration file
 (e.g. AptGetPathToConfig(vm)) and functions that return the linux service
 name (e.g. YumGetServiceName(vm)). If the package only installs
-packages through the package manager or places files in the temp directory
-on the VM (vm_util.VM_TMP_DIR), then it does not need to define an uninstall
-function. If the package manually places files in other locations
-(e.g. /user/bin), then it also needs to define uninstall functions
-(e.g. YumUninstall(vm)).
+packages through the package manager, then it does not need to define an
+uninstall function.  If the package manually places files in other locations
+(e.g. /usr/bin, /opt/pkb), then it also needs to define uninstall functions
+(e.g.  YumUninstall(vm)).
+
+Package installation should persist across reboots.
 
 All functions in each package module should be prefixed with the type of package
 manager, and all functions should accept a BaseVirtualMachine object as their
@@ -36,6 +37,10 @@ packages in benchmarks.
 """
 
 from perfkitbenchmarker import import_util
+
+
+# Place to install stuff. Persists across reboots.
+INSTALL_DIR = '/opt/pkb'
 
 
 def _LoadPackages():

--- a/perfkitbenchmarker/linux_packages/aerospike_server.py
+++ b/perfkitbenchmarker/linux_packages/aerospike_server.py
@@ -19,13 +19,13 @@ import time
 
 from perfkitbenchmarker import data
 from perfkitbenchmarker import flags
-from perfkitbenchmarker import vm_util
+from perfkitbenchmarker.linux_packages import INSTALL_DIR
 
 FLAGS = flags.FLAGS
 
 GIT_REPO = 'https://github.com/aerospike/aerospike-server.git'
 GIT_TAG = '3.7.5'
-AEROSPIKE_DIR = '%s/aerospike-server' % vm_util.VM_TMP_DIR
+AEROSPIKE_DIR = '%s/aerospike-server' % INSTALL_DIR
 AEROSPIKE_CONF_PATH = '%s/as/etc/aerospike_dev.conf' % AEROSPIKE_DIR
 
 MEMORY = 'memory'

--- a/perfkitbenchmarker/linux_packages/ant.py
+++ b/perfkitbenchmarker/linux_packages/ant.py
@@ -17,12 +17,12 @@
 
 import posixpath
 
-from perfkitbenchmarker import vm_util
+from perfkitbenchmarker.linux_packages import INSTALL_DIR
 
 ANT_TAR_URL = ('archive.apache.org/dist/ant/binaries/'
                'apache-ant-1.9.6-bin.tar.gz')
 
-ANT_HOME_DIR = posixpath.join(vm_util.VM_TMP_DIR, 'ant')
+ANT_HOME_DIR = posixpath.join(INSTALL_DIR, 'ant')
 
 
 def _Install(vm):
@@ -33,7 +33,7 @@ def _Install(vm):
                    'wget {1} && '
                    'tar -zxf apache-ant-1.9.6-bin.tar.gz && '
                    'ln -s {0}/apache-ant-1.9.6/ {2}'.format(
-                       vm_util.VM_TMP_DIR, ANT_TAR_URL, ANT_HOME_DIR))
+                       INSTALL_DIR, ANT_TAR_URL, ANT_HOME_DIR))
 
 
 def YumInstall(vm):

--- a/perfkitbenchmarker/linux_packages/cassandra.py
+++ b/perfkitbenchmarker/linux_packages/cassandra.py
@@ -29,6 +29,7 @@ from perfkitbenchmarker import errors
 from perfkitbenchmarker import flags
 from perfkitbenchmarker import os_types
 from perfkitbenchmarker import vm_util
+from perfkitbenchmarker.linux_packages import INSTALL_DIR
 from perfkitbenchmarker.linux_packages.ant import ANT_HOME_DIR
 
 
@@ -38,7 +39,7 @@ CASSANDRA_GIT_REPRO = 'https://github.com/apache/cassandra.git'
 CASSANDRA_VERSION = 'cassandra-2.1.10'
 CASSANDRA_YAML_TEMPLATE = 'cassandra/cassandra.yaml.j2'
 CASSANDRA_ENV_TEMPLATE = 'cassandra/cassandra-env.sh.j2'
-CASSANDRA_DIR = posixpath.join(vm_util.VM_TMP_DIR, 'cassandra')
+CASSANDRA_DIR = posixpath.join(INSTALL_DIR, 'cassandra')
 CASSANDRA_PID = posixpath.join(CASSANDRA_DIR, 'cassandra.pid')
 CASSANDRA_OUT = posixpath.join(CASSANDRA_DIR, 'cassandra.out')
 CASSANDRA_ERR = posixpath.join(CASSANDRA_DIR, 'cassandra.err')
@@ -73,7 +74,7 @@ def _Install(vm):
   vm.Install('curl')
   vm.RemoteCommand(
       'cd {0}; git clone {1}; cd {2}; git checkout {3}; {4}/bin/ant'.format(
-          vm_util.VM_TMP_DIR,
+          INSTALL_DIR,
           CASSANDRA_GIT_REPRO,
           CASSANDRA_DIR,
           CASSANDRA_VERSION,
@@ -123,7 +124,7 @@ def JujuInstall(vm, vm_group_name):
 
   for unit in vm.units:
     # Make sure the cassandra/conf dir is created, since we're skipping
-    # the manual installation to /tmp/pkb.
+    # the manual installation to /opt/pkb.
     remote_path = posixpath.join(CASSANDRA_DIR, 'conf')
     unit.RemoteCommand('mkdir -p %s' % remote_path)
 

--- a/perfkitbenchmarker/linux_packages/cassandra_stress.py
+++ b/perfkitbenchmarker/linux_packages/cassandra_stress.py
@@ -22,9 +22,9 @@ https://docs.datastax.com/en/cassandra/2.1/cassandra/tools/toolsCStress_t.html
 import posixpath
 
 from perfkitbenchmarker.linux_packages import cassandra
-from perfkitbenchmarker import vm_util
+from perfkitbenchmarker.linux_packages import INSTALL_DIR
 
-CASSANDRA_DIR = posixpath.join(vm_util.VM_TMP_DIR, 'cassandra')
+CASSANDRA_DIR = posixpath.join(INSTALL_DIR, 'cassandra')
 
 
 def YumInstall(vm):
@@ -50,6 +50,6 @@ def JujuInstall(vm, vm_group_name):
 
   for unit in vm.units:
     # Make sure the cassandra/conf dir is created, since we're skipping
-    # the manual installation to /tmp/pkb.
+    # the manual installation to /opt/pkb.
     remote_path = posixpath.join(CASSANDRA_DIR, 'conf')
     unit.RemoteCommand('mkdir -p %s' % remote_path)

--- a/perfkitbenchmarker/linux_packages/collectd.py
+++ b/perfkitbenchmarker/linux_packages/collectd.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Builds collectd from source, installs to VM_TMP_DIR.
+"""Builds collectd from source, installs to INSTALL_DIR.
 
 https://collectd.org/
 
@@ -23,16 +23,16 @@ perfkitbenchmarker/data/build_collectd.sh.j2 for configuration details.
 import posixpath
 
 from perfkitbenchmarker import data
-from perfkitbenchmarker import vm_util
+from perfkitbenchmarker.linux_packages import INSTALL_DIR
 
 # TODO: Make collection interval configurable.
 INTERVAL = 10
 SCRIPT_NAME = 'build_collectd.sh.j2'
 COLLECTD_URL = ('https://github.com/collectd/collectd/archive/'
                 'collectd-5.5.0.tar.gz')
-BUILD_DIR = posixpath.join(vm_util.VM_TMP_DIR, 'collectd-build')
-CSV_DIR = posixpath.join(vm_util.VM_TMP_DIR, 'collectd-csv')
-PREFIX = posixpath.join(vm_util.VM_TMP_DIR, 'collectd')
+BUILD_DIR = posixpath.join(INSTALL_DIR, 'collectd-build')
+CSV_DIR = posixpath.join(INSTALL_DIR, 'collectd-csv')
+PREFIX = posixpath.join(INSTALL_DIR, 'collectd')
 PID_FILE = posixpath.join(PREFIX, 'var', 'run', 'collectd.pid')
 
 
@@ -45,7 +45,7 @@ def _Install(vm):
       'interval': INTERVAL}
 
   remote_path = posixpath.join(
-      vm_util.VM_TMP_DIR,
+      INSTALL_DIR,
       posixpath.splitext(posixpath.basename(SCRIPT_NAME))[0])
   vm.RenderTemplate(data.ResourcePath(SCRIPT_NAME),
                     remote_path, context=context)

--- a/perfkitbenchmarker/linux_packages/docker.py
+++ b/perfkitbenchmarker/linux_packages/docker.py
@@ -20,7 +20,7 @@ of RemoteCommand, since Docker has to be installed directly on the remote VM
 and not within a container running on that VM.
 """
 
-from perfkitbenchmarker import vm_util
+from perfkitbenchmarker.linux_packages import INSTALL_DIR
 
 DOCKER_RPM_URL = ('https://get.docker.com/rpm/1.7.0/centos-6/'
                   'RPMS/x86_64/docker-engine-1.7.0-1.el6.x86_64.rpm')
@@ -74,9 +74,9 @@ def CreateImagePackages():
 def YumInstall(vm):
   """Installs the docker package on the VM."""
   vm.RemoteHostCommand('curl -o %s/docker.rpm -sSL %s'
-                       % (vm_util.VM_TMP_DIR, DOCKER_RPM_URL))
+                       % (INSTALL_DIR, DOCKER_RPM_URL))
   vm.RemoteHostCommand('sudo yum localinstall '
-                       '--nogpgcheck %s/docker.rpm -y' % vm_util.VM_TMP_DIR)
+                       '--nogpgcheck %s/docker.rpm -y' % INSTALL_DIR)
   vm.RemoteHostCommand('sudo service docker start')
 
 

--- a/perfkitbenchmarker/linux_packages/fio.py
+++ b/perfkitbenchmarker/linux_packages/fio.py
@@ -19,9 +19,9 @@ import time
 
 from perfkitbenchmarker import regex_util
 from perfkitbenchmarker import sample
-from perfkitbenchmarker import vm_util
+from perfkitbenchmarker.linux_packages import INSTALL_DIR
 
-FIO_DIR = '%s/fio' % vm_util.VM_TMP_DIR
+FIO_DIR = '%s/fio' % INSTALL_DIR
 GIT_REPO = 'http://git.kernel.dk/fio.git'
 GIT_TAG = 'fio-2.7'
 FIO_PATH = FIO_DIR + '/fio'

--- a/perfkitbenchmarker/linux_packages/hadoop.py
+++ b/perfkitbenchmarker/linux_packages/hadoop.py
@@ -26,6 +26,7 @@ import time
 from perfkitbenchmarker import data
 from perfkitbenchmarker import regex_util
 from perfkitbenchmarker import vm_util
+from perfkitbenchmarker.linux_packages import INSTALL_DIR
 
 HADOOP_VERSION = '2.5.2'
 HADOOP_URL = ('http://www.us.apache.org/dist/hadoop/common/hadoop-{0}/'
@@ -36,7 +37,7 @@ DATA_FILES = ['hadoop/core-site.xml.j2', 'hadoop/yarn-site.xml.j2',
               'hadoop/hadoop-env.sh.j2', 'hadoop/slaves.j2']
 START_HADOOP_SCRIPT = 'hadoop/start-hadoop.sh.j2'
 
-HADOOP_DIR = posixpath.join(vm_util.VM_TMP_DIR, 'hadoop')
+HADOOP_DIR = posixpath.join(INSTALL_DIR, 'hadoop')
 HADOOP_BIN = posixpath.join(HADOOP_DIR, 'bin')
 HADOOP_SBIN = posixpath.join(HADOOP_DIR, 'sbin')
 HADOOP_CONF_DIR = posixpath.join(HADOOP_DIR, 'etc', 'hadoop')

--- a/perfkitbenchmarker/linux_packages/hbase.py
+++ b/perfkitbenchmarker/linux_packages/hbase.py
@@ -26,6 +26,7 @@ import urllib2
 from perfkitbenchmarker import data
 from perfkitbenchmarker import vm_util
 from perfkitbenchmarker.linux_packages import hadoop
+from perfkitbenchmarker.linux_packages import INSTALL_DIR
 
 
 HBASE_URL_BASE = 'http://www.us.apache.org/dist/hbase/stable/'
@@ -34,7 +35,7 @@ HBASE_PATTERN = r'>(hbase-\d+.\d+.\d+-bin.tar.gz)<'
 DATA_FILES = ['hbase/hbase-site.xml.j2', 'hbase/regionservers.j2',
               'hbase/hbase-env.sh.j2']
 
-HBASE_DIR = posixpath.join(vm_util.VM_TMP_DIR, 'hbase')
+HBASE_DIR = posixpath.join(INSTALL_DIR, 'hbase')
 HBASE_BIN = posixpath.join(HBASE_DIR, 'bin')
 HBASE_CONF_DIR = posixpath.join(HBASE_DIR, 'conf')
 

--- a/perfkitbenchmarker/linux_packages/hpcc.py
+++ b/perfkitbenchmarker/linux_packages/hpcc.py
@@ -22,12 +22,12 @@ http://icl.cs.utk.edu/hpcc/
 
 import re
 
-from perfkitbenchmarker import vm_util
 from perfkitbenchmarker.linux_packages import openblas
+from perfkitbenchmarker.linux_packages import INSTALL_DIR
 
 HPCC_TAR = 'hpcc-1.4.3.tar.gz'
 HPCC_URL = 'http://icl.cs.utk.edu/projectsfiles/hpcc/download/' + HPCC_TAR
-HPCC_DIR = '%s/hpcc-1.4.3' % vm_util.VM_TMP_DIR
+HPCC_DIR = '%s/hpcc-1.4.3' % INSTALL_DIR
 MAKE_FLAVOR = 'Linux_PII_CBLAS'
 HPCC_MAKEFILE = 'Make.' + MAKE_FLAVOR
 HPCC_MAKEFILE_PATH = HPCC_DIR + '/hpl/' + HPCC_MAKEFILE
@@ -38,8 +38,8 @@ def _Install(vm):
   vm.Install('wget')
   vm.Install('openmpi')
   vm.Install('openblas')
-  vm.RemoteCommand('wget %s -P %s' % (HPCC_URL, vm_util.VM_TMP_DIR))
-  vm.RemoteCommand('cd %s && tar xvfz %s' % (vm_util.VM_TMP_DIR, HPCC_TAR))
+  vm.RemoteCommand('wget %s -P %s' % (HPCC_URL, INSTALL_DIR))
+  vm.RemoteCommand('cd %s && tar xvfz %s' % (INSTALL_DIR, HPCC_TAR))
   vm.RemoteCommand(
       'cp %s/hpl/setup/%s %s' % (HPCC_DIR, HPCC_MAKEFILE, HPCC_MAKEFILE_PATH))
   sed_cmd = (

--- a/perfkitbenchmarker/linux_packages/memtier.py
+++ b/perfkitbenchmarker/linux_packages/memtier.py
@@ -15,14 +15,14 @@
 
 """Module containing memtier installation and cleanup functions."""
 
-from perfkitbenchmarker import vm_util
+from perfkitbenchmarker.linux_packages import INSTALL_DIR
 
 GIT_REPO = 'https://github.com/RedisLabs/memtier_benchmark'
 GIT_TAG = '1.2.0'
 LIBEVENT_TAR = 'libevent-2.0.21-stable.tar.gz'
 LIBEVENT_URL = 'https://github.com/downloads/libevent/libevent/' + LIBEVENT_TAR
-LIBEVENT_DIR = '%s/libevent-2.0.21-stable' % vm_util.VM_TMP_DIR
-MEMTIER_DIR = '%s/memtier_benchmark' % vm_util.VM_TMP_DIR
+LIBEVENT_DIR = '%s/libevent-2.0.21-stable' % INSTALL_DIR
+MEMTIER_DIR = '%s/memtier_benchmark' % INSTALL_DIR
 APT_PACKAGES = ('autoconf automake libpcre3-dev '
                 'libevent-dev pkg-config zlib1g-dev')
 YUM_PACKAGES = 'zlib-devel pcre-devel libmemcached-devel'
@@ -33,8 +33,8 @@ def YumInstall(vm):
   vm.Install('build_tools')
   vm.InstallPackages(YUM_PACKAGES)
   vm.Install('wget')
-  vm.RemoteCommand('wget {0} -P {1}'.format(LIBEVENT_URL, vm_util.VM_TMP_DIR))
-  vm.RemoteCommand('cd {0} && tar xvzf {1}'.format(vm_util.VM_TMP_DIR,
+  vm.RemoteCommand('wget {0} -P {1}'.format(LIBEVENT_URL, INSTALL_DIR))
+  vm.RemoteCommand('cd {0} && tar xvzf {1}'.format(INSTALL_DIR,
                                                    LIBEVENT_TAR))
   vm.RemoteCommand('cd {0} && ./configure && sudo make install'.format(
       LIBEVENT_DIR))

--- a/perfkitbenchmarker/linux_packages/netperf.py
+++ b/perfkitbenchmarker/linux_packages/netperf.py
@@ -19,7 +19,7 @@ import re
 
 from perfkitbenchmarker import flags
 from perfkitbenchmarker import regex_util
-from perfkitbenchmarker import vm_util
+from perfkitbenchmarker.linux_packages import INSTALL_DIR
 
 flags.DEFINE_integer(
     'netperf_histogram_buckets', 100,
@@ -32,7 +32,7 @@ flags.DEFINE_integer(
 FLAGS = flags.FLAGS
 NETPERF_TAR = 'netperf-2.6.0.tar.gz'
 NETPERF_URL = 'ftp://ftp.netperf.org/netperf/archive/%s' % NETPERF_TAR
-NETPERF_DIR = '%s/netperf-2.6.0' % vm_util.VM_TMP_DIR
+NETPERF_DIR = '%s/netperf-2.6.0' % INSTALL_DIR
 NETPERF_SRC_DIR = NETPERF_DIR + '/src'
 NETSERVER_PATH = NETPERF_SRC_DIR + '/netserver'
 NETPERF_PATH = NETPERF_SRC_DIR + '/netperf'
@@ -44,8 +44,8 @@ def _Install(vm):
   vm.Install('build_tools')
   vm.Install('curl')
   vm.RemoteCommand('curl %s -o %s/%s' % (
-      NETPERF_URL, vm_util.VM_TMP_DIR, NETPERF_TAR))
-  vm.RemoteCommand('cd %s && tar xvzf %s' % (vm_util.VM_TMP_DIR, NETPERF_TAR))
+      NETPERF_URL, INSTALL_DIR, NETPERF_TAR))
+  vm.RemoteCommand('cd %s && tar xvzf %s' % (INSTALL_DIR, NETPERF_TAR))
   # Modify netperf to print out all buckets in its histogram rather than
   # aggregating.
   vm.PushDataFile('netperf.patch', NETLIB_PATCH)

--- a/perfkitbenchmarker/linux_packages/node_js.py
+++ b/perfkitbenchmarker/linux_packages/node_js.py
@@ -15,11 +15,11 @@
 
 """Module containing node.js installation and cleanup functions."""
 
-from perfkitbenchmarker import vm_util
+from perfkitbenchmarker.linux_packages import INSTALL_DIR
 
 GIT_REPO = 'https://github.com/joyent/node.git'
 GIT_TAG = 'v0.11.14'
-NODE_DIR = '%s/node' % vm_util.VM_TMP_DIR
+NODE_DIR = '%s/node' % INSTALL_DIR
 
 
 def _Install(vm):

--- a/perfkitbenchmarker/linux_packages/openblas.py
+++ b/perfkitbenchmarker/linux_packages/openblas.py
@@ -14,9 +14,9 @@
 
 """Module containing OpenBLAS installation and cleanup functions."""
 
-from perfkitbenchmarker import vm_util
+from perfkitbenchmarker.linux_packages import INSTALL_DIR
 
-OPENBLAS_DIR = '%s/OpenBLAS' % vm_util.VM_TMP_DIR
+OPENBLAS_DIR = '%s/OpenBLAS' % INSTALL_DIR
 GIT_REPO = 'https://github.com/xianyi/OpenBLAS'
 GIT_TAG = 'v0.2.15'
 

--- a/perfkitbenchmarker/linux_packages/openmpi.py
+++ b/perfkitbenchmarker/linux_packages/openmpi.py
@@ -15,9 +15,9 @@
 
 """Module containing OpenMPI installation and cleanup functions."""
 
-from perfkitbenchmarker import vm_util
+from perfkitbenchmarker.linux_packages import INSTALL_DIR
 
-MPI_DIR = '%s/openmpi-1.6.5' % vm_util.VM_TMP_DIR
+MPI_DIR = '%s/openmpi-1.6.5' % INSTALL_DIR
 MPI_TAR = 'openmpi-1.6.5.tar.gz'
 MPI_URL = 'http://www.open-mpi.org/software/ompi/v1.6/downloads/' + MPI_TAR
 
@@ -26,8 +26,8 @@ def _Install(vm):
   """Installs the OpenMPI package on the VM."""
   vm.Install('build_tools')
   vm.Install('wget')
-  vm.RemoteCommand('wget %s -P %s' % (MPI_URL, vm_util.VM_TMP_DIR))
-  vm.RemoteCommand('cd %s && tar xvfz %s' % (vm_util.VM_TMP_DIR, MPI_TAR))
+  vm.RemoteCommand('wget %s -P %s' % (MPI_URL, INSTALL_DIR))
+  vm.RemoteCommand('cd %s && tar xvfz %s' % (INSTALL_DIR, MPI_TAR))
   make_jobs = vm.num_cpus
   config_cmd = ('./configure --enable-static --disable-shared --disable-dlopen '
                 '--prefix=/usr')

--- a/perfkitbenchmarker/linux_packages/pip.py
+++ b/perfkitbenchmarker/linux_packages/pip.py
@@ -19,7 +19,7 @@ Uninstalling the pip package will also remove all python packages
 added after installation.
 """
 
-from perfkitbenchmarker import vm_util
+from perfkitbenchmarker.linux_packages import INSTALL_DIR
 
 
 def _Install(vm):
@@ -27,7 +27,7 @@ def _Install(vm):
   vm.InstallPackages('python-pip')
   vm.RemoteCommand('sudo pip install -U pip')  # Make pip upgrade pip
   vm.RemoteCommand('mkdir -p {0} && pip freeze > {0}/requirements.txt'.format(
-      vm_util.VM_TMP_DIR))
+      INSTALL_DIR))
 
 
 def YumInstall(vm):
@@ -46,7 +46,7 @@ def _Uninstall(vm):
   vm.RemoteCommand('pip freeze | grep --fixed-strings --line-regexp '
                    '--invert-match --file {0}/requirements.txt | '
                    'xargs --no-run-if-empty sudo pip uninstall -y'.format(
-                       vm_util.VM_TMP_DIR))
+                       INSTALL_DIR))
 
 
 def YumUninstall(vm):

--- a/perfkitbenchmarker/linux_packages/redis_server.py
+++ b/perfkitbenchmarker/linux_packages/redis_server.py
@@ -16,7 +16,7 @@
 """Module containing redis installation and cleanup functions."""
 
 from perfkitbenchmarker import flags
-from perfkitbenchmarker import vm_util
+from perfkitbenchmarker.linux_packages import INSTALL_DIR
 
 
 flags.DEFINE_integer('redis_total_num_processes', 1,
@@ -26,7 +26,7 @@ flags.DEFINE_integer('redis_total_num_processes', 1,
 
 REDIS_VERSION = '2.8.9'
 REDIS_TAR = 'redis-%s.tar.gz' % REDIS_VERSION
-REDIS_DIR = '%s/redis-%s' % (vm_util.VM_TMP_DIR, REDIS_VERSION)
+REDIS_DIR = '%s/redis-%s' % (INSTALL_DIR, REDIS_VERSION)
 REDIS_URL = 'http://download.redis.io/releases/' + REDIS_TAR
 REDIS_FIRST_PORT = 6379
 REDIS_PID_FILE = 'redis.pid'
@@ -37,8 +37,8 @@ def _Install(vm):
   """Installs the redis package on the VM."""
   vm.Install('build_tools')
   vm.Install('wget')
-  vm.RemoteCommand('wget %s -P %s' % (REDIS_URL, vm_util.VM_TMP_DIR))
-  vm.RemoteCommand('cd %s && tar xvfz %s' % (vm_util.VM_TMP_DIR, REDIS_TAR))
+  vm.RemoteCommand('wget %s -P %s' % (REDIS_URL, INSTALL_DIR))
+  vm.RemoteCommand('cd %s && tar xvfz %s' % (INSTALL_DIR, REDIS_TAR))
   vm.RemoteCommand('cd %s && make' % REDIS_DIR)
 
 

--- a/perfkitbenchmarker/linux_packages/scimark2.py
+++ b/perfkitbenchmarker/linux_packages/scimark2.py
@@ -1,0 +1,59 @@
+# Copyright 2016 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Module containing scimark2 installation and cleanup functions."""
+from perfkitbenchmarker import vm_util
+
+
+# Use this directory for all data stored in the VM for this test.
+PATH = '{0}/scimark2'.format(vm_util.VM_TMP_DIR)
+
+# Download location for both the C and Java tests.
+BASE_URL = 'http://math.nist.gov/scimark2'
+
+# Java-specific constants.
+JAVA_JAR = 'scimark2lib.jar'
+JAVA_MAIN = 'jnt.scimark2.commandline'
+
+# C-specific constants.
+C_ZIP = 'scimark2_1c.zip'
+C_SRC = '{0}/src'.format(PATH)
+# SciMark2 does not set optimization flags, it leaves this to the
+# discretion of the tester. The following gets good performance and
+# has been used for LLVM and GCC regression testing, see for example
+# https://llvm.org/bugs/show_bug.cgi?id=22589 .
+C_CFLAGS = '-O3 -march=native'
+
+
+def Install(vm):
+  """Installs scimark2 on the vm."""
+  vm.Install('build_tools')
+  vm.Install('wget')
+  vm.Install('openjdk')
+  vm.Install('unzip')
+  cmds = [
+      'rm -rf {0} && mkdir {0}'.format(PATH),
+      'wget {0}/{1} -O {2}/{1}'.format(BASE_URL, JAVA_JAR, PATH),
+      'wget {0}/{1} -O {2}/{1}'.format(BASE_URL, C_ZIP, PATH),
+      '(mkdir {0} && cd {0} && unzip {1}/{2})'.format(C_SRC, PATH, C_ZIP),
+      '(cd {0} && make CFLAGS="{1}")'.format(C_SRC, C_CFLAGS),
+  ]
+  for cmd in cmds:
+    vm.RemoteCommand(cmd, should_log=True)
+
+
+def Uninstall(vm):
+  """Uninstalls scimark2 from the vm."""
+  vm.RemoteCommand('rm -rf {0}'.format(PATH))

--- a/perfkitbenchmarker/linux_packages/scimark2.py
+++ b/perfkitbenchmarker/linux_packages/scimark2.py
@@ -14,11 +14,11 @@
 
 
 """Module containing scimark2 installation and cleanup functions."""
-from perfkitbenchmarker import vm_util
+from perfkitbenchmarker.linux_packages import INSTALL_DIR
 
 
 # Use this directory for all data stored in the VM for this test.
-PATH = '{0}/scimark2'.format(vm_util.VM_TMP_DIR)
+PATH = '{0}/scimark2'.format(INSTALL_DIR)
 
 # Download location for both the C and Java tests.
 BASE_URL = 'http://math.nist.gov/scimark2'

--- a/perfkitbenchmarker/linux_packages/silo.py
+++ b/perfkitbenchmarker/linux_packages/silo.py
@@ -15,11 +15,11 @@
 
 """Module containing Silo installation and cleanup functions."""
 
-from perfkitbenchmarker import vm_util
+from perfkitbenchmarker.linux_packages import INSTALL_DIR
 
 GIT_REPO = 'https://github.com/stephentu/silo.git'
 GIT_TAG = '62d2d498984bf69d3b46a74e310e1fd12fd1f692'
-SILO_DIR = '%s/silo' % vm_util.VM_TMP_DIR
+SILO_DIR = '%s/silo' % INSTALL_DIR
 APT_PACKAGES = ('libjemalloc-dev libnuma-dev libdb++-dev '
                 'libmysqld-dev libaio-dev libssl-dev')
 YUM_PACKAGES = ('jemalloc-devel numactl-devel libdb-cxx-devel mysql-devel '

--- a/perfkitbenchmarker/linux_packages/sysbench05plus.py
+++ b/perfkitbenchmarker/linux_packages/sysbench05plus.py
@@ -21,7 +21,7 @@ install 0.5 or later for them. Therefore, it's necessary that we have a
 separate installer here for 0.5 and later.
 """
 from perfkitbenchmarker import os_types
-from perfkitbenchmarker import vm_util
+from perfkitbenchmarker.linux_packages import INSTALL_DIR
 
 
 def PathPrefix(vm):
@@ -34,7 +34,7 @@ def PathPrefix(vm):
     A string representing the sysbench command prefix.
   """
   if vm.OS_TYPE == os_types.RHEL:
-    return vm_util.VM_TMP_DIR
+    return INSTALL_DIR
   else:
     return '/usr/'
 
@@ -47,14 +47,14 @@ def YumInstall(vm):
   vm.RemoteCommand('cd ~ && bzr branch lp:sysbench')
   vm.RemoteCommand(('cd ~/sysbench && ./autogen.sh &&'
                     ' ./configure --prefix=%s --mandir=%s/share/man &&'
-                    ' make') % (vm_util.VM_TMP_DIR, vm_util.VM_TMP_DIR))
+                    ' make') % (INSTALL_DIR, INSTALL_DIR))
   vm.RemoteCommand('cd ~/sysbench && sudo make install')
   vm.RemoteCommand('sudo mkdir %s/share/doc/sysbench/tests/db -p' %
-                   vm_util.VM_TMP_DIR)
+                   INSTALL_DIR)
   vm.RemoteCommand('sudo cp ~/sysbench/sysbench/tests/db/*'
-                   ' %s/share/doc/sysbench/tests/db/' % vm_util.VM_TMP_DIR)
+                   ' %s/share/doc/sysbench/tests/db/' % INSTALL_DIR)
   vm.RemoteCommand('echo "export PATH=$PATH:%s/bin" >> ~/.bashrc && '
-                   'source ~/.bashrc' % vm_util.VM_TMP_DIR)
+                   'source ~/.bashrc' % INSTALL_DIR)
 
   # Cleanup the source code enlisthment from bzr, we don't need it anymore.
   vm.RemoteCommand('cd ~ && rm -fr ./sysbench')

--- a/perfkitbenchmarker/linux_packages/sysbench05plus.py
+++ b/perfkitbenchmarker/linux_packages/sysbench05plus.py
@@ -20,7 +20,23 @@ oltp benchmarks depending on older version of sysbench will break if we
 install 0.5 or later for them. Therefore, it's necessary that we have a
 separate installer here for 0.5 and later.
 """
+from perfkitbenchmarker import os_types
 from perfkitbenchmarker import vm_util
+
+
+def PathPrefix(vm):
+  """Determines the prefix for a sysbench command based on the operating system.
+
+  Args:
+    vm: VM  on which the sysbench command will be executed.
+
+  Returns:
+    A string representing the sysbench command prefix.
+  """
+  if vm.OS_TYPE == os_types.RHEL:
+    return vm_util.VM_TMP_DIR
+  else:
+    return '/usr/'
 
 
 def YumInstall(vm):

--- a/perfkitbenchmarker/linux_packages/tomcat.py
+++ b/perfkitbenchmarker/linux_packages/tomcat.py
@@ -24,12 +24,12 @@ https://tomcat.apache.org/
 """
 import posixpath
 from perfkitbenchmarker import flags
-from perfkitbenchmarker import vm_util
+from perfkitbenchmarker.linux_packages import INSTALL_DIR
 
 
 TOMCAT_URL = ('https://archive.apache.org/dist/tomcat/tomcat-8/v8.0.28/bin/'
               'apache-tomcat-8.0.28.tar.gz')
-TOMCAT_DIR = posixpath.join(vm_util.VM_TMP_DIR, 'tomcat')
+TOMCAT_DIR = posixpath.join(INSTALL_DIR, 'tomcat')
 TOMCAT_HTTP_PORT = 8080
 
 flags.DEFINE_string('tomcat_url', TOMCAT_URL, 'Tomcat 8 download URL.')

--- a/perfkitbenchmarker/linux_packages/unixbench.py
+++ b/perfkitbenchmarker/linux_packages/unixbench.py
@@ -15,20 +15,20 @@
 
 """Module containing UnixBench installation and cleanup functions."""
 
-from perfkitbenchmarker import vm_util
+from perfkitbenchmarker.linux_packages import INSTALL_DIR
 
 UNIXBENCH_TAR = 'v5.1.3.tar.gz'
 UNIXBENCH_URL = ('https://github.com/kdlucas/byte-unixbench/archive/'
                  + UNIXBENCH_TAR)
-UNIXBENCH_DIR = '%s/byte-unixbench-5.1.3/UnixBench' % vm_util.VM_TMP_DIR
+UNIXBENCH_DIR = '%s/byte-unixbench-5.1.3/UnixBench' % INSTALL_DIR
 
 
 def _Install(vm):
   """Installs the UnixBench package on the VM."""
   vm.Install('build_tools')
   vm.Install('wget')
-  vm.RemoteCommand('wget {0} -P {1}'.format(UNIXBENCH_URL, vm_util.VM_TMP_DIR))
-  vm.RemoteCommand('cd {0} && tar xvzf {1}'.format(vm_util.VM_TMP_DIR,
+  vm.RemoteCommand('wget {0} -P {1}'.format(UNIXBENCH_URL, INSTALL_DIR))
+  vm.RemoteCommand('cd {0} && tar xvzf {1}'.format(INSTALL_DIR,
                                                    UNIXBENCH_TAR))
 
 

--- a/perfkitbenchmarker/linux_packages/wrk.py
+++ b/perfkitbenchmarker/linux_packages/wrk.py
@@ -24,11 +24,11 @@ import io
 import posixpath
 
 from perfkitbenchmarker import sample
-from perfkitbenchmarker import vm_util
+from perfkitbenchmarker.linux_packages import INSTALL_DIR
 
 
 WRK_URL = 'https://github.com/wg/wrk/archive/4.0.1.tar.gz'
-WRK_DIR = posixpath.join(vm_util.VM_TMP_DIR, 'wrk')
+WRK_DIR = posixpath.join(INSTALL_DIR, 'wrk')
 WRK_PATH = posixpath.join(WRK_DIR, 'wrk')
 
 # Rather than parse WRK's free text output, this script is used to generate a

--- a/perfkitbenchmarker/linux_packages/ycsb.py
+++ b/perfkitbenchmarker/linux_packages/ycsb.py
@@ -54,13 +54,14 @@ from perfkitbenchmarker import events
 from perfkitbenchmarker import flags
 from perfkitbenchmarker import sample
 from perfkitbenchmarker import vm_util
+from perfkitbenchmarker.linux_packages import INSTALL_DIR
 
 FLAGS = flags.FLAGS
 
 YCSB_VERSION = '0.9.0'
 YCSB_TAR_URL = ('https://github.com/brianfrankcooper/YCSB/releases/'
                 'download/{0}/ycsb-{0}.tar.gz').format(YCSB_VERSION)
-YCSB_DIR = posixpath.join(vm_util.VM_TMP_DIR, 'ycsb')
+YCSB_DIR = posixpath.join(INSTALL_DIR, 'ycsb')
 YCSB_EXE = posixpath.join(YCSB_DIR, 'bin', 'ycsb')
 
 _DEFAULT_PERCENTILES = 50, 75, 90, 95, 99, 99.9
@@ -587,7 +588,7 @@ class YCSBExecutor(object):
     """
     results = []
 
-    remote_path = posixpath.join(vm_util.VM_TMP_DIR,
+    remote_path = posixpath.join(INSTALL_DIR,
                                  os.path.basename(workload_file))
     kwargs.setdefault('threads', self._default_preload_threads)
     kwargs.setdefault('recordcount', FLAGS.ycsb_record_count)
@@ -722,7 +723,7 @@ class YCSBExecutor(object):
       if FLAGS.ycsb_timelimit:
         parameters['maxexecutiontime'] = FLAGS.ycsb_timelimit
       parameters.update(kwargs)
-      remote_path = posixpath.join(vm_util.VM_TMP_DIR,
+      remote_path = posixpath.join(INSTALL_DIR,
                                    os.path.basename(workload_file))
 
       with open(workload_file) as fp:


### PR DESCRIPTION
Rather than installing stuff in /tmp/pkb, which gets wiped out on
reboot, use /opt/pkb. Keeping packages around after a reboot is
essential for re-using the perfkitbenchmarker.linux_packages.* code
for image preparation.