### PR TITLE
Update GIT tag to 4.0.0.1 for Aerospike server

### DIFF
--- a/perfkitbenchmarker/linux_packages/aerospike_server.py
+++ b/perfkitbenchmarker/linux_packages/aerospike_server.py
@@ -26,7 +26,7 @@ from perfkitbenchmarker.linux_packages import INSTALL_DIR
 FLAGS = flags.FLAGS
 
 GIT_REPO = 'https://github.com/aerospike/aerospike-server.git'
-GIT_TAG = '3.7.5'
+GIT_TAG = '4.0.0.1'
 AEROSPIKE_DIR = '%s/aerospike-server' % INSTALL_DIR
 AEROSPIKE_CONF_PATH = '%s/as/etc/aerospike_dev.conf' % AEROSPIKE_DIR
 


### PR DESCRIPTION
Tag 3.7.5 no longer exists under https://github.com/aerospike/aerospike-server. It is now on tag 4.0.0.1 I have been able to perform the tests on Azure changing this tag without issue.