### PR TITLE
Let publisher.py republish already-collected samples.

### DIFF
--- a/perfkitbenchmarker/publisher.py
+++ b/perfkitbenchmarker/publisher.py
@@ -675,7 +675,7 @@ class SampleCollector(object):
     else:
       self.metadata_providers = DEFAULT_METADATA_PROVIDERS
 
-    self.publishers = publishers.copy()
+    self.publishers = publishers[:]
     if publishers_from_flags:
       publishers.extend(SampleCollector._PublishersFromFlags())
     if add_default_publishers:


### PR DESCRIPTION
I often collect data and then realize I wish I had exported to
CSV. This change lets publisher.py run independently. In this mode, it
will read the JSON sample file that it always generates by default
(inside the run directory) and run the publish step again, in the same
way that it does during normal PKB runs. This gives the flexibility to
re-publish samples to anywhere they could be published initially.