### PR TITLE
PKB scheduler initial commit

### DIFF
--- a/tools/pkb_scheduler/README.md
+++ b/tools/pkb_scheduler/README.md
@@ -1,0 +1,81 @@
+# PKB Scheduler
+
+The PKB scheduler is a tool for running PKB benchmarks periodically and logging/publishing the results. It also provides a web dashboard to view the completion status of past runs.
+
+## Running the scheduler
+
+You need to create a scheduler config file. Here's an example:
+
+```yaml
+pkb_executable: /home/tedsta/code/PerfKitBenchmarker/pkb.py
+logs_path: logs/
+results_path: results/
+completion_status_path: .pkb_completion_status/
+results_gcs_bucket: pkb-data
+benchmark_config: pkb_configs.yaml
+run_benchmarks:
+  netperf_same_zone:
+    AWS:
+      seconds_between_launches: 300
+      run_processes: 1
+    GCP:
+      seconds_between_launches: 1800
+      run_processes: 4
+```
+
+And here's its corresponding PKB benchmark config file:
+
+```yaml
+netperf_same_zone:
+  name: netperf
+  flags:
+    netperf_histogram_buckets: 1000
+  flag_matrix_defs:
+    AWS:
+      cloud: [AWS]
+      zones: [us-west-1a]
+      machine_type: [c4.xlarge]
+      netperf_num_streams: ["1"]
+      netperf_benchmarks: ["TCP_STREAM"]
+    Azure:
+      cloud: [Azure]
+      zones: [westus]
+      machine_type: [Standard_F4, Standard_F8]
+      netperf_num_streams: ["1"]
+      netperf_benchmarks: ["TCP_STREAM"]
+    GCP:
+      gce_network_name: [default]
+      cloud: [GCP]
+      zones: [us-east1-b, us-west1-a]
+      machine_type: [n1-standard-4, n1-standard-8]
+      netperf_num_streams: ["1"]
+      netperf_benchmarks: ["TCP_STREAM"]
+```
+
+Notice you don't have to run every benchmark/flag_matrix that is defined. Here we don't run the Azure flag matrix in netperf_same_zone.
+
+The `pkb_executable`, `benchmark_config`, and `run_benchmarks` fields in the scheduler config are required. If the `results_gcs_bucket` field is omitted, the results won't be published to GCS, but they'll still be stored locally.
+
+## Running the scheduler dashboard
+
+The code is stored in `dashboard/`. Run:
+
+```
+dashboard/deploy.py <dashboard config>
+```
+
+from the directory where the PKB scheduler is running. It'll be hosted on port 8080.
+
+Here's an example dashboard config:
+
+```yaml
+scheduler_config: scheduler_config.yaml
+categories:
+  "Networking":
+  - benchmark: netperf_same_zone
+    flag_axes:
+      AWS: [zones, machine_type]
+      GCP: [zones, machine_type]
+```
+
+As you can see you can group benchmarks into categories. In the example we just have one category named "Networking".

--- a/tools/pkb_scheduler/dashboard/dashboard.py
+++ b/tools/pkb_scheduler/dashboard/dashboard.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+import multiprocessing as mp
+import os
+import pickle
+import socket
+import subprocess
+import sys
+import yaml
+
+from flask import Flask, Response, make_response, render_template, g
+
+from service_util import ServiceConnection
+from site_service import run_site_service
+
+app = Flask(__name__)
+app.jinja_env.add_extension("jinja2.ext.do")
+
+SERVICE_PORT = 32422
+
+########################################
+# app context stuff
+########################################
+
+def connect_service(host, port):
+  s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+  s.connect((host, port))
+  return ServiceConnection(s)
+
+def get_site_service_connection():
+  if not hasattr(g, "site_service"):
+    g.site_service = connect_service("localhost", SERVICE_PORT)
+  return g.site_service
+
+@app.teardown_appcontext
+def teardown_site_service_connection(error):
+  if hasattr(g, "site_service"):
+    g.site_service.close()
+
+########################################
+# app serving stuff
+########################################
+
+@app.route("/")
+@app.route("/run", strict_slashes=False)
+def index():
+  site_service = get_site_service_connection()
+
+  site_service.send_str("get_categories")
+  categories = pickle.loads(site_service.recv())
+
+  html = render_template("index.html", categories=categories)
+
+  return make_response(html)
+
+@app.route("/run/<benchmark>")
+def benchmark_page(benchmark):
+  site_service = get_site_service_connection()
+
+  site_service.send_str("benchmark %s" % benchmark)
+  page_context = pickle.loads(site_service.recv())
+
+  html = render_template("benchmark_page.html", **page_context)
+
+  return make_response(html)
+
+@app.route("/run/<benchmark>/<timestamp>")
+def benchmark_run_page(benchmark, timestamp):
+  site_service = get_site_service_connection()
+
+  site_service.send_str("run %s,%s" % (benchmark, timestamp))
+  page_context = pickle.loads(site_service.recv())
+
+  html = render_template("run_page.html", **page_context)
+
+  return make_response(html)
+
+########################################
+
+def start_services(page_spec):
+  # Start page service
+  site_service_proc = mp.Process(target=run_site_service,
+                                 args=("localhost", SERVICE_PORT, page_spec))
+  site_service_proc.start()
+
+  return site_service_proc
+
+def main():
+  if len(sys.argv) != 2:
+    print("Usage: python3 chart_server.py <page_spec>")
+    exit()
+
+  page_spec = sys.argv[1]
+
+  # Launch the page and data services
+  site_service_proc = start_services(page_spec)
+
+  # Start webserver
+  try:
+    app.run(host="0.0.0.0", port=8080)
+  except KeyboardInterrupt:
+    site_service_proc.terminate()
+
+########################################
+
+if __name__ == "__main__":
+  main()

--- a/tools/pkb_scheduler/dashboard/deploy.py
+++ b/tools/pkb_scheduler/dashboard/deploy.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+import sys
+
+from cheroot import wsgi
+from dashboard import app, start_services
+
+def main():
+  if len(sys.argv) != 2:
+    print("Usage: python3 deploy.py <page_spec>")
+    exit()
+
+  page_spec = sys.argv[1]
+
+  # Launch the services
+  site_service_proc = start_services(page_spec)
+
+  dispatcher = wsgi.WSGIPathInfoDispatcher({'/': app})
+  server = wsgi.WSGIServer(('0.0.0.0', 8080), wsgi_app=dispatcher)
+
+  try:
+    server.start()
+  except KeyboardInterrupt:
+    server.stop()
+    site_service_proc.terminate()
+
+########################################
+
+if __name__ == '__main__':
+  main()

--- a/tools/pkb_scheduler/dashboard/requirements.txt
+++ b/tools/pkb_scheduler/dashboard/requirements.txt
@@ -1,0 +1,15 @@
+# Copyright 2017 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+Flask
+cheroot

--- a/tools/pkb_scheduler/dashboard/service_util.py
+++ b/tools/pkb_scheduler/dashboard/service_util.py
@@ -1,0 +1,38 @@
+import pickle
+
+def _recv_all(sock, length):
+  data = b''
+  while len(data) < length:
+    packet = sock.recv(length - len(data))
+    if len(packet) == 0:
+      return None
+    data += packet
+  return data
+
+class ServiceConnection:
+  def __init__(self, sock):
+    self.socket = sock
+
+  def send(self, msg):
+    msg_len = len(msg).to_bytes(4, byteorder='little')
+    self.socket.sendall(msg_len + msg)
+
+  def recv(self):
+    msg_len = self.socket.recv(4)
+    msg_len = int.from_bytes(msg_len, byteorder='little')
+    return _recv_all(self.socket, msg_len)
+
+  def send_str(self, msg):
+    self.send(msg.encode('utf-8'))
+
+  def recv_str(self):
+    return self.recv().decode('utf-8')
+
+  def send_pickle(self, obj):
+    self.send(pickle.dumps(obj))
+
+  def recv_pickle(self):
+    return pickle.loads(self.recv())
+  
+  def close(self):
+    self.socket.close()

--- a/tools/pkb_scheduler/dashboard/site_service.py
+++ b/tools/pkb_scheduler/dashboard/site_service.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+import itertools
+import json
+import multiprocessing as mp
+import os
+import pickle
+import sys
+import time
+import traceback
+import yaml
+
+from collections import deque
+from socketserver import BaseRequestHandler, ThreadingMixIn, TCPServer
+
+from service_util import ServiceConnection
+
+########################################
+
+class StatusArray:
+  """ A recursive structure describing the completion statuses of every
+  config in a PKB flag matrix.
+  """
+
+  def __init__(self, flag_name, subarrays, statuses=None):
+    """ Create a StatusArray.
+
+    Args:
+      flag_name: the name of this node's flag axis
+      subarrays: { <flag value> : StatusArray }
+      statuses: { <flag value> : <completion status>
+    """
+    self.flag_name = flag_name
+    self.statuses = statuses or dict(StatusArray._aggregate_statuses(subarrays))
+    self.subarrays = subarrays
+
+  def _aggregate_statuses(subarrays):
+    for flag_value, subarray in subarrays.items():
+      statuses = set()
+      for status in subarray.statuses.values():
+        assert status is not None
+        statuses.add(status)
+      if len(statuses) > 1:
+        yield (flag_value, "mixed")
+      else:
+        assert len(statuses) == 1
+        yield (flag_value, list(statuses)[0])
+
+  def as_dict(self):
+    return {
+      "flag_name": self.flag_name,
+      "statuses": self.statuses,
+      "subarrays": {flag_value: subarray.as_dict()
+                     for flag_value, subarray in self.subarrays.items()},
+    }
+
+def build_status_array(run_configs, flag_matrix, flag_axes, flag_values=None):
+  flag_name = flag_axes[0]
+  flag_values = flag_values or {}
+
+  statuses = None
+  subarrays = {}
+  if len(flag_axes) == 1:
+    statuses = {config["flags"][flag_name]: config["status"]
+                for config in run_configs}
+  else:
+    next_flag_name = flag_axes[1]
+    for flag_value in flag_matrix[flag_name]:
+      next_flag_values = flag_values.copy()
+      next_flag_values[flag_name] = flag_value
+
+      # Filter out irrelevant run configs
+      next_run_configs = [c for c in run_configs
+                          if c["flags"].items() >= next_flag_values.items()]
+      if not next_run_configs:
+        continue
+
+      subarrays[flag_value] = build_status_array(next_run_configs, flag_matrix,
+                                                 flag_axes[1:],
+                                                 next_flag_values)
+  return StatusArray(flag_name, subarrays, statuses)
+
+def load_completion_statuses(flag_matrix, flag_axes, completion_status_path):
+  status_array = None
+  print("Building status matrix %s:" % completion_status_path)
+  try:
+    with open(completion_status_path) as status_file:
+      run_configs = [json.loads(line) for line in status_file if line]
+      status_array = build_status_array(run_configs, flag_matrix, flag_axes)
+  except:
+    print("Failed to build status matrix %s:" % completion_status_path)
+    traceback.print_exc()
+  return status_array
+
+########################################
+
+def _load_yaml(yaml_path):
+  yaml_dict = None
+  with open(yaml_path) as yaml_file:
+    # Try to parse the chart page spec yaml
+    try:
+      yaml_dict = yaml.load(yaml_file.read())
+    except Exception as e:
+      sys.stderr.write("ERROR: invalid yaml: %s: %s\n" % (self.spec_path, e))
+  if yaml_dict is None:
+    sys.stderr.write("ERROR: Failed to open: %s\n" % self.spec_path)
+  return yaml_dict
+
+class Dashboard:
+  def __init__(self, spec_path):
+    self.spec_path = spec_path
+    self.last_spec_update = None
+
+    self.completion_status_dir = None
+
+    # {<category name> : [<benchmark name>]}
+    self.categories = {}
+    # {<benchmark name> : <category name>}
+    self.benchmark_categories = {}
+    # {<benchmark name> : {<timestamp> : StatusArray}}
+    self.status_arrays = {}
+    # {<benchmark name> : <flag matrix>}
+    self.flag_matrices = {}
+    # {<benchmark name> : [<flag axis>]}
+    self.diff_axes = {}
+
+  def maybe_refresh_spec(self):
+    spec_dir = os.path.dirname(self.spec_path)
+
+    modified_time = os.path.getmtime(self.spec_path)
+    if modified_time != self.last_spec_update:
+      print("Refreshing dashboard spec: %s" % self.spec_path)
+      self.last_spec_update = modified_time
+
+      spec = _load_yaml(self.spec_path)
+      if spec is None:
+        return False
+
+      # Spec loaded properly - now let's read it
+      scheduler_config = _load_yaml(spec["scheduler_config"])
+      benchmark_config = _load_yaml(scheduler_config["benchmark_config"])
+
+      # Get PKB completion status path
+      self.completion_status_dir = scheduler_config["completion_status_path"]
+
+      def get_benchmark_name(benchmark, flag_matrix):
+        return "%s_%s" % (benchmark, flag_matrix.lower())
+
+      # Load the flag matrix definitions
+      for benchmark_name in scheduler_config["run_benchmarks"]:
+        flag_matrix_defs = benchmark_config[benchmark_name]["flag_matrix_defs"]
+        for flag_matrix_name, flag_matrix in flag_matrix_defs.items():
+          full_benchmark_name = (
+              get_benchmark_name(benchmark_name, flag_matrix_name))
+          self.flag_matrices[full_benchmark_name] = flag_matrix
+          print(full_benchmark_name)
+      # Load the categories, benchmark_categories, and differentiating axes
+      for category_name, benchmarks in spec["categories"].items():
+        self.categories[category_name] = []
+        for benchmark in benchmarks:
+          for flag_matrix_name, flag_axes in benchmark["flag_axes"].items():
+            benchmark_name = get_benchmark_name(benchmark["benchmark"],
+                                                flag_matrix_name)
+            self.categories[category_name].append(benchmark_name)
+            self.benchmark_categories[benchmark_name] = category_name
+            self.diff_axes[benchmark_name] = flag_axes
+      return True
+
+    return False
+
+  def update_site_context(self, site_context):
+    site_context["categories"] = self.categories
+    site_context["benchmark_categories"] = self.benchmark_categories
+    # {benchmark_name: [timestamp_string]}
+    site_context["runs"] = {
+        benchmark: list(reversed(sorted(timestamps.keys())))
+        for benchmark, timestamps in self.status_arrays.items()
+    }
+
+  def load_completion_statuses(self):
+    for benchmark_name in os.listdir(self.completion_status_dir):
+      if benchmark_name not in self.diff_axes:
+        continue
+      if benchmark_name not in self.status_arrays:
+        self.status_arrays[benchmark_name] = {}
+      benchmark_path = os.path.join(self.completion_status_dir, benchmark_name)
+      for timestamp_file in os.listdir(benchmark_path):
+        # Get the run's timestamp
+        timestamp, _ = timestamp_file.rsplit(".", 1)
+        completion_status_path = os.path.join(benchmark_path, timestamp_file)
+
+        if timestamp not in self.status_arrays[benchmark_name]:
+          # Build the run's completion status array
+          flag_matrix = self.flag_matrices[benchmark_name]
+          diff_axes = self.diff_axes[benchmark_name]
+          status_array = load_completion_statuses(flag_matrix, diff_axes,
+                                                  completion_status_path)
+          if status_array is None:
+            continue
+          self.status_arrays[benchmark_name][timestamp] = \
+              status_array
+          yield (benchmark_name, timestamp, status_array)
+
+########################################
+
+class DashboardServerHandler(BaseRequestHandler):
+  def handle(self):
+    status_array_store = self.server.status_array_store
+    site_context = self.server.site_context
+    request = ServiceConnection(self.request)
+
+    split_cmd = request.recv_str().split(" ", 1)
+    if len(split_cmd) == 1:
+      split_cmd.append("")
+    cmd, args = split_cmd
+    if cmd == "run":
+      benchmark, timestamp = args.split(",")
+      print("Sending run context %s/%s to %s" % (
+          benchmark, timestamp, self.request.getsockname()))
+
+      category = site_context["benchmark_categories"][benchmark]
+          
+      page_context = {
+        "category": category,
+        "benchmark_name": benchmark,
+        "timestamp": timestamp,
+        "categories": site_context["categories"],
+        "status_array": status_array_store[(benchmark, timestamp)],
+      }
+      request.send_pickle(page_context)
+    elif cmd == "benchmark":
+      benchmark = args
+      print("Sending benchmark context %s to %s" % (
+          benchmark, self.request.getsockname()))
+      category = site_context["benchmark_categories"][benchmark]
+      page_context = {
+        "category": category,
+        "benchmark_name": benchmark,
+        "categories": site_context["categories"],
+        "runs": site_context["runs"][benchmark],
+      }
+      request.send_pickle(page_context)
+    elif cmd == "get_categories":
+      print("Sending categories to %s" % str(self.request.getsockname()))
+      request.send_pickle(site_context["categories"])
+
+class ThreadedTCPServer(ThreadingMixIn, TCPServer):
+  pass
+
+########################################
+
+def run_site_service(host, port, spec_path):
+  # Create the shared page store
+  mp_manager = mp.Manager()
+  status_array_store = mp_manager.dict()
+  site_context = mp_manager.dict()
+
+  def _dashboard_refresh():
+    dashboard = Dashboard(spec_path)
+    while True:
+      dashboard.maybe_refresh_spec()
+      dashboard.load_completion_statuses()
+      for benchmark, timestamp, status_array in \
+          dashboard.load_completion_statuses():
+        print("Loaded new status array: %s/%s" % (benchmark, timestamp))
+        # Build a dict version of the status array and store it
+        status_array_store[(benchmark, timestamp)] = \
+            status_array.as_dict()
+      dashboard.update_site_context(site_context)
+      # Only try to refresh dashboard spec every second
+      time.sleep(1)
+
+  # Start the dashboard refresher
+  dashboard_refresh_proc = mp.Process(target=_dashboard_refresh)
+  dashboard_refresh_proc.daemon = True
+  dashboard_refresh_proc.start()
+
+  # Start the page server
+  page_server = ThreadedTCPServer((host, port), DashboardServerHandler)
+  page_server.status_array_store = status_array_store
+  page_server.site_context = site_context
+  page_server.serve_forever()
+        
+def main():
+  if len(sys.argv) != 2:
+    print("Usage: python3 site_service.py <dashboard_spec_yaml>")
+    exit()
+  spec_path = sys.argv[1]
+  run_site_service("localhost", 32422, spec_path)
+
+########################################
+
+if __name__ == "__main__":
+  main()

--- a/tools/pkb_scheduler/dashboard/templates/benchmark_page.html
+++ b/tools/pkb_scheduler/dashboard/templates/benchmark_page.html
@@ -1,0 +1,44 @@
+<html>
+  <head>
+
+<style>
+div.status-cell-succeeded {
+width: 32px; height: 32px;
+  background-color: green;
+}
+div.status-cell-failed {
+  width: 32px; height: 32px;
+  background-color: red;
+}
+div.status-cell-skipped {
+  width: 32px; height: 32px;
+  background-color: gray;
+}
+</style>
+
+<script type="text/javascript">
+</script>
+
+  </head>
+  <body>
+    <h1>PKB Scheduler Dashboard</h1>
+  {% for category, benchmark_names in categories.items() %}
+    <h3>{{ category }}</h3>
+  {% for benchmark in benchmark_names %}
+    <a href="/run/{{ benchmark }}">{{ benchmark }}</a><br>
+  {% endfor %}
+  {% endfor %}
+    <hr>
+    <h1 style="margin-top: 0;">{{ category }} - {{ benchmark_name }}</h1>
+    <!-- Most recent run -->
+    <h2>Most Recent Run</h2>
+    {% set timestamp = runs[0] %}
+    <a href="/run/{{ benchmark_name }}/{{ timestamp }}">{{ timestamp }}</a>
+    <!-- Historical runs -->
+    <h2>Historical Runs</h2>
+    {% for timestamp in runs[1:] %}
+      <a href="/run/{{ benchmark_name }}/{{ timestamp }}">{{ timestamp }}</a>
+      <br>
+    {% endfor %}
+  </body>
+</html>

--- a/tools/pkb_scheduler/dashboard/templates/index.html
+++ b/tools/pkb_scheduler/dashboard/templates/index.html
@@ -1,0 +1,32 @@
+<html>
+  <head>
+
+<style>
+div.status-cell-succeeded {
+width: 32px; height: 32px;
+  background-color: green;
+}
+div.status-cell-failed {
+  width: 32px; height: 32px;
+  background-color: red;
+}
+div.status-cell-skipped {
+  width: 32px; height: 32px;
+  background-color: gray;
+}
+</style>
+
+<script type="text/javascript">
+</script>
+
+  </head>
+  <body>
+    <h1>PKB Scheduler Dashboard</h1>
+  {% for category, benchmark_names in categories.items() %}
+    <h3>{{ category }}</h3>
+  {% for benchmark in benchmark_names %}
+    <a href="/run/{{ benchmark }}">{{ benchmark }}</a><br>
+  {% endfor %}
+  {% endfor %}
+  </body>
+</html>

--- a/tools/pkb_scheduler/dashboard/templates/run_page.html
+++ b/tools/pkb_scheduler/dashboard/templates/run_page.html
@@ -1,0 +1,55 @@
+<html>
+  <head>
+
+<style>
+div.status-cell-succeeded {
+width: 32px; height: 32px;
+  background-color: green;
+}
+div.status-cell-failed {
+  width: 32px; height: 32px;
+  background-color: red;
+}
+div.status-cell-skipped {
+  width: 32px; height: 32px;
+  background-color: gray;
+}
+div.status-cell-mixed {
+  width: 32px; height: 32px;
+  background-color: yellow;
+}
+</style>
+
+<script type="text/javascript">
+</script>
+
+  </head>
+  <body>
+    <h1>PKB Scheduler Dashboard</h1>
+  {% for category, benchmark_names in categories.items() %}
+    <h3>{{ category }}</h3>
+  {% for benchmark in benchmark_names %}
+    <a href="/run/{{ benchmark }}">{{ benchmark }}</a><br>
+  {% endfor %}
+  {% endfor %}
+    <hr>
+    <h1 style="margin-top: 0;">{{ category }} - {{ benchmark_name }} at {{ timestamp }}</h1>
+    <ul>
+    {% set parent_stack = [status_array] %}
+    {% for flag_value, status in status_array.statuses|dictsort recursive %}
+      {% set parent = parent_stack[-1] %}
+      {% set status = {'SUCCEEDED': 'succeeded', 'FAILED': 'failed', 'SKIPPED': 'skipped', 'mixed': 'mixed'}[status] %}
+      <li>{{ parent.flag_name }} = {{ flag_value }}
+      {% set subarray = parent.subarrays[flag_value] %}
+      {% if subarray %}
+      {% do parent_stack.append(subarray) %}
+        <ul>{{ loop(subarray.statuses|dictsort) }}</ul>
+      {% do parent_stack.pop() %}
+      {% else %}
+        <div class="{{ 'status-cell-%s' % status }}"/>
+      {% endif %}
+      </li>
+    {% endfor %}
+    </ul>
+  </body>
+</html>

--- a/tools/pkb_scheduler/dashboard/util.py
+++ b/tools/pkb_scheduler/dashboard/util.py
@@ -1,0 +1,9 @@
+def timestamp_from_str(timestamp_str):
+  """ Builds a timestamp tuple from a timestamp string of the format:
+      "year-month-day_hour-minute"
+  Returns: (<year>, <month>, <day>, <hour>, <minute>)
+  """
+  year_month_day, hour_minute = timestamp_str.split('_')
+  year, month, day = year_month_day.split('-')
+  hour, minute = hour_minute.split('-')
+  return (int(year), int(month), int(day), int(hour), int(minute))

--- a/tools/pkb_scheduler/pkb_scheduler.py
+++ b/tools/pkb_scheduler/pkb_scheduler.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+
+import os
+import signal
+import sys
+import time
+import traceback
+import yaml
+
+from google.cloud import storage as gcs
+
+from src.run_config import add_pkb_run_configs, PkbRunConfig
+from src.log import log_error, log_info, log_warning
+
+########################################
+
+class Config:
+  """Loads the configuration file and stores the settings.
+  """
+
+  def __init__(self, config_path):
+    self.config_path = config_path
+    self.last_reload = None
+
+    self.pkb_executable = None
+    self.benchmark_config_path = None
+    self.logs_path = None
+    self.results_path = None
+    self.completion_status_path = None
+
+    self.gcs_client = None
+    self.results_gcs_bucket = None
+
+    self.run_benchmarks = None
+
+  def load(self, run_configs):
+    """Load the scheduler config from a file.
+
+    If the load fails the old configuration will be kept.
+
+    Args:
+      run_configs: the dict storing the current PkbRunConfigs
+
+    Returns:
+      True if the config file was successfully loaded. False otherwise.
+    """
+    self.last_reload = os.path.getmtime(self.config_path)
+
+    config_dict = _load_config_yaml(self.config_path)
+
+    pkb_executable = config_dict["pkb_executable"]
+    benchmark_config_path = config_dict["benchmark_config"]
+    logs_path = config_dict.get("logs_path") or "logs/"
+    results_path = config_dict.get("results_path") or "results/"
+    completion_status_path = (
+        config_dict.get("completion_status_path") or ".pkb_completion_status")
+
+    if not os.path.exists(pkb_executable):
+      log_error("Specified pkb_executable file does not exist")
+      return False
+    if not os.path.exists(benchmark_config_path):
+      log_error("Specified benchmark_config file does not exist.")
+      return False
+    
+    gcs_client = None
+    results_gcs_bucket = None
+    results_gcs_bucket_name = config_dict.get("results_gcs_bucket")
+    if results_gcs_bucket_name:
+      gcs_client = gcs.Client()
+      results_gcs_bucket = gcs.Bucket(gcs_client, results_gcs_bucket_name)
+      if not results_gcs_bucket.exists():
+        log_error("Specified results_gcs_bucket %s does not exist." % (
+            results_gcs_bucket))
+        return False
+
+    run_benchmarks = config_dict["run_benchmarks"]
+
+    # Create the new run configs
+    new_run_configs = {}
+    for name, run_dict in run_benchmarks.items():
+      add_pkb_run_configs(
+          new_run_configs, benchmark_config_path, name, run_dict)
+
+    # Carry over the state from the old run configs
+    for name, run_config in run_configs.items():
+      new_run_config = new_run_configs.get(name)
+      if new_run_config is not None:
+        new_run_config.last_launch_time = run_config.last_launch_time
+
+    # Load succeeded, store all the new config values
+    self.benchmark_config_path = benchmark_config_path
+    self.pkb_executable = pkb_executable
+    self.logs_path = logs_path
+    self.results_path = results_path
+    self.completion_status_path = completion_status_path
+    self.run_benchmarks = run_benchmarks
+    self.gcs_client = gcs_client
+    self.results_gcs_bucket = results_gcs_bucket
+
+    # Replace the old run configs with the new ones
+    run_configs.clear()
+    run_configs.update(new_run_configs)
+
+    return True
+
+  def maybe_reload(self, run_configs):
+    """Reloads the config file if it was modified since we last loaded it.
+
+    If the load fails, the old configuration is kept.
+    
+    Args:
+      run_configs: the dict storing the current PkbRunConfigs
+    """
+    # Maybe reload scheduler config
+    modified_time = os.path.getmtime(self.config_path)
+    if modified_time != self.last_reload:
+      log_info("Reloading scheduler config")
+      try:
+        if not self.load(run_configs):
+          log_error("Failed to reload scheduler config. Sticking with the "
+                    "already-loaded configuration.")
+      except:
+        log_error("Failed to reload scheduler config. Sticking with the "
+                  "already-loaded configuration. Traceback:\n%s" % (
+                      traceback.format_exc()))
+
+########################################
+
+class ExitHandler:
+  """Tells the scheduler to shutdown if our process receives SIGINT or SIGTERM.
+  """
+
+  def __init__(self):
+    self.should_exit = False
+    signal.signal(signal.SIGTERM, self._handle_signal)
+    signal.signal(signal.SIGINT, self._handle_signal)
+
+  def _handle_signal(self, sig, frame):
+    """The callback for SIGINT and SIGTERM.
+    """
+    self.should_exit = True
+
+########################################
+
+def _load_config_yaml(yaml_path):
+  config_dict = None
+  try:
+    with open(yaml_path) as config_yaml:
+      config_dict = yaml.load(config_yaml.read())
+  except Exception as e:
+    sys.stderr.write("Failed to open yaml %s: %s\n" % (yaml_path, e))
+  assert config_dict is not None
+  return config_dict
+
+def main():
+  if len(sys.argv) != 2:
+    print("USAGE: pkb_scheduler.py <config_yaml>")
+    exit()
+
+  # Load the config yaml
+  config_path = sys.argv[1]
+  config_dict = _load_config_yaml(config_path)
+
+  # Build the Config object
+  config = Config(config_path)
+
+  run_configs = {}
+  try:
+    if not config.load(run_configs):
+      log_error("Failed to load scheduler config. Aborting.")
+      return 1
+  except:
+    log_error("Failed to load scheduler config. Aborting. Traceback:\n%s" % (
+        traceback.format_exc()))
+    return 1
+
+  # Try to read the state from the last run
+  try:
+    with open(".pkb_scheduler_state") as state_file:
+      for line in state_file:
+        run_name, last_launch_time = [s.strip() for s in line.split("=", 1)]
+        if run_name in run_configs:
+          run_configs[run_name].last_launch_time = float(last_launch_time)
+  except:
+    log_warning("Failed to load .pkb_scheduler_state:\n"
+                "%s" % traceback.format_exc())
+
+  exit_handler = ExitHandler()
+  runs = [] # Currently running PKB processes
+  try:
+    while True:
+      config.maybe_reload(run_configs)
+      # Maybe launch some runs
+      for run_config in run_configs.values():
+        new_run = run_config.maybe_launch(config)
+        if new_run is not None:
+          dup_runs = [run for run in runs if run.name == new_run.name]
+          if len(dup_runs) != 0:
+            log_warning("Launching another %s run even though there are %d "
+                        "existing runs" % (new_run.name, len(dup_runs)))
+          runs.append(new_run)
+      # Maybe publish some results to GCS
+      for run in runs:
+        run.maybe_publish_results_to_gcs(config)
+      # Maybe finish some runs
+      runs = [run for run in runs if not run.maybe_finish(config)]
+      # Write the state file
+      with open(".pkb_scheduler_state", "w") as state_file:
+        for run_config in run_configs.values():
+          state_file.write("%s=%d\n" % (run_config.name,
+                                        run_config.last_launch_time))
+      # Sleep for 5 seconds
+      time.sleep(5)
+      # Maybe stop
+      if exit_handler.should_exit:
+        raise Exception("Received either SIGINT or SIGTERM.")
+  except:
+    log_error("Exception occurred, waiting for all runs to finish:\n%s" % \
+              traceback.format_exc())
+    # Send SIGINT to all of the runs' process groups
+    for run in runs:
+      try:
+        os.killpg(os.getpgid(run.process.pid), signal.SIGINT)
+      except:
+        pass
+    # Wait for all of the runs to finish
+    for run in runs:
+      if run.process:
+        run.process.wait()
+  log_info("pkb_scheduler shutdown successfully")
+  return 0
+
+########################################
+
+if __name__ == "__main__":
+  exit(main())

--- a/tools/pkb_scheduler/requirements.txt
+++ b/tools/pkb_scheduler/requirements.txt
@@ -1,0 +1,15 @@
+# Copyright 2017 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+google-cloud-storage
+pyaml

--- a/tools/pkb_scheduler/src/__init__.py
+++ b/tools/pkb_scheduler/src/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2017 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tools/pkb_scheduler/src/log.py
+++ b/tools/pkb_scheduler/src/log.py
@@ -1,0 +1,32 @@
+import datetime
+import sys
+import time
+
+END_COLOR = '\033[0m'
+
+def log_info(msg):
+  OK_GREEN = '\033[92m'
+  timestamp = datetime.datetime \
+                      .fromtimestamp(time.time()) \
+                      .strftime('%Y-%m-%d %H:%M:%S')
+  print('%s%s INFO%s\t%s\n' % (OK_GREEN, timestamp, END_COLOR, msg))
+  sys.stdout.flush()
+  sys.stderr.flush()
+
+def log_error(msg):
+  FAIL = '\033[91m'
+  timestamp = datetime.datetime \
+                      .fromtimestamp(time.time()) \
+                      .strftime('%Y-%m-%d %H:%M:%S')
+  print('%s%s ERRO%s\t%s\n' % (FAIL, timestamp, END_COLOR, msg))
+  sys.stdout.flush()
+  sys.stderr.flush()
+
+def log_warning(msg):
+  WARNING = '\033[93m'
+  timestamp = datetime.datetime \
+                      .fromtimestamp(time.time()) \
+                      .strftime('%Y-%m-%d %H:%M:%S')
+  print('%s%s WARN%s\t%s\n' % (WARNING, timestamp, END_COLOR, msg))
+  sys.stdout.flush()
+  sys.stderr.flush()

--- a/tools/pkb_scheduler/src/run.py
+++ b/tools/pkb_scheduler/src/run.py
@@ -1,0 +1,157 @@
+import datetime
+import fcntl
+import json
+import os
+import time
+import uuid
+
+from .log import log_error, log_info, log_warning
+
+########################################
+
+class PkbResultsWatcher:
+  """Manages loading new results from a results json file from PKB.
+
+  This is needed so we can publish results from long-running benchmarks as soon
+  as they are available.
+  """
+
+  def __init__(self, path):
+    self.path = path
+    self.last_refresh = None
+    self.next_seek = 0
+
+  def maybe_load_results(self, process_results):
+    """Process any new results using a caller-specified function.
+
+    If our file was modified since we last read it, seek to where we last left
+    off and pass the file and the number of bytes to be processed to the
+    caller-specified function.
+
+    Args:
+      process_results: A function with following parameters:
+        (file object, number of bytes to process)
+
+    Returns:
+      True if there were new results to process. False otherwise.
+    """
+    try:
+      modified_time = os.path.getmtime(self.path)
+    except:
+      return False
+    if modified_time and modified_time != self.last_refresh:
+      # Need to pull from this data source again
+      with open(self.path) as samples_json:
+        fcntl.flock(samples_json, fcntl.LOCK_EX)
+        # Get the number of new bytes
+        samples_json.seek(0, 2)
+        results_size = samples_json.tell() - self.next_seek
+        # Seek to most recent data and process it
+        if results_size > 0:
+          samples_json.seek(self.next_seek)
+          process_results(samples_json, results_size)
+          self.next_seek += results_size
+      self.last_refresh = modified_time
+      return True
+    return False
+
+########################################
+
+class PkbRun:
+  """Manages a single run of a PKB benchmark.
+
+  - Publishes results to GCS objects grouped by benchmark and day.
+  - Reports when the run has finished.
+  - Counts the number of succeeded, failed, and skipped sub-runs.
+  """
+
+  def __init__(self, name, process, log_path,
+               results_path, completion_status_path):
+    self.name = name
+    self.process = process
+    self.log_path = log_path
+    self.completion_status_path = completion_status_path
+    self.results_watcher = PkbResultsWatcher(results_path)
+
+  def maybe_finish(self, config):
+    """Process the results of a benchmark if its process has finished.
+    
+    If the run completed:
+    - Load the completion status file and count the number of succeeded, failed,
+      and skipped sub-runs.
+    - Log whether the run succeeded, partially succeeded, or failed.
+    - Publish any unpublished results to a GCS object.
+
+    Args:
+      config: the scheduler config
+
+    Returns:
+      True if the benchmark run completed. False otherwise.
+    """
+    return_code = self.process.poll()
+    if return_code is None:
+      # Process is still running
+      return False
+    # The current run has finished
+
+    # Aggregate completion statuses
+    success_count = 0
+    fail_count = 0
+    skip_count = 0
+    try:
+      with open(self.completion_status_path) as status_file:
+        status_dicts = [json.loads(line) for line in status_file]
+
+        success_count = (
+            sum(1 for s in status_dicts if s['status'] == "SUCCEEDED"))
+        fail_count = sum(1 for s in status_dicts if s['status'] == "FAILED")
+        skip_count = sum(1 for s in status_dicts if s['status'] == "SKIPPED")
+    except:
+      pass
+
+    if return_code == 0:
+      # Run finished successfully
+      log_info("%s finished successfully\n"
+               "log file: %s" % (self.name, self.log_path))
+      self.maybe_publish_results_to_gcs(config)
+    else:
+      if success_count > 0:
+        # Some benchmarks succeeded
+        log_warning("%s partially succeeded:"
+                    "%d succeeded, %d failed, %d skipped\n"
+                    "log file: %s" % (self.name,
+                                      success_count, fail_count, skip_count,
+                                      self.log_path))
+        self.maybe_publish_results_to_gcs(config)
+      else:
+        # Run failed
+        log_error("%s failed. Returned %d\n"
+                  "log file: %s" % (self.name, return_code,
+                                    self.log_path))
+    return True
+
+  def maybe_publish_results_to_gcs(self, config):
+    """Publish any new results to a file in the user-specified GCS bucket.
+
+    The files are named: <benchmark name>.<year>.<month>.<day>/<some random id>
+
+    Args:
+      config: the scheduler config
+    """
+    if config.results_gcs_bucket is None:
+      return
+
+    timestamp = datetime.datetime.fromtimestamp(time.time())
+    results_blob_name = ("{benchmark}.{year}.{month}.{day}/{name}").format(
+        benchmark=self.name.rsplit("_", 1)[0],
+        year=timestamp.year,
+        month=timestamp.month,
+        day=timestamp.day,
+        name=str(uuid.uuid4()))
+
+    results_blob = config.results_gcs_bucket.blob(results_blob_name)
+    upload = lambda f, size: results_blob.upload_from_file(f, size=size)
+
+    if self.results_watcher.maybe_load_results(upload):
+      log_info("uploaded some results from %s to gs://%s/%s\n" % (
+          self.name, config.results_gcs_bucket.name, results_blob_name))

--- a/tools/pkb_scheduler/src/run_config.py
+++ b/tools/pkb_scheduler/src/run_config.py
@@ -1,0 +1,124 @@
+import datetime
+import os
+import subprocess
+import time
+
+from .log import log_info
+from .run import PkbRun
+
+########################################
+
+class PkbRunConfig:
+  """Represents a benchmark flag matrix defined in a PKB benchark config file.
+
+  Each instance of this class is associated with a flag matrix defined in a
+  user specified PKB benchmark config file. This class stores how to run the
+  associated benchmark (flags to pass to PKB) and how often to run it. It also
+  provides a method (maybe_launch) that launches the benchmark if enough time
+  has passed since the previous launch.
+  """
+
+  def __init__(self, name, flags, seconds_between_launches):
+    self.name = name
+    self.flags = flags
+    self.seconds_between_launches = seconds_between_launches
+    self.last_launch_time = 0
+
+  def out_dir(self, base_path):
+    """Returns the path to a folder where output files from PKB can be placed.
+
+    Args:
+      base_path: The parent folder path.
+    """
+    return os.path.join(base_path, self.name)
+
+  def maybe_create_out_dir(self, base_path):
+    """Create a directory for output files from PKB if necessary.
+
+    Args:
+      base_path: The parent folder path.
+    """
+    out_dir = self.out_dir(base_path)
+    if not os.path.exists(out_dir):
+      os.makedirs(out_dir)
+
+  def maybe_launch(self, config):
+    """Launch a new run if enough time has passed since the previous launch.
+
+    Args:
+      config: The scheduler config.
+
+    Returns:
+      A PkbRun if a new run was launched. None if not.
+    """
+    if time.time() - self.last_launch_time < self.seconds_between_launches:
+      # It's not time yet
+      return None
+    # It's time to launch a new process
+
+    self.last_launch_time = time.time()
+
+    # Open the log file
+    self.maybe_create_out_dir(config.logs_path)
+    timestamp = (datetime.datetime
+        .fromtimestamp(time.time()).strftime("%Y-%m-%d_%H-%M"))
+    log_path = os.path.join(self.out_dir(config.logs_path),
+                            "%s.log" % timestamp)
+    log_file = open(log_path, "w")
+
+    log_info("Launching %s\nlog file: %s" % (self.name, log_path))
+
+    # Create file path for the completion status file
+    self.maybe_create_out_dir(config.completion_status_path)
+    completion_status_path = os.path.join(
+        self.out_dir(config.completion_status_path), '%s.json' % timestamp)
+
+    # Create file path for json results file
+    self.maybe_create_out_dir(config.results_path)
+    results_path = os.path.join(self.out_dir(config.results_path),
+                                '%s.json' % timestamp)
+
+    # Build the flags for the pkb command
+    flags = [
+        "--completion_status_file=%s" % completion_status_path,
+        "--json_path=%s" % results_path, "--json_write_mode=ab",
+    ]
+    flags += ["--%s=%s" % (flag, value) for flag, value in self.flags.items()]
+
+    def _detach_from_process_group():
+      # The subprocess calls this function before executing. It detaches from
+      # the parent's (this script) process group.
+      # We do this so that the launched process doesn't receive signals sent
+      # to the pkb_scheduler.py process
+      os.setpgrp()
+
+    process = subprocess.Popen([config.pkb_executable] + flags,
+                               preexec_fn=_detach_from_process_group,
+                               stderr=subprocess.STDOUT,
+                               stdout=log_file)
+    return PkbRun(self.name, process, log_path, results_path,
+                  completion_status_path)
+
+########################################
+
+def add_pkb_run_configs(run_configs, benchmark_config_path,
+                        benchmark_name, run_dict):
+  """Create a PkbRunConfig for each flag matrix in the specified benchmark.
+
+  Args:
+    run_configs: The dict to store PkbRunConfigs in
+    benchmark_config_path: The path to the PKB benchmark config file
+    benchmark_name: The name of the benchmark in the PKB benchmark config file.
+    run_dict: The scheduler options for this benchmark defined in the scheduler
+      config file.
+  """
+  for flag_matrix, options in run_dict.items():
+    flags = {
+        "benchmark_config_file": benchmark_config_path,
+        "flag_matrix": flag_matrix,
+        "benchmarks": benchmark_name,
+        "run_processes": options.get("run_processes") or 1
+    }
+    name = "%s_%s" % (benchmark_name, flag_matrix.lower())
+    run_config = PkbRunConfig(name, flags, options["seconds_between_launches"])
+    run_configs[name] = run_config


### PR DESCRIPTION
# PKB Scheduler

The PKB scheduler is a tool for running PKB benchmarks periodically and logging/publishing the results. It also provides a web dashboard to view the completion status of past runs.

## Running the scheduler

You need to create a scheduler config file. Here's an example:

```yaml
pkb_executable: /home/tedsta/code/PerfKitBenchmarker/pkb.py
logs_path: logs/
results_path: results/
completion_status_path: .pkb_completion_status/
results_gcs_bucket: p3rf-artemis-data
benchmark_config: pkb_configs.yaml
run_benchmarks:
  netperf_same_zone:
    AWS:
      seconds_between_launches: 300
      run_processes: 1
    GCP:
      seconds_between_launches: 1800
      run_processes: 4
```

And here's its corresponding PKB benchmark config file:

```yaml
netperf_same_zone:
  name: netperf
  flags:
    netperf_histogram_buckets: 1000
  flag_matrix_defs:
    AWS:
      cloud: [AWS]
      zones: [us-west-1a]
      machine_type: [c4.xlarge]
      netperf_num_streams: ["1"]
      netperf_benchmarks: ["TCP_STREAM"]
    Azure:
      cloud: [Azure]
      zones: [westus]
      machine_type: [Standard_F4, Standard_F8]
      netperf_num_streams: ["1"]
      netperf_benchmarks: ["TCP_STREAM"]
    GCP:
      gce_network_name: [default]
      cloud: [GCP]
      zones: [us-east1-b, us-west1-a]
      machine_type: [n1-standard-4, n1-standard-8]
      netperf_num_streams: ["1"]
      netperf_benchmarks: ["TCP_STREAM"]
```

Notice you don't have to run every benchmark/flag_matrix that is defined. Here we don't run the Azure flag matrix in netperf_same_zone.

The `pkb_executable`, `benchmark_config`, and `run_benchmarks` fields in the scheduler config are required. If the `results_gcs_bucket` field is omitted, the results won't be published to GCS, but they'll still be stored locally.

## Running the scheduler dashboard

The code is stored in `dashboard/`. Run:

```
dashboard/deploy.py <dashboard config>
```

from the directory where the PKB scheduler is running. It'll be hosted on port 8080.

Here's an example dashboard config:

```yaml
scheduler_config: scheduler_config.yaml
categories:
  "Networking":
  - benchmark: netperf_same_zone
    flag_axes:
      AWS: [zones, machine_type]
      GCP: [zones, machine_type]
```

As you can see you can group benchmarks into categories. In the example we just have one category named "Networking".