### PR TITLE
Change --openstack_additional_flags to be a list flag.

### DIFF
--- a/perfkitbenchmarker/providers/openstack/flags.py
+++ b/perfkitbenchmarker/providers/openstack/flags.py
@@ -18,10 +18,11 @@ flags.DEFINE_string('openstack_cli_path',
                     default='openstack',
                     help='The path to the OpenStack CLI binary.')
 
-flags.DEFINE_string('openstack_additional_flags',
-                    default=[],
-                    help='Additional flags to pass to every OpenStack CLI '
-                         'command. See "openstack --help" for more.')
+flags.DEFINE_list('openstack_additional_flags',
+                  default=[],
+                  help='Additional comma separated flags to pass to every '
+                       'OpenStack CLI command. See "openstack --help" for '
+                       'more.')
 
 flags.DEFINE_string('openstack_public_network', None,
                     '(DEPRECATED: Use openstack_floating_ip_pool) '


### PR DESCRIPTION
Otherwise when a string value is passed, each individual character in the string will be added here:  https://github.com/GoogleCloudPlatform/PerfKitBenchmarker/blob/ba0e0aa67bd6c8e4a4a92be2e2f6dad10113627e/perfkitbenchmarker/providers/openstack/utils.py#L112

If this indeed is a string flag, then the default value should be changed to None or an empty string.