### PR TITLE
Fix Netperf installation and upgrade to version 2.7.0

### DIFF
--- a/perfkitbenchmarker/data/netperf.patch
+++ b/perfkitbenchmarker/data/netperf.patch
@@ -139,8 +139,8 @@ diff -u -r netperf-2.6.0/src/nettest_omni.c netperf-2.6.0-patch/src/nettest_omni
  
  {
  
--#define OMNI_ARGS "b:cCd:DG:hH:kK:l:L:m:M:nNoOp:P:r:R:s:S:t:T:u:Vw:W:46"
-+#define OMNI_ARGS "b:cCd:DG:hH:kK:l:L:m:M:nNoOp:P:r:R:s:S:t:T:U:u:Vw:W:46"
+-#define OMNI_ARGS "aBb:cCd:De:FgG:hH:i:Ij:kK:l:L:m:M:nNoOp:P:r:R:s:S:t:T:u:UVw:W:46"
++#define OMNI_ARGS "aBb:cCd:De:FgG:hH:i:Ij:kK:l:L:m:M:nNoOp:P:r:R:s:S:t:T:u:UVw:W:X:46"
  
    extern char	*optarg;	  /* pointer to option string	*/
  
@@ -148,7 +148,7 @@ diff -u -r netperf-2.6.0/src/nettest_omni.c netperf-2.6.0-patch/src/nettest_omni
        test_uuid[sizeof(test_uuid) - 1] = 0;
        have_uuid = 1;
        break;
-+    case 'U':
++    case 'X':
 +      break_args(optarg, arg1, arg2);
 +      break_args(optarg+strlen(arg1)+1, arg2, arg3);
 +      think_time = convert(arg1);

--- a/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
@@ -302,7 +302,7 @@ def RunNetperf(vm, benchmark_name, server_ip, num_streams):
                      length=FLAGS.netperf_test_length,
                      confidence=confidence, verbosity=verbosity)
   if FLAGS.netperf_thinktime != 0:
-    netperf_cmd += (' -U {thinktime},{thinktime_array_size},'
+    netperf_cmd += (' -X {thinktime},{thinktime_array_size},'
                     '{thinktime_run_length} ').format(
                         thinktime=FLAGS.netperf_thinktime,
                         thinktime_array_size=FLAGS.netperf_thinktime_array_size,

--- a/perfkitbenchmarker/linux_packages/netperf.py
+++ b/perfkitbenchmarker/linux_packages/netperf.py
@@ -31,9 +31,11 @@ flags.DEFINE_integer(
     'increase the precision of the histogram samples that the netperf '
     'benchmark produces.')
 FLAGS = flags.FLAGS
-NETPERF_TAR = 'netperf-2.6.0.tar.gz'
-NETPERF_URL = 'ftp://ftp.netperf.org/netperf/archive/%s' % NETPERF_TAR
-NETPERF_DIR = '%s/netperf-2.6.0' % INSTALL_DIR
+NETPERF_TAR = 'netperf-2.7.0.tar.gz'
+NETPERF_URL = 'https://github.com/HewlettPackard/netperf/archive/%s' % (
+              NETPERF_TAR)
+NETPERF_DIR = '%s/netperf-netperf-2.7.0' % INSTALL_DIR
+
 NETPERF_SRC_DIR = NETPERF_DIR + '/src'
 NETSERVER_PATH = NETPERF_SRC_DIR + '/netserver'
 NETPERF_PATH = NETPERF_SRC_DIR + '/netperf'
@@ -67,7 +69,7 @@ def _CopyTar(vm):
     vm.PushDataFile(NETPERF_TAR, remote_path=(INSTALL_DIR + '/'))
   except ResourceNotFound:
     vm.Install('curl')
-    vm.RemoteCommand('curl %s -o %s/%s' % (
+    vm.RemoteCommand('curl %s -L -o %s/%s' % (
         NETPERF_URL, INSTALL_DIR, NETPERF_TAR))
 
 


### PR DESCRIPTION
Netperf 2.6.0 installation is broken because its ftp site does not
exist anymore.  Also, the current version of Netperf is 2.7.0.

This commit installs Netperf 2.7.0 from Github.

Signed-off-by: Saied Kazemi <saied@google.com>