### PR TITLE
Fix gcp managed sql database is ready

### DIFF
--- a/perfkitbenchmarker/providers/gcp/gcp_managed_relational_db.py
+++ b/perfkitbenchmarker/providers/gcp/gcp_managed_relational_db.py
@@ -227,14 +227,14 @@ class GCPManagedRelationalDb(managed_relational_db.BaseManagedRelationalDb):
     stdout, _, _ = cmd.Issue()
     try:
       json_output = json.loads(stdout)
-      json_output['state'] == 'RUNNABLE')
+      if not json_output['state'] == 'RUNNABLE':
+        return False
     except:
       logging.exception('Error attempting to read stdout. Creation failure.')
-      is_ready = False
-    if is_ready:
-      self.endpoint = self._ParseEndpoint(json_output)
-      self.port = self.MYSQL_DEFAULT_PORT
-    return is_ready
+      return False
+    self.endpoint = self._ParseEndpoint(json_output)
+    self.port = self.MYSQL_DEFAULT_PORT
+    return True
 
   def _ParseEndpoint(self, describe_instance_json):
     """Return the URI of the resource given the metadata as JSON.

--- a/perfkitbenchmarker/providers/gcp/gcp_managed_relational_db.py
+++ b/perfkitbenchmarker/providers/gcp/gcp_managed_relational_db.py
@@ -208,10 +208,9 @@ class GCPManagedRelationalDb(managed_relational_db.BaseManagedRelationalDb):
     stdout, _, _ = cmd.Issue()
     try:
       json_output = json.loads(stdout)
-      exists = (json_output[0]['kind'] == 'sql#instance')
+      return json_output['kind'] == 'sql#instance'
     except:
-      exists = False
-    return exists
+      return False
 
   def _IsReady(self):
     """Return true if the underlying resource is ready.
@@ -228,7 +227,7 @@ class GCPManagedRelationalDb(managed_relational_db.BaseManagedRelationalDb):
     stdout, _, _ = cmd.Issue()
     try:
       json_output = json.loads(stdout)
-      is_ready = (json_output[0]['state'] == 'RUNNABLE')
+      json_output['state'] == 'RUNNABLE')
     except:
       logging.exception('Error attempting to read stdout. Creation failure.')
       is_ready = False

--- a/tests/data/gcloud-describe-db-instances-available.json
+++ b/tests/data/gcloud-describe-db-instances-available.json
@@ -1,52 +1,50 @@
-[
-  {
-    "backendType": "SECOND_GEN",
-    "connectionName": "sql-benchmarking:us-central1:pkb-db-instance-123",
-    "databaseVersion": "MYSQL_5_6",
-    "etag": "\"7nzH-h2yIa30F8s0g/MQ\"",
-    "instanceType": "CLOUD_SQL_INSTANCE",
-    "ipAddresses": [
-      {
-        "ipAddress": "000.000.000.35",
-        "type": "PRIMARY"
-      }
-    ],
-    "kind": "sql#instance",
-    "name": "pkb-db-instance-123",
-    "project": "sql-benchmarking",
-    "region": "us-central1",
-    "selfLink": "https://www.googleapis.com/sql/pkb-db-instance-123",
-    "serverCaCert": {
-      "cert": "-----BEGIN CERTIFICATE-----\n9n\nbJ\nBG\ns\nC\ng\nCeA==\n-----END CERTIFICATE-----",
-      "certSerialNumber": "0",
-      "commonName": "C=US,O=Google\\, Inc,CN=Google Cloud SQL Server CA",
-      "createTime": "2017-06-21T17:54:45.430000+00:00",
-      "expirationTime": "2019-06-21T17:55:45.430000+00:00",
-      "instance": "pkb-db-instance-123",
-      "kind": "sql#sslCert",
-      "sha1Fingerprint": "58ca6"
+{
+  "backendType": "SECOND_GEN",
+  "connectionName": "sql-benchmarking:us-central1:pkb-db-instance-123",
+  "databaseVersion": "MYSQL_5_6",
+  "etag": "\"7nzH-h2yIa30F8s0g/MQ\"",
+  "instanceType": "CLOUD_SQL_INSTANCE",
+  "ipAddresses": [
+    {
+      "ipAddress": "000.000.000.35",
+      "type": "PRIMARY"
+    }
+  ],
+  "kind": "sql#instance",
+  "name": "pkb-db-instance-123",
+  "project": "sql-benchmarking",
+  "region": "us-central1",
+  "selfLink": "https://www.googleapis.com/sql/pkb-db-instance-123",
+  "serverCaCert": {
+    "cert": "-----BEGIN CERTIFICATE-----\n9n\nbJ\nBG\ns\nC\ng\nCeA==\n-----END CERTIFICATE-----",
+    "certSerialNumber": "0",
+    "commonName": "C=US,O=Google\\, Inc,CN=Google Cloud SQL Server CA",
+    "createTime": "2017-06-21T17:54:45.430000+00:00",
+    "expirationTime": "2019-06-21T17:55:45.430000+00:00",
+    "instance": "pkb-db-instance-123",
+    "kind": "sql#sslCert",
+    "sha1Fingerprint": "58ca6"
+  },
+  "serviceAccountEmailAddress": "wsi@speckle-ella-5.iam.gserviceaccount.com",
+  "settings": {
+    "activationPolicy": "ALWAYS",
+    "backupConfiguration": {
+      "enabled": false,
+      "kind": "sql#backupConfiguration",
+      "startTime": "05:00"
     },
-    "serviceAccountEmailAddress": "wsi@speckle-ella-5.iam.gserviceaccount.com",
-    "settings": {
-      "activationPolicy": "ALWAYS",
-      "backupConfiguration": {
-        "enabled": false,
-        "kind": "sql#backupConfiguration",
-        "startTime": "05:00"
-      },
-      "dataDiskSizeGb": "10",
-      "dataDiskType": "PD_SSD",
-      "ipConfiguration": {
-        "ipv4Enabled": true
-      },
-      "kind": "sql#settings",
-      "pricingPlan": "PER_USE",
-      "replicationType": "SYNCHRONOUS",
-      "settingsVersion": "1",
-      "storageAutoResize": true,
-      "storageAutoResizeLimit": "0",
-      "tier": "db-n1-standard-1"
+    "dataDiskSizeGb": "10",
+    "dataDiskType": "PD_SSD",
+    "ipConfiguration": {
+      "ipv4Enabled": true
     },
-    "state": "RUNNABLE"
-  }
-]
+    "kind": "sql#settings",
+    "pricingPlan": "PER_USE",
+    "replicationType": "SYNCHRONOUS",
+    "settingsVersion": "1",
+    "storageAutoResize": true,
+    "storageAutoResizeLimit": "0",
+    "tier": "db-n1-standard-1"
+  },
+  "state": "RUNNABLE"
+}


### PR DESCRIPTION
_IsReady and _Exists in GcpManagedRelationalDatabase were looking for an array in the json output of `gcloud sql instances describe`, which was failing. The latests version of gcloud, 159.0.0, does not return an array, so the methods need to be changed.