### PR TITLE
Fix bug with run_processes

### DIFF
--- a/perfkitbenchmarker/pkb.py
+++ b/perfkitbenchmarker/pkb.py
@@ -536,7 +536,7 @@ def RunBenchmarkTask(spec):
   # benchmarks in parallel, this causes name collisions on resources.
   # By modifying the run_uri, we avoid the collisions.
   if FLAGS.run_processes > 1:
-    FLAGS.run_uri = FLAGS.run_uri + str(spec.sequence_number)
+    spec.config.flags['run_uri'] = FLAGS.run_uri + str(spec.sequence_number)
 
   collector = SampleCollector()
   try:


### PR DESCRIPTION
Because RunParallelProcesses uses a process pool, processes get reused and when they do, the run_uri reflects the modification from previous runs in the same process. This fixes that by only modifying the run_uri flag in the config because config flag redirection always gets undone.