### PR TITLE
if the image_project flag is set always use it in disk creation

### DIFF
--- a/perfkitbenchmarker/providers/gcp/gce_disk.py
+++ b/perfkitbenchmarker/providers/gcp/gce_disk.py
@@ -71,8 +71,8 @@ class GceDisk(disk.BaseDisk):
     cmd.flags['type'] = self.disk_type
     if self.image:
       cmd.flags['image'] = self.image
-      if FLAGS.image_project:
-        cmd.flags['image-project'] = FLAGS.image_project
+    if FLAGS.image_project:
+      cmd.flags['image-project'] = FLAGS.image_project
     cmd.Issue()
 
   def _Delete(self):


### PR DESCRIPTION
When using the --image_project flag for GCE to create VMs we must use it when creating disks, otherwise an error "Invalid value for field 'resource.disks[0].initializeParams.sourceImage'"

The current code has that capability but only when we pass in the image name.  Since we need that image_project value when creating a disk regardless if we're passing in the image I moved out the code to always run.