### PR TITLE
Add pip symbolic link to /usr/local/bin/pip.

### DIFF
--- a/CHANGES.next.md
+++ b/CHANGES.next.md
@@ -124,3 +124,5 @@
 - Fixed default behavior of using /usr/bin/time --quiet on all commands
 - Fixed ycsb failure when the same workload is ran more than once.
 - Create destination directory for Azure blob storage downloads.
+- Made the pip package more robust by adding a symbolic link in /usr/bin if pip
+  is installed in /usr/local/bin.

--- a/perfkitbenchmarker/linux_packages/pip.py
+++ b/perfkitbenchmarker/linux_packages/pip.py
@@ -26,6 +26,15 @@ def Install(vm, package_name='python-pip'):
   """Install pip on the VM."""
   vm.InstallPackages(package_name)
   vm.RemoteCommand('sudo pip install -U pip')  # Make pip upgrade pip
+
+  # Add a symbolic link to /usr/local/bin/pip if pip ends up there. This lets
+  # us run pip under sudo since /usr/local/bin is not typically available to
+  # sudo.
+  if not vm.TryRemoteCommand('sudo which pip'):
+    pip_location, _ = vm.RemoteCommand('which pip')
+    if pip_location.startswith('/usr/local/bin/pip'):
+      vm.RemoteCommand('sudo ln -s /usr/local/bin/pip /usr/bin/pip')
+
   vm.RemoteCommand('mkdir -p {0} && pip freeze > {0}/requirements.txt'.format(
       INSTALL_DIR))
 


### PR DESCRIPTION
This change fixes `sudo pip` usage if we upgrade pip via `sudo pip install -U pip`. PKB uses `sudo pip` in various places but, if there is a new pip available, we sometimes upgrade it so that the binary is in /usr/local/bin/pip. In this case, we add a symbolic link in /usr/bin so that we can still run `sudo pip`.

-------------
Created by MOE: https://github.com/google/moe
MOE_MIGRATED_REVID=189638747