### PR TITLE
Add options for beam benchmarks: prebuilt, runner, option

### DIFF
--- a/perfkitbenchmarker/beam_benchmark_helper.py
+++ b/perfkitbenchmarker/beam_benchmark_helper.py
@@ -41,6 +41,16 @@ flags.DEFINE_string('beam_it_module', None,
                     'comma-separated list to include multiple modules.')
 flags.DEFINE_string('beam_it_profile', None,
                     'Profile to activate integration test.')
+flags.DEFINE_string('beam_runner_profile', None,
+                    'Overrides the normal runner profile associated with'
+                    ' the dpb_service')
+flags.DEFINE_string('beam_runner_option', None,
+                    'Overrides any pipeline options by the dpb service to'
+                    ' specify the runner.')
+flags.DEFINE_boolean('beam_prebuilt', False, 'Set this to indicate that the'
+                                             ' repo in beam_location does not'
+                                             ' need to be rebuilt before'
+                                             ' being used')
 flags.DEFINE_integer('beam_it_timeout', 600, 'Integration Test Timeout.')
 flags.DEFINE_string('git_binary', 'git', 'Path to git binary.')
 flags.DEFINE_string('beam_version', None, 'Version of Beam to download. Use'
@@ -61,6 +71,33 @@ SUPPORTED_RUNNERS = [
 BEAM_REPO_LOCATION = 'https://github.com/apache/beam.git'
 INSTALL_COMMAND_ARGS = ["clean", "install", "-DskipTests",
                         "-Dcheckstyle.skip=true"]
+
+
+def AddRunnerProfileMvnArgument(service_type, mvn_command,
+                                runner_profile_override):
+  runner_profile = ''
+
+  if service_type == dpb_service.DATAFLOW:
+    runner_profile = 'dataflow-runner'
+
+  if runner_profile_override is not None:
+    runner_profile = runner_profile_override
+
+  if len(runner_profile) > 0:
+    mvn_command.append('-P{}'.format(runner_profile))
+
+
+def AddRunnerOptionMvnArgument(service_type, beam_args, runner_option_override):
+  runner_pipeline_option = ''
+
+  if service_type == dpb_service.DATAFLOW:
+    runner_pipeline_option = ('"--runner=TestDataflowRunner"')
+
+  if runner_option_override is not None:
+    runner_pipeline_option = runner_option_override
+
+  if len(runner_pipeline_option) > 0:
+    beam_args.append(runner_pipeline_option)
 
 
 def InitializeBeamRepo(benchmark_spec):
@@ -92,10 +129,11 @@ def InitializeBeamRepo(benchmark_spec):
         'Directory indicated by beam_location does not exist: '
         '{}.'.format(FLAGS.beam_location))
 
-  if benchmark_spec.dpb_service.SERVICE_TYPE == dpb_service.DATAFLOW:
+  if not FLAGS.beam_prebuilt:
     mvn_command = [FLAGS.maven_binary]
     mvn_command.extend(INSTALL_COMMAND_ARGS)
-    mvn_command.append('-Pdataflow-runner')
+    AddRunnerProfileMvnArgument(benchmark_spec.dpb_service.SERVICE_TYPE,
+                                mvn_command)
     vm_util.IssueCommand(mvn_command, timeout=1500, cwd=_GetBeamDir())
 
 
@@ -160,11 +198,17 @@ def _BuildMavenCommand(benchmark_spec, classname, job_arguments):
 
   beam_args = job_arguments if job_arguments else []
 
-  if benchmark_spec.service_type == dpb_service.DATAFLOW:
-    cmd.append('-P{}'.format('dataflow-runner'))
-    beam_args.append('"--runner=org.apache.beam.runners.'
-                     'dataflow.testing.TestDataflowRunner"')
+  # Don't add any args when the user overrides beam_runner_profile since it is
+  # expected that they know what they are doing and we can't know what args
+  # to pass since it differs by runner.
+  if (benchmark_spec.service_type == dpb_service.DATAFLOW
+      and FLAGS.beam_runner_profile is not None):
     beam_args.append('"--defaultWorkerLogLevel={}"'.format(FLAGS.dpb_log_level))
+
+  AddRunnerProfileMvnArgument(benchmark_spec.service_type, cmd,
+                              FLAGS.beam_runner_profile)
+  AddRunnerOptionMvnArgument(benchmark_spec.service_type, beam_args,
+                             FLAGS.beam_runner_option)
 
   cmd.append("-DintegrationTestPipelineOptions="
              "[{}]".format(','.join(beam_args)))

--- a/tests/beam_benchmark_helper_test.py
+++ b/tests/beam_benchmark_helper_test.py
@@ -1,0 +1,89 @@
+# Copyright 2014 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for beam_benchmark_helper."""
+
+import unittest
+
+from perfkitbenchmarker import beam_benchmark_helper
+from perfkitbenchmarker import dpb_service
+
+
+class BeamBenchmarkHelperTestCase(unittest.TestCase):
+  def test_runner_option_override_non_dataflow(self):
+    # This is documenting the current behavior - when we add an EMR
+    # service_type, this test should change.
+    actual_options = []
+    beam_benchmark_helper.AddRunnerOptionMvnArgument(
+        dpb_service.EMR, actual_options, None)
+    self.assertListEqual([], actual_options)
+
+
+  def test_runner_option_override_dataflow(self):
+    actual_options = []
+    beam_benchmark_helper.AddRunnerOptionMvnArgument(
+        dpb_service.DATAFLOW, actual_options, None)
+    self.assertListEqual(['"--runner=TestDataflowRunner"'], actual_options)
+
+
+  def test_runner_option_override_use_override(self):
+    testOptionVal = "--runner=TestVal"
+    actual_options = []
+    beam_benchmark_helper.AddRunnerOptionMvnArgument(
+        dpb_service.DATAFLOW, actual_options, testOptionVal)
+    self.assertListEqual([testOptionVal], actual_options)
+
+
+  def test_runner_option_override_empty_override(self):
+    testOptionVal = ""
+    actual_options = []
+    beam_benchmark_helper.AddRunnerOptionMvnArgument(
+        dpb_service.DATAFLOW, actual_options, testOptionVal)
+    self.assertListEqual([], actual_options)
+
+
+  def test_runner_profile_override_dataflow(self):
+    actual_mvn_command = []
+    beam_benchmark_helper.AddRunnerProfileMvnArgument(
+        dpb_service.DATAFLOW, actual_mvn_command, None)
+    self.assertListEqual(['-Pdataflow-runner'], actual_mvn_command)
+
+
+  def test_runner_profile_override_non_dataflow(self):
+    # This is documenting the current behavior - when we add an EMR
+    # service_type, this test should change.
+    actual_mvn_command = []
+    beam_benchmark_helper.AddRunnerProfileMvnArgument(
+        dpb_service.EMR, actual_mvn_command, None)
+    self.assertListEqual([], actual_mvn_command)
+
+
+  def test_runner_profile_override_use_override(self):
+    testOptionVal = "testval"
+    actual_mvn_command = []
+    beam_benchmark_helper.AddRunnerProfileMvnArgument(
+        dpb_service.DATAFLOW, actual_mvn_command, testOptionVal)
+    self.assertListEqual(['-P' + testOptionVal], actual_mvn_command)
+
+
+  def test_runner_profile_override_empty_override(self):
+    testOptionVal = ""
+    actual_mvn_command = []
+    beam_benchmark_helper.AddRunnerProfileMvnArgument(
+        dpb_service.DATAFLOW, actual_mvn_command, testOptionVal)
+    self.assertListEqual([], actual_mvn_command)
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
This PR adds several options for the beam_integration_benchmark - these are useful for people running beam pipelines and enable faster benchmarking runs when working on a dev machine.

cc @asaksena who I've been working with on this.