### PR TITLE
Feat/remote-json-publisher

### DIFF
--- a/CHANGES.next.md
+++ b/CHANGES.next.md
@@ -14,6 +14,7 @@
   - Add new location, `us/ewr`
 - Add aws_image_name_filter flag to ease specifying images.
 - Add c5/m5 support for NVME disks.
+- Add universal remote JSON publisher
 
 ###Bug fixes and maintenance updates:
 - Moved GPU-related specs from GceVmSpec to BaseVmSpec

--- a/README.md
+++ b/README.md
@@ -998,6 +998,10 @@ the user is required to at the very least call the `--influx_uri` flag to publis
 | `--influx_uri`     | The Influx DB address and port. Expects the format hostname:port     | localhost:8086 |
 | `--influx_db_name` | The name of Influx DB database that you wish to publish to or create | perfkit        |
 
+Using Plain JSON Publisher
+=================
+To send JSON data from benchmark results to remote server using HTTP POST, you can specify argument `--remote_json_uri` (eg. `--remote_json_uri http://localhost:9000/results`).
+
 How to Extend PerfKit Benchmarker
 =================
 First start with the [CONTRIBUTING.md](https://github.com/GoogleCloudPlatform/PerfKitBenchmarker/blob/master/CONTRIBUTING.md)

--- a/perfkitbenchmarker/publisher.py
+++ b/perfkitbenchmarker/publisher.py
@@ -127,6 +127,12 @@ flags.DEFINE_string(
     'influx_db_name', 'perfkit',
     'Name of Influx DB database that you wish to publish to or create')
 
+flags.DEFINE_string(
+    'remote_json_uri', None,
+    'URI to remote listener for JSON data. Expects format '
+    'hostname:port or format accepted by python requests library e.g. '
+    'http://localhost:9000/endpoint')
+
 DEFAULT_JSON_OUTPUT_NAME = 'perfkitbenchmarker_results.json'
 DEFAULT_CREDENTIALS_JSON = 'credentials.json'
 GCS_OBJECT_NAME_LENGTH = 20

--- a/perfkitbenchmarker/publisher.py
+++ b/perfkitbenchmarker/publisher.py
@@ -468,6 +468,7 @@ class NewlineDelimitedJSONPublisher(SamplePublisher):
           sample['labels'] = GetLabelsFromDict(sample.pop('metadata', {}))
         fp.write(json.dumps(sample) + '\n')
 
+
 class RemoteJSONPublisher(SamplePublisher):
   """Publishes pure JSON via requests POST
 

--- a/perfkitbenchmarker/publisher.py
+++ b/perfkitbenchmarker/publisher.py
@@ -480,7 +480,11 @@ class RemoteJSONPublisher(SamplePublisher):
     self.remote_json_uri = remote_json_uri
 
   def PublishSamples(self, samples):
+    if not samples:
+      logging.warn('No samples: not publishing to RemoteJSONPublisher')
+      return
     try:
+      logging.info('Publishing %d samples to %s', len(samples), str(self.remote_json_uri))
       r = requests.post(self.remote_json_uri, json=samples)
       r.raise_for_status()
     except requests.exceptions.RequestException as e:

--- a/perfkitbenchmarker/publisher.py
+++ b/perfkitbenchmarker/publisher.py
@@ -474,7 +474,11 @@ class RemoteJSONPublisher(SamplePublisher):
     self.remote_json_uri = remote_json_uri
 
   def PublishSamples(self, samples):
-    requests.post(self.remote_json_uri, json=samples)
+    try:
+      requests.post(self.remote_json_uri, json=samples)
+    except requests.exceptions.RequestException as e:
+      logging.error(e)
+
 
 class BigQueryPublisher(SamplePublisher):
   """Publishes samples to BigQuery.

--- a/perfkitbenchmarker/publisher.py
+++ b/perfkitbenchmarker/publisher.py
@@ -473,7 +473,7 @@ class RemoteJSONPublisher(SamplePublisher):
 
   Attributes:
     remote_json_uri: string. URI to which will JSON data be published. It should
-      be in format protocol://domain:port/endpoint
+      be in format hostname:port
   """
 
   def __init__(self, remote_json_uri=None):
@@ -861,7 +861,7 @@ class SampleCollector(object):
                                           influx_db_name=FLAGS.influx_db_name))
 
     if FLAGS.remote_json_uri:
-      publishers.append(RemoteJSONPublisher(remote_json_uri=FLAGS.remote_json_uri)
+      publishers.append(RemoteJSONPublisher(remote_json_uri=FLAGS.remote_json_uri))
 
     return publishers
 

--- a/perfkitbenchmarker/publisher.py
+++ b/perfkitbenchmarker/publisher.py
@@ -33,6 +33,7 @@ import sys
 import time
 import urllib
 import uuid
+import requests
 
 from perfkitbenchmarker import flags
 from perfkitbenchmarker import flag_util
@@ -461,6 +462,19 @@ class NewlineDelimitedJSONPublisher(SamplePublisher):
           sample['labels'] = GetLabelsFromDict(sample.pop('metadata', {}))
         fp.write(json.dumps(sample) + '\n')
 
+class RemoteJSONPublisher(SamplePublisher):
+  """Publishes pure JSON via requests POST
+
+  Attributes:
+    json_uri: string. URI to which will JSON data be published. It should
+      be in format protocol://domain:port/endpoint
+  """
+
+  def __init__(self, json_uri):
+    self.json_uri = json_uri
+
+  def PublishSamples(self, samples):
+    requests.post(self.json_uri, json=samples)
 
 class BigQueryPublisher(SamplePublisher):
   """Publishes samples to BigQuery.

--- a/perfkitbenchmarker/publisher.py
+++ b/perfkitbenchmarker/publisher.py
@@ -29,11 +29,11 @@ import logging
 import math
 import operator
 import pprint
+import requests
 import sys
 import time
 import urllib
 import uuid
-import requests
 
 from perfkitbenchmarker import flags
 from perfkitbenchmarker import flag_util

--- a/perfkitbenchmarker/publisher.py
+++ b/perfkitbenchmarker/publisher.py
@@ -475,7 +475,8 @@ class RemoteJSONPublisher(SamplePublisher):
 
   def PublishSamples(self, samples):
     try:
-      requests.post(self.remote_json_uri, json=samples)
+      r = requests.post(self.remote_json_uri, json=samples)
+      r.raise_for_status()
     except requests.exceptions.RequestException as e:
       logging.error(e)
 

--- a/perfkitbenchmarker/publisher.py
+++ b/perfkitbenchmarker/publisher.py
@@ -466,15 +466,15 @@ class RemoteJSONPublisher(SamplePublisher):
   """Publishes pure JSON via requests POST
 
   Attributes:
-    json_uri: string. URI to which will JSON data be published. It should
+    remote_json_uri: string. URI to which will JSON data be published. It should
       be in format protocol://domain:port/endpoint
   """
 
-  def __init__(self, json_uri):
-    self.json_uri = json_uri
+  def __init__(self, remote_json_uri=None):
+    self.remote_json_uri = remote_json_uri
 
   def PublishSamples(self, samples):
-    requests.post(self.json_uri, json=samples)
+    requests.post(self.remote_json_uri, json=samples)
 
 class BigQueryPublisher(SamplePublisher):
   """Publishes samples to BigQuery.
@@ -848,6 +848,9 @@ class SampleCollector(object):
     if FLAGS.influx_uri:
       publishers.append(InfluxDBPublisher(influx_uri=FLAGS.influx_uri,
                                           influx_db_name=FLAGS.influx_db_name))
+
+    if FLAGS.remote_json_uri:
+      publishers.append(RemoteJSONPublisher(remote_json_uri=FLAGS.remote_json_uri)
 
     return publishers
 

--- a/perfkitbenchmarker/publisher.py
+++ b/perfkitbenchmarker/publisher.py
@@ -18,7 +18,7 @@
 
 import abc
 import collections
-import copy
+from copy import copy, deepcopy
 import csv
 import fcntl
 import httplib
@@ -483,9 +483,15 @@ class RemoteJSONPublisher(SamplePublisher):
     if not samples:
       logging.warn('No samples: not publishing to RemoteJSONPublisher')
       return
+
+    # Copy `metadata` object to string `labels` with format |key:value|,...
+    samples_copy = deepcopy(samples)
+    for sample in samples_copy:
+      sample['labels'] = GetLabelsFromDict(sample['metadata'])
+
     try:
-      logging.info('Publishing %d samples to %s', len(samples), str(self.remote_json_uri))
-      r = requests.post(self.remote_json_uri, json=samples)
+      logging.info('Publishing %d samples to %s', len(samples_copy), str(self.remote_json_uri))
+      r = requests.post(self.remote_json_uri, json=samples_copy)
       r.raise_for_status()
     except requests.exceptions.RequestException as e:
       logging.error(e)

--- a/perfkitbenchmarker/publisher.py
+++ b/perfkitbenchmarker/publisher.py
@@ -18,7 +18,7 @@
 
 import abc
 import collections
-from copy import copy, deepcopy
+import copy
 import csv
 import fcntl
 import httplib
@@ -486,7 +486,7 @@ class RemoteJSONPublisher(SamplePublisher):
       return
 
     # Copy `metadata` object to string `labels` with format |key:value|,...
-    samples_copy = deepcopy(samples)
+    samples_copy = copy.deepcopy(samples)
     for sample in samples_copy:
       sample['labels'] = GetLabelsFromDict(sample['metadata'])
 

--- a/tests/publisher_test.py
+++ b/tests/publisher_test.py
@@ -106,14 +106,17 @@ class NewlineDelimitedJSONPublisherTestCase(unittest.TestCase):
 
 class RemoteJSONPublisherTestCase(unittest.TestCase):
 
-  def setUp(self):
+  @mock.patch.object(publisher.RemoteJSONPublisher, 'PublishSamples')
+  def testPublishSamples(self, mock_publish_samples):
+    samples = [{'test': 'testa', 'metric': '1', 'value': 1.0, 'unit': 'MB',
+                'metadata': {}, 'labels': '|machine_type:StandardA1|,|cloud:Azb|'},
+               {'test': 'testb', 'metric': '2', 'value': 14.0, 'unit': 'MB',
+                'metadata': {}, 'labels': '|machine_type:StandardA2|,|cloud:Azb|'}]
 
-  def testNoSamples(self):
-    self.instance = publisher.RemoteJSONPublisher("")
-
-  def testPublish(self):
-
-  def cleanup(self):
+    self.instance = publisher.RemoteJSONPublisher('testuri')
+    self.instance.PublishSamples(samples)
+    mock_publish_samples.return_value = None
+    mock_publish_samples.assert_called_once_with(samples)
 
 
 class BigQueryPublisherTestCase(unittest.TestCase):

--- a/tests/publisher_test.py
+++ b/tests/publisher_test.py
@@ -104,6 +104,18 @@ class NewlineDelimitedJSONPublisherTestCase(unittest.TestCase):
                          result)
 
 
+class RemoteJSONPublisherTestCase(unittest.TestCase):
+
+  def setUp(self):
+
+  def testNoSamples(self):
+    self.instance = publisher.RemoteJSONPublisher("")
+
+  def testPublish(self):
+
+  def cleanup(self):
+
+
 class BigQueryPublisherTestCase(unittest.TestCase):
 
   def setUp(self):


### PR DESCRIPTION
This PR implements universal remote JSON publisher which connects to URI given by argument `--remote_json_uri` and sends pure JSON data using HTTP POST request using python library `requests`. 

More info in #1550.

Closes #1550 