### PR TITLE
If possible, do not use FlagValues.FlagDict.  Or use FlagValues._flags instead.

### DIFF
--- a/perfkitbenchmarker/configs/benchmark_config_spec.py
+++ b/perfkitbenchmarker/configs/benchmark_config_spec.py
@@ -76,7 +76,10 @@ class FlagsDecoder(option_decoders.TypeVerifier):
                 'Invalid {0}.{1} value: "{2}" (of type "{3}").{4}{5}'.format(
                     self._GetOptionFullName(component_full_name), key, value,
                     value.__class__.__name__, os.linesep, e))
-    return merged_flag_values.FlagDict()
+    if hasattr(merged_flag_values, '_flags'):
+      return merged_flag_values._flags()  # pylint: disable=protected-access
+    else:
+      return merged_flag_values.FlagDict()
 
 
 class _PerCloudConfigSpec(spec.BaseSpec):

--- a/perfkitbenchmarker/pkb.py
+++ b/perfkitbenchmarker/pkb.py
@@ -558,7 +558,8 @@ def RunBenchmarkTask(spec):
 
 def _LogCommandLineFlags():
   result = []
-  for flag in FLAGS.FlagDict().values():
+  for name in FLAGS:
+    flag = FLAGS[name]
     if flag.present:
       result.append(flag.Serialize())
   logging.info('Flag values:\n%s', '\n'.join(result))

--- a/tests/configs/benchmark_config_spec_test.py
+++ b/tests/configs/benchmark_config_spec_test.py
@@ -38,6 +38,10 @@ _GCP_AWS_VM_CONFIG = {'GCP': {'machine_type': 'n1-standard-1'},
 _GCP_AWS_DISK_CONFIG = {'GCP': {}, 'AWS': {}}
 
 
+def _GetFlagDict(flag_values):
+  return {name: flag_values[name] for name in flag_values}
+
+
 class FlagsDecoderTestCase(unittest.TestCase):
 
   def setUp(self):
@@ -53,7 +57,7 @@ class FlagsDecoderTestCase(unittest.TestCase):
     self.assertEqual(len(result), 1)
     self.assertEqual(result['test_flag'].value, expected_flag_value)
     self.assertEqual(result['test_flag'].present, expected_flag_present)
-    self.assertIsNot(result, self._flag_values.FlagDict())
+    self.assertIsNot(result, _GetFlagDict(self._flag_values))
 
   def testNone(self):
     result = self._decoder.Decode(None, _COMPONENT, self._flag_values)
@@ -443,7 +447,7 @@ class BenchmarkConfigSpecTestCase(unittest.TestCase):
                               **self._kwargs)
     self.assertIsInstance(result, benchmark_config_spec.BenchmarkConfigSpec)
     self.assertEqual(result.description, 'Test description.')
-    self.assertIsNot(result.flags, flags.FLAGS.FlagDict())
+    self.assertIsNot(result.flags, _GetFlagDict(flags.FLAGS))
     self.assertIsInstance(result.vm_groups, dict)
     self.assertEqual(len(result.vm_groups), 1)
     self.assertIsInstance(result.vm_groups['default'],
@@ -486,7 +490,7 @@ class BenchmarkConfigSpecTestCase(unittest.TestCase):
     self.assertIsInstance(result, benchmark_config_spec.BenchmarkConfigSpec)
     self.assertEqual(result.description, 'Test description.')
     self.assertIsInstance(result.flags, dict)
-    self.assertIsNot(result.flags, flags.FLAGS.FlagDict())
+    self.assertIsNot(result.flags, _GetFlagDict(flags.FLAGS))
     self.assertEqual(result.flags['cloud'], 'AWS')
     self.assertEqual(flags.FLAGS['cloud'].value, 'GCP')
     self.assertIsInstance(result.vm_groups, dict)

--- a/tests/flag_util_test.py
+++ b/tests/flag_util_test.py
@@ -120,10 +120,11 @@ class FlagDictSubstitutionTestCase(unittest.TestCase):
     flag_values_copy.test_flag = 1
     self.assertFlagState(flag_values, 0, False)
     self.assertFlagState(flag_values_copy, 1, False)
-    flag_dict_func_name = (
-        '_flags' if hasattr(flag_values_copy, '_flags') else 'FlagDict')
-    with flag_util.FlagDictSubstitution(
-        flag_values, getattr(flag_values_copy, flag_dict_func_name)):
+    if hasattr(flag_values_copy, '_flags'):
+      flag_dict_func = flag_values_copy._flags
+    else:
+      flag_dict_func = flag_values_copy.FlagDict
+    with flag_util.FlagDictSubstitution(flag_values, flag_dict_func):
       self.assertFlagState(flag_values, 1, False)
       self.assertFlagState(flag_values_copy, 1, False)
       flag_values.test_flag = 2

--- a/tests/flag_util_test.py
+++ b/tests/flag_util_test.py
@@ -120,7 +120,10 @@ class FlagDictSubstitutionTestCase(unittest.TestCase):
     flag_values_copy.test_flag = 1
     self.assertFlagState(flag_values, 0, False)
     self.assertFlagState(flag_values_copy, 1, False)
-    with flag_util.FlagDictSubstitution(flag_values, flag_values_copy.FlagDict):
+    flag_dict_func_name = (
+        '_flags' if hasattr(flag_values_copy, '_flags') else 'FlagDict')
+    with flag_util.FlagDictSubstitution(
+        flag_values, getattr(flag_values_copy, flag_dict_func_name)):
       self.assertFlagState(flag_values, 1, False)
       self.assertFlagState(flag_values_copy, 1, False)
       flag_values.test_flag = 2


### PR DESCRIPTION
This is a followup for https://github.com/GoogleCloudPlatform/PerfKitBenchmarker/pull/1175/commits/4b6c2dbeac5a2fc2b46686a78fd65da468631ca7