### PR TITLE
Add the minimum tox version to the *tox is not installed* message

### DIFF
--- a/hooks/lib/check-lint.sh
+++ b/hooks/lib/check-lint.sh
@@ -17,7 +17,7 @@
 set -euo pipefail
 
 if [[ -z "$(command -v tox)" ]]; then
-  >&2 echo "Missing tox. Install it via 'pip' to enable linting."
+  >&2 echo "Missing tox >= 2.0.0. Install it via 'pip' to enable linting."
   exit 1
 fi
 

--- a/hooks/lib/check-unittest.sh
+++ b/hooks/lib/check-unittest.sh
@@ -17,7 +17,7 @@
 set -euo pipefail
 
 if [[ -z $(command -v tox) ]]; then
-  >&2 echo "Missing tox. Install it via 'pip' to enable unit testing."
+  >&2 echo "Missing tox >= 2.0.0. Install it via 'pip' to enable unit testing."
   exit 1
 fi
 


### PR DESCRIPTION
Tox less than version 2.0 does not work with PKB. A message was added to clarify this point when the user is informed that he/she does not have tox installed.