### PR TITLE
Lock samples json file before writing to it

### DIFF
--- a/perfkitbenchmarker/publisher.py
+++ b/perfkitbenchmarker/publisher.py
@@ -18,6 +18,7 @@ import abc
 import collections
 import copy
 import csv
+import fcntl
 import httplib
 import io
 import itertools
@@ -457,6 +458,7 @@ class NewlineDelimitedJSONPublisher(SamplePublisher):
     logging.info('Publishing %d samples to %s', len(samples),
                  self.file_path)
     with open(self.file_path, self.mode) as fp:
+      fcntl.flock(fp, fcntl.LOCK_EX)
       for sample in samples:
         sample = sample.copy()
         if self.collapse_labels:


### PR DESCRIPTION
This ensures the samples json file doesn't get mangled when two processes are appending the same file (`--json_write_mode=ab`). The lock is automatically released when the file is closed.