### PR TITLE
Add some metadata to netperf samples

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
@@ -330,7 +330,7 @@ def RunNetperf(vm, benchmark_name, server_ip, num_streams):
   # Metadata to attach to samples
   metadata = {'netperf_test_length': FLAGS.netperf_test_length,
               'max_iter': FLAGS.netperf_max_iter or 1,
-              'num_streams': num_streams}
+              'sending_thread_count': num_streams}
 
   parsed_output = [_ParseNetperfOutput(stdout, metadata, benchmark_name,
                                        enable_latency_histograms)
@@ -398,15 +398,16 @@ def Run(benchmark_spec):
     A list of sample.Sample objects.
   """
   vms = benchmark_spec.vms
-  client_vm = vms[0]
-  server_vm = vms[1]
+  client_vm = vms[0] # Client aka "sending vm"
+  server_vm = vms[1] # Server aka "receiving vm"
   logging.info('netperf running on %s', client_vm)
   results = []
-  metadata = {'ip_type': 'external'}
-  for vm_specifier, vm in ('receiving', server_vm), ('sending', client_vm):
-    metadata['{0}_zone'.format(vm_specifier)] = vm.zone
-    for k, v in vm.GetMachineTypeDict().iteritems():
-      metadata['{0}_{1}'.format(vm_specifier, k)] = v
+  metadata = {
+      'sending_zone': client_vm.zone,
+      'sending_machine_type': client_vm.machine_type,
+      'receiving_zone': server_vm.zone,
+      'receiving_machine_type': server_vm.machine_type
+  }
 
   for num_streams in FLAGS.netperf_num_streams:
     assert(num_streams >= 1)
@@ -416,6 +417,7 @@ def Run(benchmark_spec):
         external_ip_results = RunNetperf(client_vm, netperf_benchmark,
                                          server_vm.ip_address, num_streams)
         for external_ip_result in external_ip_results:
+          external_ip_result.metadata['ip_type'] = 'external'
           external_ip_result.metadata.update(metadata)
         results.extend(external_ip_results)
 

--- a/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
@@ -398,8 +398,8 @@ def Run(benchmark_spec):
     A list of sample.Sample objects.
   """
   vms = benchmark_spec.vms
-  client_vm = vms[0] # Client aka "sending vm"
-  server_vm = vms[1] # Server aka "receiving vm"
+  client_vm = vms[0]  # Client aka "sending vm"
+  server_vm = vms[1]  # Server aka "receiving vm"
   logging.info('netperf running on %s', client_vm)
   results = []
   metadata = {


### PR DESCRIPTION
So that we can change the iperf queries to netperf queries.

@ehankland PTAL