### PR TITLE
Always set internal IP-Address on OpenStack VMs

### DIFF
--- a/perfkitbenchmarker/providers/openstack/os_virtual_machine.py
+++ b/perfkitbenchmarker/providers/openstack/os_virtual_machine.py
@@ -340,6 +340,7 @@ class OpenStackVirtualMachine(virtual_machine.BaseVirtualMachine):
     stdout, _, _ = show_cmd.Issue()
     server_dict = json.loads(stdout)
     self.ip_address = self._GetNetworkIPAddress(server_dict, self.network_name)
+    self.internal_ip = self.ip_address
     if self.floating_ip_pool_name:
       self.floating_ip = self._AllocateFloatingIP()
       self.internal_ip = self.ip_address


### PR DESCRIPTION
in order for all benchmarks to function. (e.g. cloud suite_data_serving)