### PR TITLE
- Added a metadata attribute 'spark_svc_cloud' 

### DIFF
--- a/perfkitbenchmarker/spark_service.py
+++ b/perfkitbenchmarker/spark_service.py
@@ -144,6 +144,7 @@ class BaseSparkService(resource.BaseResource):
   def GetMetadata(self):
     """Return a dictionary of the metadata for this cluster."""
     basic_data = {'spark_service': self.SERVICE_NAME,
+                  'spark_svc_cloud': self.CLOUD,
                   'spark_cluster_id': self.cluster_id}
     # TODO grab this information for user_managed clusters.
     if not self.user_managed:


### PR DESCRIPTION
…s in order to identify the providers from benchmark results.