### PR TITLE
Update Elasticsearch publisher to work with current version of Elasticsearch

### DIFF
--- a/perfkitbenchmarker/publisher.py
+++ b/perfkitbenchmarker/publisher.py
@@ -675,7 +675,7 @@ class ElasticsearchPublisher(SamplePublisher):
       else:
         es.indices.create(index=self.es_index, body=self.mapping_old)
         logging.info('Create index %s and default mappings for'
-                     ' elasticsearch version < 5.0.0', 
+                     ' elasticsearch version < 5.0.0',
                      self.es_index)
     for s in samples:
       sample = copy.deepcopy(s)

--- a/perfkitbenchmarker/publisher.py
+++ b/perfkitbenchmarker/publisher.py
@@ -592,7 +592,7 @@ class ElasticsearchPublisher(SamplePublisher):
     self.es_uri = es_uri
     self.es_index = es_index.lower()
     self.es_type = es_type
-    self.mapping = {
+    self.mapping_5_plus = {
         "mappings": {
             "result": {
                 "numeric_detection": True,
@@ -623,7 +623,7 @@ class ElasticsearchPublisher(SamplePublisher):
         }
     }
 
-    self.mapping_old = {
+    self.mapping_before_5 = {
         "mappings": {
             "result": {
                 "numeric_detection": True,
@@ -668,12 +668,12 @@ class ElasticsearchPublisher(SamplePublisher):
       # choose whether to use old or new mapings based on
       # the version of elasticsearch that is being used
       if int(es.info()['version']['number'].split('.')[0]) >= 5:
-        es.indices.create(index=self.es_index, body=self.mapping)
+        es.indices.create(index=self.es_index, body=self.mapping_5_plus)
         logging.info('Create index %s and default mappings for'
-                     ' elasticsearch version > 5.0.0',
+                     ' elasticsearch version >= 5.0.0',
                      self.es_index)
       else:
-        es.indices.create(index=self.es_index, body=self.mapping_old)
+        es.indices.create(index=self.es_index, body=self.mapping_before_5)
         logging.info('Create index %s and default mappings for'
                      ' elasticsearch version < 5.0.0',
                      self.es_index)

--- a/perfkitbenchmarker/publisher.py
+++ b/perfkitbenchmarker/publisher.py
@@ -667,7 +667,7 @@ class ElasticsearchPublisher(SamplePublisher):
     if not es.indices.exists(index=self.es_index):
       # choose whether to use old or new mapings based on
       # the version of elasticsearch that is being used
-      if int(es.info()['version']['number'][0]) >= 5:
+      if int(es.info()['version']['number'].split('.')[0]) >= 5:
         es.indices.create(index=self.es_index, body=self.mapping)
         logging.info('Create index %s and default mappings for'
                      ' elasticsearch version > 5.0.0',


### PR DESCRIPTION
Updated ElasticsearchPublisher in publisher.py to support current version of Elasticsearch. Also maintains backwards compatibility to older versions of Elasticsearch. 

The problem was that after Elasticsearch 5.0.0, they removed the 'string' type and replaced it with the types 'text' and 'keyword', as explained in this [blog post](https://www.elastic.co/blog/strings-are-dead-long-live-strings)

This means the mappings needed to be changed slightly to work in newer versions, but I kept in the old mappings as well in case anyone wants to use an older version of elasticsearch for whatever reason.