### PR TITLE
Parse all HPCC metrics and record them as samples.

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/hpcc_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/hpcc_benchmark.py
@@ -195,8 +195,9 @@ def ParseOutput(hpcc_output, benchmark_spec):
   UpdateMetadata(metadata)
 
   # Parse all metrics from metric=value lines in the HPCC output.
-  for metric, value in regex_util.ExtractAllFloatMetrics(
-      hpcc_output).iteritems():
+  metric_values = regex_util.ExtractAllFloatMetrics(
+      hpcc_output)
+  for metric, value in metric_values.iteritems():
     results.append(sample.Sample(metric, value, '', metadata))
 
   # Parse some metrics separately and add units. Although these metrics are
@@ -234,6 +235,10 @@ def Run(benchmark_spec):
   """
   vms = benchmark_spec.vms
   master_vm = vms[0]
+  # backup existing HPCC output, if any
+  master_vm.RemoteCommand(('if [ -f hpccoutf.txt ]; then '
+                           'mv hpccoutf.txt hpccoutf-$(date +%s).txt; '
+                           'fi'))
   num_processes = len(vms) * master_vm.num_cpus
   mpi_env = ' '.join(['-x %s' % v for v in FLAGS.hpcc_mpi_env])
   mpi_cmd = ('mpirun -np %s -machinefile %s --mca orte_rsh_agent '

--- a/perfkitbenchmarker/linux_benchmarks/hpcc_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/hpcc_benchmark.py
@@ -193,19 +193,29 @@ def ParseOutput(hpcc_output, benchmark_spec):
   metadata['num_cpus'] = match.group(1)
   metadata['num_machines'] = len(benchmark_spec.vms)
   UpdateMetadata(metadata)
+
+  # Parse all metrics from metric=value lines in the HPCC output.
+  for metric, value in regex_util.ExtractAllFloatMetrics(
+      hpcc_output).iteritems():
+    results.append(sample.Sample(metric, value, '', metadata))
+
+  # Parse some metrics separately and add units. Although these metrics are
+  # parsed above and added to results, this handling is left so that existing
+  # uses of these metric names will continue to work.
   value = regex_util.ExtractFloat('HPL_Tflops=([0-9]*\\.[0-9]*)', hpcc_output)
   results.append(sample.Sample('HPL Throughput', value, 'Tflops', metadata))
 
   value = regex_util.ExtractFloat('SingleRandomAccess_GUPs=([0-9]*\\.[0-9]*)',
                                   hpcc_output)
-  results.append(sample.Sample('Random Access Throughput', value,
-                               'GigaUpdates/sec'))
+  results.append(
+      sample.Sample('Random Access Throughput', value, 'GigaUpdates/sec',
+                    metadata))
 
   for metric in STREAM_METRICS:
     regex = 'SingleSTREAM_%s=([0-9]*\\.[0-9]*)' % metric
     value = regex_util.ExtractFloat(regex, hpcc_output)
-    results.append(sample.Sample('STREAM %s Throughput' % metric, value,
-                                 'GB/s'))
+    results.append(
+        sample.Sample('STREAM %s Throughput' % metric, value, 'GB/s', metadata))
 
   value = regex_util.ExtractFloat(r'PTRANS_GBs=([0-9]*\.[0-9]*)', hpcc_output)
   results.append(sample.Sample('PTRANS Throughput', value, 'GB/s', metadata))
@@ -224,10 +234,6 @@ def Run(benchmark_spec):
   """
   vms = benchmark_spec.vms
   master_vm = vms[0]
-  # backup existing HPCC output, if any
-  master_vm.RemoteCommand(('if [ -f hpccoutf.txt ]; then '
-                           'mv hpccoutf.txt hpccoutf-$(date +%s).txt; '
-                           'fi'))
   num_processes = len(vms) * master_vm.num_cpus
   mpi_env = ' '.join(['-x %s' % v for v in FLAGS.hpcc_mpi_env])
   mpi_cmd = ('mpirun -np %s -machinefile %s --mca orte_rsh_agent '

--- a/perfkitbenchmarker/regex_util.py
+++ b/perfkitbenchmarker/regex_util.py
@@ -18,6 +18,9 @@ import re
 
 _IPV4_REGEX = r'[0-9]+(?:\.[0-9]+){3}'
 
+# From https://docs.python.org/2/library/re.html#simulating-scanf.
+FLOAT_REGEX = r'[-+]?(\d+(\.\d*)?|\.\d+)([eE][-+]?\d+)?'
+
 
 class NoMatchError(ValueError):
   """Raised when no matches for a regex are found within a string."""
@@ -58,6 +61,31 @@ def ExtractGroup(regex, text, group=1, flags=0):
 def ExtractFloat(regex, text, group=1):
   """Extracts a float from a regular expression matched to 'text'."""
   return float(ExtractGroup(regex, text, group=group))
+
+
+def ExtractAllFloatMetrics(text,
+                           metric_regex=r'\w+',
+                           value_regex=FLOAT_REGEX,
+                           delimiter_regex='='):
+  """Extracts metrics and their values into a dict.
+
+  Args:
+    text: The text to parse to find metric and values.
+    metric_regex: A regular expression to find metric names. The metric regex
+        should not contain any parenthesized groups.
+    value_regex: A regular expression to find float values. By default, this
+        works well for floating-point numbers found via scanf.
+    delimiter_regex: A regular expression between the metric name and value.
+
+  Returns:
+    A dict mapping metrics to values.
+  """
+  if '(' in metric_regex:
+    raise NotImplementedError('ExtractAllFloatMetrics does not support a '
+                              'metric regex with groups.')
+  matches = re.findall('(%s)%s(%s)' % (metric_regex, delimiter_regex,
+                                       value_regex), text)
+  return {match[0]: float(match[1]) for match in matches}
 
 
 def ExtractIpv4Addresses(text):

--- a/tests/linux_benchmarks/hpcc_benchmark_test.py
+++ b/tests/linux_benchmarks/hpcc_benchmark_test.py
@@ -35,9 +35,8 @@ class HPCCTestCase(unittest.TestCase):
   def testParseHpcc(self):
     benchmark_spec = mock.MagicMock()
     result = hpcc_benchmark.ParseOutput(self.contents, benchmark_spec)
-    self.assertEqual(7, len(result))
+    self.assertEqual(150, len(result))
     results = {i[0]: i[1] for i in result}
-
     self.assertAlmostEqual(0.0331844, results['HPL Throughput'])
     self.assertAlmostEqual(0.0151415, results['Random Access Throughput'])
     self.assertAlmostEqual(11.5032, results['STREAM Copy Throughput'])
@@ -45,6 +44,11 @@ class HPCCTestCase(unittest.TestCase):
     self.assertAlmostEqual(12.7265, results['STREAM Add Throughput'])
     self.assertAlmostEqual(12.2433, results['STREAM Triad Throughput'])
     self.assertAlmostEqual(0.338561, results['PTRANS Throughput'])
+
+    # Spot check a few of the metrics without units.
+    self.assertAlmostEqual(4, results['sizeof_float'])
+    self.assertAlmostEqual(5.80539, results['StarSTREAM_Add'])
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/tests/regex_util_test.py
+++ b/tests/regex_util_test.py
@@ -75,6 +75,40 @@ class ExtractFloatTestCase(unittest.TestCase):
                       group=1)
 
 
+class ExtractAllFloatMetricsTestCase(unittest.TestCase):
+
+  def testParseSuccessful(self):
+    matches = regex_util.ExtractAllFloatMetrics(
+        """
+        metric=value
+        a=1
+        b=2.0
+        c=.3
+        d=-4.5
+        ef=3.2e+2
+        """)
+    self.assertEqual(len(matches), 5)
+    self.assertEqual(1.0, matches['a'])
+    self.assertEqual(2.0, matches['b'])
+    self.assertEqual(0.3, matches['c'])
+    self.assertEqual(-4.5, matches['d'])
+    self.assertEqual(3.2e+2, matches['ef'])
+
+  def testInvalidMetricRegex(self):
+    self.assertRaises(
+        NotImplementedError,
+        regex_util.ExtractAllFloatMetrics,
+        'metric=1.0',
+        metric_regex=r'\w(\w)')
+
+  def testIntegerValueRegex(self):
+    matches = regex_util.ExtractAllFloatMetrics(
+        'a=1.2,b=3', value_regex=r'\d+')
+    self.assertEqual(len(matches), 2)
+    self.assertEqual(1.0, matches['a'])
+    self.assertEqual(3, matches['b'])
+
+
 class ExtractAllMatchesTestCase(unittest.TestCase):
 
   def testParseSuccessfully(self):


### PR DESCRIPTION
This PR adds all of the metrics in the HPCC summary section as benchmark samples. These samples use the name exactly as it appears in the summary section.  The previous samples are left in case any tools are parsing those results.
