### PR TITLE
Changed the documentation to reflect that work should be on master.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ GitHub has [a great tutorial](https://help.github.com/articles/fork-a-repo/) (we
 
 - Clone the repository:
 ```
-$ git clone git@github.com:<your-user-name>/PerfKitBenchmarker.git -b dev && cd PerfKitBenchmarker
+$ git clone git@github.com:<your-user-name>/PerfKitBenchmarker.git && cd PerfKitBenchmarker
 ```
 - Install Python 2.7.
 - Install [pip](https://pypi.python.org/pypi/pip):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ GitHub has [a great tutorial](https://help.github.com/articles/fork-a-repo/) (we
 
 - Clone the repository:
 ```
-$ git clone git@github.com:<your-user-name>/PerfKitBenchmarker.git master && cd PerfKitBenchmarker
+$ git clone git@github.com:<your-user-name>/PerfKitBenchmarker.git -b master && cd PerfKitBenchmarker
 ```
 - Install Python 2.7.
 - Install [pip](https://pypi.python.org/pypi/pip):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ GitHub has [a great tutorial](https://help.github.com/articles/fork-a-repo/) (we
 
 - Clone the repository:
 ```
-$ git clone git@github.com:<your-user-name>/PerfKitBenchmarker.git && cd PerfKitBenchmarker
+$ git clone git@github.com:<your-user-name>/PerfKitBenchmarker.git master && cd PerfKitBenchmarker
 ```
 - Install Python 2.7.
 - Install [pip](https://pypi.python.org/pypi/pip):


### PR DESCRIPTION
The dev branch is not as up to date as the master branch, so I made the change to remove the dev branch identifier in the instructions on how to clone the repo. Now, the contributor will know to download and work off of the master branch.