### PR TITLE
Install sysbench05plus package in a separate path from sysbench.

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/mysql_service_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/mysql_service_benchmark.py
@@ -113,9 +113,6 @@ MYSQL_ROOT_USER = 'root'
 MYSQL_ROOT_PASSWORD_PREFIX = 'Perfkit8'
 MYSQL_PORT = '3306'
 
-PREPARE_SCRIPT_PATH = '/share/doc/sysbench/tests/db/parallel_prepare.lua'
-OLTP_SCRIPT_PATH = '/share/doc/sysbench/tests/db/oltp.lua'
-
 SYSBENCH_RESULT_NAME_DATA_LOAD = 'sysbench data load time'
 SYSBENCH_RESULT_NAME_TPS = 'sysbench tps'
 SYSBENCH_RESULT_NAME_LATENCY = 'sysbench latency'
@@ -281,9 +278,9 @@ def _IssueSysbenchCommand(vm, duration):
   """
   stdout = ''
   stderr = ''
-  oltp_script_path = sysbench05plus.PathPrefix(vm) + OLTP_SCRIPT_PATH
+  oltp_script_path = sysbench05plus.OLTP_SCRIPT_PATH
   if duration > 0:
-    run_cmd_tokens = ['sysbench',
+    run_cmd_tokens = ['%s' % sysbench05plus.SYSBENCH05PLUS_PATH,
                       '--test=%s' % oltp_script_path,
                       '--mysql_svc_oltp_tables_count=%d' %
                       FLAGS.mysql_svc_oltp_tables_count,
@@ -345,8 +342,8 @@ def _RunSysbench(vm, metadata):
   # Provision the Sysbench test based on the input flags (load data into DB)
   # Could take a long time if the data to be loaded is large.
   data_load_start_time = time.time()
-  prepare_script_path = sysbench05plus.PathPrefix(vm) + PREPARE_SCRIPT_PATH
-  data_load_cmd_tokens = ['sysbench',
+  prepare_script_path = sysbench05plus.PREPARE_SCRIPT_PATH
+  data_load_cmd_tokens = ['%s' % sysbench05plus.SYSBENCH05PLUS_PATH,
                           '--test=%s' % prepare_script_path,
                           '--mysql_svc_oltp_tables_count=%d' %
                           FLAGS.mysql_svc_oltp_tables_count,


### PR DESCRIPTION
Sysbench 0.5 contains breaking changes from previous versions. All existing oltp benchmarks depending on older version of sysbench will break if we install 0.5 or later for them. Therefore, it's necessary that we have a separate installation path here for 0.5 and later so that when we install both sysbench and sybench 0.5, the test knows in which path to run the sysbench command.