### PR TITLE
added support for custom format for dynamicPipelineOptions

### DIFF
--- a/perfkitbenchmarker/beam_pipeline_options.py
+++ b/perfkitbenchmarker/beam_pipeline_options.py
@@ -46,13 +46,16 @@ def EvaluateDynamicPipelineOptions(dynamic_options):
   """
   Takes the user's dynamic args and retrieves the information to fill them in.
 
-  dynamic_args is a python map of argument name -> {type, kubernetesSelector}
+  dynamic_args is a python map of argument name -> {type, kubernetesSelector, *format}
   returns a list of tuples containing (argName, argValue)
+
+  if optional format it passed, argValue is equal to format with "{{type}}" being replaced with actual value.
   """
   filledOptions = []
   for optionDescriptor in dynamic_options:
     fillType = optionDescriptor['type']
     optionName = optionDescriptor['name']
+    valueFormat = optionDescriptor.get('format')
 
     if not fillType:
       raise errors.Config.InvalidValue(
@@ -68,6 +71,8 @@ def EvaluateDynamicPipelineOptions(dynamic_options):
       raise errors.Config.InvalidValue(
           'Unknown dynamic argument type: %s' % (fillType))
 
+    if valueFormat:
+      argValue = valueFormat.replace("{{" + fillType + "}}", argValue)
     filledOptions.append((optionName, argValue))
 
   return filledOptions

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ blinker>=1.3
 futures>=3.0.3
 PyYAML==3.12
 pint>=0.7
-numpy
+numpy==1.13.3
 functools32
 contextlib2>=0.5.1
 pywinrm

--- a/tests/linux_benchmarks/beam_integration_benchmark_test.py
+++ b/tests/linux_benchmarks/beam_integration_benchmark_test.py
@@ -59,6 +59,29 @@ class BeamArgsOptionsTestCase(unittest.TestCase):
                          ["\"--project=testProj\"",
                           "\"--gcpTempLocation=gs://test-bucket/staging\""])
 
+  def testDynamicPipelineOpionsWithFormat(self):
+      dynamic_options = [
+          {
+              "name": "test_value_A",
+              "type": "TestValue",
+              "value": "a_value",
+              "format": "other representation of {{TestValue}}",
+          },
+          {
+              "name": "test_value_B",
+              "type": "TestValue",
+              "value": "b_value"
+          }
+      ]
+
+      self.assertListEqual(
+          beam_pipeline_options.EvaluateDynamicPipelineOptions(dynamic_options),
+          [
+              ("test_value_A", "other representation of a_value"),
+              ("test_value_B", "b_value"),
+          ]
+      )
+
 
   def dynamicPipelineOptions(self):
     beam_pipeline_options.EvaluateDynamicPipelineOptions()

--- a/tests/linux_benchmarks/beam_integration_benchmark_test.py
+++ b/tests/linux_benchmarks/beam_integration_benchmark_test.py
@@ -25,7 +25,6 @@ class BeamArgsOptionsTestCase(unittest.TestCase):
         None, None, [], [])
     self.assertListEqual(options_list, [])
 
-
   def testAllFlagsPassed(self):
     options_list = beam_pipeline_options.GenerateAllPipelineOptions(
         "--itargone=anarg,--itargtwo=anotherarg",
@@ -45,7 +44,6 @@ class BeamArgsOptionsTestCase(unittest.TestCase):
                           "\"--testier=another_test\"",
                           "\"--postgresUsername=postgres\"",
                           "\"--postgresPassword=mypass\""])
-
 
   def testItOptionsWithSpaces(self):
     options_list = beam_pipeline_options.GenerateAllPipelineOptions(
@@ -81,7 +79,6 @@ class BeamArgsOptionsTestCase(unittest.TestCase):
               ("test_value_B", "b_value"),
           ]
       )
-
 
   def dynamicPipelineOptions(self):
     beam_pipeline_options.EvaluateDynamicPipelineOptions()


### PR DESCRIPTION
this PR solves #1555. It allows PerfKit to return dynamic pipeline option with custom, user-defined format.