### PR TITLE
Set default azure_lib_version to 1.0.3

### DIFF
--- a/CHANGES.next.md
+++ b/CHANGES.next.md
@@ -9,3 +9,4 @@ Enhancements:
 
 Bug fixes and maintenance updates:
 - Fix type of `--beam_it_timeout` flag (was string, must be integer) (GH-1375)
+- Set default version of azure_lib_version to 1.0.3 (GH-1385)

--- a/perfkitbenchmarker/providers/azure/flags.py
+++ b/perfkitbenchmarker/providers/azure/flags.py
@@ -50,5 +50,5 @@ flags.DEFINE_enum(
     'will let you use ZRS storage. Choosing BlobStorage will give you access '
     'to Hot and Cold storage tiers.')
 
-flags.DEFINE_string('azure_lib_version', None,
-                    'Use a particular version of azure client lib, e.g.: 1.0.2')
+flags.DEFINE_string('azure_lib_version', '1.0.3',
+                    'Use a particular version of azure client lib, e.g.: 1.0.3')


### PR DESCRIPTION
`object_storage_service` benchmark was breaking with the latest version on pip. Something about TLS errors and wanting us to upgrade to python 3.4. This is a quick fix for now.