### PR TITLE
Fix yum proxy bug

### DIFF
--- a/perfkitbenchmarker/linux_virtual_machine.py
+++ b/perfkitbenchmarker/linux_virtual_machine.py
@@ -991,7 +991,7 @@ class RhelMixin(BaseLinuxMixin):
     yum_proxy_file = '/etc/yum.conf'
 
     if FLAGS.http_proxy:
-      self.RemoteCommand("echo -e 'proxy= \"%s\";' | sudo tee -a %s" % (
+      self.RemoteCommand("echo -e 'proxy= %s' | sudo tee -a %s" % (
           FLAGS.http_proxy, yum_proxy_file))
 
 


### PR DESCRIPTION
This removes unnecessary quotation marks and semicolon. Before that Perfkit fails with yum error
```
Options error: Error parsing "proxy = '\'"http://10.10.10.1:8080";\''": URL must be http, ftp, https, socks4, socks4a, socks5 or socks5h not ""
```
We don't need those quotation marks and a semicolon at the end in ```/etc/yum.conf```