### PR TITLE
Object storage service benchmark updates

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/object_storage_service_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/object_storage_service_benchmark.py
@@ -49,6 +49,7 @@ from perfkitbenchmarker import flags
 from perfkitbenchmarker import flag_util
 from perfkitbenchmarker import object_storage_service
 from perfkitbenchmarker import sample
+from perfkitbenchmarker import temp_dir
 from perfkitbenchmarker import units
 from perfkitbenchmarker import vm_util
 from perfkitbenchmarker.providers.gcp import gcs
@@ -70,7 +71,8 @@ flags.DEFINE_string('object_storage_storage_class', None,
 
 flags.DEFINE_enum('object_storage_scenario', 'all',
                   ['all', 'cli', 'api_data', 'api_namespace',
-                   'api_multistream', 'api_multistream_writes'],
+                   'api_multistream', 'api_multistream_writes',
+                   'api_multistream_reads'],
                   'select all, or one particular scenario to run: \n'
                   'ALL: runs all scenarios. This is the default. \n'
                   'cli: runs the command line only scenario. \n'
@@ -120,10 +122,34 @@ flags.DEFINE_enum('object_storage_object_naming_scheme', 'sequential_by_stream',
                   'different name prefixes. '
                   'approximately_sequential: object names from all '
                   'streams will roughly increase together.')
+flags.DEFINE_string('object_storage_objects_written_file', None,
+                    'If specified, the bucket and all of the objects will not '
+                    'be deleted, and the list of object names will be written '
+                    'to the specified file in the following format: '
+                    '<bucket>/<object>. This file can be passed to this '
+                    'benchmark in a later run via via the '
+                    'object_storage_read_objects flag. Only valid for the '
+                    'api_multistream and api_multistream_writes scenarios.')
+flags.DEFINE_string('object_storage_read_objects', None,
+                    'If specified, no new bucket or objects will be created. '
+                    'Instead, the benchmark will read the objects listed in '
+                    'the specified file. Only valid for the '
+                    'api_multistream_reads scenario.')
+flags.DEFINE_boolean('object_storage_dont_delete_bucket', False,
+                     'If True, the storage bucket won\'t be deleted. Useful '
+                     'for running the api_multistream_reads scenario multiple '
+                     'times against the same objects.')
 
 flags.DEFINE_string('object_storage_worker_output', None,
                     'If set, the worker threads\' output will be written to the'
                     'path provided.')
+flags.DEFINE_float('object_storage_latency_histogram_interval', None,
+                   'If set, a latency histogram sample will be created with '
+                   'buckets of the specified interval in seconds. Individual '
+                   'histogram samples are created for each different object '
+                   'size in the distribution, because it is easy to aggregate '
+                   'the histograms during post-processing, but impossible to '
+                   'go in the opposite direction.')
 
 FLAGS = flags.FLAGS
 
@@ -339,6 +365,7 @@ def _ProcessMultiStreamResults(start_times, latencies, sizes, operation,
   metadata['num_streams'] = num_streams
   metadata['objects_per_stream'] = (
       FLAGS.object_storage_multistream_objects_per_stream)
+  metadata['object_naming'] = FLAGS.object_storage_object_naming_scheme
 
   num_records = sum((len(start_time) for start_time in start_times))
   logging.info('Processing %s total operation records', num_records)
@@ -399,7 +426,10 @@ def _ProcessMultiStreamResults(start_times, latencies, sizes, operation,
   # searching metadata is easier when all records with the same metric
   # name have the same set of metadata fields.
   distribution_metadata = metadata.copy()
-  distribution_metadata['object_size_B'] = 'distribution'
+  if len(all_sizes) == 1:
+    distribution_metadata['object_size_B'] = all_sizes[0]
+  else:
+    distribution_metadata['object_size_B'] = 'distribution'
 
   latency_prefix = 'Multi-stream %s latency' % operation
   logging.info('Processing %s multi-stream %s results for the full '
@@ -425,6 +455,26 @@ def _ProcessMultiStreamResults(start_times, latencies, sizes, operation,
         latency_prefix,
         LATENCY_UNIT,
         this_size_metadata)
+    # Build the object latency histogram if user requested it
+    if FLAGS.object_storage_latency_histogram_interval:
+      histogram_interval = FLAGS.object_storage_latency_histogram_interval
+      hist_latencies = [[l for l, s in zip(*w_l_s) if s == size]
+                        for w_l_s in zip(latencies, sizes)]
+      max_latency = max([max(l) for l in hist_latencies])
+      # Note that int() floors for us
+      num_histogram_buckets = int(max_latency / histogram_interval) + 1
+      histogram_buckets = [0 for _ in range(num_histogram_buckets)]
+      for worker_latencies in hist_latencies:
+        for latency in worker_latencies:
+          # Note that int() floors for us
+          histogram_buckets[int(latency / histogram_interval)] += 1
+      histogram_str = ','.join([str(c) for c in histogram_buckets])
+      histogram_metadata = this_size_metadata.copy()
+      histogram_metadata['interval'] = histogram_interval
+      histogram_metadata['histogram'] = histogram_str
+      results.append(sample.Sample(
+          'Multi-stream %s latency histogram' % operation,
+          0.0, 'histogram', metadata=histogram_metadata))
 
   # Throughput metrics
   total_active_times = [np.sum(latency) for latency in active_latencies]
@@ -786,7 +836,7 @@ def _RunMultiStreamProcesses(vms, command_builder, cmd_args, streams_per_vm):
     logging.info('Running on VM %s.', vm_idx)
     cmd = command_builder.BuildCommand(
         cmd_args + ['--stream_num_start=%s' % (vm_idx * streams_per_vm)])
-    out, _ = vms[vm_idx].RobustRemoteCommand(cmd, should_log=True)
+    out, _ = vms[vm_idx].RobustRemoteCommand(cmd, should_log=False)
     output[vm_idx] = out
 
   # Each vm/process has a thread managing it.
@@ -861,8 +911,24 @@ def _MultiStreamOneWay(results, metadata, vms, command_builder,
     with open(FLAGS.object_storage_worker_output, 'w') as out_file:
       out_file.write(json.dumps(output))
   _ProcessMultiStreamResults(start_times, latencies, sizes, operation,
-                             size_distribution.iterkeys(), results,
+                             list(size_distribution.iterkeys()), results,
                              metadata=metadata)
+
+  # Write the objects written file if the flag is set and this is an upload
+  objects_written_path_local = FLAGS.object_storage_objects_written_file
+  if operation == 'upload' and objects_written_path_local is not None:
+    # Get the objects written from all the VMs
+    # Note these are JSON lists with the following format:
+    # [[object1_name, object1_size],[object2_name, object2_size],...]
+    outs = vm_util.RunThreaded(
+        lambda vm: vm.RemoteCommand('cat ' + objects_written_file), vms)
+    # Merge the objects written from all the VMs into a single string
+    objects_written_json = '{"bucket_name": "%s", "objects_written": %s}' % \
+                           (bucket_name,
+                            '[' + ','.join([out for out, _ in outs]) + ']')
+    # Write the file
+    with open(objects_written_path_local, 'w') as objects_written_file_local:
+      objects_written_file_local.write(objects_written_json)
 
 
 def MultiStreamRWBenchmark(results, metadata, vms, command_builder,
@@ -919,6 +985,55 @@ def MultiStreamWriteBenchmark(results, metadata, vms, command_builder,
                      'upload')
 
   logging.info('Finished multi-stream write test.')
+
+
+def MultiStreamReadBenchmark(results, metadata, vms, command_builder,
+                             bucket_name, read_objects):
+
+  """A benchmark for multi-stream read latency and throughput.
+
+  Args:
+    results: the results array to append to.
+    metadata: a dictionary of metadata to add to samples.
+    vms: the VMs to run the benchmark on.
+    command_builder: an APIScriptCommandBuilder.
+    bucket_name: the primary bucket to benchmark.
+    read_objects: List of lists of [object_name, object_size]. In the outermost
+      list, each element corresponds to a VM's worker process.
+
+  Raises:
+    ValueError if an unexpected test outcome is found from the API
+    test script.
+  """
+
+  logging.info('Starting multi-stream read test on %s VMs.', len(vms))
+
+  assert read_objects is not None, \
+      "api_multistream_reads scenario requires the " + \
+      "object_storage_read_objects flag to be set."
+
+  # Send over the objects written file
+  try:
+    # Write the per-VM objects-written-files
+    assert len(read_objects) == len(vms), \
+        "object_storage_read_objects file specified requires exactly %d " \
+        "VMs, but %d were provisioned." % (len(read_objects), len(vms))
+    for vm, vm_objects_written in zip(vms, read_objects):
+      # Note that this overwrites the same local file over and over, because
+      # each VM's worker process expects it to have the same file name.
+      tmp_objects_written_path = os.path.join(temp_dir.GetRunDirPath(),
+                                              OBJECTS_WRITTEN_FILE)
+      with open(tmp_objects_written_path, 'w') as objects_written_file:
+        objects_written_file.write(json.dumps(vm_objects_written))
+      vm.PushFile(tmp_objects_written_path, '/tmp/pkb/')
+  except Exception as e:
+    raise Exception("Failed to upload the objects written files to the VMs: "
+                    "%s" % e)
+
+  _MultiStreamOneWay(results, metadata, vms, command_builder, bucket_name,
+                     'download')
+
+  logging.info('Finished multi-stream read test.')
 
 
 def CheckPrerequisites(benchmark_config):
@@ -1104,16 +1219,30 @@ def Prepare(benchmark_spec):
   # We would like to always cleanup server side states when exception happens.
   benchmark_spec.always_call_cleanup = True
 
+  # Load the objects to read file if specified
+  benchmark_spec.read_objects = None
+  if FLAGS.object_storage_read_objects is not None:
+    with open(FLAGS.object_storage_read_objects) as read_objects_file:
+      # Format of json structure is:
+      # {"bucket_name": <bucket_name>,
+      #  "objects_written": <objects_written_array>}
+      benchmark_spec.read_objects = json.loads(read_objects_file.read())
+    assert benchmark_spec.read_objects is not None, \
+        "Failed to read the file specified by --object_storag_read_objects"
+
   # Make the bucket(s)
-  bucket_name = 'pkb%s' % FLAGS.run_uri
-  if FLAGS.storage != 'GCP' or not FLAGS.object_storage_gcs_multiregion:
-    service.MakeBucket(bucket_name)
+  if benchmark_spec.read_objects is not None:
+    bucket_name = benchmark_spec.read_objects['bucket_name']
   else:
-    # Use a GCS multiregional bucket
-    multiregional_service = gcs.GoogleCloudStorageService()
-    multiregional_service.PrepareService(FLAGS.object_storage_gcs_multiregion
-                                         or DEFAULT_GCS_MULTIREGION)
-    multiregional_service.MakeBucket(bucket_name)
+    bucket_name = 'pkb%s' % FLAGS.run_uri
+    if FLAGS.storage != 'GCP' or not FLAGS.object_storage_gcs_multiregion:
+      service.MakeBucket(bucket_name)
+    else:
+      # Use a GCS multiregional bucket
+      multiregional_service = gcs.GoogleCloudStorageService()
+      multiregional_service.PrepareService(FLAGS.object_storage_gcs_multiregion
+                                           or DEFAULT_GCS_MULTIREGION)
+      multiregional_service.MakeBucket(bucket_name)
 
   # Save the service and the buckets for later
   benchmark_spec.service = service
@@ -1138,7 +1267,7 @@ def Run(benchmark_spec):
   service = benchmark_spec.service
   buckets = benchmark_spec.buckets
 
-  metadata = {'storage provider': FLAGS.storage}
+  metadata = {'storage_provider': FLAGS.storage}
 
   vms = benchmark_spec.vms
 
@@ -1170,15 +1299,19 @@ def Run(benchmark_spec):
       benchmark(results, metadata, vms[0], command_builder,
                 service, buckets[0])
 
-  # MultiStreamRW and MultiStreamWrite are the only benchmarks that support
-  # multiple VMs, so they have a slightly different calling convention than the
-  # others.
+  # MultiStreamRW and MultiStreamWrite support multiple VMs, so they have a
+  # slightly different calling convention than the others.
   for name, benchmark in [('api_multistream', MultiStreamRWBenchmark),
                           ('api_multistream_writes',
                            MultiStreamWriteBenchmark)]:
     if FLAGS.object_storage_scenario in {name, 'all'}:
       benchmark(results, metadata, vms, command_builder, buckets[0])
 
+  # MultiStreamRead has the additional 'read_objects' parameter
+  if FLAGS.object_storage_scenario in {'api_multistream_reads', 'all'}:
+    MultiStreamReadBenchmark(results, metadata, vms, command_builder,
+                             buckets[0],
+                             benchmark_spec.read_objects['objects_written'])
 
   return results
 
@@ -1197,7 +1330,10 @@ def Cleanup(benchmark_spec):
 
   vm_util.RunThreaded(lambda vm: CleanupVM(vm, service), vms)
 
-  for bucket in buckets:
-    service.DeleteBucket(bucket)
+  # Only clean up buckets if we're not saving the objects for a later run
+  if FLAGS.object_storage_objects_written_file is None and \
+     not FLAGS.object_storage_dont_delete_bucket:
+    for bucket in buckets:
+      service.DeleteBucket(bucket)
 
   service.CleanupService()

--- a/perfkitbenchmarker/linux_benchmarks/object_storage_service_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/object_storage_service_benchmark.py
@@ -84,6 +84,9 @@ flags.DEFINE_enum('object_storage_scenario', 'all',
                   'api_multistream_writes: runs API-based benchmarking with '
                   'multiple upload streams.')
 
+flags.DEFINE_string('object_storage_bucket_name', None,
+                    'If set, the bucket will be created with this name')
+
 flags.DEFINE_enum('cli_test_size', 'normal',
                   ['normal', 'large'],
                   'size of the cli tests. Normal means a mixture of various \n'
@@ -1235,8 +1238,11 @@ def Prepare(benchmark_spec):
   # Make the bucket(s)
   if benchmark_spec.read_objects is not None:
     bucket_name = benchmark_spec.read_objects['bucket_name']
+    if FLAGS.object_storage_bucket_name is not None:
+      logging.warning('--object_storage_bucket_name ignored because '
+                      '--object_storage_read_objects was specified')
   else:
-    bucket_name = 'pkb%s' % FLAGS.run_uri
+    bucket_name = FLAGS.object_storage_bucket_name or 'pkb%s' % FLAGS.run_uri
     if FLAGS.storage != 'GCP' or not FLAGS.object_storage_gcs_multiregion:
       service.MakeBucket(bucket_name)
     else:

--- a/perfkitbenchmarker/linux_benchmarks/object_storage_service_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/object_storage_service_benchmark.py
@@ -172,6 +172,8 @@ object_storage_service:
     default:
       vm_spec: *default_single_core
       vm_count: null
+  flags:
+    gcloud_scopes: https://www.googleapis.com/auth/devstorage.read_write
 """
 
 DATA_FILE = 'cloud-storage-workload.sh'

--- a/perfkitbenchmarker/providers/azure/azure_blob_storage.py
+++ b/perfkitbenchmarker/providers/azure/azure_blob_storage.py
@@ -20,9 +20,6 @@ from perfkitbenchmarker import vm_util
 from perfkitbenchmarker.providers import azure
 from perfkitbenchmarker.providers.azure import azure_network
 
-flags.DEFINE_string('azure_lib_version', None,
-                    'Use a particular version of azure client lib, e.g.: 1.0.2')
-
 FLAGS = flags.FLAGS
 
 DEFAULT_AZURE_REGION = 'eastus2'

--- a/perfkitbenchmarker/providers/azure/azure_blob_storage.py
+++ b/perfkitbenchmarker/providers/azure/azure_blob_storage.py
@@ -35,10 +35,27 @@ class AzureBlobStorageService(object_storage_service.ObjectStorageService):
 
   STORAGE_NAME = providers.AZURE
 
-  def PrepareService(self, location):
+  def PrepareService(self, location,
+                     existing_storage_account_and_resource_group=None):
     # abs is "Azure Blob Storage"
     prefix = 'pkb%sabs' % FLAGS.run_uri
-    self.resource_group = azure_network.GetResourceGroup()
+
+    # Maybe extract existing storage account and resource group names
+    existing_storage_account, existing_resource_group = None, None
+    if existing_storage_account_and_resource_group:
+      existing_storage_account, existing_resource_group = \
+          existing_storage_account_and_resource_group
+      assert existing_storage_account is not None
+      assert existing_resource_group is not None
+    storage_account_name = existing_storage_account or prefix + 'storage'
+    resource_group_name = existing_resource_group or prefix + '-resource-group'
+
+    # We use a separate resource group so that our buckets can optionally stick
+    # around after PKB runs. This is useful for things like cold reads tests
+    self.resource_group = \
+        azure_network.AzureResourceGroup(resource_group_name,
+                                         existing_resource_group is not None)
+    self.resource_group.Create()
 
     # We use a different Azure storage account than the VM account
     # because a) we need to be able to set the storage class
@@ -48,12 +65,15 @@ class AzureBlobStorageService(object_storage_service.ObjectStorageService):
     self.storage_account = azure_network.AzureStorageAccount(
         FLAGS.azure_storage_type,
         location or DEFAULT_AZURE_REGION,
-        prefix + 'storage',
-        kind=FLAGS.azure_blob_account_kind)
+        storage_account_name,
+        kind=FLAGS.azure_blob_account_kind,
+        resource_group=self.resource_group,
+        use_existing=existing_storage_account is not None)
     self.storage_account.Create()
 
   def CleanupService(self):
     self.storage_account.Delete()
+    self.resource_group.Delete()
 
   def MakeBucket(self, bucket):
     vm_util.IssueRetryableCommand([

--- a/perfkitbenchmarker/providers/azure/azure_network.py
+++ b/perfkitbenchmarker/providers/azure/azure_network.py
@@ -48,7 +48,7 @@ def GetResourceGroup():
   try:
     return spec.azure_resource_group
   except AttributeError:
-    group = AzureResourceGroup(FLAGS.run_uri, spec.uid)
+    group = AzureResourceGroup('pkb%s-%s' % (FLAGS.run_uri, spec.uid))
     spec.azure_resource_group = group
     return group
 
@@ -56,11 +56,10 @@ def GetResourceGroup():
 class AzureResourceGroup(resource.BaseResource):
   """A Resource Group, the basic unit of Azure provisioning."""
 
-  def __init__(self, run_uri, spec_uid):
+  def __init__(self, name, use_existing=False):
     super(AzureResourceGroup, self).__init__()
-    self.name = 'pkb%s-%s' % (run_uri, spec_uid)
-    # Storage account names can't include separator characters :(.
-    self.storage_account_prefix = 'pkb%s' % run_uri
+    self.name = name
+    self.use_existing = use_existing
     # A resource group's location doesn't affect the location of
     # actual resources, but we need to choose *some* region for every
     # benchmark, even if the user doesn't specify one.
@@ -70,16 +69,17 @@ class AzureResourceGroup(resource.BaseResource):
     self.args = ['--resource-group', self.name]
 
   def _Create(self):
-    # A resource group can own resources in multiple zones, but the
-    # group itself needs to have a location. Therefore,
-    # FLAGS.zones[0].
-    _, _, retcode = vm_util.IssueCommand(
-        [azure.AZURE_PATH, 'group', 'create',
-         self.name, self.location])
+    if not self.use_existing:
+      # A resource group can own resources in multiple zones, but the
+      # group itself needs to have a location. Therefore,
+      # FLAGS.zones[0].
+      _, _, retcode = vm_util.IssueCommand(
+          [azure.AZURE_PATH, 'group', 'create',
+           self.name, self.location])
 
-    if retcode:
-      raise errors.RetryableCreationError(
-          'Error creating Azure resource group')
+      if retcode:
+        raise errors.RetryableCreationError(
+            'Error creating Azure resource group')
 
   def _Exists(self):
     _, _, retcode = vm_util.IssueCommand(
@@ -137,13 +137,15 @@ class AzureStorageAccount(resource.BaseResource):
   total_storage_accounts = 0
 
   def __init__(self, storage_type, location, name,
-               kind=None, access_tier=None):
+               kind=None, access_tier=None, resource_group=None,
+               use_existing=False):
     super(AzureStorageAccount, self).__init__()
     self.storage_type = storage_type
     self.name = name
-    self.resource_group = GetResourceGroup()
+    self.resource_group = resource_group or GetResourceGroup()
     self.location = location
     self.kind = kind or 'Storage'
+    self.use_existing = use_existing
 
     AzureStorageAccount.total_storage_accounts += 1
 
@@ -156,20 +158,21 @@ class AzureStorageAccount(resource.BaseResource):
 
   def _Create(self):
     """Creates the storage account."""
-    create_cmd = [azure.AZURE_PATH,
-                  'storage',
-                  'account',
-                  'create',
-                  '--kind', self.kind,
-                  '--sku-name', self.storage_type,
-                  self.name] + self.resource_group.args
-    if self.location:
-      create_cmd.extend(
-          ['--location', self.location])
-    if self.kind == 'BlobStorage':
-      create_cmd.extend(
-          ['--access-tier', self.access_tier])
-    vm_util.IssueCommand(create_cmd)
+    if not self.use_existing:
+      create_cmd = [azure.AZURE_PATH,
+                    'storage',
+                    'account',
+                    'create',
+                    '--kind', self.kind,
+                    '--sku-name', self.storage_type,
+                    self.name] + self.resource_group.args
+      if self.location:
+        create_cmd.extend(
+            ['--location', self.location])
+      if self.kind == 'BlobStorage':
+        create_cmd.extend(
+            ['--access-tier', self.access_tier])
+      vm_util.IssueCommand(create_cmd)
 
   def _PostCreate(self):
     """Get our connection string and our keys."""
@@ -411,13 +414,16 @@ class AzureNetwork(network.BaseNetwork):
     self.resource_group = GetResourceGroup()
     self.avail_set = AzureAvailSet(self.resource_group.name, self.zone)
 
+    # Storage account names can't include separator characters :(.
+    storage_account_prefix = 'pkb%s' % FLAGS.run_uri
+
     # Storage account names must be 3-24 characters long and use
     # numbers and lower-case letters only, which leads us to this
     # awful naming scheme.
     suffix = 'storage%d' % AzureStorageAccount.total_storage_accounts
     self.storage_account = AzureStorageAccount(
         FLAGS.azure_storage_type, self.zone,
-        self.resource_group.storage_account_prefix[:24 - len(suffix)] + suffix)
+        storage_account_prefix[:24 - len(suffix)] + suffix)
     prefix = '%s-%s' % (self.resource_group.name, self.zone)
     self.vnet = AzureVirtualNetwork(self.zone, prefix + '-vnet')
     self.subnet = AzureSubnet(self.vnet, self.vnet.name + '-subnet')

--- a/perfkitbenchmarker/providers/azure/azure_network.py
+++ b/perfkitbenchmarker/providers/azure/azure_network.py
@@ -60,7 +60,7 @@ class AzureResourceGroup(resource.BaseResource):
     super(AzureResourceGroup, self).__init__()
     self.name = 'pkb%s-%s' % (run_uri, spec_uid)
     # Storage account names can't include separator characters :(.
-    self.storage_account_prefix = 'pkb%s%s' % (run_uri, spec_uid)
+    self.storage_account_prefix = 'pkb%s' % run_uri
     # A resource group's location doesn't affect the location of
     # actual resources, but we need to choose *some* region for every
     # benchmark, even if the user doesn't specify one.
@@ -134,6 +134,8 @@ class AzureAvailSet(resource.BaseResource):
 class AzureStorageAccount(resource.BaseResource):
   """Object representing an Azure Storage Account."""
 
+  total_storage_accounts = 0
+
   def __init__(self, storage_type, location, name,
                kind=None, access_tier=None):
     super(AzureStorageAccount, self).__init__()
@@ -142,6 +144,8 @@ class AzureStorageAccount(resource.BaseResource):
     self.resource_group = GetResourceGroup()
     self.location = location
     self.kind = kind or 'Storage'
+
+    AzureStorageAccount.total_storage_accounts += 1
 
     if kind == 'BlobStorage':
       self.access_tier = access_tier or 'Hot'
@@ -193,7 +197,13 @@ class AzureStorageAccount(resource.BaseResource):
 
   def _Delete(self):
     """Deletes the storage account."""
-    pass
+    delete_cmd = [azure.AZURE_PATH,
+                  'storage',
+                  'account',
+                  'delete',
+                  self.name,
+                  '--quiet'] + self.resource_group.args
+    vm_util.IssueCommand(delete_cmd)
 
   def _Exists(self):
     """Returns true if the storage account exists."""
@@ -404,7 +414,7 @@ class AzureNetwork(network.BaseNetwork):
     # Storage account names must be 3-24 characters long and use
     # numbers and lower-case letters only, which leads us to this
     # awful naming scheme.
-    suffix = '%sstorage' % self.zone
+    suffix = 'storage%d' % AzureStorageAccount.total_storage_accounts
     self.storage_account = AzureStorageAccount(
         FLAGS.azure_storage_type, self.zone,
         self.resource_group.storage_account_prefix[:24 - len(suffix)] + suffix)

--- a/perfkitbenchmarker/providers/azure/flags.py
+++ b/perfkitbenchmarker/providers/azure/flags.py
@@ -49,3 +49,6 @@ flags.DEFINE_enum(
     'The type of storage account to use for blob storage. Choosing Storage '
     'will let you use ZRS storage. Choosing BlobStorage will give you access '
     'to Hot and Cold storage tiers.')
+
+flags.DEFINE_string('azure_lib_version', None,
+                    'Use a particular version of azure client lib, e.g.: 1.0.2')

--- a/tests/linux_benchmarks/object_storage_service_benchmark_test.py
+++ b/tests/linux_benchmarks/object_storage_service_benchmark_test.py
@@ -37,6 +37,7 @@ class TestBuildCommands(unittest.TestCase):
     vm.RobustRemoteCommand = mock.MagicMock(return_value=('', ''))
 
     command_builder = mock.MagicMock()
+    service = mock.MagicMock()
 
     with mock.patch(time.__name__ + '.time', return_value=1.0):
       with mock.patch(object_storage_service_benchmark.__name__ +
@@ -44,7 +45,7 @@ class TestBuildCommands(unittest.TestCase):
         with mock.patch(object_storage_service_benchmark.__name__ +
                         '.LoadWorkerOutput', return_value=(None, None, None)):
           object_storage_service_benchmark.MultiStreamRWBenchmark(
-              [], {}, [vm], command_builder, 'bucket')
+              [], {}, [vm], command_builder, service, 'bucket')
 
     self.assertEqual(
         command_builder.BuildCommand.call_args_list[0],


### PR DESCRIPTION
- Fix object_storage_service benchmark for Azure
- Add option to create latency histogram samples
- Add support for cold reads tests via `--object_storage_objects_written_file`, `--object_storage_read_objects`, and `--object_storage_dont_delete_bucket`

To create objects for a cold reads test, you run the `api_multistream_writes` (`api_multistream` will work too) scenario with the `--object_storage_objects_written_file` flag specified. It'll dump a json structure storing the bucket name as well as all the objects' names and sizes.

To perform a cold reads test, you run the `api_multistream_reads` scenario with the `--object_storage_read_objects` flag pointed at the file that was created with the `--object_storage_written_file`. You can specify `--object_storage_dont_delete_bucket` if you want to keep the bucket around for another cold reads test later on. Otherwise, the bucket will be deleted at the end of the `api_multistream_reads` run.