### PR TITLE
Add --runspec_estimate_spec flag

### DIFF
--- a/CHANGES.next.md
+++ b/CHANGES.next.md
@@ -11,6 +11,7 @@ Enhancements:
 - Added total_free_memory_kb to VirtualMachine class and implemented it for
   Linux vms (GH-1397)
 - Created hpc_util for a place to share common HPC functions
+- Added --runspec_estimate_spec flag to calculate an estimated spec score (GH-1401)
 
 Bug fixes and maintenance updates:
 - Fix provision phase of memcached_ycsb benchmark for non-managed memcached instances (GH-1384)

--- a/perfkitbenchmarker/linux_benchmarks/speccpu2006_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/speccpu2006_benchmark.py
@@ -85,7 +85,6 @@ flags.DEFINE_boolean(
     'failed with status "NR". Available results will be saved, and PKB samples '
     'will be marked with a metadata value of partial=true. If unset, partial '
     'failures are treated as errors.')
-
 flags.DEFINE_boolean(
     'runspec_estimate_spec', False,
     'Used by the PKB speccpu2006 benchmark. If set, the benchmark will report '
@@ -96,7 +95,7 @@ flags.DEFINE_boolean(
     'estimated_SPECfp(R)_rate_base2006.  Available results will be saved, '
     'and PKB samples will be marked with a metadata value of partial=true. If '
     'unset, SPECint(R)_rate_base2006 and SPECfp(R)_rate_base2006 are listed '
-    'in the metadata under missing_results')
+    'in the metadata under missing_results.')
 
 BENCHMARK_NAME = 'speccpu2006'
 BENCHMARK_CONFIG = """

--- a/perfkitbenchmarker/linux_benchmarks/speccpu2006_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/speccpu2006_benchmark.py
@@ -29,6 +29,7 @@ import posixpath
 import re
 import tarfile
 
+from operator import mul
 from perfkitbenchmarker import configs
 from perfkitbenchmarker import data
 from perfkitbenchmarker import errors
@@ -84,6 +85,18 @@ flags.DEFINE_boolean(
     'failed with status "NR". Available results will be saved, and PKB samples '
     'will be marked with a metadata value of partial=true. If unset, partial '
     'failures are treated as errors.')
+
+flags.DEFINE_boolean(
+    'runspec_estimate_spec', False,
+    'Used by the PKB speccpu2006 benchmark. If set, the benchmark will report '
+    'an estimated aggregate score even if SPEC CPU2006 did not compute one. '
+    'This usually occurs when --runspec_iterations is less than 3.  '
+    '--runspec_keep_partial_results is also required to be set. Samples will be'
+    'created as estimated_SPECint(R)_rate_base2006 and '
+    'estimated_SPECfp(R)_rate_base2006.  Available results will be saved, '
+    'and PKB samples will be marked with a metadata value of partial=true. If '
+    'unset, SPECint(R)_rate_base2006 and SPECfp(R)_rate_base2006 are listed '
+    'in the metadata under missing_results')
 
 BENCHMARK_NAME = 'speccpu2006'
 BENCHMARK_CONFIG = """
@@ -308,7 +321,7 @@ def _PrepareWithIsoFile(vm, speccpu_vm_state):
   vm.RobustRemoteCommand('yes | {0}'.format(install_script_path))
 
 
-def _ExtractScore(stdout, vm, keep_partial_results):
+def _ExtractScore(stdout, vm, keep_partial_results, estimate_spec):
   """Extracts the SPEC(int|fp) score from stdout.
 
   Args:
@@ -401,6 +414,7 @@ def _ExtractScore(stdout, vm, keep_partial_results):
   metadata.update(vm.GetMachineTypeDict())
 
   missing_results = []
+  scores = []
 
   for benchmark in result_section:
     # Skip over failed runs, but count them since they make the overall
@@ -410,8 +424,10 @@ def _ExtractScore(stdout, vm, keep_partial_results):
       missing_results.append(str(benchmark.split()[0]))
       continue
     # name, ref_time, time, score, misc
-    name, _, _, score, _ = benchmark.split()
-    results.append(sample.Sample(str(name), float(score), '', metadata))
+    name, _, _, score_str, _ = benchmark.split()
+    score_float = float(score_str)
+    scores.append(score_float)
+    results.append(sample.Sample(str(name), score_float, '', metadata))
 
   if spec_score is None:
     missing_results.append(spec_name)
@@ -426,8 +442,17 @@ def _ExtractScore(stdout, vm, keep_partial_results):
 
   if spec_score is not None:
     results.append(sample.Sample(spec_name, spec_score, '', metadata))
+  elif estimate_spec:
+    estimated_spec_score = _GeometricMean(scores)
+    results.append(sample.Sample('estimated_' + spec_name,
+                                 estimated_spec_score, '', metadata))
 
   return results
+
+
+def _GeometricMean(arr):
+  "Calculates the geometric mean of the array."
+  return reduce(mul, arr) ** (1.0 / len(arr))
 
 
 def _ParseOutput(vm, spec_dir):
@@ -458,7 +483,8 @@ def _ParseOutput(vm, spec_dir):
                                  should_log=True)
     results.extend(_ExtractScore(
         stdout, vm, FLAGS.runspec_keep_partial_results or (
-            FLAGS.benchmark_subset not in _SPECCPU_SUBSETS)))
+            FLAGS.benchmark_subset not in _SPECCPU_SUBSETS),
+        FLAGS.runspec_estimate_spec))
 
   return results
 

--- a/tests/linux_benchmarks/speccpu2006_benchmark_test.py
+++ b/tests/linux_benchmarks/speccpu2006_benchmark_test.py
@@ -222,6 +222,59 @@ EXPECTED_RESULT_BAD2 = [
                   metadata=EXPECTED_BAD2_METADATA),
 ]
 
+TEST_OUTPUT_EST = """
+==============================================================================
+400.perlbench       1        359       27.3 *
+401.bzip2           1        597       16.2 *
+403.gcc             1        368       21.9 *
+429.mcf             1        374       24.4 *
+445.gobmk           1        541       19.4 *
+456.hmmer           1        425       22.0 *
+458.sjeng           1        571       21.2 *
+462.libquantum      1        517       40.1 *
+464.h264ref         1        607       36.4 *
+471.omnetpp         1        513       12.2 *
+473.astar           1        491       14.3 *
+483.xalancbmk       1        318       21.7 *
+ Est. SPECint(R)_rate_base2006           --
+ """
+
+EXPECTED_EST_METADATA = GOOD_METADATA.copy()
+EXPECTED_EST_METADATA.update({
+    'partial': 'true',
+    'missing_results': 'SPECint(R)_rate_base2006',
+    'num_cpus': 256})
+
+EXPECTED_RESULT_EST = [
+    sample.Sample(metric='400.perlbench', value=27.3, unit='',
+                  metadata=EXPECTED_EST_METADATA),
+    sample.Sample(metric='401.bzip2', value=16.2, unit='',
+                  metadata=EXPECTED_EST_METADATA),
+    sample.Sample(metric='403.gcc', value=21.9, unit='',
+                  metadata=EXPECTED_EST_METADATA),
+    sample.Sample(metric='429.mcf', value=24.4, unit='',
+                  metadata=EXPECTED_EST_METADATA),
+    sample.Sample(metric='445.gobmk', value=19.4, unit='',
+                  metadata=EXPECTED_EST_METADATA),
+    sample.Sample(metric='456.hmmer', value=22.0, unit='',
+                  metadata=EXPECTED_EST_METADATA),
+    sample.Sample(metric='458.sjeng', value=21.2, unit='',
+                  metadata=EXPECTED_EST_METADATA),
+    sample.Sample(metric='462.libquantum', value=40.1, unit='',
+                  metadata=EXPECTED_EST_METADATA),
+    sample.Sample(metric='464.h264ref', value=36.4, unit='',
+                  metadata=EXPECTED_EST_METADATA),
+    sample.Sample(metric='471.omnetpp', value=12.2, unit='',
+                  metadata=EXPECTED_EST_METADATA),
+    sample.Sample(metric='473.astar', value=14.3, unit='',
+                  metadata=EXPECTED_EST_METADATA),
+    sample.Sample(metric='483.xalancbmk', value=21.7, unit='',
+                  metadata=EXPECTED_EST_METADATA),
+    sample.Sample(metric='estimated_SPECint(R)_rate_base2006',
+                  value=21.846042257681507, unit='',
+                  metadata=EXPECTED_EST_METADATA),
+]
+
 
 class DummyVM(object):
 
@@ -241,22 +294,32 @@ class Speccpu2006BenchmarkTestCase(unittest.TestCase,
     vm = DummyVM()
 
     samples = speccpu2006_benchmark._ExtractScore(TEST_OUTPUT_SPECINT, vm,
-                                                  False)
+                                                  False, False)
     self.assertSampleListsEqualUpToTimestamp(samples, EXPECTED_RESULT_SPECINT)
 
-    samples = speccpu2006_benchmark._ExtractScore(TEST_OUTPUT_SPECFP, vm, False)
+    samples = speccpu2006_benchmark._ExtractScore(TEST_OUTPUT_SPECFP, vm,
+                                                  False, False)
     self.assertSampleListsEqualUpToTimestamp(samples, EXPECTED_RESULT_SPECFP)
 
     # By default, incomplete results result in error.
     with self.assertRaises(errors.Benchmarks.RunError):
-      samples = speccpu2006_benchmark._ExtractScore(TEST_OUTPUT_BAD1, vm, False)
+      samples = speccpu2006_benchmark._ExtractScore(TEST_OUTPUT_BAD1, vm,
+                                                    False, False)
 
     with self.assertRaises(errors.Benchmarks.RunError):
-      samples = speccpu2006_benchmark._ExtractScore(TEST_OUTPUT_BAD2, vm, False)
+      samples = speccpu2006_benchmark._ExtractScore(TEST_OUTPUT_BAD2, vm,
+                                                    False, False)
 
     # Now use keep_partial_results
-    samples = speccpu2006_benchmark._ExtractScore(TEST_OUTPUT_BAD1, vm, True)
+    samples = speccpu2006_benchmark._ExtractScore(TEST_OUTPUT_BAD1, vm,
+                                                  True, False)
     self.assertSampleListsEqualUpToTimestamp(samples, EXPECTED_RESULT_BAD1)
 
-    samples = speccpu2006_benchmark._ExtractScore(TEST_OUTPUT_BAD2, vm, True)
+    samples = speccpu2006_benchmark._ExtractScore(TEST_OUTPUT_BAD2, vm,
+                                                  True, False)
     self.assertSampleListsEqualUpToTimestamp(samples, EXPECTED_RESULT_BAD2)
+
+    # Estimate scores
+    samples = speccpu2006_benchmark._ExtractScore(TEST_OUTPUT_EST, vm,
+                                                  True, True)
+    self.assertSampleListsEqualUpToTimestamp(samples, EXPECTED_RESULT_EST)


### PR DESCRIPTION
Allows an estimated spec score to be calculated for runs with single iterations of tests.