### PR TITLE
Add version option to spark_service.

### DIFF
--- a/perfkitbenchmarker/configs/benchmark_config_spec.py
+++ b/perfkitbenchmarker/configs/benchmark_config_spec.py
@@ -203,6 +203,9 @@ class _SparkServiceSpec(spec.BaseSpec):
             'default': spark_service.PROVIDER_MANAGED,
             'valid_values': [spark_service.PROVIDER_MANAGED,
                              spark_service.PKB_MANAGED]}),
+        'version': (option_decoders.EnumDecoder, {
+            'default': spark_service.SPARK_1_6_2,
+            'valid_values': spark_service.SPARK_VERSIONS}),
         'worker_group': (_VmGroupSpecDecoder, {}),
         'master_group': (_VmGroupSpecDecoder,
                          {'default': None,

--- a/perfkitbenchmarker/linux_benchmarks/spark_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/spark_benchmark.py
@@ -64,6 +64,7 @@ spark:
   description: Run a jar on a spark cluster.
   spark_service:
     service_type: managed
+    version: 1.6.2
     worker_group:
       vm_spec:
         GCP:

--- a/perfkitbenchmarker/providers/aws/aws_emr.py
+++ b/perfkitbenchmarker/providers/aws/aws_emr.py
@@ -47,9 +47,9 @@ WORKER_SG = 'EmrManagedSlaveSecurityGroup'
 NEEDS_SUBNET = ['m4', 'c4']
 
 EMR_VERSION_MAP = {
-  spark_service.SPARK_1_6_1: 'emr-4.8.0',
-  spark_service.SPARK_1_6_2: 'emr-4.8.2',
-  spark_service.SPARK_2_0_2: 'emr-5.2.0',
+    spark_service.SPARK_1_6_1: 'emr-4.8.0',
+    spark_service.SPARK_1_6_2: 'emr-4.8.2',
+    spark_service.SPARK_2_0_2: 'emr-5.2.0',
 }
 
 

--- a/perfkitbenchmarker/providers/gcp/gcp_dataproc.py
+++ b/perfkitbenchmarker/providers/gcp/gcp_dataproc.py
@@ -31,9 +31,9 @@ FLAGS = flags.FLAGS
 GCP_TIME_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
 
 DATAPROC_VERSION_MAP = {
-  spark_service.SPARK_1_6_1: None,
-  spark_service.SPARK_1_6_2: '1.0',
-  spark_service.SPARK_2_0_2: '1.1',
+    spark_service.SPARK_1_6_1: None,
+    spark_service.SPARK_1_6_2: '1.0',
+    spark_service.SPARK_2_0_2: '1.1',
 }
 
 

--- a/perfkitbenchmarker/providers/gcp/gcp_dataproc.py
+++ b/perfkitbenchmarker/providers/gcp/gcp_dataproc.py
@@ -30,6 +30,12 @@ FLAGS = flags.FLAGS
 
 GCP_TIME_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
 
+DATAPROC_VERSION_MAP = {
+  spark_service.SPARK_1_6_1: None,
+  spark_service.SPARK_1_6_2: '1.0',
+  spark_service.SPARK_2_0_2: '1.1',
+}
+
 
 class GcpDataproc(spark_service.BaseSparkService):
   """Object representing a GCP Dataproc cluster.
@@ -93,6 +99,11 @@ class GcpDataproc(spark_service.BaseSparkService):
       if group_spec.vm_spec.boot_disk_size:
         disk_flag = group_type + '-boot-disk-size'
         cmd.flags[disk_flag] = group_spec.vm_spec.boot_disk_size
+
+    if self.spec.version is not None:
+      if DATAPROC_VERSION_MAP[self.spec.version] is None:
+        raise Exception('Spark version specified not supported on Dataproc.')
+      cmd.flags['image-version'] = DATAPROC_VERSION_MAP[self.spec.version]
 
     cmd.Issue()
 

--- a/perfkitbenchmarker/spark_service.py
+++ b/perfkitbenchmarker/spark_service.py
@@ -44,6 +44,12 @@ flags.DEFINE_string('spark_static_cluster_id', None,
 PKB_MANAGED = 'pkb_managed'
 PROVIDER_MANAGED = 'managed'
 
+# Spark version options.
+SPARK_1_6_1 = '1.6.1'
+SPARK_1_6_2 = '1.6.2'
+SPARK_2_0_2 = '2.0.2'
+SPARK_VERSIONS = [SPARK_1_6_1, SPARK_1_6_2, SPARK_2_0_2]
+
 SUCCESS = 'success'
 RUNTIME = 'running_time'
 WAITING = 'pending_time'


### PR DESCRIPTION
Signed-off-by: Jason Kuster <jasonkuster@google.com>

Allows specifying version of Spark to use in managed Spark benchmarks.