### PR TITLE
fix the destination path

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
@@ -138,7 +138,7 @@ def Prepare(benchmark_spec):
   # Copy remote test script to client
   path = data.ResourcePath(os.path.join(REMOTE_SCRIPTS_DIR, REMOTE_SCRIPT))
   logging.info('Uploading %s to %s', path, vms[0])
-  vms[0].PushFile(path)
+  vms[0].PushFile(path, REMOTE_SCRIPT)
   vms[0].RemoteCommand('sudo chmod 777 %s' % REMOTE_SCRIPT)
 
 


### PR DESCRIPTION
fix the error below:

```
RemoteCommandError: Got non-zero return code (2) executing /usr/local/bin/kubectl --kubeconfig=/k8s-custer-config/config cp /PerfKitBenchmarker/perfkitbenchmarker/scripts/netperf_test_scripts/netperf_test.py pkb-d018838a-0:
STDOUT: STDERR: panic: runtime error: index out of range
```