### PR TITLE
Various object storage service benchmark improvements

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/object_storage_service_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/object_storage_service_benchmark.py
@@ -890,12 +890,8 @@ def MultiStreamRWBenchmark(results, metadata, vms, command_builder,
   logging.info('Finished multi-stream write test. Starting '
                'multi-stream read test.')
 
-  try:
-    _MultiStreamOneWay(results, metadata, vms, command_builder, bucket_name,
-                       'download')
-  except Exception as ex:
-    logging.info('MultiStreamRead test failed with exception %s. Still '
-                 'recording write data: %s', ex)
+  _MultiStreamOneWay(results, metadata, vms, command_builder, bucket_name,
+                     'download')
 
   logging.info('Finished multi-stream read test.')
 

--- a/perfkitbenchmarker/linux_benchmarks/object_storage_service_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/object_storage_service_benchmark.py
@@ -728,7 +728,7 @@ def ListConsistencyBenchmark(results, metadata, vm, command_builder,
                                    metadata)
 
 
-def LoadWorkerOutput(output):
+def LoadWorkerOutput(output, streams_per_vm):
   """Load output from worker processes to our internal format.
 
   Args:
@@ -762,39 +762,21 @@ def LoadWorkerOutput(output):
   latencies = []
   sizes = []
 
-  prev_stream_num = None
   for worker_out in output:
     json_out = json.loads(worker_out)
-    num_records = len(json_out)
 
-    assert (not prev_stream_num or
-            json_out[0]['stream_num'] == prev_stream_num + 1)
-    prev_stream_num = prev_stream_num + 1 if prev_stream_num else 0
+    for stream in json_out:
+      assert len(stream['start_times']) == len(stream['latencies'])
+      assert len(stream['latencies']) == len(stream['sizes'])
 
-    start_time = np.zeros([num_records], dtype=np.float64)
-    latency = np.zeros([num_records], dtype=np.float64)
-    size = np.zeros([num_records], dtype=np.int64)
-
-    prev_start = None
-    prev_latency = None
-    for i in xrange(num_records):
-      start_time[i] = json_out[i]['start_time']
-      latency[i] = json_out[i]['latency']
-      size[i] = json_out[i]['size']
-
-      assert i == 0 or start_time[i] >= (prev_start + prev_latency)
-      prev_start = start_time[i]
-      prev_latency = latency[i]
-    start_times.append(start_time)
-    latencies.append(latency)
-    sizes.append(size)
+      start_times.append(np.asarray(stream['start_times'], dtype=np.float64))
+      latencies.append(np.asarray(stream['latencies'], dtype=np.float64))
+      sizes.append(np.asarray(stream['sizes'], dtype=np.int64))
 
   return start_times, latencies, sizes
 
 
-def _RunMultiStreamProcesses(vms, command_builder, cmd_args,
-                             streams_per_vm, num_streams):
-
+def _RunMultiStreamProcesses(vms, command_builder, cmd_args, streams_per_vm):
   """Runs all of the multistream read or write processes and doesn't return
      until they complete.
 
@@ -803,26 +785,24 @@ def _RunMultiStreamProcesses(vms, command_builder, cmd_args,
     command_builder: an APIScriptCommandBuilder.
     cmd_args: arguments for the command_builder.
     streams_per_vm: number of threads per vm.
-    num_streams: total number of threads to launch.
   """
 
-  output = [None] * num_streams
+  output = [None] * len(vms)
 
-  def RunOneProcess(proc_idx):
-    vm_idx = proc_idx // streams_per_vm
+  def RunOneProcess(vm_idx):
     logging.info('Running on VM %s.', vm_idx)
     cmd = command_builder.BuildCommand(
-        cmd_args + ['--stream_num_start=%s' % proc_idx])
+        cmd_args + ['--stream_num_start=%s' % (vm_idx * streams_per_vm)])
     out, _ = vms[vm_idx].RobustRemoteCommand(cmd, should_log=True)
-    output[proc_idx] = out
+    output[vm_idx] = out
 
-  # Each process has a thread managing it.
+  # Each vm/process has a thread managing it.
   threads = [
-      threading.Thread(target=RunOneProcess, args=(i,))
-      for i in xrange(num_streams)]
+      threading.Thread(target=RunOneProcess, args=(vm_idx,))
+      for vm_idx in xrange(len(vms))]
   for thread in threads:
     thread.start()
-  logging.info('Started %s processes.', num_streams)
+  logging.info('Started %s processes.', len(vms))
   # Wait for the threads to finish
   for thread in threads:
     thread.join()
@@ -832,7 +812,6 @@ def _RunMultiStreamProcesses(vms, command_builder, cmd_args,
 
 def _MultiStreamOneWay(results, metadata, vms, command_builder,
                        bucket_name, operation):
-
   """Measures multi-stream latency and throughput in one direction.
 
   Args:
@@ -856,7 +835,6 @@ def _MultiStreamOneWay(results, metadata, vms, command_builder,
                FLAGS.object_storage_object_sizes, size_distribution)
 
   streams_per_vm = FLAGS.object_storage_streams_per_vm
-  num_streams = streams_per_vm * len(vms)
 
   start_time = (
       time.time() +
@@ -868,7 +846,7 @@ def _MultiStreamOneWay(results, metadata, vms, command_builder,
       '--bucket=%s' % bucket_name,
       '--objects_per_stream=%s' % (
           FLAGS.object_storage_multistream_objects_per_stream),
-      '--num_streams=1',
+      '--num_streams=%s' % streams_per_vm,
       '--start_time=%s' % start_time,
       '--objects_written_file=%s' % objects_written_file]
 
@@ -884,8 +862,8 @@ def _MultiStreamOneWay(results, metadata, vms, command_builder,
                     'Value is: \'' + operation + '\'')
 
   output = _RunMultiStreamProcesses(vms, command_builder, cmd_args,
-                                    streams_per_vm, num_streams)
-  start_times, latencies, sizes = LoadWorkerOutput(output)
+                                    streams_per_vm)
+  start_times, latencies, sizes = LoadWorkerOutput(output, streams_per_vm)
   _ProcessMultiStreamResults(start_times, latencies, sizes, operation,
                              size_distribution.iterkeys(), results,
                              metadata=metadata)

--- a/perfkitbenchmarker/linux_benchmarks/object_storage_service_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/object_storage_service_benchmark.py
@@ -905,7 +905,7 @@ def MultiStreamRWBenchmark(results, metadata, vms, command_builder,
                        'download')
   except Exception as ex:
     logging.info('MultiStreamRead test failed with exception %s. Still '
-                 'recording write data.', ex.msg)
+                 'recording write data: %s', ex)
 
   logging.info('Finished multi-stream read test.')
 

--- a/perfkitbenchmarker/scripts/object_storage_api_test_scripts/object_storage_api_tests.py
+++ b/perfkitbenchmarker/scripts/object_storage_api_test_scripts/object_storage_api_tests.py
@@ -26,10 +26,9 @@ import cStringIO
 import json
 import logging
 import os
-import Queue
 import sys
+import multiprocessing as mp
 from threading import Thread
-import threading
 import string
 import random
 import time
@@ -574,58 +573,44 @@ def SingleStreamThroughputBenchmark(service):
     service.DeleteObjects(FLAGS.bucket, objects_written)
 
 
-def RunThreadedWorkers(worker, worker_args, per_thread_args=None):
-  """Run a worker function in many threads, then gather and return the results.
+def RunWorkerProcesses(worker, worker_args, per_process_args=None):
+  """Run a worker function in many processes, then gather and return the results
 
   Args:
     worker: either WriteWorker or ReadWorker. The worker function to call.
     worker_args: a tuple. The arguments to pass to the worker function. The
       result queue and stream number will be appended as the last two arguments.
-    per_thread_args: if given, an array with length equal to the
-      number of threads. Thread number i will be passed
-      per_thread_args[i] after its regular arguments and before the
+    per_process_args: if given, an array with length equal to the
+      number of processes. Process number i will be passed
+      per_process_args[i] after its regular arguments and before the
       result queue and stream number.
 
   Returns:
     A list of the results returned by the workers.
   """
 
-  result_queue = Queue.Queue()
+  result_queue = mp.Queue()
+  num_streams = FLAGS.num_streams
 
-  logging.info('Creating %s threads', FLAGS.num_streams)
-  if per_thread_args is None:
-    threads = [threading.Thread(target=worker,
-                                args=worker_args + (result_queue, i))
-               for i in xrange(FLAGS.num_streams)]
+  logging.info('Creating %s processes', FLAGS.num_streams)
+  if per_process_args is None:
+    processes = [mp.Process(target=worker,
+                            args=worker_args + (result_queue, i))
+                 for i in xrange(num_streams)]
   else:
-    threads = [threading.Thread(target=worker,
-                                args=worker_args +
-                                (per_thread_args[i],) +
-                                (result_queue, i))
-               for i in xrange(FLAGS.num_streams)]
-  logging.info('Threads created. Starting threads.')
-  for thread in threads:
-    thread.start()
-  logging.info('Threads started.')
-  while True:
-    time.sleep(THREAD_STATUS_LOG_INTERVAL)
-    num_alive = sum((thread.isAlive() for thread in threads))
-    if num_alive == 0:
-      break
-    else:
-      logging.info('%s of %s threads are still working.',
-                   num_alive, FLAGS.num_streams)
-  logging.info('All threads complete.')
+    processes = [mp.Process(target=worker,
+                            args=worker_args +
+                            (per_process_args[i],) +
+                            (result_queue, i))
+                 for i in xrange(num_streams)]
+  logging.info('Processes created. Starting processes.')
+  for process in processes:
+    process.start()
+  logging.info('Processes started.')
 
-  results = []
-
-  try:
-    while True:
-      res = result_queue.get_nowait()
-      results.append(res)
-  except Queue.Empty:
-    pass
-
+  # Wait for all the results. Each worker will put one result onto the queue
+  results = [result_queue.get() for _ in range(num_streams)]
+  logging.info('All processes complete.')
   return results
 
 
@@ -652,8 +637,8 @@ def MultiStreamWrites(service):
 
   [{"operation": "upload", "start_time": start_time_1,
     "latency": latency_1, "size": size_1, "stream_num": stream_num_1},
-   [{"operation": "upload", "start_time": start_time_2,
-    "latency": latency_2, "size": size_2, "stream_num": stream_num_2}
+   {"operation": "upload", "start_time": start_time_2,
+    "latency": latency_2, "size": size_2, "stream_num": stream_num_2},
    ...]
 
   Both kinds of output are written as JSON, for easy serialization and
@@ -665,7 +650,7 @@ def MultiStreamWrites(service):
 
   payload = GenerateWritePayload(MaxSizeInDistribution(size_distribution))
 
-  results = RunThreadedWorkers(
+  results = RunWorkerProcesses(
       WriteWorker,
       (service,
        payload,
@@ -693,28 +678,23 @@ def MultiStreamWrites(service):
       logging.info('Got exception %s while trying to write objects written '
                    'file.', ex)
 
-  # operation_records is the data we send back to the controller.
-  operation_records = []
-  for result in results:
-    operation = result['operation']
-    stream_num = result['stream_num']
-    for start_time, latency, size in zip(result['start_times'],
-                                         result['latencies'],
-                                         result['sizes']):
-      operation_records.append({'operation': operation,
-                                'start_time': start_time,
-                                'latency': latency,
-                                'size': size,
-                                'stream_num': stream_num})
+  logging.info('len(results) = %s', len(results))
 
+  # streams is the data we send back to the controller.
+  streams = []
+  for result in results:
+    result_keys = ('stream_num', 'start_times', 'latencies', 'sizes')
+    streams.append({k: result[k] for k in result_keys})
+
+  num_writes = sum([len(stream['start_times']) for stream in streams])
   num_writes_requested = FLAGS.objects_per_stream * FLAGS.num_streams
   min_writes_required = num_writes_requested * (1.0 - FAILURE_TOLERANCE)
-  if len(operation_records) < min_writes_required:
+  if num_writes < min_writes_required:
     raise LowAvailabilityError(
         'Wrote %s objects out of %s requested (%s requred)' %
-        (len(operation_records), num_writes_requested, min_writes_required))
+        (num_writes, num_writes_requested, min_writes_required))
 
-  json.dump(operation_records, sys.stdout, indent=0)
+  json.dump(streams, sys.stdout, indent=0)
 
 
 def MultiStreamReads(service):
@@ -751,21 +731,20 @@ def MultiStreamReads(service):
   objects_by_worker = [object_records[i::num_workers]
                        for i in xrange(num_workers)]
 
-  results = RunThreadedWorkers(
+  results = RunWorkerProcesses(
       ReadWorker,
       (service,
        FLAGS.start_time),
-      per_thread_args=objects_by_worker)
+      per_process_args=objects_by_worker)
 
   # send data back to the controller
   operation_records = []
   for result in results:
-    operation = result['operation']
     stream_num = result['stream_num']
     for start_time, latency, size in zip(result['start_times'],
                                          result['latencies'],
                                          result['sizes']):
-      operation_records.append({'operation': operation,
+      operation_records.append({'operation': 'download',
                                 'stream_num': stream_num,
                                 'start_time': start_time,
                                 'latency': latency,
@@ -810,7 +789,7 @@ def WriteWorker(service, payload,
     num_objects: the number of objects to upload.
     start_time: a POSIX timestamp. When to start uploading.
     naming_scheme: how to name objects. See flag.
-    result_queue: a Queue.Queue to record results in.
+    result_queue: a mp.Queue to record results in.
     worker_num: the thread number of this worker.
   """
 
@@ -850,8 +829,9 @@ def WriteWorker(service, payload,
       logging.info('Worker %s caught exception %s while writing object %s' %
                    (worker_num, e, object_name))
 
-  result_queue.put({'operation': 'upload',
-                    'object_names': object_names,
+  logging.info('Worker %s finished writing its objects' % worker_num)
+
+  result_queue.put({'object_names': object_names,
                     'start_times': start_times,
                     'latencies': latencies,
                     'sizes': sizes,
@@ -880,8 +860,7 @@ def ReadWorker(service, start_time, object_records,
                    (worker_num, e, name))
 
 
-  result_queue.put({'operation': 'download',
-                    'start_times': start_times,
+  result_queue.put({'start_times': start_times,
                     'latencies': latencies,
                     'sizes': sizes,
                     'stream_num': worker_num + FLAGS.stream_num_start})

--- a/tools/object_storage_timeline.py
+++ b/tools/object_storage_timeline.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python
+
+# Copyright 2016 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import numpy as np
+import matplotlib.collections as mplc
+import matplotlib.pyplot as plt
+import matplotlib.patches as mpl_patches
+import sys
+
+
+class DraggableXRange:
+  def __init__(self, figure, updater):
+    self.figure = figure
+    self.span = None
+    self.start = None
+    self.end = None
+    self.background = None
+    self.updater = updater
+
+  def connect(self):
+    'connect to all the events we need'
+    self.cidpress = self.figure.canvas.mpl_connect(
+        'button_press_event', self.on_press)
+    self.cidrelease = self.figure.canvas.mpl_connect(
+        'button_release_event', self.on_release)
+    self.cidmotion = self.figure.canvas.mpl_connect(
+        'motion_notify_event', self.on_motion)
+
+  def on_press(self, event):
+    'on button press we will see if the mouse is over us and store some data'
+    if event.button != 3:
+      # Only continue for right mouse button
+      return
+    if self.span is not None:
+      return
+
+    self.start = event.xdata
+    self.end = event.xdata
+    self.span = plt.axvspan(self.start, self.end, color='blue', alpha=0.5)
+
+    # draw everything but the selected rectangle and store the pixel buffer
+    canvas = self.figure.canvas
+    axes = self.span.axes
+    canvas.draw()
+    self.background = canvas.copy_from_bbox(self.span.axes.bbox)
+
+    # now redraw just the rectangle
+    axes.draw_artist(self.span)
+    # and blit just the redrawn area
+    canvas.blit(axes.bbox)
+
+    self.updater.update(self.start, self.end)
+
+  def on_motion(self, event):
+    'on motion we will move the rect if the mouse is over us'
+    if self.span is None:
+      return
+
+    self.span.remove()
+
+    self.end = event.xdata
+    self.span = plt.axvspan(self.start, self.end, color='blue', alpha=0.5)
+
+    canvas = self.figure.canvas
+    axes = self.span.axes
+    # restore the background region
+    canvas.restore_region(self.background)
+    # Save the new background
+    self.background = canvas.copy_from_bbox(self.span.axes.bbox)
+
+    # redraw just the current rectangle
+    axes.draw_artist(self.span)
+    # blit just the redrawn area
+    canvas.blit(axes.bbox)
+
+    self.updater.update(self.start, self.end)
+
+  def on_release(self, event):
+    'on release we reset the press data'
+    if event.button != 3:
+      # Only continue for right mouse button
+      return
+    if self.span is None:
+      return
+
+    self.span.remove()
+
+    self.start = None
+    self.end = None
+    self.span = None
+    self.background = None
+
+    # redraw the full figure
+    self.figure.canvas.draw()
+
+    self.updater.update(self.start, self.end)
+
+  def disconnect(self):
+    'disconnect all the stored connection ids'
+    self.figure.canvas.mpl_disconnect(self.cidpress)
+    self.figure.canvas.mpl_disconnect(self.cidrelease)
+    self.figure.canvas.mpl_disconnect(self.cidmotion)
+
+
+class SelectionUpdate:
+  def __init__(self, figure, ax, start_times, latencies):
+    self.text = None
+    self.figure = figure
+    self.ax = ax
+    self.start_times = start_times
+    self.latencies = latencies
+
+  def update(self, start, end):
+    if self.text is not None:
+      axes = self.text.axes
+      self.text.remove()
+      self.text = None
+      self.figure.canvas.blit(axes.bbox)
+    if start is None:
+      assert end is None
+      return
+
+    start, end = min(start, end), max(start, end)
+
+    if start == end:
+      return
+
+    active_start_indexes = []
+    for start_time in self.start_times:
+      for i in xrange(len(start_time)):
+        if start_time[i] >= start:
+          active_start_indexes.append(i)
+          break
+    active_stop_indexes = []
+    for start_time, latency in zip(self.start_times, self.latencies):
+      for i in xrange(len(start_time) - 1, -1, -1):
+        if start_time[i] + latency[i] <= end:
+          active_stop_indexes.append(i + 1)
+          break
+    active_latencies = [
+        self.latencies[i][active_start_indexes[i]:active_stop_indexes[i]]
+        for i in range(len(self.latencies))]
+    all_active_latencies = np.concatenate(active_latencies)
+
+    qps = len(all_active_latencies) / (end - start)
+    latency_min = min(all_active_latencies)
+    latency_max = max(all_active_latencies)
+    latency_avg = sum(all_active_latencies) / len(all_active_latencies)
+    latency_stddev = np.std(all_active_latencies)
+
+    text_str = ('Duration: %s\nQPS: %s\nlatency min: %s\nlatency max: %s\n'
+                'latency avg: %s\nlatency stddev: %s'
+                % (end - start, qps, latency_min, latency_max,
+                   latency_avg, latency_stddev))
+
+    # place a text box in upper left in axes coords
+    props = dict(boxstyle='round', facecolor='wheat', alpha=0.5)
+    self.text = self.ax.text(0.05, 0.95, text_str,
+                             transform=self.ax.transAxes, fontsize=14,
+                             verticalalignment='top', bbox=props)
+    # redraw just the text
+    self.text.axes.draw_artist(self.text)
+    # blit just the redrawn area
+    self.figure.canvas.blit(self.text.axes.bbox)
+
+
+def GenerateObjectTimeline(file_name, start_times, latencies):
+  print("Generating object timeline")
+  assert len(start_times) == len(latencies)
+  rects = []
+  for i, worker_times in enumerate(zip(start_times, latencies)):
+    for j, (start_time, latency) in enumerate(np.vstack(worker_times).T):
+      rect = mpl_patches.Rectangle((start_time, i + 0.5), latency, 1.0,
+                                   color=(0.5 * (j % 2) + 0.5, 0, 0),
+                                   linewidth=0)
+      rects.append(rect)
+  pc = mplc.PatchCollection(rects, match_original=True)
+  fig, ax = plt.subplots(figsize=(30, 5))
+  ax.add_collection(pc)
+  ax.autoscale()
+  ax.margins(0.1)
+  print("Saving figure as %s" % file_name)
+  plt.savefig(file_name, bbox_inches='tight', dpi=1200)
+  print("Figured saved. Rendering figure...")
+
+  selection = DraggableXRange(fig, SelectionUpdate(fig, ax, start_times,
+                                                   latencies))
+  selection.connect()
+  plt.show()
+  selection.disconnect()
+
+
+def LoadWorkerOutput(output):
+  """Load output from worker processes to our internal format.
+
+  Args:
+    output: list of strings. The stdouts of all worker processes.
+
+  Returns:
+    A tuple of start_time, latency, size. Each of these is a list of
+    numpy arrays, one array per worker process. start_time[i],
+    latency[i], and size[i] together form a table giving the start
+    time, latency, and size (bytes transmitted or received) of all
+    send/receive operations for worker i.
+
+    start_time holds POSIX timestamps, stored as np.float64. latency
+    holds times in seconds, stored as np.float64. size holds sizes in
+    bytes, stored as np.int64.
+
+    Example:
+      start_time[i]  latency[i]  size[i]
+      -------------  ----------  -------
+               0.0         0.5      100
+               1.0         0.7      200
+               2.3         0.3      100
+
+  Raises:
+    AssertionError, if an individual worker doesn't have the same number of
+    start_times, latencies, or sizes.
+  """
+
+  start_times = []
+  latencies = []
+  sizes = []
+
+  for worker_out in output:
+    json_out = json.loads(worker_out)
+
+    for stream in json_out:
+      assert len(stream['start_times']) == len(stream['latencies'])
+      assert len(stream['latencies']) == len(stream['sizes'])
+
+      start_times.append(np.asarray(stream['start_times'], dtype=np.float64))
+      latencies.append(np.asarray(stream['latencies'], dtype=np.float64))
+      sizes.append(np.asarray(stream['sizes'], dtype=np.int64))
+
+  return start_times, latencies, sizes
+
+
+def main():
+  worker_output = None
+  print("Reading worker output")
+  with open(sys.argv[1], 'r') as worker_out_file:
+    worker_output = json.loads(worker_out_file.read())
+  print("Parsing worker output")
+  start_times, latencies, _ = LoadWorkerOutput(worker_output)
+  GenerateObjectTimeline(sys.argv[2], start_times, latencies)
+
+########################################
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
- Spawn many processes from worker-side script via Python's multiprocessing module instead of SSHing into each machine many times. This improves high VM x Thread runs significantly.
- Created an interactive object timeline. Useful for debugging as well as seeing throughput during different times in the run.
- Make GCS use regional buckets by default, like the other providers already do.