### PR TITLE
Making CheckPrerequisites more comprehensive

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/aerospike_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/aerospike_benchmark.py
@@ -84,7 +84,7 @@ def GetConfig(user_config):
   return config
 
 
-def CheckPrerequisites():
+def CheckPrerequisites(benchmark_config):
   """Verifies that the required resources are present.
 
   Raises:

--- a/perfkitbenchmarker/linux_benchmarks/aerospike_ycsb_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/aerospike_ycsb_benchmark.py
@@ -68,7 +68,7 @@ def GetConfig(user_config):
   return config
 
 
-def CheckPrerequisites():
+def CheckPrerequisites(benchmark_config):
   """Verifies that the required resources are present.
 
   Raises:

--- a/perfkitbenchmarker/linux_benchmarks/blazemark_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/blazemark_benchmark.py
@@ -51,7 +51,7 @@ def GetConfig(user_config):
   return configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
 
 
-def CheckPrerequisites():
+def CheckPrerequisites(benchmark_config):
   """Perform flag checks."""
   if 'all' not in FLAGS.blazemark_set:
     requested = frozenset(FLAGS.blazemark_set)

--- a/perfkitbenchmarker/linux_benchmarks/cassandra_stress_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/cassandra_stress_benchmark.py
@@ -200,7 +200,7 @@ def GetConfig(user_config):
   return configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
 
 
-def CheckPrerequisites():
+def CheckPrerequisites(benchmark_config):
   """Verifies that the required resources are present.
 
   Raises:

--- a/perfkitbenchmarker/linux_benchmarks/cassandra_ycsb_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/cassandra_ycsb_benchmark.py
@@ -67,7 +67,7 @@ def GetConfig(user_config):
   return config
 
 
-def CheckPrerequisites():
+def CheckPrerequisites(benchmark_config):
   """Verifies that the required resources are present.
 
   Raises:

--- a/perfkitbenchmarker/linux_benchmarks/cloud_bigtable_ycsb_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/cloud_bigtable_ycsb_benchmark.py
@@ -105,7 +105,7 @@ def GetConfig(user_config):
   return configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
 
 
-def CheckPrerequisites():
+def CheckPrerequisites(benchmark_config):
   """Verifies that the required resources are present.
 
   Raises:

--- a/perfkitbenchmarker/linux_benchmarks/cloud_datastore_ycsb_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/cloud_datastore_ycsb_benchmark.py
@@ -74,7 +74,7 @@ def GetConfig(user_config):
     return config
 
 
-def CheckPrerequisites():
+def CheckPrerequisites(benchmark_config):
     # Before YCSB Cloud Datastore supports Application Default Credential,
     # we should always make sure valid credential flags are set.
     if not FLAGS.google_datastore_keyfile:

--- a/perfkitbenchmarker/linux_benchmarks/cloudsuite_web_serving_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/cloudsuite_web_serving_benchmark.py
@@ -55,7 +55,7 @@ def GetConfig(user_config):
   return configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
 
 
-def CheckPrerequisites():
+def CheckPrerequisites(benchmark_config):
   """Verifies that the required resources are present.
   Raises:
     perfkitbenchmarker.data.ResourceNotFound: On missing resource.

--- a/perfkitbenchmarker/linux_benchmarks/copy_throughput_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/copy_throughput_benchmark.py
@@ -65,7 +65,7 @@ def GetConfig(user_config):
   return config
 
 
-def CheckPrerequisites():
+def CheckPrerequisites(benchmark_config):
   """Verifies that the required resources are present.
 
   Raises:

--- a/perfkitbenchmarker/linux_benchmarks/coremark_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/coremark_benchmark.py
@@ -48,7 +48,7 @@ def GetConfig(user_config):
   return configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
 
 
-def CheckPrerequisites():
+def CheckPrerequisites(benchmark_config):
   """Verifies that the required resources are present.
 
   Raises:

--- a/perfkitbenchmarker/linux_benchmarks/dpb_wordcount_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/dpb_wordcount_benchmark.py
@@ -94,7 +94,7 @@ def GetConfig(user_config):
   return configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
 
 
-def CheckPrerequisites():
+def CheckPrerequisites(benchmark_config):
   """Verifies that the required resources are present.
 
   Raises:

--- a/perfkitbenchmarker/linux_benchmarks/fio_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/fio_benchmark.py
@@ -401,7 +401,7 @@ def GetLogFlags():
                               'interval': FLAGS.fio_log_avg_msec}
 
 
-def CheckPrerequisites():
+def CheckPrerequisites(benchmark_config):
   """Perform flag checks."""
   WarnOnBadFlags()
 

--- a/perfkitbenchmarker/linux_benchmarks/gpu_pcie_bandwidth_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/gpu_pcie_bandwidth_benchmark.py
@@ -82,7 +82,7 @@ def GetConfig(user_config):
   return config
 
 
-def CheckPrerequisites():
+def CheckPrerequisites(benchmark_config):
   """Verifies that the required resources are present.
 
   Raises:

--- a/perfkitbenchmarker/linux_benchmarks/hbase_ycsb_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/hbase_ycsb_benchmark.py
@@ -97,7 +97,7 @@ def GetConfig(user_config):
   return config
 
 
-def CheckPrerequisites():
+def CheckPrerequisites(benchmark_config):
   """Verifies that the required resources are present.
 
   Raises:

--- a/perfkitbenchmarker/linux_benchmarks/hpcc_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/hpcc_benchmark.py
@@ -83,7 +83,7 @@ def GetConfig(user_config):
   return configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
 
 
-def CheckPrerequisites():
+def CheckPrerequisites(benchmark_config):
   """Verifies that the required resources are present.
 
   Raises:

--- a/perfkitbenchmarker/linux_benchmarks/jdbc_ycsb_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/jdbc_ycsb_benchmark.py
@@ -86,7 +86,7 @@ def GetConfig(user_config):
     return config
 
 
-def CheckPrerequisites():
+def CheckPrerequisites(benchmark_config):
     # Before YCSB Cloud Datastore supports Application Default Credential,
     # we should always make sure valid credential flags are set.
     if not FLAGS.jdbc_ycsb_db_driver:

--- a/perfkitbenchmarker/linux_benchmarks/memcached_ycsb_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/memcached_ycsb_benchmark.py
@@ -58,7 +58,7 @@ def GetConfig(user_config):
   return config
 
 
-def CheckPrerequisites():
+def CheckPrerequisites(benchmark_config):
   """Verifies that the required resources are present.
 
   Raises:

--- a/perfkitbenchmarker/linux_benchmarks/multichase_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/multichase_benchmark.py
@@ -205,7 +205,7 @@ def GetConfig(user_config):
   return configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
 
 
-def CheckPrerequisites():
+def CheckPrerequisites(benchmark_config):
   """Performs input verification checks.
 
   Raises:

--- a/perfkitbenchmarker/linux_benchmarks/object_storage_service_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/object_storage_service_benchmark.py
@@ -951,7 +951,7 @@ def MultiStreamWriteBenchmark(results, metadata, vms, command_builder,
   logging.info('Finished multi-stream write test.')
 
 
-def CheckPrerequisites():
+def CheckPrerequisites(benchmark_config):
   """Verifies that the required resources are present.
 
   Raises:

--- a/perfkitbenchmarker/linux_benchmarks/scimark2_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/scimark2_benchmark.py
@@ -46,7 +46,7 @@ def GetConfig(user_config):
   return configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
 
 
-def CheckPrerequisites():
+def CheckPrerequisites(benchmark_config):
   pass
 
 

--- a/perfkitbenchmarker/linux_benchmarks/speccpu2006_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/speccpu2006_benchmark.py
@@ -107,7 +107,7 @@ def GetConfig(user_config):
   return configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
 
 
-def CheckPrerequisites():
+def CheckPrerequisites(benchmark_config):
   """Verifies that the required input files are present."""
   try:
     # Peeking into the tar file is slow. If running in stages, it's

--- a/perfkitbenchmarker/linux_benchmarks/specsfs2014_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/specsfs2014_benchmark.py
@@ -104,7 +104,7 @@ def GetConfig(user_config):
   return configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
 
 
-def CheckPrerequisites():
+def CheckPrerequisites(benchmark_config):
   """Verifies that the required resources are present.
 
   Raises:

--- a/perfkitbenchmarker/linux_benchmarks/unixbench_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/unixbench_benchmark.py
@@ -63,7 +63,7 @@ def GetConfig(user_config):
   return configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
 
 
-def CheckPrerequisites():
+def CheckPrerequisites(benchmark_config):
   """Verifies that the required resources for UnixBench are present.
 
   Raises:

--- a/perfkitbenchmarker/pkb.py
+++ b/perfkitbenchmarker/pkb.py
@@ -328,7 +328,7 @@ def _CreateBenchmarkSpecs():
     if check_prereqs:
       try:
         with config.RedirectFlags(FLAGS):
-          check_prereqs()
+          check_prereqs(config)
       except:
         logging.exception('Prerequisite check failed for %s', name)
         raise


### PR DESCRIPTION
Passing benchmark_config as argument to the CheckPrerequisites method of benchmarks to enable more comprehensive validation