### PR TITLE
Optionally create failed run sample

### DIFF
--- a/perfkitbenchmarker/flag_util.py
+++ b/perfkitbenchmarker/flag_util.py
@@ -483,7 +483,7 @@ def ParseKeyValuePairs(strings):
   return pairs
 
 
-def GetPresentFlags():
+def GetProvidedCommandLineFlags():
   """Return flag names and values that were specified on the command line.
 
   Returns:

--- a/perfkitbenchmarker/flag_util.py
+++ b/perfkitbenchmarker/flag_util.py
@@ -481,3 +481,12 @@ def ParseKeyValuePairs(strings):
       continue
 
   return pairs
+
+
+def GetPresentFlags():
+  """Return flag names and values that were specified on the command line.
+
+  Returns:
+    A dictionary of provided flags in the form: {flag_name: flag_value}.
+  """
+  return {k: v.value for k, v in FLAGS.FlagDict().iteritems() if v.present}

--- a/perfkitbenchmarker/pkb.py
+++ b/perfkitbenchmarker/pkb.py
@@ -594,12 +594,33 @@ def RunBenchmark(spec, collector):
 
 
 def MakeFailedRunSample(error_message, run_stage_that_failed):
-    metadata = {
-        'error_message': error_message,
-        'run_stage': run_stage_that_failed,
-        'flags': str(flag_util.GetProvidedCommandLineFlags())
-    }
-    return [sample.Sample('Run Failed', 1, 'Run Failed', metadata)]
+  """Create a sample.Sample representing a failed run stage.
+
+  The sample metric will have the name 'Run Failed';
+  the value will be 1 (has to be convertable to a float),
+  and the unit will be 'Run Failed' (for lack of a better idea).
+
+  The sample metadata will include the error message from the
+  Exception, the run stage that failed, as well as all PKB
+  command line flags that were passed in.
+
+  Args:
+    error_message: error message that was caught, resulting in the
+      run stage failure.
+    run_stage_that_failed: run stage that failed by raising an Exception
+
+  Returns:
+    a sample.Sample representing the run stage failure.
+  """
+  # Note: currently all provided PKB command line flags are included in the
+  # metadata. We may want to only include flags specific to the benchmark that
+  # failed. This can be acomplished using gflag's FlagsByModuleDict().
+  metadata = {
+      'error_message': error_message,
+      'run_stage': run_stage_that_failed,
+      'flags': str(flag_util.GetProvidedCommandLineFlags())
+  }
+  return [sample.Sample('Run Failed', 1, 'Run Failed', metadata)]
 
 
 def RunBenchmarkTask(spec):

--- a/perfkitbenchmarker/pkb.py
+++ b/perfkitbenchmarker/pkb.py
@@ -82,6 +82,7 @@ from perfkitbenchmarker import linux_benchmarks
 from perfkitbenchmarker import log_util
 from perfkitbenchmarker import os_types
 from perfkitbenchmarker import requirements
+from perfkitbenchmarker import sample
 from perfkitbenchmarker import spark_service
 from perfkitbenchmarker import stages
 from perfkitbenchmarker import static_virtual_machine
@@ -226,6 +227,12 @@ flags.DEFINE_string(
 flags.DEFINE_string(
     'helpmatch', '',
     'Shows only flags defined in a module whose name matches the given regex.')
+flags.DEFINE_boolean(
+    'create_failed_run_samples', False,
+    'If true, PKB will create a sample specifying that a run stage failed. '
+    'This sample will include metadata specifying the run stage that '
+    'failed, the exception that occured, as well as all the flags that '
+    'were provided to PKB on the command line.')
 
 # Support for using a proxy in the cloud environment.
 flags.DEFINE_string('http_proxy', '',
@@ -474,8 +481,8 @@ def DoRunPhase(spec, collector, timer):
     events.samples_created.send(
         events.RUN_PHASE, benchmark_spec=spec, samples=samples)
     if FLAGS.run_stage_time:
-      for sample in samples:
-        sample.metadata['run_number'] = run_number
+      for s in samples:
+        s.metadata['run_number'] = run_number
     collector.AddSamples(samples, spec.name, spec)
     if FLAGS.publish_after_run:
       collector.PublishSamples()
@@ -523,6 +530,7 @@ def RunBenchmark(spec, collector):
     collector: The SampleCollector object to add samples to.
   """
   spec.status = benchmark_status.FAILED
+  current_run_stage = stages.PROVISION
   # Modify the logger prompt for messages logged within this function.
   label_extension = '{}({}/{})'.format(
       spec.name, spec.sequence_number, spec.total_benchmarks)
@@ -538,15 +546,19 @@ def RunBenchmark(spec, collector):
             DoProvisionPhase(spec, detailed_timer)
 
           if stages.PREPARE in FLAGS.run_stage:
+            current_run_stage = stages.PREPARE
             DoPreparePhase(spec, detailed_timer)
 
           if stages.RUN in FLAGS.run_stage:
+            current_run_stage = stages.RUN
             DoRunPhase(spec, collector, detailed_timer)
 
           if stages.CLEANUP in FLAGS.run_stage:
+            current_run_stage = stages.CLEANUP
             DoCleanupPhase(spec, detailed_timer)
 
           if stages.TEARDOWN in FLAGS.run_stage:
+            current_run_stage = stages.TEARDOWN
             DoTeardownPhase(spec, detailed_timer)
 
         # Add timing samples.
@@ -558,10 +570,15 @@ def RunBenchmark(spec, collector):
           collector.AddSamples(
               detailed_timer.GenerateSamples(), spec.name, spec)
 
-      except:
+      except Exception as e:
         # Resource cleanup (below) can take a long time. Log the error to give
         # immediate feedback, then re-throw.
         logging.exception('Error during benchmark %s', spec.name)
+        if FLAGS.create_failed_run_samples:
+          collector.AddSamples(MakeFailedRunSample(str(e),
+                                                   current_run_stage),
+                               spec.name,
+                               spec)
         # If the particular benchmark requests us to always call cleanup, do it
         # here.
         if stages.CLEANUP in FLAGS.run_stage and spec.always_call_cleanup:
@@ -574,6 +591,15 @@ def RunBenchmark(spec, collector):
         # Pickle spec to save final resource state.
         spec.Pickle()
   spec.status = benchmark_status.SUCCEEDED
+
+
+def MakeFailedRunSample(error_message, run_stage_that_failed):
+    metadata = {
+        'error_message': error_message,
+        'run_stage': run_stage_that_failed,
+        'flags': str(flag_util.GetPresentFlags())
+    }
+    return [sample.Sample('Run Failed', 1, 'Run Failed', metadata)]
 
 
 def RunBenchmarkTask(spec):

--- a/perfkitbenchmarker/pkb.py
+++ b/perfkitbenchmarker/pkb.py
@@ -597,7 +597,7 @@ def MakeFailedRunSample(error_message, run_stage_that_failed):
     metadata = {
         'error_message': error_message,
         'run_stage': run_stage_that_failed,
-        'flags': str(flag_util.GetPresentFlags())
+        'flags': str(flag_util.GetProvidedCommandLineFlags())
     }
     return [sample.Sample('Run Failed', 1, 'Run Failed', metadata)]
 

--- a/tests/flag_util_test.py
+++ b/tests/flag_util_test.py
@@ -1,4 +1,4 @@
-# Copyright 2015 PerfKitBenchmarker Authors. All rights reserved.
+# Copyright 2017 PerfKitBenchmarker Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 import copy
 import sys
 import unittest
+import mock
 
 from perfkitbenchmarker import flags
 from perfkitbenchmarker import flag_util
@@ -290,6 +291,32 @@ class TestYAMLParser(unittest.TestCase):
   def testBadYAML(self):
     with self.assertRaises(ValueError):
       self.parser.parse('{a')
+
+
+class MockFlag():
+  def __init__(self, name, value, present):
+    self.name = name
+    self.value = value
+    self.present = present
+
+
+class TestGetProvidedCommandLineFlags(unittest.TestCase):
+  def setUp(self):
+    flag_dict = {
+        'flag1': MockFlag('flag1', '1', True),
+        'flag2': MockFlag('flag2', '2', True),
+        'flag3': MockFlag('flag3', '3', False)
+    }
+    patcher = mock.patch(flag_util.__name__ + '.FLAGS')
+    flags_mock = patcher.start()
+    flags_mock.FlagDict.return_value = flag_dict
+    self.addCleanup(patcher.stop)
+
+  def testGetProvidedCommandLineFlags(self):
+    self.assertDictEqual({
+        'flag1': '1',
+        'flag2': '2',
+    }, flag_util.GetProvidedCommandLineFlags())
 
 
 if __name__ == '__main__':

--- a/tests/flag_util_test.py
+++ b/tests/flag_util_test.py
@@ -301,6 +301,7 @@ class MockFlag():
 
 
 class TestGetProvidedCommandLineFlags(unittest.TestCase):
+
   def setUp(self):
     flag_dict = {
         'flag1': MockFlag('flag1', '1', True),

--- a/tests/pkb_test.py
+++ b/tests/pkb_test.py
@@ -1,0 +1,123 @@
+# Copyright 2017 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for pkb.py"""
+
+from perfkitbenchmarker import pkb
+from perfkitbenchmarker import stages
+import unittest
+import mock
+
+
+class TestCreateFailedRunSamplesFlag(unittest.TestCase):
+
+  def patchPkbFunction(self, function_name):
+    patcher = mock.patch(pkb.__name__ + '.' + function_name)
+    mock_function = patcher.start()
+    self.addCleanup(patcher.stop)
+    return mock_function
+
+  def setUp(self):
+    self.flags_mock = self.patchPkbFunction('FLAGS')
+    self.provision_mock = self.patchPkbFunction('DoProvisionPhase')
+    self.prepare_mock = self.patchPkbFunction('DoPreparePhase')
+    self.run_mock = self.patchPkbFunction('DoRunPhase')
+    self.cleanup_mock = self.patchPkbFunction('DoCleanupPhase')
+    self.teardown_mock = self.patchPkbFunction('DoTeardownPhase')
+    self.make_failed_run_sample_mock = self.patchPkbFunction(
+        'MakeFailedRunSample')
+
+    self.flags_mock.run_stage = [
+        stages.PROVISION, stages.PREPARE, stages.RUN, stages.CLEANUP,
+        stages.TEARDOWN
+    ]
+
+  def testCreateProvisionFailedSamples(self):
+    spec = mock.MagicMock()
+    collector = mock.Mock()
+    self.flags_mock.create_failed_run_samples = True
+    error_msg = 'error'
+    self.provision_mock.side_effect = Exception(error_msg)
+
+    self.assertRaises(Exception, pkb.RunBenchmark, spec, collector)
+    self.make_failed_run_sample_mock.assert_called_once_with(
+        error_msg, stages.PROVISION)
+
+  def testCreatePrepareFailedSamples(self):
+    spec = mock.MagicMock()
+    collector = mock.Mock()
+    self.flags_mock.create_failed_run_samples = True
+    error_msg = 'error'
+    self.prepare_mock.side_effect = Exception(error_msg)
+
+    self.assertRaises(Exception, pkb.RunBenchmark, spec, collector)
+    self.make_failed_run_sample_mock.assert_called_once_with(
+        error_msg, stages.PREPARE)
+
+  def testCreateRunFailedSamples(self):
+    spec = mock.MagicMock()
+    collector = mock.Mock()
+    self.flags_mock.create_failed_run_samples = True
+    error_msg = 'error'
+    self.run_mock.side_effect = Exception(error_msg)
+
+    self.assertRaises(Exception, pkb.RunBenchmark, spec, collector)
+    self.make_failed_run_sample_mock.assert_called_once_with(
+        error_msg, stages.RUN)
+
+  def testCreateCleanupFailedSamples(self):
+    spec = mock.MagicMock()
+    collector = mock.Mock()
+    self.flags_mock.create_failed_run_samples = True
+    error_msg = 'error'
+    self.cleanup_mock.side_effect = Exception(error_msg)
+
+    self.assertRaises(Exception, pkb.RunBenchmark, spec, collector)
+    self.make_failed_run_sample_mock.assert_called_once_with(
+        error_msg, stages.CLEANUP)
+
+  def testCreateTeardownFailedSamples(self):
+    spec = mock.MagicMock()
+    collector = mock.Mock()
+    self.flags_mock.create_failed_run_samples = True
+    error_msg = 'error'
+    self.teardown_mock.side_effect = Exception(error_msg)
+
+    self.assertRaises(Exception, pkb.RunBenchmark, spec, collector)
+    self.make_failed_run_sample_mock.assert_called_once_with(
+        error_msg, stages.TEARDOWN)
+
+  def testDontCreateFailedRunSamples(self):
+    spec = mock.MagicMock()
+    collector = mock.Mock()
+    self.flags_mock.create_failed_run_samples = False
+    self.run_mock.side_effect = Exception('error')
+
+    self.assertRaises(Exception, pkb.RunBenchmark, spec, collector)
+    self.make_failed_run_sample_mock.assert_not_called()
+
+
+class TestMakeFailedRunSample(unittest.TestCase):
+
+  @mock.patch('perfkitbenchmarker.sample.Sample')
+  def testMakeFailedRunSample(self, sample_mock):
+    error_msg = 'error'
+    pkb.MakeFailedRunSample(error_msg, stages.PROVISION)
+
+    sample_mock.assert_called_once()
+    sample_mock.assert_called_with('Run Failed', 1, 'Run Failed', {
+        'error_message': error_msg,
+        'run_stage': stages.PROVISION,
+        'flags': '{}'
+    })

--- a/tests/pkb_test.py
+++ b/tests/pkb_test.py
@@ -20,7 +20,7 @@ import unittest
 import mock
 
 
-class TestCreateFailedRunSamplesFlag(unittest.TestCase):
+class TestCreateFailedRunSampleFlag(unittest.TestCase):
 
   def patchPkbFunction(self, function_name):
     patcher = mock.patch(pkb.__name__ + '.' + function_name)
@@ -43,68 +43,59 @@ class TestCreateFailedRunSamplesFlag(unittest.TestCase):
         stages.TEARDOWN
     ]
 
-  def testCreateProvisionFailedSamples(self):
-    spec = mock.MagicMock()
-    collector = mock.Mock()
+    self.spec = mock.MagicMock()
+    self.collector = mock.Mock()
+
+  def testCreateProvisionFailedSample(self):
     self.flags_mock.create_failed_run_samples = True
     error_msg = 'error'
     self.provision_mock.side_effect = Exception(error_msg)
 
-    self.assertRaises(Exception, pkb.RunBenchmark, spec, collector)
+    self.assertRaises(Exception, pkb.RunBenchmark, self.spec, self.collector)
     self.make_failed_run_sample_mock.assert_called_once_with(
         error_msg, stages.PROVISION)
 
-  def testCreatePrepareFailedSamples(self):
-    spec = mock.MagicMock()
-    collector = mock.Mock()
+  def testCreatePrepareFailedSample(self):
     self.flags_mock.create_failed_run_samples = True
     error_msg = 'error'
     self.prepare_mock.side_effect = Exception(error_msg)
 
-    self.assertRaises(Exception, pkb.RunBenchmark, spec, collector)
+    self.assertRaises(Exception, pkb.RunBenchmark, self.spec, self.collector)
     self.make_failed_run_sample_mock.assert_called_once_with(
         error_msg, stages.PREPARE)
 
-  def testCreateRunFailedSamples(self):
-    spec = mock.MagicMock()
-    collector = mock.Mock()
+  def testCreateRunFailedSample(self):
     self.flags_mock.create_failed_run_samples = True
     error_msg = 'error'
     self.run_mock.side_effect = Exception(error_msg)
 
-    self.assertRaises(Exception, pkb.RunBenchmark, spec, collector)
+    self.assertRaises(Exception, pkb.RunBenchmark, self.spec, self.collector)
     self.make_failed_run_sample_mock.assert_called_once_with(
         error_msg, stages.RUN)
 
-  def testCreateCleanupFailedSamples(self):
-    spec = mock.MagicMock()
-    collector = mock.Mock()
+  def testCreateCleanupFailedSample(self):
     self.flags_mock.create_failed_run_samples = True
     error_msg = 'error'
     self.cleanup_mock.side_effect = Exception(error_msg)
 
-    self.assertRaises(Exception, pkb.RunBenchmark, spec, collector)
+    self.assertRaises(Exception, pkb.RunBenchmark, self.spec, self.collector)
     self.make_failed_run_sample_mock.assert_called_once_with(
         error_msg, stages.CLEANUP)
 
-  def testCreateTeardownFailedSamples(self):
-    spec = mock.MagicMock()
-    collector = mock.Mock()
+  def testCreateTeardownFailedSample(self):
     self.flags_mock.create_failed_run_samples = True
     error_msg = 'error'
     self.teardown_mock.side_effect = Exception(error_msg)
 
-    self.assertRaises(Exception, pkb.RunBenchmark, spec, collector)
+    self.assertRaises(Exception, pkb.RunBenchmark, self.spec, self.collector)
     self.make_failed_run_sample_mock.assert_called_once_with(
         error_msg, stages.TEARDOWN)
 
-  def testDontCreateFailedRunSamples(self):
-    spec = mock.MagicMock()
-    collector = mock.Mock()
+  def testDontCreateFailedRunSample(self):
     self.flags_mock.create_failed_run_samples = False
     self.run_mock.side_effect = Exception('error')
 
-    self.assertRaises(Exception, pkb.RunBenchmark, spec, collector)
+    self.assertRaises(Exception, pkb.RunBenchmark, self.spec, self.collector)
     self.make_failed_run_sample_mock.assert_not_called()
 
 


### PR DESCRIPTION
## Release Notes:
* Added a command line flag, `create_failed_run_samples` which, if `True`, will instruct PKB to create 'Run Failed' samples for failed run stages. If a publisher is used, then these failed run samples will be published as well.