### PR TITLE
Add with_return_value parameter to RemoteCommand()

### DIFF
--- a/perfkitbenchmarker/linux_virtual_machine.py
+++ b/perfkitbenchmarker/linux_virtual_machine.py
@@ -429,17 +429,17 @@ class BaseLinuxMixin(virtual_machine.BaseOsMixin):
                     should_log=False, retries=SSH_RETRIES,
                     ignore_failure=False, login_shell=False,
                     suppress_warning=False, timeout=None,
-                    with_return_value=False):
+                    include_return_code=False):
     return self.RemoteHostCommand(command, should_log, retries,
                                   ignore_failure, login_shell,
                                   suppress_warning, timeout,
-                                  with_return_value)
+                                  include_return_code)
 
   def RemoteHostCommand(self, command,
                         should_log=False, retries=SSH_RETRIES,
                         ignore_failure=False, login_shell=False,
                         suppress_warning=False, timeout=None,
-                        with_return_value=False):
+                        include_return_code=False):
     """Runs a command on the VM.
 
     This is guaranteed to run on the host VM, whereas RemoteCommand might run
@@ -456,14 +456,14 @@ class BaseLinuxMixin(virtual_machine.BaseOsMixin):
       login_shell: Run command in a login shell.
       suppress_warning: Suppress the result logging from IssueCommand when the
           return code is non-zero.
-      with_return_value: Append the return code to the stdout, stderr tuple
+      include_return_code: Append the return code to the stdout, stderr tuple
         that is returned from the function
 
     Returns:
-      If with_return_value is False:
+      If include_return_code is False:
         A tuple of stdout and stderr from running the command
-      If with_return_value is True:
-        A tuple of stdout, stderr, return_value from running the command
+      If include_return_code is True:
+        A tuple of stdout, stderr, return_code from running the command
 
     Raises:
       RemoteCommandError: If there was a problem establishing the connection.
@@ -502,7 +502,7 @@ class BaseLinuxMixin(virtual_machine.BaseOsMixin):
       if not ignore_failure:
         raise errors.VirtualMachine.RemoteCommandError(error_text)
 
-    return (stdout, stderr, retcode) if with_return_value else (stdout, stderr)
+    return (stdout, stderr, retcode) if include_return_code else (stdout, stderr)
 
   def _Reboot(self):
     """OS-specific implementation of reboot command"""

--- a/perfkitbenchmarker/linux_virtual_machine.py
+++ b/perfkitbenchmarker/linux_virtual_machine.py
@@ -428,15 +428,18 @@ class BaseLinuxMixin(virtual_machine.BaseOsMixin):
   def RemoteCommand(self, command,
                     should_log=False, retries=SSH_RETRIES,
                     ignore_failure=False, login_shell=False,
-                    suppress_warning=False, timeout=None):
+                    suppress_warning=False, timeout=None,
+                    with_return_value=False):
     return self.RemoteHostCommand(command, should_log, retries,
                                   ignore_failure, login_shell,
-                                  suppress_warning, timeout)
+                                  suppress_warning, timeout,
+                                  with_return_value)
 
   def RemoteHostCommand(self, command,
                         should_log=False, retries=SSH_RETRIES,
                         ignore_failure=False, login_shell=False,
-                        suppress_warning=False, timeout=None):
+                        suppress_warning=False, timeout=None,
+                        with_return_value=False):
     """Runs a command on the VM.
 
     This is guaranteed to run on the host VM, whereas RemoteCommand might run
@@ -453,9 +456,14 @@ class BaseLinuxMixin(virtual_machine.BaseOsMixin):
       login_shell: Run command in a login shell.
       suppress_warning: Suppress the result logging from IssueCommand when the
           return code is non-zero.
+      with_return_value: Append the return code to the stdout, stderr tuple
+        that is returned from the function
 
     Returns:
-      A tuple of stdout and stderr from running the command.
+      If with_return_value is False:
+        A tuple of stdout and stderr from running the command
+      If with_return_value is True:
+        A tuple of stdout, stderr, return_value from running the command
 
     Raises:
       RemoteCommandError: If there was a problem establishing the connection.
@@ -494,7 +502,7 @@ class BaseLinuxMixin(virtual_machine.BaseOsMixin):
       if not ignore_failure:
         raise errors.VirtualMachine.RemoteCommandError(error_text)
 
-    return stdout, stderr
+    return (stdout, stderr, retcode) if with_return_value else (stdout, stderr)
 
   def _Reboot(self):
     """OS-specific implementation of reboot command"""

--- a/perfkitbenchmarker/linux_virtual_machine.py
+++ b/perfkitbenchmarker/linux_virtual_machine.py
@@ -502,7 +502,8 @@ class BaseLinuxMixin(virtual_machine.BaseOsMixin):
       if not ignore_failure:
         raise errors.VirtualMachine.RemoteCommandError(error_text)
 
-    return (stdout, stderr, retcode) if include_return_code else (stdout, stderr)
+    return ((stdout, stderr, retcode) if include_return_code
+            else (stdout, stderr))
 
   def _Reboot(self):
     """OS-specific implementation of reboot command"""

--- a/perfkitbenchmarker/linux_virtual_machine.py
+++ b/perfkitbenchmarker/linux_virtual_machine.py
@@ -425,21 +425,29 @@ class BaseLinuxMixin(virtual_machine.BaseOsMixin):
                     (retcode, full_cmd, stdout, stderr))
       raise errors.VirtualMachine.RemoteCommandError(error_text)
 
+  def RemoteCommandWithReturnCode(self, command, should_log=False,
+                                  retries=SSH_RETRIES, ignore_failure=False,
+                                  login_shell=False, suppress_warning=False,
+                                  timeout=None):
+    return self.RemoteHostCommandWithReturnCode(
+        command, should_log, retries,
+        ignore_failure, login_shell,
+        suppress_warning, timeout)
+
   def RemoteCommand(self, command,
                     should_log=False, retries=SSH_RETRIES,
                     ignore_failure=False, login_shell=False,
-                    suppress_warning=False, timeout=None,
-                    include_return_code=False):
-    return self.RemoteHostCommand(command, should_log, retries,
-                                  ignore_failure, login_shell,
-                                  suppress_warning, timeout,
-                                  include_return_code)
+                    suppress_warning=False, timeout=None):
+    return self.RemoteCommandWithReturnCode(
+        command, should_log, retries,
+        ignore_failure, login_shell,
+        suppress_warning, timeout)[:2]
 
-  def RemoteHostCommand(self, command,
-                        should_log=False, retries=SSH_RETRIES,
-                        ignore_failure=False, login_shell=False,
-                        suppress_warning=False, timeout=None,
-                        include_return_code=False):
+  def RemoteHostCommandWithReturnCode(self, command, should_log=False,
+                                      retries=SSH_RETRIES,
+                                      ignore_failure=False,
+                                      login_shell=False,
+                                      suppress_warning=False, timeout=None):
     """Runs a command on the VM.
 
     This is guaranteed to run on the host VM, whereas RemoteCommand might run
@@ -456,13 +464,8 @@ class BaseLinuxMixin(virtual_machine.BaseOsMixin):
       login_shell: Run command in a login shell.
       suppress_warning: Suppress the result logging from IssueCommand when the
           return code is non-zero.
-      include_return_code: Append the return code to the stdout, stderr tuple
-        that is returned from the function
 
     Returns:
-      If include_return_code is False:
-        A tuple of stdout and stderr from running the command
-      If include_return_code is True:
         A tuple of stdout, stderr, return_code from running the command
 
     Raises:
@@ -502,8 +505,37 @@ class BaseLinuxMixin(virtual_machine.BaseOsMixin):
       if not ignore_failure:
         raise errors.VirtualMachine.RemoteCommandError(error_text)
 
-    return ((stdout, stderr, retcode) if include_return_code
-            else (stdout, stderr))
+    return (stdout, stderr, retcode)
+
+  def RemoteHostCommand(self, command, should_log=False, retries=SSH_RETRIES,
+                        ignore_failure=False, login_shell=False,
+                        suppress_warning=False, timeout=None):
+    """Runs a command on the VM.
+
+    This is guaranteed to run on the host VM, whereas RemoteCommand might run
+    within i.e. a container in the host VM.
+
+    Args:
+      command: A valid bash command.
+      should_log: A boolean indicating whether the command result should be
+          logged at the info level. Even if it is false, the results will
+          still be logged at the debug level.
+      retries: The maximum number of times RemoteCommand should retry SSHing
+          when it receives a 255 return code.
+      ignore_failure: Ignore any failure if set to true.
+      login_shell: Run command in a login shell.
+      suppress_warning: Suppress the result logging from IssueCommand when the
+          return code is non-zero.
+
+    Returns:
+      A tuple of stdout, stderr from running the command
+
+    Raises:
+      RemoteCommandError: If there was a problem establishing the connection.
+    """
+    return self.RemoteHostCommandWithReturnCode(
+        command, should_log, retries, ignore_failure, login_shell,
+        suppress_warning, timeout)[:2]
 
   def _Reboot(self):
     """OS-specific implementation of reboot command"""

--- a/perfkitbenchmarker/linux_virtual_machine.py
+++ b/perfkitbenchmarker/linux_virtual_machine.py
@@ -466,7 +466,7 @@ class BaseLinuxMixin(virtual_machine.BaseOsMixin):
           return code is non-zero.
 
     Returns:
-        A tuple of stdout, stderr, return_code from running the command
+      A tuple of stdout, stderr, return_code from running the command.
 
     Raises:
       RemoteCommandError: If there was a problem establishing the connection.
@@ -528,7 +528,7 @@ class BaseLinuxMixin(virtual_machine.BaseOsMixin):
           return code is non-zero.
 
     Returns:
-      A tuple of stdout, stderr from running the command
+      A tuple of stdout, stderr from running the command.
 
     Raises:
       RemoteCommandError: If there was a problem establishing the connection.


### PR DESCRIPTION
If with_return_value is True, RemoteCommand will return a tuple of (stdout, stderr, return_value) instead of just (stdout, stderr)