### PR TITLE
Use FLAGS.aws_user_name if set for Rhel

### DIFF
--- a/perfkitbenchmarker/providers/aws/aws_virtual_machine.py
+++ b/perfkitbenchmarker/providers/aws/aws_virtual_machine.py
@@ -545,7 +545,8 @@ class RhelBasedAwsVirtualMachine(AwsVirtualMachine,
 
   def __init__(self, vm_spec):
     super(RhelBasedAwsVirtualMachine, self).__init__(vm_spec)
-    self.user_name = FLAGS.aws_user_name if FLAGS['aws_user_name'].present else 'ec2-user'
+    user_name_set = FLAGS['aws_user_name'].present
+    self.user_name = FLAGS.aws_user_name if user_name_set else 'ec2-user'
 
 
 class WindowsAwsVirtualMachine(AwsVirtualMachine,

--- a/perfkitbenchmarker/providers/aws/aws_virtual_machine.py
+++ b/perfkitbenchmarker/providers/aws/aws_virtual_machine.py
@@ -545,10 +545,8 @@ class RhelBasedAwsVirtualMachine(AwsVirtualMachine,
 
   def __init__(self, vm_spec):
     super(RhelBasedAwsVirtualMachine, self).__init__(vm_spec)
-    if FLAGS['aws_user_name'].present:
-      self.user_name = FLAGS.aws_user_name
-    else:
-      self.user_name = 'ec2-user'
+    user_name_set = FLAGS['aws_user_name'].present
+    self.user_name = FLAGS.aws_user_name if user_name_set else 'ec2-user'
 
 
 class WindowsAwsVirtualMachine(AwsVirtualMachine,

--- a/perfkitbenchmarker/providers/aws/aws_virtual_machine.py
+++ b/perfkitbenchmarker/providers/aws/aws_virtual_machine.py
@@ -545,7 +545,10 @@ class RhelBasedAwsVirtualMachine(AwsVirtualMachine,
 
   def __init__(self, vm_spec):
     super(RhelBasedAwsVirtualMachine, self).__init__(vm_spec)
-    self.user_name = 'ec2-user'
+    if FLAGS.aws_user_name:
+      self.user_name = FLAGS.aws_user_name
+    else:
+      self.user_name = 'ec2-user'
 
 
 class WindowsAwsVirtualMachine(AwsVirtualMachine,

--- a/perfkitbenchmarker/providers/aws/aws_virtual_machine.py
+++ b/perfkitbenchmarker/providers/aws/aws_virtual_machine.py
@@ -545,7 +545,7 @@ class RhelBasedAwsVirtualMachine(AwsVirtualMachine,
 
   def __init__(self, vm_spec):
     super(RhelBasedAwsVirtualMachine, self).__init__(vm_spec)
-    if FLAGS.aws_user_name:
+    if FLAGS['aws_user_name'].present:
       self.user_name = FLAGS.aws_user_name
     else:
       self.user_name = 'ec2-user'

--- a/perfkitbenchmarker/providers/aws/aws_virtual_machine.py
+++ b/perfkitbenchmarker/providers/aws/aws_virtual_machine.py
@@ -545,8 +545,7 @@ class RhelBasedAwsVirtualMachine(AwsVirtualMachine,
 
   def __init__(self, vm_spec):
     super(RhelBasedAwsVirtualMachine, self).__init__(vm_spec)
-    user_name_set = FLAGS['aws_user_name'].present
-    self.user_name = FLAGS.aws_user_name if user_name_set else 'ec2-user'
+    self.user_name = FLAGS.aws_user_name if FLAGS['aws_user_name'].present else 'ec2-user'
 
 
 class WindowsAwsVirtualMachine(AwsVirtualMachine,


### PR DESCRIPTION
The official CentOS AMI user name is "centos" and not "ec2-user"  This patch enables passing in the AWS user name to be used, ie:
```
--aws_user_name=centos
```
It defaults to ec2-user if none is passed in.