### PR TITLE
Support Beam Python in beam_integration_benchmark

### DIFF
--- a/perfkitbenchmarker/beam_benchmark_helper.py
+++ b/perfkitbenchmarker/beam_benchmark_helper.py
@@ -63,6 +63,7 @@ BEAM_REPO_LOCATION = 'https://github.com/apache/beam.git'
 INSTALL_COMMAND_ARGS = ["clean", "install", "-DskipTests",
                         "-Dcheckstyle.skip=true"]
 
+
 def InitializeBeamRepo(benchmark_spec):
   """Ensures environment is prepared for running Beam benchmarks.
 
@@ -127,6 +128,7 @@ def BuildBeamCommand(benchmark_spec, classname, job_arguments):
 
   return cmd, base_dir
 
+
 def _BuildMavenCommand(benchmark_spec, classname, job_arguments):
   """ Constructs a maven command for the benchmark.
 
@@ -189,7 +191,7 @@ def _BuildPythonCommand(benchmark_spec, modulename, job_arguments):
   python_executable = FLAGS.python_binary
   if not vm_util.ExecutableOnPath(python_executable):
     raise errors.Setup.MissingExecutableError(
-      'Could not find required executable "%s"' % python_executable)
+        'Could not find required executable "%s"' % python_executable)
   cmd.append(python_executable)
 
   cmd.append('setup.py')
@@ -218,7 +220,7 @@ def _BuildPythonCommand(benchmark_spec, modulename, job_arguments):
 def _GetBeamDir():
   # TODO: This is temporary, find a better way.
   return FLAGS.beam_location if FLAGS.beam_location else os.path.join(
-    vm_util.GetTempDir(), 'beam')
+      vm_util.GetTempDir(), 'beam')
 
 
 def _FindFiles(base_path, pattern):

--- a/perfkitbenchmarker/beam_benchmark_helper.py
+++ b/perfkitbenchmarker/beam_benchmark_helper.py
@@ -18,6 +18,8 @@ This file contains methods which are common to all Beam benchmarks and
 executions.
 """
 
+import fnmatch
+import logging
 import os
 
 from perfkitbenchmarker import dpb_service
@@ -25,14 +27,19 @@ from perfkitbenchmarker import errors
 from perfkitbenchmarker import flags
 from perfkitbenchmarker import vm_util
 
+BEAM_JAVA_SDK = 'java'
+BEAM_PYTHON_SDK = 'python'
 
 # TODO: Find a better place for the maven_binary flag.
 flags.DEFINE_string('maven_binary', 'mvn',
                     'Set to use a different mvn binary than is on the PATH.')
+flags.DEFINE_string('python_binary', 'python',
+                    'Set to use a different python binary that is on the PATH.')
 flags.DEFINE_string('beam_location', None,
                     'Location of already checked out Beam codebase.')
 flags.DEFINE_string('beam_it_module', None,
-                    'Module containing integration test.')
+                    'Module containing integration test. For Python SDK, use '
+                    'comma-separated list to include multiple modules.')
 flags.DEFINE_string('beam_it_profile', None,
                     'Profile to activate integration test.')
 flags.DEFINE_integer('beam_it_timeout', 600, 'Integration Test Timeout.')
@@ -40,6 +47,11 @@ flags.DEFINE_string('git_binary', 'git', 'Path to git binary.')
 flags.DEFINE_string('beam_version', None, 'Version of Beam to download. Use'
                                           ' tag from Github as value. If not'
                                           ' specified, will use HEAD.')
+flags.DEFINE_enum('beam_sdk', None, [BEAM_JAVA_SDK, BEAM_PYTHON_SDK],
+                  'Which BEAM SDK is used to build the benchmark pipeline.')
+flags.DEFINE_string('beam_python_attr', 'IT',
+                    'Test decorator that is used in Beam Python to filter a '
+                    'specific category.')
 
 FLAGS = flags.FLAGS
 
@@ -50,7 +62,6 @@ SUPPORTED_RUNNERS = [
 BEAM_REPO_LOCATION = 'https://github.com/apache/beam.git'
 INSTALL_COMMAND_ARGS = ["clean", "install", "-DskipTests",
                         "-Dcheckstyle.skip=true"]
-
 
 def InitializeBeamRepo(benchmark_spec):
   """Ensures environment is prepared for running Beam benchmarks.
@@ -76,23 +87,21 @@ def InitializeBeamRepo(benchmark_spec):
       clone_command.append('--branch={}'.format(FLAGS.beam_version))
       clone_command.append('--single-branch')
     vm_util.IssueCommand(clone_command, cwd=vm_util.GetTempDir())
-    beam_dir = os.path.join(vm_util.GetTempDir(), 'beam')
-  else:
-    if not os.path.exists(FLAGS.beam_location):
-      raise errors.Config.InvalidValue(
-          'Directory indicated by beam_location does not exist: '
-          '{}.'.format(FLAGS.beam_location))
-    beam_dir = FLAGS.beam_location
+  elif not os.path.exists(FLAGS.beam_location):
+    raise errors.Config.InvalidValue(
+        'Directory indicated by beam_location does not exist: '
+        '{}.'.format(FLAGS.beam_location))
 
   if benchmark_spec.dpb_service.SERVICE_TYPE == dpb_service.DATAFLOW:
     mvn_command = [FLAGS.maven_binary]
     mvn_command.extend(INSTALL_COMMAND_ARGS)
     mvn_command.append('-Pdataflow-runner')
-    vm_util.IssueCommand(mvn_command, cwd=beam_dir)
+    logging.info("Running: %s", mvn_command)
+    vm_util.IssueCommand(mvn_command, cwd=_GetBeamDir())
 
 
-def BuildMavenCommand(benchmark_spec, classname, job_arguments):
-  """ Constructs a maven command for the benchmark.
+def BuildBeamCommand(benchmark_spec, classname, job_arguments):
+  """ Constructs a Beam execution command for the benchmark.
 
   Args:
     benchmark_spec: The PKB spec for the benchmark to run.
@@ -106,6 +115,29 @@ def BuildMavenCommand(benchmark_spec, classname, job_arguments):
   if benchmark_spec.service_type not in SUPPORTED_RUNNERS:
     raise NotImplementedError('Unsupported Runner')
 
+  base_dir = _GetBeamDir()
+
+  if FLAGS.beam_sdk == BEAM_JAVA_SDK:
+    cmd = _BuildMavenCommand(benchmark_spec, classname, job_arguments)
+  elif FLAGS.beam_sdk == BEAM_PYTHON_SDK:
+    cmd = _BuildPythonCommand(benchmark_spec, classname, job_arguments)
+    base_dir = os.path.join(base_dir, 'sdks/python')
+  else:
+    raise NotImplementedError('Unsupported Beam SDK: %s.' % FLAGS.beam_sdk)
+
+  return cmd, base_dir
+
+def _BuildMavenCommand(benchmark_spec, classname, job_arguments):
+  """ Constructs a maven command for the benchmark.
+
+  Args:
+    benchmark_spec: The PKB spec for the benchmark to run.
+    classname: The classname of the class to run.
+    job_arguments: The additional job arguments provided for the run.
+
+  Returns:
+    cmd: Array containing the built command.
+  """
   cmd = []
   maven_executable = FLAGS.maven_binary
 
@@ -137,7 +169,65 @@ def BuildMavenCommand(benchmark_spec, classname, job_arguments):
   cmd.append("-DintegrationTestPipelineOptions="
              "[{}]".format(','.join(beam_args)))
 
+  return cmd
+
+
+def _BuildPythonCommand(benchmark_spec, modulename, job_arguments):
+  """ Constructs a Python command for the benchmark.
+
+  Args:
+    benchmark_spec: The PKB spec for the benchmark to run.
+    modulename: The name of the python module to run.
+    job_arguments: The additional job arguments provided for the run.
+
+  Returns:
+    cmd: Array containg the built command.
+  """
+
+  cmd = []
+
+  python_executable = FLAGS.python_binary
+  if not vm_util.ExecutableOnPath(python_executable):
+    raise errors.Setup.MissingExecutableError(
+      'Could not find required executable "%s"' % python_executable)
+  cmd.append(python_executable)
+
+  cmd.append('setup.py')
+  cmd.append('nosetests')
+  cmd.append('--tests={}'.format(modulename))
+  cmd.append('--attr={}'.format(FLAGS.beam_python_attr))
+
+  beam_args = job_arguments if job_arguments else []
+
+  if benchmark_spec.service_type == dpb_service.DATAFLOW:
+    python_binary = _FindFiles(os.path.join(_GetBeamDir(),
+                                            'sdks/python/target'),
+                               'apache-beam*.tar.gz')
+    if len(python_binary) == 0:
+      raise RuntimeError('No python binary is found')
+
+    beam_args.append('--runner=TestDataflowRunner')
+    beam_args.append('--sdk_location={}'.format(python_binary[0]))
+
+  cmd.append('--test-pipeline-options='
+             '{}'.format(' '.join(beam_args)))
+
+  return cmd
+
+
+def _GetBeamDir():
   # TODO: This is temporary, find a better way.
-  beam_dir = FLAGS.beam_location if FLAGS.beam_location else os.path.join(
-      vm_util.GetTempDir(), 'beam')
-  return cmd, beam_dir
+  return FLAGS.beam_location if FLAGS.beam_location else os.path.join(
+    vm_util.GetTempDir(), 'beam')
+
+
+def _FindFiles(base_path, pattern):
+  if not os.path.exists(base_path):
+    raise RuntimeError('No such directory: %s' % base_path)
+
+  results = []
+  for root, dirname, files in os.walk(base_path):
+    for file in files:
+      if fnmatch.fnmatch(file, pattern):
+        results.append(os.path.join(root, file))
+  return results

--- a/perfkitbenchmarker/providers/gcp/gcp_dpb_dataflow.py
+++ b/perfkitbenchmarker/providers/gcp/gcp_dpb_dataflow.py
@@ -72,9 +72,9 @@ class GcpDpbDataflow(dpb_service.BaseDpbService):
     """See base class."""
 
     if job_type == self.BEAM_JOB_TYPE:
-      full_cmd, beam_dir = beam_benchmark_helper.BuildMavenCommand(
+      full_cmd, base_dir = beam_benchmark_helper.BuildBeamCommand(
           self.spec, classname, job_arguments)
-      stdout, _, retcode = vm_util.IssueCommand(full_cmd, cwd=beam_dir,
+      stdout, _, retcode = vm_util.IssueCommand(full_cmd, cwd=base_dir,
                                                 timeout=FLAGS.beam_it_timeout)
       assert retcode == 0, "Integration Test Failed."
       return


### PR DESCRIPTION
Currently beam_integration_benchmark can only run Beam Java pipeline. Improve it so that people can use it to run integration test with Python SDK. 