### PR TITLE
Fixed wrong argument in readme and added note on Amazon ES publisher.

### DIFF
--- a/README.md
+++ b/README.md
@@ -691,11 +691,11 @@ Flag | Notes
 `--benchmarks`   | A comma separated list of benchmarks or benchmark sets to run such as `--benchmarks=iperf,ping` . To see the full list, run `./pkb.py --help`
 `--cloud`        | Cloud where the benchmarks are run. See the table below for choices.
 `--machine_type` | Type of machine to provision if pre-provisioned machines are not used. Most cloud providers accept the names of pre-defined provider-specific machine types (for example, GCP supports `--machine_type=n1-standard-8` for a GCE n1-standard-8 VM). Some cloud providers support YAML expressions that match the corresponding VM spec machine_type property in the [YAML configs](#configurations-and-configuration-overrides) (for example, GCP supports `--machine_type="{cpus: 1, memory: 4.5GiB}"` for a GCE custom VM with 1 vCPU and 4.5GiB memory). Note that the value provided by this flag will affect all provisioned machines; users who wish to provision different machine types for different roles within a single benchmark run should use the [YAML configs](#configurations-and-configuration-overrides) for finer control.
-`--zone`         | This flag allows you to override the default zone. See the table below.
+`--zones`         | This flag allows you to override the default zone. See the table below.
 `--data_disk_type` | Type of disk to use. Names are provider-specific, but see table below.
 
 The default cloud is 'GCP', override with the `--cloud` flag. Each cloud has a default
-zone which you can override with the `--zone` flag, the flag supports the same values
+zone which you can override with the `--zones` flag, the flag supports the same values
 that the corresponding Cloud CLIs take:
 
 Cloud name | Default zone | Notes
@@ -714,7 +714,7 @@ ProfitBricks | AUTO | Additional zones: ZONE_1, ZONE_2, or ZONE_3
 Example:
 
 ```bash
-./pkb.py --cloud=GCP --zone=us-central1-a --benchmarks=iperf,ping
+./pkb.py --cloud=GCP --zones=us-central1-a --benchmarks=iperf,ping
 ```
 
 The disk type names vary by provider, but the following table summarizes some
@@ -889,7 +889,7 @@ iperf:
 I called my file `iperf.yaml` and used it to run iperf from Siberia to a GCP VM in us-central1-f as follows:
 
 ```bash
-$ ./pkb.py --benchmarks=iperf --machine_type=f1-micro --benchmark_config_file=iperf.yaml --zone=us-central1-f --ip_addresses=EXTERNAL
+$ ./pkb.py --benchmarks=iperf --machine_type=f1-micro --benchmark_config_file=iperf.yaml --zones=us-central1-f --ip_addresses=EXTERNAL
 ```
 
 * `ip_addresses=EXTERNAL` tells PerfKit Benchmarker not to use 10.X (ie Internal) machine addresses that all Cloud VMs have.  Just use the external IP address.
@@ -962,6 +962,8 @@ Flag | Notes
 `--es_uri`         | The Elasticsearch server address and port (e.g. localhost:9200)
 `--es_index`       | The Elasticsearch index name to store documents (default: perfkit)
 `--es_type`        | The Elasticsearch document type (default: result)
+
+Note: Amazon ElasticSearch service currently does not support transport on port 9200 therefore you must use endpoint with port 80 eg. `search-<ID>.es.amazonaws.com:80` and allow your IP address in the cluster.
 
 Using InfluxDB Publisher
 =================


### PR DESCRIPTION
Just small update to README. 

I mentioned that argument --zone is not working, there is only defined argument --zones. 

And I added one note on using AWS ElasticSearch Publisher from, where port 9200 is closed and only accessible port is 80. 
https://forums.aws.amazon.com/thread.jspa?messageID=681938