### PR TITLE
Fix temp dir used by object_storage_service_benchmark

### DIFF
--- a/perfkitbenchmarker/temp_dir.py
+++ b/perfkitbenchmarker/temp_dir.py
@@ -18,6 +18,7 @@ PerfKit Benchmarker creates files under a temporary directory (typically in
 more information).
 """
 
+import functools32
 import os
 import tempfile
 
@@ -40,10 +41,13 @@ def GetAllRunsDirPath():
   return os.path.join(FLAGS.temp_dir, _RUNS)
 
 
-def GetRunDirPath(run_uri=None):
+# Caching this will have the effect that even if the
+# run_uri changes, the temp dir will stay the same.
+@functools32.lru_cache()
+def GetRunDirPath():
   """Gets path to the directory containing files specific to a PKB run."""
   return os.path.join(
-      FLAGS.temp_dir, _RUNS, run_uri or str(flags.FLAGS.run_uri))
+      FLAGS.temp_dir, _RUNS, str(flags.FLAGS.run_uri))
 
 
 def GetVersionDirPath(version=version.VERSION):

--- a/perfkitbenchmarker/vm_util.py
+++ b/perfkitbenchmarker/vm_util.py
@@ -15,7 +15,6 @@
 """Set of utility functions for working with virtual machines."""
 
 import contextlib
-import functools32
 import logging
 import os
 import random
@@ -107,9 +106,6 @@ flags.DEFINE_enum('background_network_ip_type', IpAddressSubset.EXTERNAL,
                   'traffic')
 
 
-# Caching this will have the effect that even if the
-# run_uri changes, the temp dir will stay the same.
-@functools32.lru_cache()
 def GetTempDir():
   """Returns the tmp dir of the current run."""
   return temp_dir.GetRunDirPath()


### PR DESCRIPTION
The temporary directory was found with temp_dir.GetRunDirPath rather
than vm_util.GetTempDir. The latter function uses an LRU cache in case
the run_uri changes. Without this fix, the temporary directory used to
store the list of objects written would be incorrect when using the
--object_storage_read_objects flag.

This appears to be the only usage of temp_dir.GetRunDirPath that does
not call it via vm_util.GetTempDir.