### PR TITLE
Pass the program name as the argv list in FLAGS(argv).

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 from perfkitbenchmarker import flags
 
 
 # Many places in the PKB codebase directly reference the global FLAGS. Several
 # tests were written using python-gflags==2.0, which allows accessing flag
 # values before they are parsed. python-gflags>=3.0.4 discourages this behavior,
-# so parse an empty list of flags before any tests are executed.
-flags.FLAGS([])
+# so parse program name + an empty list of flags before any tests are executed.
+flags.FLAGS([sys.argv[0]])

--- a/tests/flag_util_test.py
+++ b/tests/flag_util_test.py
@@ -15,6 +15,7 @@
 """Tests for flag_util.py."""
 
 import copy
+import sys
 import unittest
 
 from perfkitbenchmarker import flags
@@ -115,7 +116,7 @@ class FlagDictSubstitutionTestCase(unittest.TestCase):
   def testReadAndWrite(self):
     flag_values = flags.FlagValues()
     flags.DEFINE_integer('test_flag', 0, 'Test flag.', flag_values=flag_values)
-    flag_values([])
+    flag_values([sys.argv[0]])
     flag_values_copy = copy.deepcopy(flag_values)
     flag_values_copy.test_flag = 1
     self.assertFlagState(flag_values, 0, False)


### PR DESCRIPTION
Accepting an empty list of argv in `FLAGS.__call__` is an accident, it
will be changed soon.