### PR TITLE
Update hadoop version.

### DIFF
--- a/perfkitbenchmarker/linux_packages/hadoop.py
+++ b/perfkitbenchmarker/linux_packages/hadoop.py
@@ -28,7 +28,7 @@ from perfkitbenchmarker import regex_util
 from perfkitbenchmarker import vm_util
 from perfkitbenchmarker.linux_packages import INSTALL_DIR
 
-HADOOP_VERSION = '2.5.2'
+HADOOP_VERSION = '2.7.2'
 HADOOP_URL = ('http://www.us.apache.org/dist/hadoop/common/hadoop-{0}/'
               'hadoop-{0}.tar.gz').format(HADOOP_VERSION)
 


### PR DESCRIPTION
Hadoop version 2.5.2 no longer exists. Updated to newer version 2.7.2.
http://www.us.apache.org/dist/hadoop/common/