### PR TITLE
beam_integration_benchmark: add beam_it_options, work with k8s

### DIFF
--- a/perfkitbenchmarker/beam_benchmark_helper.py
+++ b/perfkitbenchmarker/beam_benchmark_helper.py
@@ -202,7 +202,8 @@ def _BuildMavenCommand(benchmark_spec, classname, job_arguments):
   # expected that they know what they are doing and we can't know what args
   # to pass since it differs by runner.
   if (benchmark_spec.service_type == dpb_service.DATAFLOW
-      and FLAGS.beam_runner_profile is not None):
+      and (FLAGS.beam_runner_profile is not None and
+           len(FLAGS.beam_runner_profile) > 0)):
     beam_args.append('"--defaultWorkerLogLevel={}"'.format(FLAGS.dpb_log_level))
 
   AddRunnerProfileMvnArgument(benchmark_spec.service_type, cmd,

--- a/perfkitbenchmarker/beam_pipeline_options.py
+++ b/perfkitbenchmarker/beam_pipeline_options.py
@@ -1,0 +1,139 @@
+# Copyright 2017 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import yaml
+
+from perfkitbenchmarker import errors
+from perfkitbenchmarker import flags
+from perfkitbenchmarker import kubernetes_helper
+
+FLAGS = flags.FLAGS
+
+
+def GetStaticPipelineOptions(options_list):
+  options = []
+  for option in options_list:
+    if not len(option.keys()) == 1:
+      raise Exception('static_pipeline_options should only have 1 key/value')
+    option_kv = option.items()[0]
+    options.append((option_kv[0], option_kv[1]))
+
+  return options
+
+
+def EvaluateDynamicPipelineOptions(dynamic_options):
+  """
+  Takes the user's dynamic args and retrieves the information to fill them in.
+
+  dynamic_args is a python map of argument name -> {type, kubernetesSelector}
+  returns a list of tuples containing (argName, argValue)
+  """
+  filledOptions = []
+  for optionDescriptor in dynamic_options:
+    fillType = optionDescriptor['type']
+    optionName = optionDescriptor['name']
+
+    if not fillType:
+      raise errors.Config.InvalidValue(
+          'For dynamic arguments, you must provide a "type"')
+
+    if fillType == 'NodePortIp':
+      argValue = RetrieveNodePortIp(optionDescriptor)
+    elif fillType == 'LoadBalancerIp':
+      argValue = RetrieveLoadBalancerIp(optionDescriptor)
+    elif fillType == 'TestValue':
+      argValue = optionDescriptor['value']
+    else:
+      raise errors.Config.InvalidValue(
+          'Unknown dynamic argument type: %s' % (fillType))
+
+    filledOptions.append((optionName, argValue))
+
+  return filledOptions
+
+
+def GenerateAllPipelineOptions(it_args, it_options, static_pipeline_options,
+                               dynamic_pipeline_options):
+  """
+  :param it_args: options list passed in via FLAGS.beam_it_args
+  :param it_options: options list passed in via FLAGS.beam_it_options
+  :param static_pipeline_options: options list passed in via
+      benchmark_spec.dpb_service.static_pipeline_options
+  :param dynamic_pipeline_options: options list passed in via
+      benchmark_spec.dpb_service.dynamic_pipeline_options
+  :return: a list of values of the form "\"--option_name=value\""
+  """
+  # beam_it_options are in [--option=value,--option2=val2] form
+  user_option_list = []
+  if it_options is not None and len(it_options) > 0:
+    user_option_list = it_options.rstrip(']').lstrip('[').split(',')
+    user_option_list = [option.rstrip('" ').lstrip('" ')
+                        for option in user_option_list]
+
+
+  # Add static options from the benchmark_spec
+  benchmark_spec_option_list = (
+      EvaluateDynamicPipelineOptions(dynamic_pipeline_options))
+  benchmark_spec_option_list.extend(
+      GetStaticPipelineOptions(static_pipeline_options))
+  option_list = ['--{}={}'.format(t[0], t[1])
+                 for t in benchmark_spec_option_list]
+
+  # beam_it_args is the old way of passing parameters
+  args_list = []
+  if it_args is not None and len(it_args) > 0:
+    args_list = it_args.split(',')
+
+  return ['"{}"'.format(arg)
+          for arg in args_list + user_option_list + option_list]
+
+
+def ReadPipelineOptionConfigFile():
+  dynamic_pipeline_options = []
+  static_pipeline_options = []
+  if FLAGS.beam_options_config_file:
+    with open(FLAGS.beam_options_config_file, 'r') as fileStream:
+      config = yaml.load(fileStream)
+      if config['static_pipeline_options']:
+        static_pipeline_options = config['static_pipeline_options']
+      if config['dynamic_pipeline_options']:
+        dynamic_pipeline_options = config['dynamic_pipeline_options']
+  return static_pipeline_options, dynamic_pipeline_options
+
+
+def RetrieveNodePortIp(argDescriptor):
+  jsonSelector = argDescriptor['podLabel']
+  if not jsonSelector:
+    raise errors.Config.InvalidValue('For NodePortIp arguments, you must'
+                                     ' provide a "selector"')
+  ip = kubernetes_helper.GetWithWaitForContents(
+      'pods', '', jsonSelector, '.items[0].status.podIP')
+  if len(ip) == 0:
+    raise "Could not retrieve NodePort IP address"
+  logging.info("Using NodePort IP Address: " + ip)
+  return ip
+
+
+def RetrieveLoadBalancerIp(argDescriptor):
+  serviceName = argDescriptor['serviceName']
+  if not serviceName:
+    raise errors.Config.InvalidValue('For LoadBalancerIp arguments, you must'
+                                     'provide a "serviceName"')
+  ip = kubernetes_helper.GetWithWaitForContents(
+      'svc', serviceName, '', '.status.loadBalancer.ingress[0].ip')
+  if len(ip) == 0:
+    raise "Could not retrieve LoadBalancer IP address"
+  logging.info("Using LoadBalancer IP Address: " + ip)
+  return ip

--- a/perfkitbenchmarker/beam_pipeline_options.py
+++ b/perfkitbenchmarker/beam_pipeline_options.py
@@ -23,13 +23,22 @@ FLAGS = flags.FLAGS
 
 
 def GetStaticPipelineOptions(options_list):
+  """
+  Takes the dictionary loaded from the yaml configuration file and returns it
+  in a form consistent with the others in GenerateAllPipelineOptions: a list of
+  (pipeline_option_name, pipline_option_value) tuples.
+
+  The options in the options_list are a dict:
+    Key is the name of the pipeline option to pass to beam
+    Value is the value of the pipeline option to pass to beam
+  """
   options = []
   for option in options_list:
     if not len(option.keys()) == 1:
-      raise Exception('static_pipeline_options should only have 1 key/value')
+      raise Exception('Each item in static_pipeline_options should only have'
+                      ' 1 key/value')
     option_kv = option.items()[0]
     options.append((option_kv[0], option_kv[1]))
-
   return options
 
 
@@ -69,10 +78,8 @@ def GenerateAllPipelineOptions(it_args, it_options, static_pipeline_options,
   """
   :param it_args: options list passed in via FLAGS.beam_it_args
   :param it_options: options list passed in via FLAGS.beam_it_options
-  :param static_pipeline_options: options list passed in via
-      benchmark_spec.dpb_service.static_pipeline_options
-  :param dynamic_pipeline_options: options list passed in via
-      benchmark_spec.dpb_service.dynamic_pipeline_options
+  :param static_pipeline_options: options list loaded from the yaml config file
+  :param dynamic_pipeline_options: options list loaded from the yaml config file
   :return: a list of values of the form "\"--option_name=value\""
   """
   # beam_it_options are in [--option=value,--option2=val2] form
@@ -101,6 +108,10 @@ def GenerateAllPipelineOptions(it_args, it_options, static_pipeline_options,
 
 
 def ReadPipelineOptionConfigFile():
+  """
+  Reads the path to the config file from FLAGS, then loads the static and
+  dynamic pipeline options from it.
+  """
   dynamic_pipeline_options = []
   static_pipeline_options = []
   if FLAGS.beam_options_config_file:

--- a/perfkitbenchmarker/data/beam/postgres-options.yml
+++ b/perfkitbenchmarker/data/beam/postgres-options.yml
@@ -1,0 +1,33 @@
+# Copyright 2017 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This file is a pipeline options configuration file, used when running
+# beam_integration_benchmark.
+#
+# This file defines pipeline options to pass to beam, as well as how to derive
+# the values for those pipeline options from kubernetes (where appropriate.)
+
+static_pipeline_options:
+  - postgresUsername: postgres
+  - postgresPassword: mypass
+  - postgresDatabaseName: postgres
+  - postgresSsl: false
+dynamic_pipeline_options:
+  - name: postgresServerName
+    type: NodePortIp
+    podLabel: name=postgres

--- a/perfkitbenchmarker/kubernetes_helper.py
+++ b/perfkitbenchmarker/kubernetes_helper.py
@@ -1,0 +1,79 @@
+# Copyright 2017 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+
+from perfkitbenchmarker import flags
+from perfkitbenchmarker import vm_util
+
+FLAGS = flags.FLAGS
+MAX_NUM_WAITS_FOR_K8S_GET = 6
+
+
+def checkKubernetesFlags():
+  if not FLAGS.kubectl:
+    raise Exception('Please provide path to kubectl tool using --kubectl '
+                    'flag. Exiting.')
+  if not FLAGS.kubeconfig:
+    raise Exception('Please provide path to kubeconfig using --kubeconfig '
+                    'flag. Exiting.')
+
+
+def CreateFromFile(file_name):
+  checkKubernetesFlags()
+  create_cmd = [FLAGS.kubectl, '--kubeconfig=%s' % FLAGS.kubeconfig, 'create',
+                '-f', file_name]
+  return vm_util.IssueCommand(create_cmd)
+
+
+def DeleteFromFile(file_name):
+  checkKubernetesFlags()
+  delete_cmd = [FLAGS.kubectl, '--kubeconfig=%s' % FLAGS.kubeconfig, 'delete',
+                '-f', file_name]
+  return vm_util.IssueCommand(delete_cmd)
+
+
+def DeleteAllFiles(file_list):
+  for file in file_list:
+    DeleteFromFile(file)
+
+
+def CreateAllFiles(file_list):
+  for file in file_list:
+    CreateFromFile(file)
+
+
+def Get(resource, resourceInstanceName, labelFilter, jsonSelector):
+  checkKubernetesFlags()
+  get_pod_cmd = [FLAGS.kubectl, '--kubeconfig=%s' % FLAGS.kubeconfig,
+                 'get', resource]
+  if len(resourceInstanceName) > 0:
+    get_pod_cmd.append(resourceInstanceName)
+  if len(labelFilter) > 0:
+    get_pod_cmd.append('-l ' + labelFilter)
+  get_pod_cmd.append('-ojsonpath={{{}}}'.format(jsonSelector))
+  stdout, stderr, _ = vm_util.IssueCommand(get_pod_cmd, suppress_warning=True)
+  if len(stderr) > 0:
+    raise Exception("Error received from kubectl get: " + stderr)
+  return stdout
+
+
+def GetWithWaitForContents(resource, resourceInstanceName, filter, jsonFilter):
+  ret = Get(resource, resourceInstanceName, filter, jsonFilter)
+  numWaitsLeft = MAX_NUM_WAITS_FOR_K8S_GET
+  while len(ret) == 0 and numWaitsLeft > 0:
+    time.sleep(10)
+    ret = Get(resource, resourceInstanceName, filter, jsonFilter)
+    numWaitsLeft -= 1
+  return ret

--- a/perfkitbenchmarker/linux_benchmarks/beam_integration_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/beam_integration_benchmark.py
@@ -64,11 +64,12 @@ flags.DEFINE_string('beam_it_args', None, 'Args to provide to the IT.'
                     ' Deprecated & replaced by beam_it_options')
 flags.DEFINE_string('beam_it_options', None, 'Pipeline Options sent to the'
                     ' integration test.')
-flags.DEFINE_string('beam_kubernetes_scripts', None, 'Kubernetes scripts to run'
-                    ' which will instantiate a datastore.')
-flags.DEFINE_string('beam_options_config_file', None, 'Yaml file defining'
-                    ' static and dynamic pipeline options to use for this'
-                    ' benchmark run.')
+flags.DEFINE_string('beam_kubernetes_scripts', None, 'A local path to the'
+                    ' Kubernetes scripts to run which will instantiate a'
+                    ' datastore.')
+flags.DEFINE_string('beam_options_config_file', None, 'A local path to the'
+                    ' yaml file defining static and dynamic pipeline options to'
+                    ' use for this benchmark run.')
 
 FLAGS = flags.FLAGS
 

--- a/perfkitbenchmarker/linux_benchmarks/beam_integration_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/beam_integration_benchmark.py
@@ -24,10 +24,12 @@ import datetime
 import tempfile
 
 from perfkitbenchmarker import beam_benchmark_helper
+from perfkitbenchmarker import beam_pipeline_options
 from perfkitbenchmarker import configs
 from perfkitbenchmarker import dpb_service
 from perfkitbenchmarker import errors
 from perfkitbenchmarker import flags
+from perfkitbenchmarker import kubernetes_helper
 from perfkitbenchmarker import sample
 from perfkitbenchmarker.dpb_service import BaseDpbService
 
@@ -58,7 +60,15 @@ DEFAULT_JAVA_IT_CLASS = 'org.apache.beam.examples.WordCountIT'
 DEFAULT_PYTHON_IT_MODULE = 'apache_beam.examples.wordcount_it_test'
 
 flags.DEFINE_string('beam_it_class', None, 'Path to IT class')
-flags.DEFINE_string('beam_it_args', None, 'Args to provide to the IT')
+flags.DEFINE_string('beam_it_args', None, 'Args to provide to the IT.'
+                    ' Deprecated & replaced by beam_it_options')
+flags.DEFINE_string('beam_it_options', None, 'Pipeline Options sent to the'
+                    ' integration test.')
+flags.DEFINE_string('beam_kubernetes_scripts', None, 'Kubernetes scripts to run'
+                    ' which will instantiate a datastore.')
+flags.DEFINE_string('beam_options_config_file', None, 'Yaml file defining'
+                    ' static and dynamic pipeline options to use for this'
+                    ' benchmark run.')
 
 FLAGS = flags.FLAGS
 
@@ -67,29 +77,44 @@ def GetConfig(user_config):
   return configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
 
 
-def CheckPrerequisites(benchmark_spec):
+def CheckPrerequisites(benchmark_config_spec):
   """Verifies that the required resources are present.
 
   Raises:
     perfkitbenchmarker.errors.Config.InvalidValue: If no Beam args are provided.
     NotImplementedError: If an invalid runner is specified.
   """
-  if FLAGS.beam_it_args is None:
+  if FLAGS.beam_it_options is None and FLAGS.beam_it_args is None:
     raise errors.Config.InvalidValue(
-        'No args provided. To run with default class (WordCountIT), must'
-        'provide --beam_it_args=--tempRoot=<temp dir, e.g. gs://my-dir/temp>.')
+        'No options provided. To run with default class (WordCountIT), must'
+        ' provide --beam_it_options=--tempRoot=<temp dir,'
+        ' e.g. gs://my-dir/temp>.')
   if FLAGS.beam_sdk is None:
     raise errors.Config.InvalidValue(
         'No sdk provided. To run Beam integration benchmark, the test must'
-        'specify which sdk is used in the pipeline. For example, java/python.'
-    )
-  if benchmark_spec.dpb_service.service_type != dpb_service.DATAFLOW:
+        'specify which sdk is used in the pipeline. For example, java/python.')
+  if benchmark_config_spec.dpb_service.service_type != dpb_service.DATAFLOW:
     raise NotImplementedError('Currently only works against Dataflow.')
+  if (len(FLAGS.beam_it_options) > 0 and
+      (not FLAGS.beam_it_options.endswith(']') or
+       not FLAGS.beam_it_options.startswith('['))):
+    raise Exception("beam_it_options must be of form"
+                    " [\"--option=value\",\"--option2=val2\"]")
 
 
 def Prepare(benchmark_spec):
   beam_benchmark_helper.InitializeBeamRepo(benchmark_spec)
+  benchmark_spec.always_call_cleanup = True
+  kubernetes_helper.CreateAllFiles(getKubernetesScripts())
   pass
+
+
+def getKubernetesScripts():
+  if FLAGS.beam_kubernetes_scripts:
+    scripts = FLAGS.beam_kubernetes_scripts.split(',')
+    return scripts
+  else:
+    return []
 
 
 def Run(benchmark_spec):
@@ -103,9 +128,6 @@ def Run(benchmark_spec):
                                             delete=False)
   stdout_file.close()
 
-  # Switch the parameters for submit job function of specific dpb service
-  job_arguments = ['"{}"'.format(arg) for arg in FLAGS.beam_it_args.split(',')]
-
   if FLAGS.beam_it_class is None:
     if FLAGS.beam_sdk == beam_benchmark_helper.BEAM_JAVA_SDK:
       classname = DEFAULT_JAVA_IT_CLASS
@@ -115,6 +137,14 @@ def Run(benchmark_spec):
       raise NotImplementedError('Unsupported Beam SDK: %s.' % FLAGS.beam_sdk)
   else:
     classname = FLAGS.beam_it_class
+
+  static_pipeline_options, dynamic_pipeline_options = \
+      beam_pipeline_options.ReadPipelineOptionConfigFile()
+
+  job_arguments = beam_pipeline_options.GenerateAllPipelineOptions(
+      FLAGS.beam_it_args, FLAGS.beam_it_options,
+      static_pipeline_options,
+      dynamic_pipeline_options)
 
   job_type = BaseDpbService.BEAM_JOB_TYPE
 
@@ -133,4 +163,5 @@ def Run(benchmark_spec):
 
 
 def Cleanup(benchmark_spec):
+  kubernetes_helper.DeleteAllFiles(getKubernetesScripts())
   pass

--- a/tests/linux_benchmarks/beam_integration_benchmark_test.py
+++ b/tests/linux_benchmarks/beam_integration_benchmark_test.py
@@ -1,0 +1,68 @@
+# Copyright 2014 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for beam_integration_benchmark."""
+
+import unittest
+
+from perfkitbenchmarker import beam_pipeline_options
+
+
+class BeamArgsOptionsTestCase(unittest.TestCase):
+  def testNoFlagsPassed(self):
+    options_list = beam_pipeline_options.GenerateAllPipelineOptions(
+        None, None, [], [])
+    self.assertListEqual(options_list, [])
+
+
+  def testAllFlagsPassed(self):
+    options_list = beam_pipeline_options.GenerateAllPipelineOptions(
+        "--itargone=anarg,--itargtwo=anotherarg",
+        "[\"--project=testProj\","
+        "\"--gcpTempLocation=gs://test-bucket/staging\"]",
+        [{"postgresUsername": "postgres"}, {"postgresPassword": "mypass"}],
+        [{"name": "aTestVal", "type": "TestValue", "value": "this_is_a_test"},
+         {"name": "testier", "type": "TestValue", "value": "another_test"}]
+    )
+
+    self.assertListEqual(options_list,
+                         ["\"--itargone=anarg\"",
+                          "\"--itargtwo=anotherarg\"",
+                          "\"--project=testProj\"",
+                          "\"--gcpTempLocation=gs://test-bucket/staging\"",
+                          "\"--aTestVal=this_is_a_test\"",
+                          "\"--testier=another_test\"",
+                          "\"--postgresUsername=postgres\"",
+                          "\"--postgresPassword=mypass\""])
+
+
+  def testItOptionsWithSpaces(self):
+    options_list = beam_pipeline_options.GenerateAllPipelineOptions(
+        None,
+        "[\"--project=testProj\", "
+        "\"--gcpTempLocation=gs://test-bucket/staging\"]",
+        [],
+        [])
+
+    self.assertListEqual(options_list,
+                         ["\"--project=testProj\"",
+                          "\"--gcpTempLocation=gs://test-bucket/staging\""])
+
+
+  def dynamicPipelineOptions(self):
+    beam_pipeline_options.EvaluateDynamicPipelineOptions()
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
Where work with k8s means:
* can spin up & teardown kubernetes resources defined in a kubernetes yml script
* can read properties from kubernetes resources and use them as options for beam piplines

It also:
* refactors some shared code for interacting with kubernetes out into kubernetes_helper.
* moves beam maven pipline options handling code out into a separate file from the benchmark

cc @asaksena 