### PR TITLE
openstack: Deprecate flag

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,42 @@
+# 1.9.0
+
+New features:
+- Add config file imports and allow for circular imports and add documentation (GH-1163)
+- Add a way to run benchmarks in parallel (GH-1192)
+
+Enhancements:
+- ContainerizedDebianMixin: Ping to a fixed docker image and remove the sudo hack (GH-1171)
+- Auto detect  openjdk, libsnappy package versions (GH-1181)
+- Add flags to govern subnet creation and Optionally create only 1 subnet (GH-1182)
+- Install docker images as packages (GH-1184)
+- Call FLAGS.get_help if it's available (GH-1187)
+- Publish boot time samples for all tests (GH-1156)
+
+Bugfixes and maintenance updates:
+- Update requirements.txt to set version of contextlib2 (GH-1164)
+- Fix bug with config flags (GH-1165)
+- Updated the cloudsuite web-serving benchmark (thanks @nooshin-mirzadeh, GH-1166)
+- Fix load command parsing (GH-1168)
+- openstack: Open all TCP and UDP ports for the internal network (GH-1169)
+- Fix aerospike metadata (GH-1170)
+- Adjust aerospike default replication factor (GH-1172)
+- Try replacing FlagValues._flags instead of FlagValues.FlagDict first (GH-1175)
+- Fix ycsb aggregator (GH-1176)
+- Fix bug during cleanup phase of object_storage_service benchmark (GH-1178)
+- Netperf thinktime fixes and support think time in nanoseconds instead of microseconds (GH-1179, GH-1186, GH-1188)
+- Fix sysbench05plus installation on ubuntu16.04 (GH-1183)
+- Fix race condition in Aerospike benchmark (GH-1190)
+- Clean up some pickling, unpickling issues (GH-1191)
+- Calculate free ram with more robust /proc/meminfo instead of `free`(GH-1194)
+- Fix multithread netperf (GH-1149)
+- Multiple fixes and refactoring of the linux package management on vms (GH-1152)
+- Fix dstat metadata in Analyze (GH-1154)
+- Obey flag overrides for static vm specs (GH-1155)
+- Fix links in README file for OpenStack and Cloudstack setup steps (thanks @shakhat, GH-1157)
+- Fix issue with GetConfig using flags (GH-1160)
+- Remove scratch disk from netperf and object_storage_service benchmark (GH-1147, GH-1148)
+- Netperf changes to add num_streams metadata to samples (GH-1177)
+
 # 1.8.1
 
 Bugfixes and maintanence updates:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ GitHub has [a great tutorial](https://help.github.com/articles/fork-a-repo/) (we
 
 - Clone the repository:
 ```
-$ git clone git@github.com:<your-user-name>/PerfKitBenchmarker.git -b dev && cd PerfKitBenchmarker
+$ git clone git@github.com:<your-user-name>/PerfKitBenchmarker.git && cd PerfKitBenchmarker
 ```
 - Install Python 2.7.
 - Install [pip](https://pypi.python.org/pypi/pip):

--- a/perfkitbenchmarker/pkb.py
+++ b/perfkitbenchmarker/pkb.py
@@ -536,7 +536,7 @@ def RunBenchmarkTask(spec):
   # benchmarks in parallel, this causes name collisions on resources.
   # By modifying the run_uri, we avoid the collisions.
   if FLAGS.run_processes > 1:
-    FLAGS.run_uri = FLAGS.run_uri + str(spec.sequence_number)
+    spec.config.flags['run_uri'] = FLAGS.run_uri + str(spec.sequence_number)
 
   collector = SampleCollector()
   try:

--- a/perfkitbenchmarker/providers/openstack/flags.py
+++ b/perfkitbenchmarker/providers/openstack/flags.py
@@ -62,7 +62,8 @@ flags.DEFINE_boolean('openstack_boot_from_volume', False,
                      'Boot from volume instead of an image')
 
 flags.DEFINE_integer('openstack_volume_size', None,
-                     'Size of the volume (GB)')
+                     '(DEPRECATED: Use data_disk_size) '
+                     'Size of the volume (GB).')
 
 flags.DEFINE_string('openstack_image_username', 'ubuntu',
                     'Ssh username for cloud image')

--- a/perfkitbenchmarker/providers/openstack/os_disk.py
+++ b/perfkitbenchmarker/providers/openstack/os_disk.py
@@ -113,8 +113,8 @@ class OpenStackDiskSpec(disk.BaseDiskSpec):
           provided config values.
     """
     super(OpenStackDiskSpec, cls)._ApplyFlags(config_values, flag_values)
-    if flag_values['openstack_volume_size'].present \
-            and not flag_values['data_disk_size'].present:
+    if (flag_values['openstack_volume_size'].present
+        and not flag_values['data_disk_size'].present):
       config_values['disk_size'] = flag_values.openstack_volume_size
     else:
       config_values['disk_size'] = flag_values.data_disk_size

--- a/perfkitbenchmarker/providers/openstack/os_disk.py
+++ b/perfkitbenchmarker/providers/openstack/os_disk.py
@@ -115,7 +115,7 @@ class OpenStackDiskSpec(disk.BaseDiskSpec):
     super(OpenStackDiskSpec, cls)._ApplyFlags(config_values, flag_values)
     if (flag_values['openstack_volume_size'].present
         and not flag_values['data_disk_size'].present):
-      config_values['disk_size'] = flag_values.openstack_volume_size
+     config_values['disk_size'] = flag_values.openstack_volume_size
     else:
       config_values['disk_size'] = flag_values.data_disk_size
 


### PR DESCRIPTION
This PR addresses #1122.  The flag 'openstack_volume_size' has been deprecated and the expected flag to pass is now 'data_disk_size'.  The following changes were made:

* Added a deprecated flag message to inform user
* Added abstract class that overrides BaseDiskSpec class from disk.py
* Added check for 'openstack_volume_size' in _ApplyFlags() method of BaseDiskSpec class