### PR TITLE
Add flag_zip_defs which behaves similarly to flag_matrix_defs

### DIFF
--- a/CHANGES.next.md
+++ b/CHANGES.next.md
@@ -6,6 +6,8 @@ New features:
 - Added CUDA-enabled HPCG benchmark (GH-1395)
 - Added ManagedRelationalDatabase base classes and tests (GH-1405)
 - Added gpus to GceVmSpec. This is now the only way to create VMs with gpus on GCE due to a gcloud API change (GH-1406)
+- Added flag_zip_defs which functions like flag_matrix_defs, but performs a zip
+  operation on the axes instead of a cross-product (GH-1414)
 
 Enhancements:
 - Added basic auth support for Mesos provider. (GH-1390)

--- a/perfkitbenchmarker/benchmark_sets.py
+++ b/perfkitbenchmarker/benchmark_sets.py
@@ -192,6 +192,13 @@ def _GetConfigForAxis(benchmark_config, flag_config):
   return config
 
 
+def _AssertZipAxesHaveSameLength(axes):
+  expected_length = len(axes[0])
+  for axis in axes[1:]:
+    if len(axis) != expected_length:
+      raise ValueError('flag_zip axes must all be the same length')
+
+
 def GetBenchmarksFromFlags():
   """Returns a list of benchmarks to run based on the benchmarks flag.
 
@@ -241,7 +248,7 @@ def GetBenchmarksFromFlags():
 
 
     # We need to remove the 'flag_matrix', 'flag_matrix_defs', 'flag_zip',
-    # 'flag_dif_defs', and 'flag_matrix_filters' keys from the config
+    # 'flag_zip_defs', and 'flag_matrix_filters' keys from the config
     # dictionary since they aren't actually part of the config spec and will
     # cause errors if they are left in.
     flag_matrix_name = benchmark_config.pop(
@@ -263,6 +270,8 @@ def GetBenchmarksFromFlags():
       flag_axes = []
       for flag, values in flag_zip.iteritems():
         flag_axes.append([{flag: v} for v in values])
+
+      _AssertZipAxesHaveSameLength(flag_axes)
 
       for flag_config in itertools.izip(*flag_axes):
         config = _GetConfigForAxis(benchmark_config, flag_config)

--- a/perfkitbenchmarker/benchmark_sets.py
+++ b/perfkitbenchmarker/benchmark_sets.py
@@ -27,6 +27,8 @@ FLAGS = flags.FLAGS
 
 flags.DEFINE_string('flag_matrix', None,
                     'The name of the flag matrix to run.')
+flags.DEFINE_string('flag_zip', None,
+                    'The name of the flag zip to run.')
 
 MESSAGE = 'message'
 BENCHMARK_LIST = 'benchmark_list'
@@ -180,6 +182,16 @@ def _GetBenchmarksFromUserConfig(user_config):
   return benchmark_config_list
 
 
+def _GetConfigForAxis(benchmark_config, flag_config):
+  config = copy.copy(benchmark_config)
+  config_local_flags = config.get('flags', {})
+  config['flags'] = copy.deepcopy(configs.GetConfigFlags())
+  config['flags'].update(config_local_flags)
+  for setting in flag_config:
+    config['flags'].update(setting)
+  return config
+
+
 def GetBenchmarksFromFlags():
   """Returns a list of benchmarks to run based on the benchmarks flag.
 
@@ -227,10 +239,11 @@ def GetBenchmarksFromFlags():
       raise ValueError('Benchmark "%s" not valid on os_type "%s"' %
                        (benchmark_name, FLAGS.os_type))
 
-    # We need to remove the 'flag_matrix', 'flag_matrix_defs', and
-    # 'flag_matrix_filters' keys from the config dictionary since
-    # they aren't actually part of the config spec and will cause
-    # errors if they are left in.
+
+    # We need to remove the 'flag_matrix', 'flag_matrix_defs', 'flag_zip',
+    # 'flag_dif_defs', and 'flag_matrix_filters' keys from the config
+    # dictionary since they aren't actually part of the config spec and will
+    # cause errors if they are left in.
     flag_matrix_name = benchmark_config.pop(
         'flag_matrix', None)
     flag_matrix_name = FLAGS.flag_matrix or flag_matrix_name
@@ -238,18 +251,31 @@ def GetBenchmarksFromFlags():
         'flag_matrix_defs', {}).get(flag_matrix_name, {})
     flag_matrix_filter = benchmark_config.pop(
         'flag_matrix_filters', {}).get(flag_matrix_name)
+    flag_zip_name = benchmark_config.pop(
+        'flag_zip', None)
+    flag_zip_name = FLAGS.flag_zip or flag_zip_name
+    flag_zip = benchmark_config.pop(
+        'flag_zip_defs', {}).get(flag_zip_name, {})
 
-    flag_axes = []
+    zipped_axes = []
+    crossed_axes = []
+    if flag_zip:
+      flag_axes = []
+      for flag, values in flag_zip.iteritems():
+        flag_axes.append([{flag: v} for v in values])
+
+      for flag_config in itertools.izip(*flag_axes):
+        config = _GetConfigForAxis(benchmark_config, flag_config)
+        zipped_axes.append((benchmark_module, config))
+
+      crossed_axes.append([benchmark_tuple[1]['flags'] for
+                           benchmark_tuple in zipped_axes])
+
     for flag, values in flag_matrix.iteritems():
-      flag_axes.append([{flag: v} for v in values])
+      crossed_axes.append([{flag: v} for v in values])
 
-    for flag_config in itertools.product(*flag_axes):
-      config = copy.copy(benchmark_config)
-      config_local_flags = config.get('flags', {})
-      config['flags'] = copy.deepcopy(configs.GetConfigFlags())
-      config['flags'].update(config_local_flags)
-      for setting in flag_config:
-        config['flags'].update(setting)
+    for flag_config in itertools.product(*crossed_axes):
+      config = _GetConfigForAxis(benchmark_config, flag_config)
       if (flag_matrix_filter and not eval(
           flag_matrix_filter, {}, config['flags'])):
           continue

--- a/test_matrix.yml
+++ b/test_matrix.yml
@@ -1,0 +1,16 @@
+hpcg:
+  name: hpcg
+  flags:
+    hpcg_runtime: 30
+    gcp_gpu_type: k80
+  flag_zip: GCP
+  flag_matrix: GCP
+  flag_zip_defs:
+    GCP:
+      machine_type: [n1-standard-4, n1-standard-8]
+      gcp_gpu_count: [1, 2]
+  flag_matrix_defs:
+    GCP:
+      num_vms: [1, 2]
+
+


### PR DESCRIPTION
* Add flag_zip_defs which behaves similarly to flag_matrix_defs, but calculates a zip of the axes instead of the cross product. It can be used in conjunction with flag_matrix_defs.

Example config file:
```
hpcg:                                                                                                                                                                                                                                   
  name: hpcg                                                                                                                                                                                                                            
  flags:                                                                                                                                                                                                                                                                                                                                                                                                                                   
    gcp_gpu_type: k80                                                                                                                                                                                                                   
  flag_zip: GCP                                                                                                                                                                                                                         
  flag_matrix: GCP                                                                                                                                                                                                                      
  flag_zip_defs:                                                                                                                                                                                                                        
    GCP:                                                                                                                                                                                                                                
      machine_type: [n1-standard-4, n1-standard-8]                                                                                                                                                                                      
      gcp_gpu_count: [1, 2]                                                                                                                                                                                                             
  flag_matrix_defs:                                                                                                                                                                                                                     
    GCP:                                                                                                                                                                                                                                
      num_vms: [1, 2]   
```

This will produce the following 4 configs:
```
[
{machine_type: n1-standard-4, gcp_gpu_count: 1, num_vms:1, gcp_gpu_type:k80},
{machine_type: n1-standard-4, gcp_gpu_count: 1, num_vms:2, gcp_gpu_type:k80},
{machine_type: n1-standard-8, gcp_gpu_count: 2, num_vms:1, gcp_gpu_type:k80},
{machine_type: n1-standard-8, gcp_gpu_count: 2, num_vms:2, gcp_gpu_type:k80},
]
```