### PR TITLE
add support for AWS Spot Instances

### DIFF
--- a/perfkitbenchmarker/benchmark_sets.py
+++ b/perfkitbenchmarker/benchmark_sets.py
@@ -226,7 +226,7 @@ def GetBenchmarksFromFlags():
                        (benchmark_name, FLAGS.os_type))
 
     # We need to remove the 'flag_matrix', 'flag_matrix_defs', and
-    # 'flag_matrix_filters' keys from the config dictionairy since
+    # 'flag_matrix_filters' keys from the config dictionary since
     # they aren't actually part of the config spec and will cause
     # errors if they are left in.
     flag_matrix_name = benchmark_config.pop(

--- a/perfkitbenchmarker/errors.py
+++ b/perfkitbenchmarker/errors.py
@@ -149,6 +149,10 @@ class Benchmarks(object):
 class Resource(object):
   """Errors related to resource creation and deletion."""
 
+  class CreationError(Error):
+    """An error on creation which is not retryable."""
+    pass
+
   class RetryableCreationError(Error):
     pass
 

--- a/perfkitbenchmarker/pkb.py
+++ b/perfkitbenchmarker/pkb.py
@@ -121,7 +121,7 @@ flags.DEFINE_list(
     'Zones that will be appended to the "zones" list. This is functionally '
     'the same, but allows flag matrices to have two zone axes.')
 # TODO(user): note that this is currently very GCE specific. Need to create a
-#    module which can traslate from some generic types to provider specific
+#    module which can translate from some generic types to provider specific
 #    nomenclature.
 flags.DEFINE_string('machine_type', None, 'Machine '
                     'types that will be created for benchmarks that don\'t '

--- a/perfkitbenchmarker/providers/aws/aws_virtual_machine.py
+++ b/perfkitbenchmarker/providers/aws/aws_virtual_machine.py
@@ -542,6 +542,8 @@ class AwsVirtualMachine(virtual_machine.BaseVirtualMachine):
     self.spot_instance_request_id =\
         create_response['SpotInstanceRequests'][0]['SpotInstanceRequestId']
 
+    util.AddDefaultTags(self.spot_instance_request_id, self.region)
+
     while True:
       describe_sir_cmd = util.AWS_PREFIX + [
           'ec2',

--- a/perfkitbenchmarker/providers/aws/aws_virtual_machine.py
+++ b/perfkitbenchmarker/providers/aws/aws_virtual_machine.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from collections import OrderedDict
 
 """Class to represent an AWS Virtual Machine object.
 
@@ -69,6 +70,19 @@ HOST_EXISTS_STATES = frozenset(
     ['available', 'under-assessment', 'permanent-failure'])
 HOST_RELEASED_STATES = frozenset(['released', 'released-permanent-failure'])
 KNOWN_HOST_STATES = HOST_EXISTS_STATES | HOST_RELEASED_STATES
+
+# See http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-bid-status.html
+SPOT_INSTANCE_REQUEST_HOLDING_STATUSES = frozenset(
+    ['capacity-not-available', 'capacity-oversubscribed', 'price-too-low',
+     'not-scheduled-yet', 'launch-group-constraint', 'az-group-constraint',
+     'placement-group-constraint', 'constraint-not-fulfillable'])
+SPOT_INSTANCE_REQUEST_TERMINAL_STATUSES = frozenset(
+    ['schedule-expired', 'canceled-before-fulfillment', 'bad-parameters',
+     'system-error', 'request-canceled-and-instance-running',
+     'marked-for-termination', 'instance-terminated-by-price',
+     'instance-terminated-by-user', 'instance-terminated-no-capacity',
+     'instance-terminated-capacity-oversubscribed',
+     'instance-terminated-launch-group-constraint'])
 
 
 def GetRootBlockDeviceSpecForImage(image_id, region):
@@ -138,9 +152,10 @@ def GetBlockDeviceMap(machine_type, root_volume_size_gb=None,
 
   if machine_type in NUM_LOCAL_VOLUMES:
     for i in xrange(NUM_LOCAL_VOLUMES[machine_type]):
-      mappings.append({
-          'VirtualName': 'ephemeral%s' % i,
-          'DeviceName': '/dev/xvd%s' % chr(ord(DRIVE_START_LETTER) + i)})
+      od = OrderedDict()
+      od['VirtualName'] = 'ephemeral%s' % i
+      od['DeviceName'] = '/dev/xvd%s' % chr(ord(DRIVE_START_LETTER) + i)
+      mappings.append(od)
   if len(mappings):
     return json.dumps(mappings)
   return None
@@ -238,6 +253,10 @@ class AwsVmSpec(virtual_machine.BaseVmSpec):
       config_values['use_dedicated_host'] = flag_values.aws_dedicated_hosts
     if flag_values['aws_boot_disk_size'].present:
       config_values['boot_disk_size'] = flag_values.aws_boot_disk_size
+    if flag_values['aws_spot_instances'].present:
+      config_values['use_spot_instance'] = flag_values.aws_spot_instances
+    if flag_values['aws_spot_price'].present:
+      config_values['spot_price'] = flag_values.aws_spot_price
 
   @classmethod
   def _GetOptionDecoderConstructions(cls):
@@ -252,6 +271,9 @@ class AwsVmSpec(virtual_machine.BaseVmSpec):
     result.update({
         'use_dedicated_host': (option_decoders.BooleanDecoder,
                                {'default': False}),
+        'use_spot_instance': (option_decoders.BooleanDecoder,
+                              {'default': False}),
+        'spot_price': (option_decoders.FloatDecoder, {'default': 0.0}),
         'boot_disk_size': (option_decoders.IntDecoder, {'default': None})})
 
     return result
@@ -285,6 +307,8 @@ class AwsVirtualMachine(virtual_machine.BaseVirtualMachine):
     self.network = aws_network.AwsNetwork.GetNetwork(self)
     self.firewall = aws_network.AwsFirewall.GetFirewall()
     self.use_dedicated_host = vm_spec.use_dedicated_host
+    self.use_spot_instance = vm_spec.use_spot_instance
+    self.spot_price = vm_spec.spot_price
     self.boot_disk_size = vm_spec.boot_disk_size
     self.client_token = str(uuid.uuid4())
     self.host = None
@@ -294,6 +318,11 @@ class AwsVirtualMachine(virtual_machine.BaseVirtualMachine):
       raise ValueError(
           'In order to use dedicated hosts, you must specify an availability '
           'zone, not a region ("zone" was %s).' % self.zone)
+
+    if self.use_spot_instance and self.spot_price <= 0.0:
+      raise ValueError(
+          'In order to use spot instances you must specify a spot price '
+          'greater than 0.0.')
 
   @property
   def host_list(self):
@@ -421,6 +450,13 @@ class AwsVirtualMachine(virtual_machine.BaseVirtualMachine):
 
   def _Create(self):
     """Create a VM instance."""
+    if self.use_spot_instance:
+      self._CreateSpot()
+    else:
+      self._CreateOnDemand()
+
+  def _CreateOnDemand(self):
+    """Create an OnDemand VM instance."""
     placement = []
     if not util.IsRegion(self.zone):
       placement.append('AvailabilityZone=%s' % self.zone)
@@ -465,6 +501,69 @@ class AwsVirtualMachine(virtual_machine.BaseVirtualMachine):
       self.client_token = str(uuid.uuid4())
       raise errors.Resource.RetryableCreationError()
 
+  def _CreateSpot(self):
+    """Create a Spot VM instance."""
+    placement = OrderedDict()
+    if not util.IsRegion(self.zone):
+      placement['AvailabilityZone'] = self.zone
+    if self.use_dedicated_host:
+      raise errors.Resource.CreationError(
+          'Tenancy=host is not supported for Spot Instances')
+    elif IsPlacementGroupCompatible(self.machine_type):
+      placement['GroupName'] = self.network.placement_group.name
+    block_device_map = GetBlockDeviceMap(self.machine_type,
+                                         self.boot_disk_size,
+                                         self.image,
+                                         self.region)
+    network_interface = [OrderedDict([
+        ('DeviceIndex', 0),
+        ('AssociatePublicIpAddress', True),
+        ('SubnetId', self.network.subnet.id)])]
+    launch_specification = OrderedDict([
+        ('ImageId', self.image),
+        ('InstanceType', self.machine_type),
+        ('KeyName', 'perfkit-key-%s' % FLAGS.run_uri),
+        ('Placement', placement)])
+    if block_device_map:
+      print 'RAW block_device_map'
+      print block_device_map
+      launch_specification['BlockDeviceMappings'] = json.loads(
+          block_device_map, object_pairs_hook=collections.OrderedDict)
+    launch_specification['NetworkInterfaces'] = network_interface
+    create_cmd = util.AWS_PREFIX + [
+        'ec2',
+        'request-spot-instances',
+        '--region=%s' % self.region,
+        '--spot-price=%s' % self.spot_price,
+        '--client-token=%s' % self.client_token,
+        '--launch-specification=%s' % json.dumps(launch_specification,
+                                                 separators=(',', ':'))]
+    print ' '.join(create_cmd)
+    stdout, stderr, _ = vm_util.IssueCommand(create_cmd)
+    create_response = json.loads(stdout)
+    self.spot_instance_request_id =\
+        create_response['SpotInstanceRequests'][0]['SpotInstanceRequestId']
+
+    while True:
+      describe_sir_cmd = util.AWS_PREFIX + [
+          'ec2',
+          'describe-spot-instance-requests',
+          '--spot-instance-request-ids=%s' % self.spot_instance_request_id]
+      stdout, stderr, _ = vm_util.IssueCommand(describe_sir_cmd)
+
+      sir_response = json.loads(stdout)['SpotInstanceRequests']
+      assert len(sir_response) == 1, 'Expected exactly 1 SpotInstanceRequest'
+
+      status_code = sir_response[0]['Status']['Code']
+
+      if status_code in SPOT_INSTANCE_REQUEST_HOLDING_STATUSES or \
+         status_code in SPOT_INSTANCE_REQUEST_TERMINAL_STATUSES:
+        message = sir_response[0]['Status']['Message']
+        raise errors.Resource.CreationError(message)
+      elif status_code == "fulfilled":
+        self.id = sir_response[0]['InstanceId']
+        break
+
   def _Delete(self):
     """Delete a VM instance."""
     if self.id:
@@ -474,14 +573,30 @@ class AwsVirtualMachine(virtual_machine.BaseVirtualMachine):
           '--region=%s' % self.region,
           '--instance-ids=%s' % self.id]
       vm_util.IssueCommand(delete_cmd)
+    if hasattr(self, 'spot_instance_request_id'):
+      cancel_cmd = util.AWS_PREFIX + [
+          'ec2',
+          'cancel-spot-instance-requests',
+          '--spot-instance-request-ids=%s' % self.spot_instance_request_id]
+      vm_util.IssueCommand(cancel_cmd)
+
 
   def _Exists(self):
     """Returns true if the VM exists."""
     describe_cmd = util.AWS_PREFIX + [
         'ec2',
         'describe-instances',
-        '--region=%s' % self.region,
-        '--filter=Name=client-token,Values=%s' % self.client_token]
+        '--region=%s' % self.region]
+
+    if self.use_spot_instance:
+      if self.id:
+        describe_cmd.append('--instance-id=%s' % self.id)
+      else:
+        return False
+    else:
+      describe_cmd.append(
+          '--filter=Name=client-token,Values=%s' % self.client_token)
+
     stdout, _ = util.IssueRetryableCommand(describe_cmd)
     response = json.loads(stdout)
     reservations = response['Reservations']
@@ -535,6 +650,8 @@ class AwsVirtualMachine(virtual_machine.BaseVirtualMachine):
     """
     result = super(AwsVirtualMachine, self).GetMachineTypeDict()
     result['dedicated_host'] = self.use_dedicated_host
+    result['spot_instance'] = self.use_spot_instance
+    result['spot_price'] = self.spot_price
     return result
 
 

--- a/perfkitbenchmarker/providers/aws/aws_virtual_machine.py
+++ b/perfkitbenchmarker/providers/aws/aws_virtual_machine.py
@@ -25,6 +25,7 @@ import json
 import logging
 import uuid
 import threading
+import time
 
 from perfkitbenchmarker import disk
 from perfkitbenchmarker import errors
@@ -525,8 +526,6 @@ class AwsVirtualMachine(virtual_machine.BaseVirtualMachine):
         ('KeyName', 'perfkit-key-%s' % FLAGS.run_uri),
         ('Placement', placement)])
     if block_device_map:
-      print 'RAW block_device_map'
-      print block_device_map
       launch_specification['BlockDeviceMappings'] = json.loads(
           block_device_map, object_pairs_hook=collections.OrderedDict)
     launch_specification['NetworkInterfaces'] = network_interface
@@ -538,7 +537,6 @@ class AwsVirtualMachine(virtual_machine.BaseVirtualMachine):
         '--client-token=%s' % self.client_token,
         '--launch-specification=%s' % json.dumps(launch_specification,
                                                  separators=(',', ':'))]
-    print ' '.join(create_cmd)
     stdout, stderr, _ = vm_util.IssueCommand(create_cmd)
     create_response = json.loads(stdout)
     self.spot_instance_request_id =\
@@ -563,6 +561,8 @@ class AwsVirtualMachine(virtual_machine.BaseVirtualMachine):
       elif status_code == "fulfilled":
         self.id = sir_response[0]['InstanceId']
         break
+
+      time.sleep(2)
 
   def _Delete(self):
     """Delete a VM instance."""

--- a/perfkitbenchmarker/providers/aws/flags.py
+++ b/perfkitbenchmarker/providers/aws/flags.py
@@ -33,5 +33,9 @@ flags.DEFINE_string('s3_custom_endpoint', None,
                     'storage region.')
 flags.DEFINE_boolean('aws_dedicated_hosts', False,
                      'Whether to use AWS dedicated hosts for any AWS VMs.')
+flags.DEFINE_boolean('aws_spot_instances', False,
+                     'Whether to use AWS spot instances for any AWS VMs.')
+flags.DEFINE_float('aws_spot_price', 0.0,
+                   'The spot price to bid for AWS spot instances.')
 flags.DEFINE_integer('aws_boot_disk_size', None,
                      'The boot disk size in GiB for AWS VMs.')

--- a/tests/data/aws-describe-spot-instance-requests.json
+++ b/tests/data/aws-describe-spot-instance-requests.json
@@ -1,0 +1,43 @@
+{
+    "SpotInstanceRequests": [
+        {
+            "Status": {
+                "UpdateTime": "2017-02-07T17:26:17.000Z", 
+                "Code": "fulfilled", 
+                "Message": "Your Spot request is fulfilled."
+            }, 
+            "ProductDescription": "Linux/UNIX", 
+            "InstanceId": "i-011682c24ab1c267e", 
+            "SpotInstanceRequestId": "sir-3wri5sgk", 
+            "State": "active", 
+            "LaunchedAvailabilityZone": "us-east-1c", 
+            "LaunchSpecification": {
+                "Placement": {
+                    "AvailabilityZone": "us-east-1c"
+                }, 
+                "ImageId": "ami-af22d9b9", 
+                "KeyName": "perfkit-key-0ebe1f3b", 
+                "SecurityGroups": [
+                    {
+                        "GroupName": "default", 
+                        "GroupId": "sg-4ed14a27"
+                    }
+                ], 
+                "Monitoring": {
+                    "Enabled": false
+                }, 
+                "InstanceType": "c4.4xlarge", 
+                "NetworkInterfaces": [
+                    {
+                        "SubnetId": "subnet-f22f7edf", 
+                        "DeviceIndex": 0, 
+                        "AssociatePublicIpAddress": true
+                    }
+                ]
+            }, 
+            "Type": "one-time", 
+            "CreateTime": "2017-02-07T17:26:06.000Z", 
+            "SpotPrice": "0.200000"
+        }
+    ]
+}


### PR DESCRIPTION
Added `aws_spot_instances` flag to spin up Spot instances instead of OnDemand.
`aws_spot_price` also needs to be set to control the max price that will be paid.

If a Spot instance cannot be spun up immediately (usually due to your price being too low), the run will abort.