### PR TITLE
perfkitbenchmarker: Add vm_util

### DIFF
--- a/perfkitbenchmarker/linux_packages/aerospike_server.py
+++ b/perfkitbenchmarker/linux_packages/aerospike_server.py
@@ -20,6 +20,7 @@ import logging
 from perfkitbenchmarker import data
 from perfkitbenchmarker import errors
 from perfkitbenchmarker import flags
+from perfkitbenchmarker import vm_util
 from perfkitbenchmarker.linux_packages import INSTALL_DIR
 
 FLAGS = flags.FLAGS


### PR DESCRIPTION
Issue #1195 describes an error due to undefined vm_util object.
This commit re-adds 'vm_util' object and fixes the broken master branch.