### PR TITLE
Quick fix beam-integration-benchmark

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/beam_integration_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/beam_integration_benchmark.py
@@ -96,7 +96,7 @@ def CheckPrerequisites(benchmark_config_spec):
         'specify which sdk is used in the pipeline. For example, java/python.')
   if benchmark_config_spec.dpb_service.service_type != dpb_service.DATAFLOW:
     raise NotImplementedError('Currently only works against Dataflow.')
-  if (len(FLAGS.beam_it_options) > 0 and
+  if (FLAGS.beam_it_options and
       (not FLAGS.beam_it_options.endswith(']') or
        not FLAGS.beam_it_options.startswith('['))):
     raise Exception("beam_it_options must be of form"


### PR DESCRIPTION
`FLAGS.beam_it_options` is optional currently. Exception will through if a beam benchmark job doesn't specify this flag.

In the future, we want to migrate to `FLAGS.beam_it_options` from `FLAGS.beam_it_args`.

Test is done by running beam_integration_benchmark on GCP and pipeline can be submitted successfully.

+R: @asaksena
+cc: @ssisk 