### PR TITLE
Add gpu pcie benchmark

### DIFF
--- a/perfkitbenchmarker/benchmark_sets.py
+++ b/perfkitbenchmarker/benchmark_sets.py
@@ -83,9 +83,9 @@ BENCHMARK_SETS = {
         BENCHMARK_LIST: [
             'aerospike_ycsb', 'block_storage_workload', 'cassandra_stress',
             'cassandra_ycsb', 'cluster_boot', 'copy_throughput',
-            'fio', 'hadoop_terasort', 'hpcc', 'iperf', 'multichase',
-            'mesh_network', 'mongodb_ycsb', 'netperf', 'object_storage_service',
-            'oldisim', 'gpu_pcie_bandwidth', 'ping', 'redis_ycsb',
+            'fio', 'gpu_pcie_bandwidth', 'hadoop_terasort', 'hpcc', 'iperf',
+            'multichase', 'mesh_network', 'mongodb_ycsb', 'netperf',
+            'object_storage_service', 'oldisim', 'ping', 'redis_ycsb',
             'speccpu2006', 'sysbench_oltp', 'tomcat_wrk', 'unixbench']
     },
     'intel_set': {

--- a/perfkitbenchmarker/benchmark_sets.py
+++ b/perfkitbenchmarker/benchmark_sets.py
@@ -85,8 +85,8 @@ BENCHMARK_SETS = {
             'cassandra_ycsb', 'cluster_boot', 'copy_throughput',
             'fio', 'hadoop_terasort', 'hpcc', 'iperf', 'multichase',
             'mesh_network', 'mongodb_ycsb', 'netperf', 'object_storage_service',
-            'oldisim', 'ping', 'redis_ycsb', 'speccpu2006', 'sysbench_oltp',
-            'tomcat_wrk', 'unixbench']
+            'oldisim', 'gpu_pcie_bandwidth', 'ping', 'redis_ycsb',
+            'speccpu2006', 'sysbench_oltp', 'tomcat_wrk', 'unixbench']
     },
     'intel_set': {
         MESSAGE: 'Intel benchmark set.',

--- a/perfkitbenchmarker/linux_benchmarks/gpu_pcie_bandwidth_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/gpu_pcie_bandwidth_benchmark.py
@@ -1,0 +1,183 @@
+# Copyright 2016 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Runs NVIDIA's CUDA PCI-E bandwidth test (https://developer.nvidia.com/cuda-code-samples)
+"""
+
+import re
+
+from perfkitbenchmarker import configs
+from perfkitbenchmarker import disk
+from perfkitbenchmarker import flags
+from perfkitbenchmarker import sample
+from perfkitbenchmarker import vm_util
+#from perfkitbenchmarker.linux_packages import aerospike_server
+#from perfkitbenchmarker.linux_packages import aerospike_client
+
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_integer('magic_number', 90,
+                     'The percent of operations which are magic.',
+                     lower_bound=0, upper_bound=100)
+
+BENCHMARK_NAME = 'gpu_pcie_bandwidth'
+BENCHMARK_CONFIG = """
+gpu_pcie_bandwidth:
+  description: Runs NVIDIA's CUDA bandwidth test.
+  vm_groups:
+    workers:
+      vm_spec: *default_single_core
+      disk_spec: *default_500_gb
+      vm_count: null
+      disk_count: 0
+    client:
+      vm_spec: *default_single_core
+"""
+
+
+def GetConfig(user_config):
+  config = configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
+
+  #if FLAGS.aerospike_storage_type == aerospike_server.DISK:
+  #  if FLAGS.data_disk_type == disk.LOCAL:
+  #    # Didn't know max number of local disks, decide later.
+  #    config['vm_groups']['workers']['disk_count'] = (
+  #        config['vm_groups']['workers']['disk_count'] or None)
+  #  else:
+  #    config['vm_groups']['workers']['disk_count'] = (
+  #        config['vm_groups']['workers']['disk_count'] or 1)
+
+  return config
+
+
+def CheckPrerequisites():
+  pass
+  """Verifies that the required resources are present.
+
+  Raises:
+    perfkitbenchmarker.data.ResourceNotFound: On missing resource.
+  """
+  #aerospike_client.CheckPrerequisites()
+
+
+def Prepare(benchmark_spec):
+  pass
+  #"""Install Aerospike server on one VM and Aerospike C client on the other.
+
+  #Args:
+  #  benchmark_spec: The benchmark specification. Contains all data that is
+  #      required to run the benchmark.
+
+  #"""
+  #client = benchmark_spec.vm_groups['client'][0]
+  #workers = benchmark_spec.vm_groups['workers']
+
+  #def _Prepare(vm):
+  #  if vm == client:
+  #    vm.Install('aerospike_client')
+  #  else:
+  #    aerospike_server.ConfigureAndStart(vm, [workers[0].internal_ip])
+
+  #vm_util.RunThreaded(_Prepare, benchmark_spec.vms)
+
+
+def Run(benchmark_spec):
+   """Runs the CUDA PCIe benchmark
+ 
+   Args:
+     benchmark_spec: The benchmark specification. Contains all data that is
+         required to run the benchmark.
+ 
+   Returns:
+     A list of sample.Sample objects.
+   """
+   client = benchmark_spec.vm_groups['client'][0]
+   servers = benchmark_spec.vm_groups['workers']
+   samples = []
+#
+#  def ParseOutput(output):
+#    """Parses Aerospike output.
+#
+#    Args:
+#      output: The stdout from running the benchmark.
+#
+#    Returns:
+#      A tuple of average TPS and average latency.
+#    """
+#    read_latency = re.findall(
+#        r'read.*Overall Average Latency \(ms\) ([0-9]+\.[0-9]+)\n', output)[-1]
+#    write_latency = re.findall(
+#        r'write.*Overall Average Latency \(ms\) ([0-9]+\.[0-9]+)\n', output)[-1]
+#    average_latency = (
+#        (FLAGS.aerospike_read_percent / 100.0) * float(read_latency) +
+#        ((100 - FLAGS.aerospike_read_percent) / 100.0) * float(write_latency))
+#    tps = map(int, re.findall(r'total\(tps=([0-9]+) ', output))
+#    return float(sum(tps)) / len(tps), average_latency
+#
+#  load_command = ('./%s/benchmarks/target/benchmarks -z 32 -n test -w I '
+#                  '-o B:1000 -k %s -h %s' %
+#                  (aerospike_client.CLIENT_DIR, FLAGS.aerospike_num_keys,
+#                   ','.join(s.internal_ip for s in servers)))
+#  client.RemoteCommand(load_command, should_log=True)
+#
+#  max_throughput_for_completion_latency_under_1ms = 0.0
+#  for threads in range(FLAGS.aerospike_min_client_threads,
+#                       FLAGS.aerospike_max_client_threads + 1,
+#                       FLAGS.aerospike_client_threads_step_size):
+#    load_command = ('timeout 60 ./%s/benchmarks/target/benchmarks '
+#                    '-z %s -n test -w RU,%s -o B:1000 -k %s '
+#                    '--latency 5,1 -h %s;:' %
+#                    (aerospike_client.CLIENT_DIR, threads,
+#                     FLAGS.aerospike_read_percent, FLAGS.aerospike_num_keys,
+#                     ','.join(s.internal_ip for s in servers)))
+#    stdout, _ = client.RemoteCommand(load_command, should_log=True)
+#    tps, latency = ParseOutput(stdout)
+#
+   metadata = {
+       'Meow': 'Yes'
+   }
+   samples.append(sample.Sample('Average Meows', 4, 'meows/second', metadata))
+#    samples.append(sample.Sample('Average Latency', latency, 'ms', metadata))
+#    if latency < 1.0:
+#      max_throughput_for_completion_latency_under_1ms = max(
+#          max_throughput_for_completion_latency_under_1ms,
+#          tps)
+#
+#  samples.append(sample.Sample(
+#                 'max_throughput_for_completion_latency_under_1ms',
+#                 max_throughput_for_completion_latency_under_1ms,
+#                 'req/s'))
+#
+   return samples
+
+
+def Cleanup(benchmark_spec):
+  pass
+  #"""Cleanup Aerospike.
+
+  #Args:
+  #  benchmark_spec: The benchmark specification. Contains all data that is
+  #      required to run the benchmark.
+  #"""
+  #servers = benchmark_spec.vm_groups['workers']
+  #client = benchmark_spec.vm_groups['client'][0]
+
+  #client.RemoteCommand('sudo rm -rf aerospike*')
+
+  #def StopServer(server):
+  #  server.RemoteCommand('cd %s && nohup sudo make stop' %
+  #                       aerospike_server.AEROSPIKE_DIR)
+  #  server.RemoteCommand('sudo rm -rf aerospike*')
+  #vm_util.RunThreaded(StopServer, servers)

--- a/perfkitbenchmarker/linux_benchmarks/gpu_pcie_bandwidth_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/gpu_pcie_bandwidth_benchmark.py
@@ -12,172 +12,120 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Runs NVIDIA's CUDA PCI-E bandwidth test (https://developer.nvidia.com/cuda-code-samples)
+
+"""Runs NVIDIA's CUDA PCI-E bandwidth test
+      (https://developer.nvidia.com/cuda-code-samples)
 """
 
 import re
 
+import numpy
 from perfkitbenchmarker import configs
-from perfkitbenchmarker import disk
 from perfkitbenchmarker import flags
 from perfkitbenchmarker import sample
-from perfkitbenchmarker import vm_util
-#from perfkitbenchmarker.linux_packages import aerospike_server
-#from perfkitbenchmarker.linux_packages import aerospike_client
+from perfkitbenchmarker.linux_packages import cuda_toolkit_8
 
+
+flags.DEFINE_integer('gpu_pcie_bandwidth_iterations', 30,
+                     'number of iterations to run',
+                     lower_bound=1)
 
 FLAGS = flags.FLAGS
-
-flags.DEFINE_integer('magic_number', 90,
-                     'The percent of operations which are magic.',
-                     lower_bound=0, upper_bound=100)
 
 BENCHMARK_NAME = 'gpu_pcie_bandwidth'
 BENCHMARK_CONFIG = """
 gpu_pcie_bandwidth:
   description: Runs NVIDIA's CUDA bandwidth test.
+  flags:
+    gce_migrate_on_maintenance: False
   vm_groups:
-    workers:
-      vm_spec: *default_single_core
-      disk_spec: *default_500_gb
-      vm_count: null
-      disk_count: 0
-    client:
-      vm_spec: *default_single_core
+    default:
+      vm_spec:
+        GCP:
+          image: /ubuntu-os-cloud/ubuntu-1604-xenial-v20161115
+          machine_type: n1-standard-4-k80x1
+          zone: us-east1-d
+          boot_disk_size: 20
+        AWS:
+          image: ami-a9d276c9
+          machine_type: p2.xlarge
+          zone: us-west-2b
+          boot_disk_size: 20
 """
+BENCHMARK_METRICS = ['Host to device bandwidth',
+                     'Device to host bandwidth',
+                     'Device to device bandwidth']
 
 
 def GetConfig(user_config):
   config = configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
-
-  #if FLAGS.aerospike_storage_type == aerospike_server.DISK:
-  #  if FLAGS.data_disk_type == disk.LOCAL:
-  #    # Didn't know max number of local disks, decide later.
-  #    config['vm_groups']['workers']['disk_count'] = (
-  #        config['vm_groups']['workers']['disk_count'] or None)
-  #  else:
-  #    config['vm_groups']['workers']['disk_count'] = (
-  #        config['vm_groups']['workers']['disk_count'] or 1)
-
   return config
 
 
 def CheckPrerequisites():
-  pass
   """Verifies that the required resources are present.
 
   Raises:
     perfkitbenchmarker.data.ResourceNotFound: On missing resource.
   """
-  #aerospike_client.CheckPrerequisites()
+  cuda_toolkit_8.CheckPrerequisites()
 
 
 def Prepare(benchmark_spec):
-  pass
-  #"""Install Aerospike server on one VM and Aerospike C client on the other.
+  """Install CUDA toolkit 8
 
-  #Args:
-  #  benchmark_spec: The benchmark specification. Contains all data that is
-  #      required to run the benchmark.
+  Args:
+    benchmark_spec: The benchmark specification. Contains all data that is
+        required to run the benchmark.
 
-  #"""
-  #client = benchmark_spec.vm_groups['client'][0]
-  #workers = benchmark_spec.vm_groups['workers']
+  """
+  vm = benchmark_spec.vms[0]
+  vm.Install('cuda_toolkit_8')
 
-  #def _Prepare(vm):
-  #  if vm == client:
-  #    vm.Install('aerospike_client')
-  #  else:
-  #    aerospike_server.ConfigureAndStart(vm, [workers[0].internal_ip])
 
-  #vm_util.RunThreaded(_Prepare, benchmark_spec.vms)
+def ParseOutput(output):
+  matches = re.findall(r'\d+\s+(\d+\.?\d*)', output)
+  results = {}
+  for i, metric in enumerate(BENCHMARK_METRICS):
+    results[metric] = float(matches[i])
+  return results
+
+
+def CalculateMetrics(samples):
+  metadata = {}
+  results = []
+  for metric in BENCHMARK_METRICS:
+    sequence = [x[metric] for x in samples]
+    results.append(sample.Sample(
+        metric + ', min', min(sequence), 'MB/s', metadata))
+    results.append(sample.Sample(
+        metric + ', max', max(sequence), 'MB/s', metadata))
+    results.append(sample.Sample(
+        metric + ', mean', numpy.mean(sequence), 'MB/s', metadata))
+    results.append(sample.Sample(
+        metric + ', stddev', numpy.std(sequence), 'MB/s', metadata))
+  return results
 
 
 def Run(benchmark_spec):
-   """Runs the CUDA PCIe benchmark
- 
-   Args:
-     benchmark_spec: The benchmark specification. Contains all data that is
-         required to run the benchmark.
- 
-   Returns:
-     A list of sample.Sample objects.
-   """
-   client = benchmark_spec.vm_groups['client'][0]
-   servers = benchmark_spec.vm_groups['workers']
-   samples = []
-#
-#  def ParseOutput(output):
-#    """Parses Aerospike output.
-#
-#    Args:
-#      output: The stdout from running the benchmark.
-#
-#    Returns:
-#      A tuple of average TPS and average latency.
-#    """
-#    read_latency = re.findall(
-#        r'read.*Overall Average Latency \(ms\) ([0-9]+\.[0-9]+)\n', output)[-1]
-#    write_latency = re.findall(
-#        r'write.*Overall Average Latency \(ms\) ([0-9]+\.[0-9]+)\n', output)[-1]
-#    average_latency = (
-#        (FLAGS.aerospike_read_percent / 100.0) * float(read_latency) +
-#        ((100 - FLAGS.aerospike_read_percent) / 100.0) * float(write_latency))
-#    tps = map(int, re.findall(r'total\(tps=([0-9]+) ', output))
-#    return float(sum(tps)) / len(tps), average_latency
-#
-#  load_command = ('./%s/benchmarks/target/benchmarks -z 32 -n test -w I '
-#                  '-o B:1000 -k %s -h %s' %
-#                  (aerospike_client.CLIENT_DIR, FLAGS.aerospike_num_keys,
-#                   ','.join(s.internal_ip for s in servers)))
-#  client.RemoteCommand(load_command, should_log=True)
-#
-#  max_throughput_for_completion_latency_under_1ms = 0.0
-#  for threads in range(FLAGS.aerospike_min_client_threads,
-#                       FLAGS.aerospike_max_client_threads + 1,
-#                       FLAGS.aerospike_client_threads_step_size):
-#    load_command = ('timeout 60 ./%s/benchmarks/target/benchmarks '
-#                    '-z %s -n test -w RU,%s -o B:1000 -k %s '
-#                    '--latency 5,1 -h %s;:' %
-#                    (aerospike_client.CLIENT_DIR, threads,
-#                     FLAGS.aerospike_read_percent, FLAGS.aerospike_num_keys,
-#                     ','.join(s.internal_ip for s in servers)))
-#    stdout, _ = client.RemoteCommand(load_command, should_log=True)
-#    tps, latency = ParseOutput(stdout)
-#
-   metadata = {
-       'Meow': 'Yes'
-   }
-   samples.append(sample.Sample('Average Meows', 4, 'meows/second', metadata))
-#    samples.append(sample.Sample('Average Latency', latency, 'ms', metadata))
-#    if latency < 1.0:
-#      max_throughput_for_completion_latency_under_1ms = max(
-#          max_throughput_for_completion_latency_under_1ms,
-#          tps)
-#
-#  samples.append(sample.Sample(
-#                 'max_throughput_for_completion_latency_under_1ms',
-#                 max_throughput_for_completion_latency_under_1ms,
-#                 'req/s'))
-#
-   return samples
+  """Runs the CUDA PCIe benchmark
+
+  Args:
+    benchmark_spec: The benchmark specification. Contains all data that is
+        required to run the benchmark.
+
+  Returns:
+    A list of sample.Sample objects.
+  """
+  vm = benchmark_spec.vms[0]
+  cuda_toolkit_8.MaximizeGPUClockSpeed(vm)
+  run_command = '/usr/local/cuda-8.0/extras/demo_suite/bandwidthTest'
+  samples = []
+  for i in range(FLAGS.gpu_pcie_bandwidth_iterations):
+    stdout, _ = vm.RemoteCommand(run_command, should_log=True)
+    samples.append(ParseOutput(stdout))
+  return CalculateMetrics(samples)
 
 
 def Cleanup(benchmark_spec):
   pass
-  #"""Cleanup Aerospike.
-
-  #Args:
-  #  benchmark_spec: The benchmark specification. Contains all data that is
-  #      required to run the benchmark.
-  #"""
-  #servers = benchmark_spec.vm_groups['workers']
-  #client = benchmark_spec.vm_groups['client'][0]
-
-  #client.RemoteCommand('sudo rm -rf aerospike*')
-
-  #def StopServer(server):
-  #  server.RemoteCommand('cd %s && nohup sudo make stop' %
-  #                       aerospike_server.AEROSPIKE_DIR)
-  #  server.RemoteCommand('sudo rm -rf aerospike*')
-  #vm_util.RunThreaded(StopServer, servers)

--- a/perfkitbenchmarker/linux_packages/cuda_toolkit_8.py
+++ b/perfkitbenchmarker/linux_packages/cuda_toolkit_8.py
@@ -1,0 +1,80 @@
+# Copyright 2016 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Module containing CUDA toolkit 8 installation and cleanup functions."""
+
+
+CUDA_TOOLKIT_UBUNTU = 'cuda-repo-ubuntu1604_8.0.44-1_amd64.deb'
+CUDA_TOOLKIT_UBUNTU_URL =\
+    'http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/%s' %\
+    CUDA_TOOLKIT_UBUNTU
+CUDA_TOOLKIT_INSTALL_DIR = '/usr/local/cuda'
+
+
+def MaximizeGPUClockSpeed(vm):
+  """Sets the K80 GPU clock to its maximum frequency and enables
+     persistence mode.
+     TODO: This clock speed is currently specific to K80 GPUs.
+
+     Note that these settings are lost after reboot and this function
+     must be called again if max clock speeds are desired.
+  """
+  vm.RemoteCommand('sudo nvidia-smi -pm 1')
+  vm.RemoteCommand('sudo nvidia-smi -ac 2505,875')
+
+
+def _Install(vm):
+  """Installs CUDA toolkit 8 on the VM."""
+  vm.Install('build_tools')
+  vm.Install('wget')
+  wget_command = 'wget %s'
+  vm.RemoteCommand(wget_command % CUDA_TOOLKIT_UBUNTU_URL)
+  install_command = ('sudo dpkg -i %s')
+  vm.RemoteCommand(install_command % (CUDA_TOOLKIT_UBUNTU))
+  vm.RemoteCommand('sudo apt-get update')
+  vm.RemoteCommand('sudo apt-get install -y cuda')
+  vm.RemoteCommand('sudo reboot', ignore_failure=True)
+  vm.WaitForBootCompletion()
+  MaximizeGPUClockSpeed(vm)
+
+
+def AptInstall(vm):
+  """Installs the CUDA toolkit 8 on the VM."""
+  _Install(vm)
+
+
+def YumInstall(vm):
+  """TODO: PKB currently only supports the installation of CUDA toolkit
+     on Ubuntu.
+  """
+  raise NotImplementedError()
+
+
+def CheckPrerequisites():
+  """Verifies that the required resources are present.
+
+  Raises:
+    perfkitbenchmarker.data.ResourceNotFound: On missing resource.
+  """
+  pass
+
+
+def Uninstall(vm):
+  """Removes the CUDA toolkit.
+     Note that reinstallation does not work correctly, i.e. you cannot reinstall
+     CUDA by calling _Install() again.
+  """
+  vm.RemoteCommand('rm %s' % CUDA_TOOLKIT_UBUNTU)
+  vm.RemoteCommand('sudo rm -rf %s' % CUDA_TOOLKIT_INSTALL_DIR)

--- a/perfkitbenchmarker/linux_packages/cuda_toolkit_8.py
+++ b/perfkitbenchmarker/linux_packages/cuda_toolkit_8.py
@@ -30,21 +30,21 @@ EXTRACT_CLOCK_SPEEDS_REGEX = r'(\d*).*,\s*(\d*)'
 
 def QueryNumberOfGpus(vm):
   """Returns the number of Nvidia GPUs on the system"""
-  stdout, _ = vm.RemoteCommand("sudo nvidia-smi --query-gpu=count --id=0 "
-                               "--format=csv", should_log=True)
+  stdout, _ = vm.RemoteCommand('sudo nvidia-smi --query-gpu=count --id=0 '
+                               '--format=csv', should_log=True)
   return int(stdout.split()[1])
 
 
 def SetGpuClockSpeed(vm, memory_clock_speed, graphics_clock_speed):
-  """Sets the K80 GPU memory and graphics clocks to the specified frequency
-     and enables persistence mode.
+  """Sets the memory and graphics clocks to the specified frequency.
 
-     Note that these settings are lost after reboot.
+  Persistence mode is enabled as well. Note that these settings are
+  lost after reboot.
 
-     Args:
-      vm: virtual machine to operate on
-      memory_clock_speed: desired speed of the memory clock, in MHz
-      graphics_clock_speed: desired speed of the graphics clock, in MHz
+  Args:
+    vm: virtual machine to operate on
+    memory_clock_speed: desired speed of the memory clock, in MHz
+    graphics_clock_speed: desired speed of the graphics clock, in MHz
   """
   vm.RemoteCommand('sudo nvidia-smi -pm 1')
   vm.RemoteCommand('sudo nvidia-smi -ac {},{}'.format(memory_clock_speed,
@@ -52,18 +52,19 @@ def SetGpuClockSpeed(vm, memory_clock_speed, graphics_clock_speed):
 
 
 def QueryGpuClockSpeed(vm, device_id):
-  """Returns the user-specified values of the memory and graphics clock
-     in MHz for the specified GPU.
+  """Returns the user-specified values of the memory and graphics clock.
 
-     Args:
-      vm: virtual machine to operate on
-      device_id: id of GPU device to query
+  All clock values are in MHz.
 
-    Returns:
-      Tuple of clock speeds in MHz in the form (memory clock, graphics clock).
+  Args:
+    vm: virtual machine to operate on
+    device_id: id of GPU device to query
+
+  Returns:
+    Tuple of clock speeds in MHz in the form (memory clock, graphics clock).
   """
-  query = ("sudo nvidia-smi --query-gpu=clocks.applications.memory,"
-           "clocks.applications.graphics --format=csv --id={0}"
+  query = ('sudo nvidia-smi --query-gpu=clocks.applications.memory,'
+           'clocks.applications.graphics --format=csv --id={0}'
            .format(device_id))
   stdout, _ = vm.RemoteCommand(query, should_log=True)
   clock_speeds = stdout.splitlines()[1]
@@ -102,8 +103,9 @@ def CheckPrerequisites():
 
 def Uninstall(vm):
   """Removes the CUDA toolkit.
-     Note that reinstallation does not work correctly, i.e. you cannot reinstall
-     CUDA by calling _Install() again.
+
+  Note that reinstallation does not work correctly, i.e. you cannot reinstall
+  CUDA by calling _Install() again.
   """
   vm.RemoteCommand('rm %s' % CUDA_TOOLKIT_UBUNTU)
   vm.RemoteCommand('sudo rm -rf %s' % CUDA_TOOLKIT_INSTALL_DIR)

--- a/perfkitbenchmarker/linux_packages/cuda_toolkit_8.py
+++ b/perfkitbenchmarker/linux_packages/cuda_toolkit_8.py
@@ -35,24 +35,17 @@ def MaximizeGPUClockSpeed(vm):
   vm.RemoteCommand('sudo nvidia-smi -ac 2505,875')
 
 
-def _Install(vm):
+def AptInstall(vm):
   """Installs CUDA toolkit 8 on the VM."""
   vm.Install('build_tools')
   vm.Install('wget')
-  wget_command = 'wget %s'
-  vm.RemoteCommand(wget_command % CUDA_TOOLKIT_UBUNTU_URL)
-  install_command = ('sudo dpkg -i %s')
-  vm.RemoteCommand(install_command % (CUDA_TOOLKIT_UBUNTU))
+  vm.RemoteCommand('wget %s' % CUDA_TOOLKIT_UBUNTU_URL)
+  vm.RemoteCommand('sudo dpkg -i %s' % CUDA_TOOLKIT_UBUNTU)
   vm.RemoteCommand('sudo apt-get update')
   vm.RemoteCommand('sudo apt-get install -y cuda')
   vm.RemoteCommand('sudo reboot', ignore_failure=True)
   vm.WaitForBootCompletion()
   MaximizeGPUClockSpeed(vm)
-
-
-def AptInstall(vm):
-  """Installs the CUDA toolkit 8 on the VM."""
-  _Install(vm)
 
 
 def YumInstall(vm):

--- a/perfkitbenchmarker/linux_packages/cuda_toolkit_8.py
+++ b/perfkitbenchmarker/linux_packages/cuda_toolkit_8.py
@@ -23,16 +23,16 @@ CUDA_TOOLKIT_UBUNTU_URL =\
 CUDA_TOOLKIT_INSTALL_DIR = '/usr/local/cuda'
 
 
-def MaximizeGPUClockSpeed(vm):
-  """Sets the K80 GPU clock to its maximum frequency and enables
-     persistence mode.
-     TODO: This clock speed is currently specific to K80 GPUs.
+def SetGPUClockSpeed(vm, memory_clock_speed, graphics_clock_speed):
+  """Sets the K80 GPU memory and graphics clocks to the specified frequency
+     and enables persistence mode.
 
      Note that these settings are lost after reboot and this function
      must be called again if max clock speeds are desired.
   """
   vm.RemoteCommand('sudo nvidia-smi -pm 1')
-  vm.RemoteCommand('sudo nvidia-smi -ac 2505,875')
+  vm.RemoteCommand('sudo nvidia-smi -ac {},{}'.format(memory_clock_speed,
+                                                      graphics_clock_speed))
 
 
 def AptInstall(vm):
@@ -45,7 +45,6 @@ def AptInstall(vm):
   vm.RemoteCommand('sudo apt-get install -y cuda')
   vm.RemoteCommand('sudo reboot', ignore_failure=True)
   vm.WaitForBootCompletion()
-  MaximizeGPUClockSpeed(vm)
 
 
 def YumInstall(vm):

--- a/perfkitbenchmarker/regex_util.py
+++ b/perfkitbenchmarker/regex_util.py
@@ -88,6 +88,7 @@ def ExtractAllMatches(regex, text, flags=0):
   Args:
     regex: string. Regular expression.
     text: string. Text to search.
+    flags: int. Flags to pass to re.findall().
   Returns:
     A list of tuples of strings that matched by 'regex' within 'text'.
   Raises:

--- a/perfkitbenchmarker/regex_util.py
+++ b/perfkitbenchmarker/regex_util.py
@@ -76,7 +76,7 @@ def ExtractIpv4Addresses(text):
   return match
 
 
-def ExtractAllMatches(regex, text):
+def ExtractAllMatches(regex, text, flags=0):
   """Extracts all matches from a regular expression matched within 'text'.
 
   Extracts all matches from a regular expression matched within 'text'. Please
@@ -93,7 +93,7 @@ def ExtractAllMatches(regex, text):
   Raises:
     NoMatchError: when 'regex' does not match 'text'.
   """
-  match = re.findall(regex, text)
+  match = re.findall(regex, text, flags=flags)
   if not match:
     raise NoMatchError('No match for pattern "{0}" in "{1}"'.format(
         regex, text))

--- a/tests/data/cuda_bandwidth_test_results.txt
+++ b/tests/data/cuda_bandwidth_test_results.txt
@@ -1,0 +1,24 @@
+[CUDA Bandwidth Test] - Starting...
+Running on...
+
+ Device 0: Tesla K80
+ Quick Mode
+
+ Host to Device Bandwidth, 1 Device(s)
+ PINNED Memory Transfers
+   Transfer Size (Bytes)	Bandwidth(MB/s)
+   33554432			9254.7
+
+ Device to Host Bandwidth, 1 Device(s)
+ PINNED Memory Transfers
+   Transfer Size (Bytes)	Bandwidth(MB/s)
+   33554432			9686.1
+
+ Device to Device Bandwidth, 1 Device(s)
+ PINNED Memory Transfers
+   Transfer Size (Bytes)	Bandwidth(MB/s)
+   33554432			155985.8
+
+Result = PASS
+
+NOTE: The CUDA Samples are not meant for performance measurements. Results may vary when GPU Boost is enabled.

--- a/tests/data/cuda_bandwidth_test_results.txt
+++ b/tests/data/cuda_bandwidth_test_results.txt
@@ -2,19 +2,20 @@
 Running on...
 
  Device 0: Tesla K80
+ Device 1: Tesla K80
  Quick Mode
 
- Host to Device Bandwidth, 1 Device(s)
+ Host to Device Bandwidth, 2 Device(s)
  PINNED Memory Transfers
    Transfer Size (Bytes)	Bandwidth(MB/s)
    33554432			9254.7
 
- Device to Host Bandwidth, 1 Device(s)
+ Device to Host Bandwidth, 2 Device(s)
  PINNED Memory Transfers
    Transfer Size (Bytes)	Bandwidth(MB/s)
    33554432			9686.1
 
- Device to Device Bandwidth, 1 Device(s)
+ Device to Device Bandwidth, 2 Device(s)
  PINNED Memory Transfers
    Transfer Size (Bytes)	Bandwidth(MB/s)
    33554432			155985.8

--- a/tests/linux_benchmarks/gpu_pcie_bandwidth_benchmark_test.py
+++ b/tests/linux_benchmarks/gpu_pcie_bandwidth_benchmark_test.py
@@ -1,0 +1,73 @@
+# Copyright 2016 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for GPU PCIe bandwidth benchmark."""
+import os
+import unittest
+
+import mock
+
+from perfkitbenchmarker.linux_benchmarks import gpu_pcie_bandwidth_benchmark
+
+
+class GpuBandwidthTestCase(unittest.TestCase):
+
+  def setUp(self):
+    p = mock.patch(gpu_pcie_bandwidth_benchmark.__name__ + '.FLAGS')
+    p.start()
+    self.addCleanup(p.stop)
+
+    path = os.path.join(os.path.dirname(__file__), '../data',
+                        'cuda_bandwidth_test_results.txt')
+    with open(path) as fp:
+      self.contents = fp.read()
+
+  def testParseCudaBandwidthTestResults(self):
+    results = gpu_pcie_bandwidth_benchmark.ParseOutput(self.contents)
+    self.assertEqual(3, len(results))
+    self.assertAlmostEqual(9254.7, results['Host to device bandwidth'])
+    self.assertAlmostEqual(9686.1, results['Device to host bandwidth'])
+    self.assertAlmostEqual(155985.8, results['Device to device bandwidth'])
+
+  def testCalculateMetrics(self):
+    raw_results = [{
+        'Host to device bandwidth': 9250,
+        'Device to host bandwidth': 9000,
+        'Device to device bandwidth': 155000
+    }, {
+        'Host to device bandwidth': 8000,
+        'Device to host bandwidth': 8500,
+        'Device to device bandwidth': 152000
+    }]
+    raw_metrics = gpu_pcie_bandwidth_benchmark.CalculateMetrics(raw_results)
+    metrics = {i[0]: i[1] for i in raw_metrics}
+
+    self.assertAlmostEqual(8000, metrics['Host to device bandwidth, min'])
+    self.assertAlmostEqual(9250, metrics['Host to device bandwidth, max'])
+    self.assertAlmostEqual(8625.0, metrics['Host to device bandwidth, mean'])
+    self.assertAlmostEqual(625.0, metrics['Host to device bandwidth, stddev'])
+
+    self.assertAlmostEqual(8500, metrics['Device to host bandwidth, min'])
+    self.assertAlmostEqual(9000, metrics['Device to host bandwidth, max'])
+    self.assertAlmostEqual(8750.0, metrics['Device to host bandwidth, mean'])
+    self.assertAlmostEqual(250.0, metrics['Device to host bandwidth, stddev'])
+
+    self.assertAlmostEqual(152000, metrics['Device to device bandwidth, min'])
+    self.assertAlmostEqual(155000, metrics['Device to device bandwidth, max'])
+    self.assertAlmostEqual(153500, metrics['Device to device bandwidth, mean'])
+    self.assertAlmostEqual(1500, metrics['Device to device bandwidth, stddev'])
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tests/linux_benchmarks/gpu_pcie_bandwidth_benchmark_test.py
+++ b/tests/linux_benchmarks/gpu_pcie_bandwidth_benchmark_test.py
@@ -31,10 +31,17 @@ class GpuBandwidthTestCase(unittest.TestCase):
     path = os.path.join(os.path.dirname(__file__), '../data',
                         'cuda_bandwidth_test_results.txt')
     with open(path) as fp:
-      self.contents = fp.read()
+      self.test_output = fp.read()
+
+  def testParseDeviceMetadata(self):
+    actual = gpu_pcie_bandwidth_benchmark.\
+        _ParseDeviceInfo(self.test_output)
+    expected = {'0': 'Tesla K80', '1': 'Tesla K80'}
+    self.assertEqual(expected, actual)
 
   def testParseCudaBandwidthTestResults(self):
-    results = gpu_pcie_bandwidth_benchmark.ParseOutput(self.contents)
+    results = gpu_pcie_bandwidth_benchmark.\
+        _ParseOutputFromSingleIteration(self.test_output)
     self.assertEqual(3, len(results))
     self.assertAlmostEqual(9254.7, results['Host to device bandwidth'])
     self.assertAlmostEqual(9686.1, results['Device to host bandwidth'])
@@ -50,7 +57,8 @@ class GpuBandwidthTestCase(unittest.TestCase):
         'Device to host bandwidth': 8500,
         'Device to device bandwidth': 152000
     }]
-    raw_metrics = gpu_pcie_bandwidth_benchmark.CalculateMetrics(raw_results)
+    raw_metrics = gpu_pcie_bandwidth_benchmark.\
+        _CalculateMetricsOverAllIterations(raw_results)
     metrics = {i[0]: i[1] for i in raw_metrics}
 
     self.assertAlmostEqual(8000, metrics['Host to device bandwidth, min'])

--- a/tests/linux_benchmarks/gpu_pcie_bandwidth_benchmark_test.py
+++ b/tests/linux_benchmarks/gpu_pcie_bandwidth_benchmark_test.py
@@ -57,9 +57,33 @@ class GpuBandwidthTestCase(unittest.TestCase):
         'Device to host bandwidth': 8500,
         'Device to device bandwidth': 152000
     }]
-    raw_metrics = gpu_pcie_bandwidth_benchmark.\
+    samples = gpu_pcie_bandwidth_benchmark.\
         _CalculateMetricsOverAllIterations(raw_results)
-    metrics = {i[0]: i[1] for i in raw_metrics}
+    metrics = {i[0]: i[1] for i in samples}
+
+    sample = next(x for x in samples if x.metadata == {'iteration': 0}
+                  and x.metric == 'Host to device bandwidth')
+    self.assertAlmostEqual(9250, sample.value)
+
+    sample = next(x for x in samples if x.metadata == {'iteration': 0}
+                  and x.metric == 'Device to host bandwidth')
+    self.assertAlmostEqual(9000, sample.value)
+
+    sample = next(x for x in samples if x.metadata == {'iteration': 0}
+                  and x.metric == 'Device to device bandwidth')
+    self.assertAlmostEqual(155000, sample.value)
+
+    sample = next(x for x in samples if x.metadata == {'iteration': 1}
+                  and x.metric == 'Host to device bandwidth')
+    self.assertAlmostEqual(8000, sample.value)
+
+    sample = next(x for x in samples if x.metadata == {'iteration': 1}
+                  and x.metric == 'Device to host bandwidth')
+    self.assertAlmostEqual(8500, sample.value)
+
+    sample = next(x for x in samples if x.metadata == {'iteration': 1}
+                  and x.metric == 'Device to device bandwidth')
+    self.assertAlmostEqual(152000, sample.value)
 
     self.assertAlmostEqual(8000, metrics['Host to device bandwidth, min'])
     self.assertAlmostEqual(9250, metrics['Host to device bandwidth, max'])

--- a/tests/linux_packages/cuda_toolkit_8_test.py
+++ b/tests/linux_packages/cuda_toolkit_8_test.py
@@ -1,0 +1,51 @@
+# Copyright 2016 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for perfkitbenchmarker.packages.cuda_toolkit_8."""
+
+import unittest
+
+import mock
+
+from perfkitbenchmarker import test_util
+from perfkitbenchmarker.linux_packages import cuda_toolkit_8
+
+
+class CudaToolkit8TestCase(unittest.TestCase, test_util.SamplesTestMixin):
+
+  def setUp(self):
+    pass
+
+  def tearDown(self):
+    pass
+
+  def testQueryNumberOfGpus(self):
+    vm = mock.MagicMock()
+    vm.RemoteCommand = mock.MagicMock(return_value=("count\n8", None))
+    self.assertEqual(8, cuda_toolkit_8.QueryNumberOfGpus(vm))
+
+  def testQueryGpuClockSpeed(self):
+    vm = mock.MagicMock()
+    vm.RemoteCommand = mock.MagicMock(
+        return_value=("clocks.applications.graphics [MHz], "
+                      "clocks.applications.memory [Mhz]\n"
+                      "324 MHz, 527 MHz", None))
+    self.assertEqual((324, 527), cuda_toolkit_8.QueryGpuClockSpeed(vm, 3))
+    vm.RemoteCommand.assert_called_with(
+        "sudo nvidia-smi "
+        "--query-gpu=clocks.applications.memory,"
+        "clocks.applications.graphics --format=csv --id=3", should_log=True)
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
## Release Notes:
* Added `cuda_toolkit_8` linux package
  * It currently only supports Nvidia Tesla K80 cards on a debian distro (no `yum`)
* Added `gpu_pcie_bandwidth` benchmark which uses the CUDA bandwidth test to measure the following:
  * host to device bandwidth
  * device to host bandwidth
  * device to device bandwidth
* Added `gpu_pcie_bandwidth` to the Google set
* Added tests