### PR TITLE
Fixes yum proxy configuration bug

### DIFF
--- a/CHANGES.next.md
+++ b/CHANGES.next.md
@@ -134,3 +134,4 @@
 - Create destination directory for Azure blob storage downloads.
 - Made the pip package more robust by adding a symbolic link in /usr/bin if pip
   is installed in /usr/local/bin.
+  

--- a/CHANGES.next.md
+++ b/CHANGES.next.md
@@ -123,3 +123,4 @@
 - Support installing azure-cli on RedHat systems.
 - Fixed default behavior of using /usr/bin/time --quiet on all commands
 - Fixed ycsb failure when the same workload is ran more than once.
+- Fixed yum proxy config bug (GH-#1598 from @kopecpiotr)

--- a/perfkitbenchmarker/linux_virtual_machine.py
+++ b/perfkitbenchmarker/linux_virtual_machine.py
@@ -991,7 +991,7 @@ class RhelMixin(BaseLinuxMixin):
     yum_proxy_file = '/etc/yum.conf'
 
     if FLAGS.http_proxy:
-      self.RemoteCommand("echo -e 'proxy= \"%s\";' | sudo tee -a %s" % (
+      self.RemoteCommand("echo -e 'proxy= %s' | sudo tee -a %s" % (
           FLAGS.http_proxy, yum_proxy_file))
 
 


### PR DESCRIPTION
This fixes yum proxy configuration bug. Before this perfkit command:
```
pkb.py --cloud=OpenStack --run_uri=browbeat --ignore_package_requirements=True --openstack_floating_ip_pool=public --machine_type=p.c2r2 --image=Centos-7 --http_proxy=http://IP.IP.IP.IP:8080 --openstack_image_username=centos --openstack_network=browbeat_private --https_proxy=http://IP.IP.IP.IP:8080 --benchmarks=fio --openstack_volume_size=1 --os_type=rhel --timing_measurements=runtimes
```
fails with yum error:
```
Options error: Error parsing "proxy = '\'"http://10.10.10.1:8080";\''": URL must be http, ftp, https, socks4, socks4a, socks5 or socks5h not ""
```

We don't need quotation marks neither semicolon at the eol in  ```/etc/yum.conf``` 