### PR TITLE
Added fully sequential object naming scheme to object_storage_service benchmark

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/object_storage_service_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/object_storage_service_benchmark.py
@@ -112,14 +112,17 @@ flags.DEFINE_integer('object_storage_list_consistency_iterations', 200,
                      'should be used (>=200).')
 flags.DEFINE_enum('object_storage_object_naming_scheme', 'sequential_by_stream',
                   ['sequential_by_stream',
-                   'approximately_sequential'],
+                   'approximately_sequential',
+                   'sequential'],
                   'How objects will be named. Only applies to the '
                   'api_multistream benchmark. '
                   'sequential_by_stream: object names from each stream '
                   'will be sequential, but different streams will have '
                   'different name prefixes. '
                   'approximately_sequential: object names from all '
-                  'streams will roughly increase together.')
+                  'streams will roughly increase together.'
+                  'sequential: object names will be completely sequential in '
+                  'time')
 
 
 FLAGS = flags.FLAGS

--- a/perfkitbenchmarker/scripts/object_storage_api_test_scripts/object_storage_api_tests.py
+++ b/perfkitbenchmarker/scripts/object_storage_api_test_scripts/object_storage_api_tests.py
@@ -303,6 +303,7 @@ class AtomicCounter:
       self.value += 1
     return self.value
 
+
 class PrefixSharedCounterIterator(ObjectNameIterator):
   def __init__(self, prefix):
     self.prefix = prefix
@@ -310,6 +311,7 @@ class PrefixSharedCounterIterator(ObjectNameIterator):
 
   def next(self):
     return '%s_%d' % (self.prefix, self.counter.increment())
+
 
 class PrefixCounterIterator(ObjectNameIterator):
   def __init__(self, prefix):


### PR DESCRIPTION
Use an atomic counter shared by all the object writer threads.