### PR TITLE
Fix for "Cannot run bonnie++ on Azure #1217"

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/bonnie_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/bonnie_benchmark.py
@@ -21,9 +21,9 @@ from perfkitbenchmarker import regex_util
 from perfkitbenchmarker import sample
 
 
-BENCHMARK_NAME = 'bonnie++'
+BENCHMARK_NAME = 'bonnieplusplus'
 BENCHMARK_CONFIG = """
-bonnie++:
+bonnieplusplus:
   description: >
       Runs Bonnie++. Running this benchmark inside
       a container is currently not supported,

--- a/perfkitbenchmarker/providers/kubernetes/provider_info.py
+++ b/perfkitbenchmarker/providers/kubernetes/provider_info.py
@@ -26,7 +26,7 @@ class KubernetesProviderInfo(provider_info.BaseProviderInfo):
                           'cassandra_stress', 'cluster_boot', 'fio',
                           'iperf', 'mesh_network', 'mongodb_ycsb',
                           'netperf', 'redis', 'sysbench_oltp']
-  UNSUPPORTED_BENCHMARKS = ['bonnie++', 'mysql_service']
+  UNSUPPORTED_BENCHMARKS = ['bonnieplusplus', 'mysql_service']
 
   CLOUD = providers.KUBERNETES
 

--- a/perfkitbenchmarker/providers/mesos/provider_info.py
+++ b/perfkitbenchmarker/providers/mesos/provider_info.py
@@ -28,7 +28,7 @@ class MesosProviderInfo(provider_info.BaseProviderInfo):
                           'iperf', 'mongodb_ycsb', 'netperf', 'oldisim', 'ping',
                           'redis', 'redis_ycsb', 'scimark2', 'silo',
                           'sysbench_oltp']
-  UNSUPPORTED_BENCHMARKS = ['bonnie++', 'mysql_service']
+  UNSUPPORTED_BENCHMARKS = ['bonnieplusplus', 'mysql_service']
 
   CLOUD = providers.MESOS
 

--- a/tests/benchmark_sets_test.py
+++ b/tests/benchmark_sets_test.py
@@ -171,7 +171,8 @@ class BenchmarkSetsTestCase(unittest.TestCase):
       self.assertIn(benchmark_tuple[0].BENCHMARK_NAME,
                     self.valid_benchmark_names)
     # make sure bonnie++ is a listed benchmark
-    self.assertTrue(self._ContainsModule('bonnieplusplus', benchmark_tuple_list))
+    self.assertTrue(self._ContainsModule('bonnieplusplus', 
+                                         benchmark_tuple_list))
 
   def testBenchmarkValidCommandLine3(self):
     # make sure the command with two benchmarks is processed correctly

--- a/tests/benchmark_sets_test.py
+++ b/tests/benchmark_sets_test.py
@@ -171,7 +171,7 @@ class BenchmarkSetsTestCase(unittest.TestCase):
       self.assertIn(benchmark_tuple[0].BENCHMARK_NAME,
                     self.valid_benchmark_names)
     # make sure bonnie++ is a listed benchmark
-    self.assertTrue(self._ContainsModule('bonnieplusplus', 
+    self.assertTrue(self._ContainsModule('bonnieplusplus',
                                          benchmark_tuple_list))
 
   def testBenchmarkValidCommandLine3(self):

--- a/tests/benchmark_sets_test.py
+++ b/tests/benchmark_sets_test.py
@@ -163,7 +163,7 @@ class BenchmarkSetsTestCase(unittest.TestCase):
   def testBenchmarkValidCommandLine2(self):
     # make sure the standard_set plus a listed benchmark expands
     # to a valid set of benchmarks
-    self.mock_flags.benchmarks = ['standard_set', 'bonnie++']
+    self.mock_flags.benchmarks = ['standard_set', 'bonnieplusplus']
     benchmark_tuple_list = benchmark_sets.GetBenchmarksFromFlags()
     self.assertIsNotNone(benchmark_tuple_list)
     self.assertGreater(len(benchmark_tuple_list), 0)
@@ -171,7 +171,7 @@ class BenchmarkSetsTestCase(unittest.TestCase):
       self.assertIn(benchmark_tuple[0].BENCHMARK_NAME,
                     self.valid_benchmark_names)
     # make sure bonnie++ is a listed benchmark
-    self.assertTrue(self._ContainsModule('bonnie++', benchmark_tuple_list))
+    self.assertTrue(self._ContainsModule('bonnieplusplus', benchmark_tuple_list))
 
   def testBenchmarkValidCommandLine3(self):
     # make sure the command with two benchmarks is processed correctly

--- a/tests/benchmark_sets_test.py
+++ b/tests/benchmark_sets_test.py
@@ -170,7 +170,7 @@ class BenchmarkSetsTestCase(unittest.TestCase):
     for benchmark_tuple in benchmark_tuple_list:
       self.assertIn(benchmark_tuple[0].BENCHMARK_NAME,
                     self.valid_benchmark_names)
-    # make sure bonnie++ is a listed benchmark
+    # make sure bonnieplusplus is a listed benchmark
     self.assertTrue(self._ContainsModule('bonnieplusplus',
                                          benchmark_tuple_list))
 


### PR DESCRIPTION
Windows Azure cannot create resource group with '+' symbol in the name. We have to match the regex as  /^[-w._]+$/ as pointed out in issue #1217.

Solution:
The benchmark name is changed from bonnie++ to bonnieplusplus.
Change has been made in two places:
(i) benchmark_name changed to bonnieplusplus, and
(ii) benchmark config yaml 'key' value changed to bonnieplusplus to match the benchmark name.