### PR TITLE
Move gflags installation from netperf benchmark to package.

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
@@ -126,10 +126,6 @@ def Prepare(benchmark_spec):
                        netserver_path=netperf.NETSERVER_PATH)
   vms[1].RemoteCommand(netserver_cmd)
 
-  # Install some stuff on the client vm
-  vms[0].Install('pip')
-  vms[0].RemoteCommand('sudo pip install python-gflags==2.0')
-
   # Create a scratch directory for the remote test script
   vms[0].RemoteCommand('sudo mkdir -p /tmp/run/')
   vms[0].RemoteCommand('sudo chmod 777 /tmp/run/')

--- a/perfkitbenchmarker/linux_packages/netperf.py
+++ b/perfkitbenchmarker/linux_packages/netperf.py
@@ -41,6 +41,8 @@ NETLIB_PATCH = NETPERF_SRC_DIR + '/netperf.patch'
 
 def _Install(vm):
   """Installs the netperf package on the VM."""
+  vm.Install('pip')
+  vm.RemoteCommand('sudo pip install python-gflags==2.0')
   vm.Install('build_tools')
   vm.Install('curl')
   vm.RemoteCommand('curl %s -o %s/%s' % (


### PR DESCRIPTION
Separate the package installation from prepare stage so that the test could run using a prebaked image under no-internet connection environment.