### PR TITLE
Add the capability to publish to InfluxDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -963,6 +963,21 @@ Flag | Notes
 `--es_index`       | The Elasticsearch index name to store documents (default: perfkit)
 `--es_type`        | The Elasticsearch document type (default: result)
 
+Using InfluxDB Publisher
+=================
+No additional packages need to be installed in order to publish Perfkit data to an InfluxDB
+server.
+
+InfluxDB Publisher takes in the flags for the Influx uri and the Influx DB name. The publisher
+will default to the pre-set defaults, identified below, if no uri or DB name is set. However,
+the user is required to at the very least call the `--influx_uri` flag to publish data to Influx.
+
+
+Flag | Notes | Defaults 
+-----|-----------------
+`--influx_uri`         | The Influx DB address and port. Expects the format hostname:port | localhost:8086
+`--influx_db_name`     | The name of Influx DB database that you wish to publish to or create | perfkit
+
 How to Extend PerfKit Benchmarker
 =================
 First start with the [CONTRIBUTING.md](https://github.com/GoogleCloudPlatform/PerfKitBenchmarker/blob/master/CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -973,10 +973,10 @@ will default to the pre-set defaults, identified below, if no uri or DB name is 
 the user is required to at the very least call the `--influx_uri` flag to publish data to Influx.
 
 
-Flag | Notes | Defaults 
------|-----------------
-`--influx_uri`         | The Influx DB address and port. Expects the format hostname:port | localhost:8086
-`--influx_db_name`     | The name of Influx DB database that you wish to publish to or create | perfkit
+| Flag               | Notes                                                                | Default        |
+|--------------------|----------------------------------------------------------------------|----------------|
+| `--influx_uri`     | The Influx DB address and port. Expects the format hostname:port     | localhost:8086 |
+| `--influx_db_name` | The name of Influx DB database that you wish to publish to or create | perfkit        |
 
 How to Extend PerfKit Benchmarker
 =================

--- a/perfkitbenchmarker/publisher.py
+++ b/perfkitbenchmarker/publisher.py
@@ -15,6 +15,7 @@
 """Classes to collect and publish performance samples to various sinks."""
 
 import abc
+import collections
 import copy
 import csv
 import httplib
@@ -672,7 +673,7 @@ class InfluxDBPublisher(SamplePublisher):
   def _Publish(self, formated_samples):
     try:
       self._CreateDB()
-      body = ' \n '.join(formated_samples)
+      body = '\n'.join(formated_samples)
       self._WriteData(body)
     except (IOError, httplib.HTTPException) as http_exception:
       logging.debug("Error connecting to the database: ", http_exception)
@@ -687,7 +688,8 @@ class InfluxDBPublisher(SamplePublisher):
         tag_set_metadata = ','.join(self._FormatToKeyValue(sample['metadata']))
     tag_keys = ('test', 'official', 'owner', 'run_uri', 'sample_uri',
                 'metric', 'unit')
-    tag_set = ','.join(self._FormatToKeyValue({k: sample[k] for k in tag_keys}))
+    ordered_tags = collections.OrderedDict([(k, sample[k]) for k in tag_keys])
+    tag_set = ','.join(self._FormatToKeyValue(ordered_tags))
     if tag_set_metadata:
       tag_set += ',' + tag_set_metadata
 

--- a/perfkitbenchmarker/publisher.py
+++ b/perfkitbenchmarker/publisher.py
@@ -702,6 +702,9 @@ class InfluxDBPublisher(SamplePublisher):
   def _FormatToKeyValue(self, sample):
     key_value_pairs = []
     for k, v in sample.iteritems():
+      v = str(v)
+      v = v.replace(',', '\,')
+      v = v.replace(' ', '\ ')
       key_value_pairs.append('%s=%s' % (k, v))
     return key_value_pairs
 

--- a/perfkitbenchmarker/publisher.py
+++ b/perfkitbenchmarker/publisher.py
@@ -717,7 +717,7 @@ class InfluxDBPublisher(SamplePublisher):
     else:
       logging.debug(response.status,
                     'Request could not be completed due to: ',
-                    response.response)
+                    response.reason)
       raise httplib.HTTPException
 
   def _WriteData(self, data):
@@ -734,7 +734,7 @@ class InfluxDBPublisher(SamplePublisher):
     else:
       logging.debug(response.status,
                     'Request could not be completed due to: ',
-                    response.response)
+                    response.reason)
       raise httplib.HTTPException
 
 

--- a/perfkitbenchmarker/publisher.py
+++ b/perfkitbenchmarker/publisher.py
@@ -676,7 +676,7 @@ class InfluxDBPublisher(SamplePublisher):
       body = '\n'.join(formated_samples)
       self._WriteData(body)
     except (IOError, httplib.HTTPException) as http_exception:
-      logging.debug("Error connecting to the database: ", http_exception)
+      logging.error('Error connecting to the database:  %s', http_exception)
 
   def _ConstructSample(self, sample):
     timestamp = str(int((10 ** 9) * sample['timestamp']))
@@ -715,11 +715,10 @@ class InfluxDBPublisher(SamplePublisher):
     response = conn.getresponse()
     conn.close()
     if response.status in successful_http_request_codes:
-      logging.debug('Success!' + self.influx_db_name + ' DB Created')
+      logging.debug('Success! %s DB Created', self.influx_db_name)
     else:
-      logging.debug(response.status
-                    + 'Request could not be completed due to: '
-                    + response.reason)
+      logging.error('%d Request could not be completed due to: %s',
+                    response.status, response.reason)
       raise httplib.HTTPException
 
   def _WriteData(self, data):
@@ -734,9 +733,8 @@ class InfluxDBPublisher(SamplePublisher):
     if response.status in successful_http_request_codes:
       logging.debug('Writing samples to publisher: writing samples.')
     else:
-      logging.debug(response.status
-                    + 'Request could not be completed due to: '
-                    + response.reason)
+      logging.error('%d Request could not be completed due to: %s %s',
+                    response.status, response.reason, data)
       raise httplib.HTTPException
 
 

--- a/perfkitbenchmarker/publisher.py
+++ b/perfkitbenchmarker/publisher.py
@@ -17,6 +17,7 @@
 import abc
 import copy
 import csv
+import httplib
 import io
 import itertools
 import json
@@ -26,6 +27,7 @@ import operator
 import pprint
 import sys
 import time
+import urllib
 import uuid
 
 from perfkitbenchmarker import disk
@@ -110,6 +112,14 @@ flags.DEFINE_multistring(
     'A colon separated key-value pair that will be added to the labels field '
     'of all samples as metadata. Multiple key-value pairs may be specified '
     'by separating each pair by commas.')
+
+flags.DEFINE_string(
+    'influx_uri', 'http://localhost:8086/',
+    'The Influx DB endpoint for queries address and port')
+
+flags.DEFINE_string(
+    'influx_db_name', 'perfkit',
+    'Name of Influx DB database that you wish to publish to or create')
 
 DEFAULT_JSON_OUTPUT_NAME = 'perfkitbenchmarker_results.json'
 DEFAULT_CREDENTIALS_JSON = 'credentials.json'
@@ -643,6 +653,81 @@ class ElasticsearchPublisher(SamplePublisher):
       if new_key != key:
         res[new_key] = res.pop(key)
     return res
+
+
+class InfluxDBPublisher(SamplePublisher):
+
+  def __init__(self, influx_uri=None, influx_db_name=None):
+    # set to default above in flags unless changed
+    self.influx_uri = influx_uri
+    self.influx_db_name = influx_db_name
+
+  def PublishSamples(self, samples):
+    successful_http_request_codes = [200, 202, 204]
+    sample = list(samples)
+    number_of_samples = 0
+    for sample in samples:
+      number_of_samples += 1
+      timestamp = int((10 ** 9) * sample['timestamp'])
+      measurement = 'perfkitbenchmarker'
+      tag_set_metadata = \
+          ', '.join(self.FormatSampleForInfluxDB(sample['metadata']))
+      tag_set = ','.join((tag_set_metadata, self.
+                          FormatSampleForInfluxDB({k: sample[k]
+                                                   for k in ('test',
+                                                             'official',
+                                                             'owner',
+                                                             'run_uri',
+                                                             'sample_uri')})))
+      field_set = '%s_%s=%s' % (self.FormatSampleForInfluxDB({k: sample[k]
+                                for k in ('metric', 'unit', 'value')}))
+      samples_constructed_body = (' '.join((','.join((measurement,
+                                           tag_set))),
+                                           (' '.join((field_set,
+                                                     timestamp))))) + "\n"
+
+    create_db_status, create_db_response = self. \
+        _createInfluxDB(self.influx_uri, self.influx_db_name)
+    if create_db_status in successful_http_request_codes:
+      logging.debug('Success!', self.influx_db_name, ' DB Created')
+    else:
+      logging.debug(create_db_status,
+                    'Request could not be completed due to: ',
+                    create_db_response)
+
+    logging.debug('writing samples to publisher: writing',
+                  number_of_samples, ' samples.')
+    self._writeData(self.influx_uri, self.influx_db_name,
+                    samples_constructed_body)
+    logging.debug(create_db_status,
+                  'Request could not be completed due to: ',
+                  create_db_response)
+
+  def FormatSampleForInfluxDB(self, sample):
+    for k, v in sample.iteritems():
+            return '%s=%s' % (k, v)
+
+  def _CreateDB(self, influx_uri, influx_db_name):
+    headers = {'Content-type': 'application/x-www-form-urlencoded',
+               'Accept': 'text/plain'}
+    body = urllib.urlencode({'q': 'CREATE DATABASE' + influx_db_name})
+    conn = httplib.HTTPConnection(influx_uri)
+    conn.request('POST', '/query?' + body, headers)
+    response = conn.getresponse()
+    response_status = response.status
+    response_response = response.response
+    return response_status, response_response
+
+  def _WriteData(self, influx_uri, influx_db_name, data):
+    body = data
+    headers = {"Content-type": "application/octet-stream"}
+    conn = httplib.HTTPConnection(influx_uri)
+    conn.request('POST', '/write?' + 'db=' + influx_db_name, body, headers)
+    response = conn.getresponse()
+    response_status = response.status
+    response_response = response.response
+    return response_status, response_response
+
 
 
 class SampleCollector(object):

--- a/perfkitbenchmarker/publisher.py
+++ b/perfkitbenchmarker/publisher.py
@@ -702,6 +702,8 @@ class InfluxDBPublisher(SamplePublisher):
   def _FormatToKeyValue(self, sample):
     key_value_pairs = []
     for k, v in sample.iteritems():
+      if v == '':
+        v = '\\"\\"'
       v = str(v)
       v = v.replace(',', '\,')
       v = v.replace(' ', '\ ')

--- a/perfkitbenchmarker/publisher.py
+++ b/perfkitbenchmarker/publisher.py
@@ -658,6 +658,15 @@ class ElasticsearchPublisher(SamplePublisher):
 
 
 class InfluxDBPublisher(SamplePublisher):
+  """Publisher writes samples to InfluxDB.
+
+  Attributes:
+    influx_uri: Takes in type string. Consists of the Influx DB address and
+      port.Expects the format hostname:port
+    influx_db_name: Takes in tupe string.
+      Consists of the name of Influx DB database that you wish to publish to or
+      create.
+  """
 
   def __init__(self, influx_uri=None, influx_db_name=None):
     # set to default above in flags unless changed
@@ -711,6 +720,9 @@ class InfluxDBPublisher(SamplePublisher):
     return key_value_pairs
 
   def _CreateDB(self):
+    """This method is idempotent. If the DB already exists it will simply
+    return a 200 code without re-creating it.
+    """
     successful_http_request_codes = [200, 202, 204]
     header = {'Content-type': 'application/x-www-form-urlencoded',
               'Accept': 'text/plain'}

--- a/perfkitbenchmarker/publisher.py
+++ b/perfkitbenchmarker/publisher.py
@@ -667,7 +667,7 @@ class InfluxDBPublisher(SamplePublisher):
     for sample in samples:
       formated_samples.append(self._ConstructSample(sample))
     self._Publish(formated_samples)
-    
+
   def _Publish(self, formated_samples):
     try:
       self._CreateDB()
@@ -679,18 +679,19 @@ class InfluxDBPublisher(SamplePublisher):
   def _ConstructSample(self, sample):
     timestamp = str(int((10 ** 9) * sample['timestamp']))
     measurement = 'perfkitbenchmarker'
-    
+
     tag_set_metadata = ''
     if 'metadata' in sample:
       if sample['metadata']:
         tag_set_metadata = ','.join(self._FormatToKeyValue(sample['metadata']))
-    tag_keys = ('test','official', 'owner','run_uri','sample_uri', 'metric', 'unit',)
+    tag_keys = ('test', 'official', 'owner', 'run_uri', 'sample_uri',
+                'metric', 'unit')
     tag_set = ','.join(self._FormatToKeyValue({k: sample[k] for k in tag_keys}))
     if tag_set_metadata:
       tag_set += ',' + tag_set_metadata
 
     field_set = '%s=%s' % ('value', sample['value'])
-    
+
     sample_constructed_body = '%s,%s %s %s' % (measurement, tag_set,
                                                field_set, timestamp)
     return sample_constructed_body
@@ -704,7 +705,7 @@ class InfluxDBPublisher(SamplePublisher):
   def _CreateDB(self):
     successful_http_request_codes = [200, 202, 204]
     header = {'Content-type': 'application/x-www-form-urlencoded',
-               'Accept': 'text/plain'}
+              'Accept': 'text/plain'}
     params = urllib.urlencode({'q': 'CREATE DATABASE ' + self.influx_db_name})
     conn = httplib.HTTPConnection(self.influx_uri)
     conn.request('POST', '/query?' + params, headers=header)
@@ -724,14 +725,15 @@ class InfluxDBPublisher(SamplePublisher):
     params = data
     header = {"Content-type": "application/octet-stream"}
     conn = httplib.HTTPConnection(self.influx_uri)
-    conn.request('POST', '/write?' + 'db=' + self.influx_db_name, params, headers=header)
+    conn.request('POST', '/write?' + 'db=' + self.influx_db_name, params,
+                 headers=header)
     response = conn.getresponse()
     response_status = response.status
     response_response = response.response
     if response_status in successful_http_request_codes:
       logging.debug('writing samples to publisher: writing samples.')
     else:
-      logging.debug(create_db_status,
+      logging.debug(response_status,
                     'Request could not be completed due to: ',
                     response_response)
       raise httplib.HTTPException
@@ -798,7 +800,7 @@ class SampleCollector(object):
                                                es_type=FLAGS.es_type))
     if FLAGS.influx_uri:
       publishers.append(InfluxDBPublisher(influx_uri=FLAGS.influx_uri,
-                                          influx_db_name=FLAGS.influx_db_name))  
+                                          influx_db_name=FLAGS.influx_db_name))
 
     return publishers
 

--- a/perfkitbenchmarker/publisher.py
+++ b/perfkitbenchmarker/publisher.py
@@ -715,11 +715,11 @@ class InfluxDBPublisher(SamplePublisher):
     response = conn.getresponse()
     conn.close()
     if response.status in successful_http_request_codes:
-      logging.debug('Success!', self.influx_db_name, ' DB Created')
+      logging.debug('Success!' + self.influx_db_name + ' DB Created')
     else:
-      logging.debug(response.status,
-                    'Request could not be completed due to: ',
-                    response.reason)
+      logging.debug(response.status
+                    + 'Request could not be completed due to: '
+                    + response.reason)
       raise httplib.HTTPException
 
   def _WriteData(self, data):
@@ -734,9 +734,9 @@ class InfluxDBPublisher(SamplePublisher):
     if response.status in successful_http_request_codes:
       logging.debug('Writing samples to publisher: writing samples.')
     else:
-      logging.debug(response.status,
-                    'Request could not be completed due to: ',
-                    response.reason)
+      logging.debug(response.status
+                    + 'Request could not be completed due to: '
+                    + response.reason)
       raise httplib.HTTPException
 
 

--- a/tests/publisher_test.py
+++ b/tests/publisher_test.py
@@ -515,7 +515,6 @@ class InfluxDBPublisherTestCase(unittest.TestCase):
     self.test_db.PublishSamples(samples)
     mock_publish_method.assert_called_once_with(expected)
 
-
   @mock.patch.object(publisher.InfluxDBPublisher, '_WriteData')
   @mock.patch.object(publisher.InfluxDBPublisher, '_CreateDB')
   def testPublish(self, mock_create_db, mock_write_data):

--- a/tests/publisher_test.py
+++ b/tests/publisher_test.py
@@ -424,10 +424,15 @@ class InfluxDBPublisherTestCase(unittest.TestCase):
                 'value': 'non', 'unit': 'MB', 'owner': 'Rackspace',
                 'run_uri': '323', 'sample_uri': '33',
                 'timestamp': 123}
+    sample_4 = {'test': 'testc', 'metric': 'some,metric', 'official': 1.0,
+                'value': 'non', 'unit': 'Some MB', 'owner': 'Rackspace',
+                'run_uri': '323', 'sample_uri': '33',
+                'timestamp': 123}
 
     sample_1_formatted_key_value = self.test_db._FormatToKeyValue(sample_1)
     sample_2_formatted_key_value = self.test_db._FormatToKeyValue(sample_2)
     sample_3_formatted_key_value = self.test_db._FormatToKeyValue(sample_3)
+    sample_4_formatted_key_value = self.test_db._FormatToKeyValue(sample_4)
 
     expected_sample_1 = ['owner=Rackspace', 'unit=us', 'run_uri=5rtw',
                          'test=testa', 'timestamp=123', 'metric=3',
@@ -438,10 +443,14 @@ class InfluxDBPublisherTestCase(unittest.TestCase):
     expected_sample_3 = ['owner=Rackspace', 'unit=MB', 'run_uri=323',
                          'test=testc', 'timestamp=123', 'metric=1',
                          'official=1.0', 'value=non', 'sample_uri=33']
+    expected_sample_4 = ['owner=Rackspace', 'unit=Some\ MB', 'run_uri=323',
+                         'test=testc', 'timestamp=123', 'metric=some\,metric',
+                         'official=1.0', 'value=non', 'sample_uri=33']
 
     self.assertItemsEqual(sample_1_formatted_key_value, expected_sample_1)
     self.assertItemsEqual(sample_2_formatted_key_value, expected_sample_2)
     self.assertItemsEqual(sample_3_formatted_key_value, expected_sample_3)
+    self.assertItemsEqual(sample_4_formatted_key_value, expected_sample_4)
 
   def testConstructSample(self):
     sample_with_metadata = {

--- a/tests/publisher_test.py
+++ b/tests/publisher_test.py
@@ -406,88 +406,110 @@ class CSVPublisherTestCase(unittest.TestCase):
     self.assertEqual(3, len(rows))
 
 
-  class InfluxDBPublisherTestCase(unittest.TestCase):
-    def setUp(self):
-      self.db_name = 'test_db'
-      self.db_uri = 'test'
-      self.mock_db = publisher.InfluxDBPublisher(self.db_uri, self.db_name)
-      self.no_meta = {'test': 'testa', 'metric': '3', 'official': 47.0,
-                      'value': 'non', 'unit': 'us', 'owner': 'Rackspace',
-                      'run_uri': '5rtw', 'sample_uri': '5r', 'timestamp': 123}
-      self.empty_meta = {'test': 'testb', 'metric': '2', 'official': 14.0,
-                         'value': 'non', 'unit': 'MB', 'owner': 'Rackspace',
-                         'run_uri': 'bba3', 'sample_uri': 'bb',
-                         'timestamp': 55, 'metadata': {}}
-      self.with_meta = {'test': 'testc', 'metric': '1', 'official': 1.0,
-                        'value': 'non', 'unit': 'MB', 'owner': 'Rackspace',
-                        'run_uri': '323', 'sample_uri': '33',
-                        'timestamp': 123, 'metadata':
-                        {'info': '1', 'more_info': '2', 'bar': 'foo'}}
-
-    def testFormatToKeyValue(self):
-      no_meta = self.mock_db._FormatToKeyValue(self.no_meta)
-      empty_meta = self.mock_db._FormatToKeyValue(self.empty_meta)
-      with_meta = self.mock_db._FormatToKeyValue(self.with_meta)
-
-      self.assertEqual(no_meta,
-                       ['owner=Rackspace', 'unit=us', 'run_uri=5rtw',
-                        'test=testa', 'timestamp=123', 'metric=3',
-                        'official=47.0', 'value=non', 'sample_uri=5r'])
-      self.assertEqual(empty_meta,
-                       ['owner=Rackspace', 'unit=MB', 'run_uri=bba3',
-                        'test=testb', 'timestamp=55', 'metric=2',
-                        'official=14.0', 'metadata={}', 'value=non',
-                        'sample_uri=bb'])
-      self.assertEqual(with_meta,
-                       ['owner=Rackspace', 'unit=MB', 'run_uri=323',
-                        'test=testc', 'timestamp=123', 'metric=1',
-                        'official=1.0', "metadata={'info': '1', \
-                        'bar': 'foo', 'more_info': '2'}", 'value=non',
-                        'sample_uri=33'])
-
-    def testConstructSample(self):
-      no_meta = self.mock_db._ConstructSample(self.no_meta)
-      empty_meta = self.mock_db._ConstructSample(self.empty_meta)
-      with_meta = self.mock_db._ConstructSample(self.with_meta)
-
-      self.assertEqual(no_meta,
-                       'perfkitbenchmarker,metric=3,official=47.0,\
-                       owner=Rackspace,run_uri=5rtw,test=testa,\
-                       unit=us,sample_uri=5r value=non 123000000000')
-      self.assertEqual(empty_meta,
-                       'perfkitbenchmarker,metric=2,official=14.0,\
-                       owner=Rackspace,run_uri=bba3,test=testb,unit=MB,\
-                       sample_uri=bb value=non 55000000000')
-      self.assertEqual(with_meta,
-                       'perfkitbenchmarker,metric=1,official=1.0,\
-                       owner=Rackspace,run_uri=323,test=testc,unit=MB,\
-                       sample_uri=33,info=1,bar=foo,\
-                       more_info=2 value=non 123000000000')
-
-    def testAggregationOfSamples(self):
-      sample_data = [{'test': 'testc', 'metric': '1', 'official': 1.0,
-                     'value': 'non', 'unit': 'MB', 'owner': 'Rackspace',
-                      'run_uri': '323', 'sample_uri': '33', 'timestamp': 123,
-                      'metadata':
-                      {'info': '1', 'more_info': '2', 'bar': 'foo'}},
-                     {'test': 'testb', 'metric': '2', 'official': 14.0,
+class InfluxDBPublisherTestCase(unittest.TestCase):
+  def setUp(self):
+    self.db_name = 'test_db'
+    self.db_uri = 'test'
+    self.test_db = publisher.InfluxDBPublisher(self.db_uri, self.db_name)
+    self.no_meta = {'test': 'testa', 'metric': '3', 'official': 47.0,
+                    'value': 'non', 'unit': 'us', 'owner': 'Rackspace',
+                    'run_uri': '5rtw', 'sample_uri': '5r', 'timestamp': 123}
+    self.empty_meta = {'test': 'testb', 'metric': '2', 'official': 14.0,
+                       'value': 'non', 'unit': 'MB', 'owner': 'Rackspace',
+                       'run_uri': 'bba3', 'sample_uri': 'bb',
+                       'timestamp': 55, 'metadata': {}}
+    self.with_meta = {'test': 'testc', 'metric': '1', 'official': 1.0,
                       'value': 'non', 'unit': 'MB', 'owner': 'Rackspace',
-                      'run_uri': 'bba3', 'sample_uri': 'bb', 'timestamp': 55,
-                      'metadata': {}},
-                     {'test': 'testa', 'metric': '3', 'official': 47.0,
-                     'value': 'non', 'unit': 'us', 'owner': 'Rackspace',
-                      'run_uri': '5rtw', 'sample_uri': '5r', 'timestamp': 123}]
-      formated_samples = []
-      expected_output = ('perfkitbenchmarker,metric=1,official=1.0,'
-                         'owner=Rackspace,run_uri=323,test=testc,unit=MB,'
-                         'sample_uri=33,info=1,bar=foo,more_info=2 value=non '
-                         '123000000000\nperfkitbenchmarker,metric=2,'
-                         'official=14.0,owner=Rackspace,run_uri=bba3,'
-                         'test=testb,unit=MB,sample_uri=bb value=non '
-                         '55000000000\nperfkitbenchmarker,metric=3,'
-                         'official=47.0,owner=Rackspace,run_uri=5rtw,'
-                         'test=testa,unit=us,sample_uri=5r '
-                         'value=non 123000000000')
-      for data in sample_data:
-        formated_samples.append(self.mock_db._ConstructSample(sample))
-        self.assertEqual(formated_samples, expected_output)
+                      'run_uri': '323', 'sample_uri': '33',
+                      'timestamp': 123, 'metadata':
+                      {'info': '1', 'more_info': '2', 'bar': 'foo'}}
+
+  def sortString(self, stuff):
+    expected_1 = stuff
+    expected_2 = expected_1.split()
+    expected_3 = ','.join(expected_2)
+    expected_4 = sorted(expected_3.split(','))
+    return expected_4
+
+  def sortList(self, stuff):
+    new_string = []
+    for i in stuff:
+      if "metadata" in i:
+        i = i.replace('metadata={', '').replace('}',
+                                                '').replace('\'',
+                                                            '').replace(' ',
+                                                                        '')
+        i = sorted(i.split(','))
+        new_string.append(i)
+      else:
+        new_string.append(i)
+    return new_string
+
+  def testFormatToKeyValue(self):
+    no_meta_keys = self.test_db._FormatToKeyValue(self.no_meta)
+    empty_meta_keys = self.test_db._FormatToKeyValue(self.empty_meta)
+    with_meta_keys = self.test_db._FormatToKeyValue(self.with_meta)
+
+    s1 = ['owner=Rackspace', 'unit=us', 'run_uri=5rtw', 'test=testa',
+          'timestamp=123', 'metric=3', 'official=47.0', 'value=non',
+          'sample_uri=5r']
+    s2 = ['owner=Rackspace', 'unit=MB', 'run_uri=bba3', 'test=testb',
+          'timestamp=55', 'metric=2', 'official=14.0', 'metadata={}',
+          'value=non', 'sample_uri=bb']
+    s3 = ['owner=Rackspace', 'unit=MB', 'run_uri=323', 'test=testc',
+          'timestamp=123', 'metric=1', 'official=1.0',
+          "metadata={'info': '1','bar': 'foo', 'more_info': '2'}", 'value=non',
+          'sample_uri=33']
+
+    self.assertEqual(self.sortList(sorted(no_meta_keys)),
+                     self.sortList(sorted(s1)))
+    self.assertEqual(self.sortList(sorted(empty_meta_keys)),
+                     self.sortList(sorted(s2)))
+    self.assertEqual(self.sortList(sorted(with_meta_keys)),
+                     self.sortList(sorted(s3)))
+
+  def testConstructSample(self):
+    no_meta_samples = self.test_db._ConstructSample(self.no_meta)
+    empty_meta_samples = self.test_db._ConstructSample(self.empty_meta)
+    with_meta_samples = self.test_db._ConstructSample(self.with_meta)
+
+    l1 = ('perfkitbenchmarker,run_uri=5rtw,test=testa,sample_uri=5r,metric=3,'
+          'official=47.0,owner=Rackspace,unit=us value=non 123000000000')
+    l2 = ('perfkitbenchmarker,metric=2,official=14.0,owner=Rackspace,'
+          'run_uri=bba3,test=testb,unit=MB,sample_uri=bb '
+          'value=non 55000000000')
+    l3 = ('perfkitbenchmarker,metric=1,official=1.0,owner=Rackspace,'
+          'run_uri=323,test=testc,unit=MB,sample_uri=33,info=1,'
+          'bar=foo,more_info=2 value=non 123000000000')
+
+    self.assertEqual(self.sortString(no_meta_samples), self.sortString(l1))
+    self.assertEqual(self.sortString(empty_meta_samples), self.sortString(l2))
+    self.assertEqual(self.sortString(with_meta_samples), self.sortString(l3))
+
+  def testAggregationOfSamples(self):
+    sample_data = [{'test': 'testc', 'metric': '1', 'official': 1.0,
+                   'value': 'non', 'unit': 'MB', 'owner': 'Rackspace',
+                    'run_uri': '323', 'sample_uri': '33', 'timestamp': 123,
+                    'metadata':
+                    {'info': '1', 'more_info': '2', 'bar': 'foo'}},
+                   {'test': 'testb', 'metric': '2', 'official': 14.0,
+                    'value': 'non', 'unit': 'MB', 'owner': 'Rackspace',
+                    'run_uri': 'bba3', 'sample_uri': 'bb', 'timestamp': 55,
+                    'metadata': {}},
+                   {'test': 'testa', 'metric': '3', 'official': 47.0,
+                   'value': 'non', 'unit': 'us', 'owner': 'Rackspace',
+                    'run_uri': '5rtw', 'sample_uri': '5r', 'timestamp': 123}]
+    formated_samples = []
+    s1 = ('perfkitbenchmarker,sample_uri=33,owner=Rackspace,official=1.0,'
+          'run_uri=323,metric=1,test=testc,unit=MB,bar=foo,more_info=2,'
+          'info=1 value=non 123000000000 \n perfkitbenchmarker,'
+          'sample_uri=bb,owner=Rackspace,official=14.0,run_uri=bba3,metric=2,'
+          'test=testb,unit=MB value=non 55000000000 \n perfkitbenchmarker,'
+          'sample_uri=5r,owner=Rackspace,official=47.0,run_uri=5rtw,metric=3,'
+          'test=testa,unit=us value=non 123000000000')
+    expected_sample_format = self.sortString(s1)
+    for data in sample_data:
+      formated_samples.append(self.test_db._ConstructSample(data))
+    body = ' \n '.join(formated_samples)
+    formated_body = self.sortString(body)
+    self.assertEqual(expected_sample_format, formated_body)

--- a/tests/publisher_test.py
+++ b/tests/publisher_test.py
@@ -478,20 +478,16 @@ class CSVPublisherTestCase(unittest.TestCase):
                      'value': 'non', 'unit': 'us', 'owner': 'Rackspace',
                       'run_uri': '5rtw', 'sample_uri': '5r', 'timestamp': 123}]
       formated_samples = []
+      expected_output = ('perfkitbenchmarker,metric=1,official=1.0,'
+                         'owner=Rackspace,run_uri=323,test=testc,unit=MB,'
+                         'sample_uri=33,info=1,bar=foo,more_info=2 value=non '
+                         '123000000000\nperfkitbenchmarker,metric=2,'
+                         'official=14.0,owner=Rackspace,run_uri=bba3,'
+                         'test=testb,unit=MB,sample_uri=bb value=non '
+                         '55000000000\nperfkitbenchmarker,metric=3,'
+                         'official=47.0,owner=Rackspace,run_uri=5rtw,'
+                         'test=testa,unit=us,sample_uri=5r '
+                         'value=non 123000000000')
       for data in sample_data:
         formated_samples.append(self.mock_db._ConstructSample(sample))
-        self.assertEqual(formated_samples, 'perfkitbenchmarker,metric=1,\
-                                          official=1.0,owner=Rackspace,\
-                                          run_uri=323,test=testc,unit=MB,\
-                                          sample_uri=33,info=1,bar=foo,\
-                                          more_info=2 value=non \
-                                          123000000000\nperfkitbenchmarker,\
-                                          metric=2,official=14.0,\
-                                          owner=Rackspace,run_uri=bba3,\
-                                          test=testb,unit=MB,sample_uri=bb \
-                                          value=non \
-                                          55000000000\nperfkitbenchmarker,\
-                                          metric=3,official=47.0,owner=\
-                                          Rackspace,run_uri=5rtw,test=testa,\
-                                          unit=us,sample_uri=5r \
-                                          value=non 123000000000')
+        self.assertEqual(formated_samples, expected_output)

--- a/tests/publisher_test.py
+++ b/tests/publisher_test.py
@@ -428,11 +428,16 @@ class InfluxDBPublisherTestCase(unittest.TestCase):
                 'value': 'non', 'unit': 'Some MB', 'owner': 'Rackspace',
                 'run_uri': '323', 'sample_uri': '33',
                 'timestamp': 123}
+    sample_5 = {'test': 'testc', 'metric': 'some,metric', 'official': 1.0,
+                'value': 'non', 'unit': '', 'owner': 'Rackspace',
+                'run_uri': '323', 'sample_uri': '',
+                'timestamp': 123}
 
     sample_1_formatted_key_value = self.test_db._FormatToKeyValue(sample_1)
     sample_2_formatted_key_value = self.test_db._FormatToKeyValue(sample_2)
     sample_3_formatted_key_value = self.test_db._FormatToKeyValue(sample_3)
     sample_4_formatted_key_value = self.test_db._FormatToKeyValue(sample_4)
+    sample_5_formatted_key_value = self.test_db._FormatToKeyValue(sample_5)
 
     expected_sample_1 = ['owner=Rackspace', 'unit=us', 'run_uri=5rtw',
                          'test=testa', 'timestamp=123', 'metric=3',
@@ -446,11 +451,15 @@ class InfluxDBPublisherTestCase(unittest.TestCase):
     expected_sample_4 = ['owner=Rackspace', 'unit=Some\ MB', 'run_uri=323',
                          'test=testc', 'timestamp=123', 'metric=some\,metric',
                          'official=1.0', 'value=non', 'sample_uri=33']
+    expected_sample_5 = ['owner=Rackspace', 'unit=\\"\\"', 'run_uri=323',
+                         'test=testc', 'timestamp=123', 'metric=some\,metric',
+                         'official=1.0', 'value=non', 'sample_uri=\\"\\"']
 
     self.assertItemsEqual(sample_1_formatted_key_value, expected_sample_1)
     self.assertItemsEqual(sample_2_formatted_key_value, expected_sample_2)
     self.assertItemsEqual(sample_3_formatted_key_value, expected_sample_3)
     self.assertItemsEqual(sample_4_formatted_key_value, expected_sample_4)
+    self.assertItemsEqual(sample_5_formatted_key_value, expected_sample_5)
 
   def testConstructSample(self):
     sample_with_metadata = {


### PR DESCRIPTION
This code aims to add the capability for PKB to publish directly to InfluxDB

The publishing of data from PKB benchmarks can done either by specifiying a pre-existing Influx DB publisher or with none specified it will create a new one or re-use a pre-existing DB called perfkit. By default if no uri is specified it will publish the data to localhost.