### PR TITLE
Add --network_enable_BBR flag to PKB

### DIFF
--- a/CHANGES.next.md
+++ b/CHANGES.next.md
@@ -11,6 +11,7 @@ New features:
 - Added flag_zip_defs which functions like flag_matrix_defs, but performs a zip
   operation on the axes instead of a cross-product (GH-1414)
 - Added TensorFlow Benchmarks. (GH-1420)
+- Added --network_enable_BBR flag (GH-1515)
 
 Enhancements:
 - Added basic auth support for Mesos provider. (GH-1390)

--- a/perfkitbenchmarker/linux_virtual_machine.py
+++ b/perfkitbenchmarker/linux_virtual_machine.py
@@ -95,11 +95,11 @@ flags.DEFINE_list('set_files', [],
                   'the benchmark.')
 
 flags.DEFINE_bool('network_enable_BBR', False,
-                  'A short cut to enable BBR congestion control on the network.'
-                  'equivalent to appending to --sysctls the following values'
+                  'A shortcut to enable BBR congestion control on the network. '
+                  'equivalent to appending to --sysctls the following values '
                   '"net.core.default_qdisc=fq, '
                   '"net.ipv4.tcp_congestion_control=bbr" '
-                  'As with other sysctrls, will cause a reboot to happen')
+                  'As with other sysctrls, will cause a reboot to happen.')
 
 
 class BaseLinuxMixin(virtual_machine.BaseOsMixin):
@@ -265,7 +265,6 @@ class BaseLinuxMixin(virtual_machine.BaseOsMixin):
       key: a string - the key to write as part of the pair
       value: a string - the value to write as part of the pair
     """
-
     self.RemoteCommand('sudo bash -c \'echo "%s=%s" >> /etc/sysctl.conf\''
                        % (key, value))
 
@@ -277,14 +276,12 @@ class BaseLinuxMixin(virtual_machine.BaseOsMixin):
        The Sysctl pairs are written persistently so that if a reboot
        occurs, the flags are not lost.
     """
-
     for pair in FLAGS.sysctl:
       key, value = pair.split('=')
       self.ApplySysctlPersistent(key, value)
 
   def DoConfigureNetworkForBBR(self):
     """Apply --network_enable_BBR to the VM."""
-
     if not FLAGS.network_enable_BBR:
       return
 
@@ -302,19 +299,18 @@ class BaseLinuxMixin(virtual_machine.BaseOsMixin):
 
   def _RebootIfNecessary(self):
     """Will reboot the VM if self._needs_reboot has been set."""
-
     if self._needs_reboot:
       self.Reboot()
       self._needs_reboot = False
 
   def TcpCongestionControl(self):
-    """Returns the congestion control used for tcp."""
+    """Return the congestion control used for tcp."""
     resp, _ = self.RemoteCommand(
         'cat /proc/sys/net/ipv4/tcp_congestion_control')
     return resp.rstrip('\n')
 
   def CheckKernelVersion(self):
-    """Returns a KernelVersion from the host VM."""
+    """Return a KernelVersion from the host VM."""
     uname, _ = self.RemoteCommand('uname -r')
     return KernelVersion(uname)
 
@@ -332,7 +328,7 @@ class BaseLinuxMixin(virtual_machine.BaseOsMixin):
 
   @vm_util.Retry(log_errors=False, poll_interval=1)
   def VMLastBootTime(self):
-    """Returns the UTC time the VM was last rebooted as reported by the VM."""
+    """Return the UTC time the VM was last rebooted as reported by the VM."""
     resp, _ = self.RemoteHostCommand('uptime -s', retries=1,
                                      suppress_warning=True)
     return resp
@@ -1155,7 +1151,6 @@ class KernelVersion(object):
     Args:
       uname: A string in the format of "uname -r" command
     """
-
     # example format would be: "4.5.0-96-generic"
     # major.minor.Rest
     # in this example, major = 4, minor = 5

--- a/perfkitbenchmarker/linux_virtual_machine.py
+++ b/perfkitbenchmarker/linux_virtual_machine.py
@@ -75,11 +75,15 @@ flags.DEFINE_bool('setup_remote_firewall', False,
 
 flags.DEFINE_list('sysctl', [],
                   'Sysctl values to set. This flag should be a comma-separated '
-                  'list of path=value pairs. Each value will be written to the '
-                  'corresponding path. For example, if you pass '
+                  'list of path=value pairs. Each pair will be appended to'
+                  '/etc/sysctl.conf.  The presence of any items in this list '
+                  'will cause a reboot to occur after VM prepare. '
+                  'For example, if you pass '
                   '--sysctls=vm.dirty_background_ratio=10,vm.dirty_ratio=25, '
-                  'PKB will run "sysctl vm.dirty_background_ratio=10 '
-                  'vm.dirty_ratio=25" before starting the benchmark.')
+                  'PKB will append "vm.dirty_background_ratio=10" and'
+                  '"vm.dirty_ratio=25" on separate lines to /etc/sysctrl.conf'
+                  ' and then the machine will be rebooted before starting'
+                  'the benchmark.')
 
 flags.DEFINE_list('set_files', [],
                   'Arbitrary filesystem configuration. This flag should be a '
@@ -89,6 +93,13 @@ flags.DEFINE_list('set_files', [],
                   'then PKB will write "always" to '
                   '/sys/kernel/mm/transparent_hugepage/enabled before starting '
                   'the benchmark.')
+
+flags.DEFINE_bool('network_enable_BBR', False,
+                  'A short cut to enable BBR congestion control on the network.'
+                  'equivalent to appending to --sysctls the following values'
+                  '"net.core.default_qdisc=fq, '
+                  '"net.ipv4.tcp_congestion_control=bbr" '
+                  'As with other sysctrls, will cause a reboot to happen')
 
 
 class BaseLinuxMixin(virtual_machine.BaseOsMixin):
@@ -107,9 +118,10 @@ class BaseLinuxMixin(virtual_machine.BaseOsMixin):
 
     self._remote_command_script_upload_lock = threading.Lock()
     self._has_remote_command_script = False
+    self._needs_reboot = False
 
   def _CreateVmTmpDir(self):
-        self.RemoteCommand('mkdir -p %s' % vm_util.VM_TMP_DIR)
+    self.RemoteCommand('mkdir -p %s' % vm_util.VM_TMP_DIR)
 
   def _PushRobustCommandScripts(self):
     """Pushes the scripts required by RobustRemoteCommand to this VM.
@@ -231,6 +243,8 @@ class BaseLinuxMixin(virtual_machine.BaseOsMixin):
       self.InstallPackages('python')
     self.SetFiles()
     self.DoSysctls()
+    self.DoConfigureNetworkForBBR()
+    self._RebootIfNecessary()
     self.BurnCpu()
 
   def SetFiles(self):
@@ -241,11 +255,68 @@ class BaseLinuxMixin(virtual_machine.BaseOsMixin):
       self.RemoteCommand('echo "%s" | sudo tee %s' %
                          (value, path))
 
-  def DoSysctls(self):
-    """Apply --sysctl to the VM."""
+  def ApplySysctlPersistent(self, key, value):
+    """Apply "key=value" pair to /etc/sysctl.conf and reboot.
 
-    if FLAGS.sysctl:
-      self.RemoteCommand('sudo sysctl -w %s' % (' '.join(FLAGS.sysctl),))
+    The reboot ensures the values take effect and remain persistent across
+    future reboots.
+
+    Args:
+      key: a string - the key to write as part of the pair
+      value: a string - the value to write as part of the pair
+    """
+
+    self.RemoteCommand('sudo bash -c \'echo "%s=%s" >> /etc/sysctl.conf\''
+                       % (key, value))
+
+    self._needs_reboot = True
+
+  def DoSysctls(self):
+    """Apply --sysctl to the VM.
+
+       The Sysctl pairs are written persistently so that if a reboot
+       occurs, the flags are not lost.
+    """
+
+    for pair in FLAGS.sysctl:
+      key, value = pair.split('=')
+      self.ApplySysctlPersistent(key, value)
+
+  def DoConfigureNetworkForBBR(self):
+    """Apply --network_enable_BBR to the VM."""
+
+    if not FLAGS.network_enable_BBR:
+      return
+
+    if not self.CheckKernelVersion().AtLeast(4, 9):
+      raise flags.ValidationError(
+          'BBR requires a linux image with kernel 4.9 or newer')
+
+    # if the current congestion control mechanism is already BBR
+    # then nothing needs to be done (avoid unnecessary reboot)
+    if self.TcpCongestionControl() == 'bbr':
+      return
+
+    self.ApplySysctlPersistent('net.core.default_qdisc', 'fq')
+    self.ApplySysctlPersistent('net.ipv4.tcp_congestion_control', 'bbr')
+
+  def _RebootIfNecessary(self):
+    """Will reboot the VM if self._needs_reboot has been set."""
+
+    if self._needs_reboot:
+      self.Reboot()
+      self._needs_reboot = False
+
+  def TcpCongestionControl(self):
+    """Returns the congestion control used for tcp."""
+    resp, _ = self.RemoteCommand(
+        'cat /proc/sys/net/ipv4/tcp_congestion_control')
+    return resp.rstrip('\n')
+
+  def CheckKernelVersion(self):
+    """Returns a KernelVersion from the host VM."""
+    uname, _ = self.RemoteCommand('uname -r')
+    return KernelVersion(uname)
 
   @vm_util.Retry(log_errors=False, poll_interval=1)
   def WaitForBootCompletion(self):
@@ -256,6 +327,15 @@ class BaseLinuxMixin(virtual_machine.BaseOsMixin):
       self.bootable_time = time.time()
     if self.hostname is None:
       self.hostname = resp[:-1]
+
+    self.tcp_congestion_control = self.TcpCongestionControl()
+
+  @vm_util.Retry(log_errors=False, poll_interval=1)
+  def VMLastBootTime(self):
+    """Returns the UTC time the VM was last rebooted as reported by the VM."""
+    resp, _ = self.RemoteHostCommand('uptime -s', retries=1,
+                                     suppress_warning=True)
+    return resp
 
   def SnapshotPackages(self):
     """Grabs a snapshot of the currently installed packages."""
@@ -1064,6 +1144,44 @@ class ContainerizedDebianMixin(DebianMixin):
 
     # Copies the file to its final destination in the container
     target.ContainerCopy(file_name, remote_path)
+
+
+class KernelVersion(object):
+  """Holds the contents of the linux kernel version returned from uname -r."""
+
+  def __init__(self, uname):
+    """KernelVersion Constructor.
+
+    Args:
+      uname: A string in the format of "uname -r" command
+    """
+
+    # example format would be: "4.5.0-96-generic"
+    # major.minor.Rest
+    # in this example, major = 4, minor = 5
+    major_string, minor_string, _ = uname.split('.')
+    self.major = int(major_string)
+    self.minor = int(minor_string)
+
+  def AtLeast(self, major, minor):
+    """Check If the kernel version meets a minimum bar.
+
+    The kernel version needs to be at least as high as the major.minor
+    specified in args.
+
+    Args:
+      major: The major number to test, as an integer
+      minor: The minor number to test, as an integer
+
+    Returns:
+      True if the kernel version is at least as high as major.minor,
+      False otherwise
+    """
+    if self.major < major:
+      return False
+    if self.major > major:
+      return True
+    return self.minor >= minor
 
 
 class JujuMixin(DebianMixin):

--- a/perfkitbenchmarker/windows_virtual_machine.py
+++ b/perfkitbenchmarker/windows_virtual_machine.py
@@ -169,6 +169,12 @@ class WindowsMixin(virtual_machine.BaseOsMixin):
     """OS-specific implementation of reboot command"""
     self.RemoteCommand('shutdown -t 0 -r -f', ignore_failure=True)
 
+  def VMLastBootTime(self):
+    """Returns the UTC time the VM was last rebooted as reported by the VM."""
+    resp, _ = self.RemoteHostCommand('systeminfo | find /i "Boot Time"',
+                                     suppress_warning=True)
+    return resp
+
   def _AfterReboot(self):
     """Performs any OS-specific setup on the VM following reboot.
 

--- a/tests/linux_virtual_machine_test.py
+++ b/tests/linux_virtual_machine_test.py
@@ -84,8 +84,10 @@ class TestSysctl(unittest.TestCase):
 
     self.assertEqual(
         remote_command.call_args_list,
-        [mock.call('sudo sysctl -w vm.dirty_background_ratio=10 '
-                   'vm.dirty_ratio=25')])
+        [mock.call('sudo bash -c \'echo "vm.dirty_background_ratio=10" >> '
+                   '/etc/sysctl.conf\''),
+         mock.call('sudo bash -c \'echo "vm.dirty_ratio=25" >> '
+                   '/etc/sysctl.conf\'')])
 
   def testNoSysctl(self):
     self.mocked_flags = mock_flags.PatchTestCaseFlags(self)


### PR DESCRIPTION
When network_enable_BBR is added on the command line, PKB will check to
make sure the linux kernel is at least verion 4.9. During machine
prepare, before benchmaks are run, This flag will set

'net.core.default_qdisc = fq'
'net.ipv4.tcp_congestion_control=bbr'

by making changes to /etc/syctrl.conf and then performing a reboot.
Metadata now includes 'tcp_congestion_control' so we can track which
runs have BBR enabled.