### PR TITLE
Fio enhancements

### DIFF
--- a/perfkitbenchmarker/flag_util.py
+++ b/perfkitbenchmarker/flag_util.py
@@ -145,6 +145,8 @@ class IntegerListParser(flags.ArgumentParser):
       return inp
     elif isinstance(inp, list):
       return IntegerList(inp)
+    elif isinstance(inp, int):
+      return IntegerList([inp])
 
     def HandleNonIncreasing():
       if self.on_nonincreasing == IntegerListParser.WARN:

--- a/perfkitbenchmarker/linux_benchmarks/fio_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/fio_benchmark.py
@@ -20,7 +20,6 @@ Quick howto: http://www.bluestop.org/fio/HOWTO.txt
 
 import json
 import logging
-import os
 import posixpath
 import re
 import time

--- a/perfkitbenchmarker/linux_benchmarks/fio_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/fio_benchmark.py
@@ -20,8 +20,10 @@ Quick howto: http://www.bluestop.org/fio/HOWTO.txt
 
 import json
 import logging
+import os
 import posixpath
 import re
+import time
 
 import jinja2
 
@@ -394,7 +396,9 @@ def GetLogFlags():
                    (FLAGS.fio_iops_log, '--write_iops_log=%(filename)s',),
                    (collect_logs, '--log_avg_msec=%(interval)d',)]
   fio_command_flags = ' '.join([flag for given, flag in fio_log_flags if given])
-  return fio_command_flags % {'filename': PKB_FIO_LOG_FILE_NAME,
+  now = time.time()
+  filename_base = '%s_%s' % (PKB_FIO_LOG_FILE_NAME, str(now))
+  return fio_command_flags % {'filename': filename_base,
                               'interval': FLAGS.fio_log_avg_msec}
 
 


### PR DESCRIPTION
Two small enhancements for the fio benchmark:

   1. When retrieving IOPS, latency or bandwidth logs, add timestamps to their names. This keeps us from overwriting old logs when running fio with `--run_stage_time`.
   2. Handle single integers as input to the IntegerList parser. This makes the parser work correctly with config files, which will turn strings of digits into integers on parsing.