### PR TITLE
Enbale OpenStack Cinder Volume Type Option

### DIFF
--- a/perfkitbenchmarker/providers/openstack/flags.py
+++ b/perfkitbenchmarker/providers/openstack/flags.py
@@ -64,6 +64,10 @@ flags.DEFINE_boolean('openstack_boot_from_volume', False,
 flags.DEFINE_integer('openstack_volume_size', None,
                      'Size of the volume (GB)')
 
+flags.DEFINE_string('openstack_volume_type',
+                    default=None,
+                    help='Optional Cinder volume type to use.')
+
 flags.DEFINE_string('openstack_image_username', 'ubuntu',
                     'Ssh username for cloud image')
 

--- a/perfkitbenchmarker/providers/openstack/os_disk.py
+++ b/perfkitbenchmarker/providers/openstack/os_disk.py
@@ -32,6 +32,8 @@ def CreateVolume(resource, name):
   vol_cmd.flags['availability-zone'] = resource.zone
   vol_cmd.flags['size'] = (FLAGS.openstack_volume_size or
                            REMOTE_VOLUME_DEFAULT_SIZE_GB)
+  if FLAGS.openstack_volume_type:
+      vol_cmd.flags['type'] = FLAGS.openstack_volume_type
   stdout, _, _ = vol_cmd.Issue()
   vol_resp = json.loads(stdout)
   return vol_resp


### PR DESCRIPTION
This small change enables the user to include a Cinder volume type when
running benchmarks such as FIO. This is useful for users of cloud
providers who offer multiple volume types.