### PR TITLE
Fix kernel check of Centos, GKE provisioning, and TCP congestion checks.

### DIFF
--- a/perfkitbenchmarker/linux_virtual_machine.py
+++ b/perfkitbenchmarker/linux_virtual_machine.py
@@ -348,7 +348,7 @@ class BaseLinuxMixin(virtual_machine.BaseOsMixin):
       resp, _ = self.RemoteCommand(
           'cat /proc/sys/net/ipv4/tcp_congestion_control')
       return resp.rstrip('\n')
-    except errors.VirtualMachine.RemoteCommandError as e:
+    except errors.VirtualMachine.RemoteCommandError:
       return 'unknown'
 
   def CheckKernelVersion(self):

--- a/perfkitbenchmarker/linux_virtual_machine.py
+++ b/perfkitbenchmarker/linux_virtual_machine.py
@@ -342,9 +342,14 @@ class BaseLinuxMixin(virtual_machine.BaseOsMixin):
 
   def TcpCongestionControl(self):
     """Return the congestion control used for tcp."""
-    resp, _ = self.RemoteCommand(
-        'cat /proc/sys/net/ipv4/tcp_congestion_control')
-    return resp.rstrip('\n')
+    # TODO(b/68257366): This was failing on default docker image used by
+    # kubernetes_virtual_machine, hence the addition of the try block.
+    try:
+      resp, _ = self.RemoteCommand(
+          'cat /proc/sys/net/ipv4/tcp_congestion_control')
+      return resp.rstrip('\n')
+    except errors.VirtualMachine.RemoteCommandError as e:
+      return 'unknown'
 
   def CheckKernelVersion(self):
     """Return a KernelVersion from the host VM."""
@@ -1240,9 +1245,10 @@ class KernelVersion(object):
     """
 
     # example format would be: "4.5.0-96-generic"
+    # or "3.10.0-514.26.2.el7.x86_64" for centos
     # major.minor.Rest
     # in this example, major = 4, minor = 5
-    major_string, minor_string, _ = uname.split('.')
+    major_string, minor_string, _ = uname.split('.', 2)
     self.major = int(major_string)
     self.minor = int(minor_string)
 

--- a/perfkitbenchmarker/providers/gcp/google_container_engine.py
+++ b/perfkitbenchmarker/providers/gcp/google_container_engine.py
@@ -70,6 +70,3 @@ class GkeCluster(container_service.KubernetesCluster):
         self, 'container', 'clusters', 'describe', self.name)
     _, _, retcode = cmd.Issue(suppress_warning=True)
     return retcode == 0
-
-
-

--- a/perfkitbenchmarker/providers/gcp/google_container_engine.py
+++ b/perfkitbenchmarker/providers/gcp/google_container_engine.py
@@ -30,6 +30,12 @@ class GkeCluster(container_service.KubernetesCluster):
 
   CLOUD = providers.GCP
 
+  @staticmethod
+  def _GetRequiredGkeEnv():
+    env = os.environ.copy()
+    env['CLOUDSDK_CONTAINER_USE_APPLICATION_DEFAULT_CREDENTIALS'] = 'true'
+    return env
+
   def __init__(self, spec):
     super(GkeCluster, self).__init__(spec)
     self.project = spec.vm_spec.project
@@ -40,7 +46,7 @@ class GkeCluster(container_service.KubernetesCluster):
     cmd.flags['num-nodes'] = self.num_nodes
     cmd.flags['machine-type'] = self.machine_type
 
-    cmd.Issue(timeout=600)
+    cmd.Issue(timeout=600, env=self._GetRequiredGkeEnv())
 
   def _PostCreate(self):
     """Acquire cluster authentication."""
@@ -48,7 +54,7 @@ class GkeCluster(container_service.KubernetesCluster):
         self, 'container', 'clusters', 'get-credentials', self.name)
     if not FLAGS.kubeconfig:
       FLAGS.kubeconfig = vm_util.PrependTempDir('kubeconfig')
-    env = os.environ.copy()
+    env = self._GetRequiredGkeEnv()
     env['KUBECONFIG'] = FLAGS.kubeconfig
     cmd.IssueRetryable(env=env)
 
@@ -64,3 +70,6 @@ class GkeCluster(container_service.KubernetesCluster):
         self, 'container', 'clusters', 'describe', self.name)
     _, _, retcode = cmd.Issue(suppress_warning=True)
     return retcode == 0
+
+
+

--- a/perfkitbenchmarker/providers/kubernetes/kubernetes_virtual_machine.py
+++ b/perfkitbenchmarker/providers/kubernetes/kubernetes_virtual_machine.py
@@ -270,10 +270,10 @@ class DebianBasedKubernetesVirtualMachine(KubernetesVirtualMachine,
                                           linux_virtual_machine.DebianMixin):
   DEFAULT_IMAGE = UBUNTU_IMAGE
 
-  def RemoteHostCommand(self, command,
-                        should_log=False, retries=None,
-                        ignore_failure=False, login_shell=False,
-                        suppress_warning=False, timeout=None):
+  def RemoteHostCommandWithReturnCode(self, command,
+                                      should_log=False, retries=None,
+                                      ignore_failure=False, login_shell=False,
+                                      suppress_warning=False, timeout=None):
     """Runs a command in the Kubernetes container."""
     cmd = [FLAGS.kubectl, '--kubeconfig=%s' % FLAGS.kubeconfig, 'exec', '-i',
            self.name, '--', '/bin/bash', '-c', command]
@@ -285,7 +285,7 @@ class DebianBasedKubernetesVirtualMachine(KubernetesVirtualMachine,
                     'Full command: %s\nSTDOUT: %sSTDERR: %s' %
                     (retcode, command, ' '.join(cmd), stdout, stderr))
       raise errors.VirtualMachine.RemoteCommandError(error_text)
-    return stdout, stderr
+    return stdout, stderr, retcode
 
   def MoveHostFile(self, target, source_path, remote_path=''):
     """Copies a file from one VM to a target VM.


### PR DESCRIPTION
This is a manual rollup of several small changes:
cwilkes:
Make kernel version check compatible with Centos.
gareth-ferneyhough:
Fix GKE provisioning bugs.
gareth-ferneyhough:
Add try block around check of tcp congestion control settings, as not all
linux_vms have the files (ubuntu-upstart docker image does not seem to).