### PR TITLE
Replace all underscores in the benchmark name with dashes before down…

### DIFF
--- a/CHANGES.next.md
+++ b/CHANGES.next.md
@@ -143,3 +143,6 @@
   is installed in /usr/local/bin.
 - Make ~/.ssh/config only readable by the owner.
 - Increased timeout for Azure `az vm create` commands.
+- Replace all underscores in the benchmark name with dashes when downloading
+  preprovisioned benchmark data from Azure. This is because Azure blob storage
+  container names cannot contain underscores.

--- a/perfkitbenchmarker/providers/azure/azure_virtual_machine.py
+++ b/perfkitbenchmarker/providers/azure/azure_virtual_machine.py
@@ -360,11 +360,19 @@ class AzureVirtualMachine(virtual_machine.BaseVirtualMachine):
 
     Use --azure_preprovisioned_data_bucket to specify the name of the account.
 
+    Note: Azure blob storage does not allow underscores in the container name,
+    so this method replaces any underscores in benchmark_name with dashes.
+    Make sure that the same convention is used when uploading the data
+    to Azure blob storage. For example: when uploading data for
+    'benchmark_name' to Azure, create a container named 'benchmark-name'.
+
     Args:
       install_path: The install path on this VM.
       benchmark_name: Name of the benchmark associated with this data file.
       filename: The name of the file that was downloaded.
     """
+    benchmark_name_with_underscores_removed = benchmark_name.replace(
+        '_', '-')
     self.Install('azure_cli')
     self.Install('azure_credentials')
     destpath = posixpath.join(install_path, filename)
@@ -376,7 +384,7 @@ class AzureVirtualMachine(virtual_machine.BaseVirtualMachine):
                        '--name %s '
                        '--file %s' % (
                            FLAGS.azure_preprovisioned_data_bucket,
-                           benchmark_name,
+                           benchmark_name_with_underscores_removed,
                            filename,
                            destpath))
 


### PR DESCRIPTION
…loading preprovisioned benchmark data from Azure. This is because Azure blob storage container names cannot contain underscores.

-------------
Created by MOE: https://github.com/google/moe
MOE_MIGRATED_REVID=190542429