### PR TITLE
Object storage clear bucket

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/object_storage_service_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/object_storage_service_benchmark.py
@@ -1351,6 +1351,14 @@ def Run(benchmark_spec):
                              benchmark_spec.service, bucket_name,
                              benchmark_spec.read_objects['objects_written'])
 
+  # Clear the bucket if we're not saving the objects for later
+  # This is needed for long running tests, or else the objects would just pile
+  # up after each run.
+  keep_bucket = (FLAGS.object_storage_objects_written_file is not None or
+                 FLAGS.object_storage_dont_delete_bucket)
+  if not keep_bucket:
+    service.EmptyBucket(bucket_name)
+
   return results
 
 

--- a/perfkitbenchmarker/providers/aws/s3.py
+++ b/perfkitbenchmarker/providers/aws/s3.py
@@ -55,6 +55,7 @@ class S3Service(object_storage_service.ObjectStorageService):
          's3://%s' % bucket_name,
          '--region=%s' % self.region])
 
+  @vm_util.Retry()
   def DeleteBucket(self, bucket):
     vm_util.IssueCommand(
         ['aws', 's3', 'rb',


### PR DESCRIPTION
Resolves some leaking and buildup issues with object_storage_service benchmark.
- `aws s3 rb --force` started failing sometimes, leaking buckets
- long running object_storage_service tests (`--run_stage_time`) would pile up large objects, causing unnecessary spending on object storage.