### PR TITLE
backup the hpccoutf.txt file before running

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/hpcc_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/hpcc_benchmark.py
@@ -224,6 +224,8 @@ def Run(benchmark_spec):
   """
   vms = benchmark_spec.vms
   master_vm = vms[0]
+  # backup existing HPCC output, if any
+  master_vm.RemoteCommand('if [ -f hpccoutf.txt ]; then mv hpccoutf.txt hpccoutf-$(date +%s).txt; fi')
   num_processes = len(vms) * master_vm.num_cpus
   mpi_env = ' '.join(['-x %s' % v for v in FLAGS.hpcc_mpi_env])
   mpi_cmd = ('mpirun -np %s -machinefile %s --mca orte_rsh_agent '


### PR DESCRIPTION
The code to parse the hpcc log file looks for the first regex match to get metrics.  Since the log file is appended to on multiple runs this only returns the first run's value.  This problem only shows up when re-running on the same VM.

Patch is to backup that small file in case someone wants to look at it later.