### PR TITLE
[launch_my_sql] Update default requirements & update per second chart title

### DIFF
--- a/perfkitbenchmarker/scripts/database_scripts/launch_mysql_service.py
+++ b/perfkitbenchmarker/scripts/database_scripts/launch_mysql_service.py
@@ -113,7 +113,7 @@ gflags.DEFINE_integer(SYSBENCH_WARMUP_SECONDS, 0,
                       'results are discarded.')
 gflags.DEFINE_list(THREAD_COUNT_LIST, [1, 2, 4, 8, 16, 32, 64, 128, 256, 512],
                    'The number of test threads on the client side.')
-gflags.DEFINE_integer(SYSBENCH_REPORT_INTERVAL, 2,
+gflags.DEFINE_integer(SYSBENCH_REPORT_INTERVAL, 1,
                       'The interval, in seconds, we ask sysbench to report '
                       'results.')
 gflags.DEFINE_string(RUN_URI, None,
@@ -123,11 +123,11 @@ gflags.DEFINE_string(RUN_STAGE, None,
                      'List of phases to be executed. For example:'
                      '"--run_uri=provision,prepare". Available phases:'
                      'prepare, provision, run, cleanup, teardown.')
-gflags.DEFINE_string(GCE_BOOT_DISK_SIZE, '300',
+gflags.DEFINE_string(GCE_BOOT_DISK_SIZE, '1000',
                      'The boot disk size in GB for GCP VMs..')
 gflags.DEFINE_string(GCE_BOOT_DISK_TYPE, 'pd-ssd',
                      'The boot disk type for GCP VMs.')
-gflags.DEFINE_string(MACHINE_TYPE, 'n1-standard-4',
+gflags.DEFINE_string(MACHINE_TYPE, 'n1-standard-16',
                      'Machine type for GCE Virtual machines.')
 gflags.DEFINE_enum(MYSQL_SVC_DB_INSTANCE_CORES, '4', ['1', '4', '8', '16'],
                    'The number of cores to be provisioned for the DB instance.')
@@ -239,7 +239,7 @@ def _run(run_uri):
     try:
       _execute_pkb_cmd(pkb_cmd, stdout_filename, stderr_filename)
     except CallFailureError:
-      logging.info('Call Failed. Ending run phase ')
+      logging.info('Call Failed. Ending run phase.')
       break
     if FLAGS.per_second_graphs:
       logging.info('Adding Sysbench STDERR to per second graph.')

--- a/perfkitbenchmarker/scripts/database_scripts/plot_scatter_points.py
+++ b/perfkitbenchmarker/scripts/database_scripts/plot_scatter_points.py
@@ -26,7 +26,8 @@ import datetime
 
 
 DATETIME_FORMAT = '{:%m_%d_%Y_%H_%M_}'
-CHART_TITLE = 'Sysbench TPS'
+DATETIME_TITLE_FORMAT = '{: %m %d %Y %H %M}'
+CHART_TITLE_PREFIX = 'Sysbench TPS'
 
 X_LABEL = 'Thread Count'
 Y_LABEL = 'TPS'
@@ -67,6 +68,8 @@ class GnuplotInfo():
       run_uri: (string) run identifier.
     """
     date_string = DATETIME_FORMAT.format(datetime.datetime.now())
+    date_title_string = DATETIME_TITLE_FORMAT.format(datetime.datetime.now())
+    self.chart_title = CHART_TITLE_PREFIX + date_title_string
     identifier = date_string + run_uri + '_sysbench_run.png'
     self.output_chart = os.path.join(
         os.path.dirname(__file__), '..', '..', '..', 'charts',
@@ -82,7 +85,7 @@ class GnuplotInfo():
     color = '38761d'
 
     # Titles for the data series
-    title = self.title or '1TB DB Instance'
+    title = self.title or 'Cloud SQL Prod'
 
     output_file = open(self.output_gnuplot_file, 'w')
     output_file.write('set terminal pngcairo size 1500,800 '
@@ -91,8 +94,8 @@ class GnuplotInfo():
     output_file.write('set multiplot\n')
     output_file.write('set grid\n')
     output_file.write('set border 4095 ls 0 lc rgb \"black\"\n')
-    output_file.write('set title (\"' + CHART_TITLE +
-                      '") font \"aerial, 14\"\n')
+    output_file.write('set title (\"' + self.chart_title +
+                      '") font \"aerial, 14\" noenhanced\n')
     output_file.write('set xlabel "' + X_LABEL + '"\n')
     output_file.write('set ylabel "' + Y_LABEL + '"\n')
 


### PR DESCRIPTION
@stfeng2 @gareth-ferneyhough 
Update default benchmarking specs:
Client machine type 4 -> 16 core (to eliminate chance of client bottlenecking DB)
Client disk size 300GB -> 1000GB (to eliminate chance of client bottlenecking DB)
Report Interval 2 sec -> 1 second (So per second graphs are actually per 1 second)

Per Second Graph:
Add nicely formatted time
Legend better labeled