### PR TITLE
Migrate Beam benchmark to use Gradle for Java runs

### DIFF
--- a/perfkitbenchmarker/beam_benchmark_helper.py
+++ b/perfkitbenchmarker/beam_benchmark_helper.py
@@ -29,90 +29,108 @@ from perfkitbenchmarker import vm_util
 BEAM_JAVA_SDK = 'java'
 BEAM_PYTHON_SDK = 'python'
 
-# TODO: Find a better place for the maven_binary flag.
+# TODO: For backwards compatibility only. To be deleted when not used.
 flags.DEFINE_string('maven_binary', 'mvn',
                     'Set to use a different mvn binary than is on the PATH.')
+
+# TODO: For backwards compatibility only. To be deleted when not used.
+flags.DEFINE_string('beam_it_profile', None, 'Profile to activate integration test.')
+
+flags.DEFINE_string('gradle_binary', None,
+                    'Set to use a different gradle binary than gradle wrapper from the repository')
 flags.DEFINE_string('python_binary', 'python',
                     'Set to use a different python binary that is on the PATH.')
-flags.DEFINE_string('beam_location', None,
-                    'Location of already checked out Beam codebase.')
+flags.DEFINE_string('beam_location', None, 'Location of already checked out Beam codebase.')
 flags.DEFINE_string('beam_it_module', None,
                     'Module containing integration test. For Python SDK, use '
                     'comma-separated list to include multiple modules.')
-flags.DEFINE_string('beam_it_profile', None,
-                    'Profile to activate integration test.')
-flags.DEFINE_string('beam_runner_profile', None,
-                    'Overrides the normal runner profile associated with'
-                    ' the dpb_service')
-flags.DEFINE_string('beam_runner_option', None,
-                    'Overrides any pipeline options by the dpb service to'
-                    ' specify the runner.')
-flags.DEFINE_boolean('beam_prebuilt', False, 'Set this to indicate that the'
-                                             ' repo in beam_location does not'
-                                             ' need to be rebuilt before'
-                                             ' being used')
+flags.DEFINE_boolean('beam_prebuilt', False, 'Set this to indicate that the repo in beam_location '
+                                             'does not need to be rebuilt before being used')
 flags.DEFINE_integer('beam_it_timeout', 600, 'Integration Test Timeout.')
 flags.DEFINE_string('git_binary', 'git', 'Path to git binary.')
-flags.DEFINE_string('beam_version', None, 'Version of Beam to download. Use'
-                                          ' tag from Github as value. If not'
-                                          ' specified, will use HEAD.')
+flags.DEFINE_string('beam_version', None, 'Version of Beam to download. Use tag from Github '
+                                          'as value. If not specified, will use HEAD.')
 flags.DEFINE_enum('beam_sdk', None, [BEAM_JAVA_SDK, BEAM_PYTHON_SDK],
                   'Which BEAM SDK is used to build the benchmark pipeline.')
 flags.DEFINE_string('beam_python_attr', 'IT',
-                    'Test decorator that is used in Beam Python to filter a '
-                    'specific category.')
+                    'Test decorator that is used in Beam Python to filter a specific category.')
+
+flags.DEFINE_string('beam_extra_properties', None,
+                    'Allows to specify list of key-value pairs that will be '
+                    'forwarded to target mvn command as system properties')
+
+# TODO: For backwards compatibility only. To be replaced by beam_extra_properties flag.
 flags.DEFINE_string('beam_extra_mvn_properties', None,
-                    'Allows to specify list of key-value pairs that will be forwarded to '
-                    'target mvn command as system properties')
+                    'Allows to specify list of key-value pairs that will be '
+                    'forwarded to target mvn command as system properties')
+
+flags.DEFINE_string('beam_runner', 'dataflow', 'Defines runner which will be used in tests')
+flags.DEFINE_string('beam_runner_option', None,
+                    'Overrides any pipeline options to specify the runner.')
+
+flags.DEFINE_string('beam_filesystem', None, "Defines filesystem which will be used in tests. "
+                                             "If not specified it will use runner's local filesystem.")
 
 FLAGS = flags.FLAGS
 
 SUPPORTED_RUNNERS = [
-    dpb_service.DATAFLOW,
+  dpb_service.DATAFLOW,
 ]
 
 BEAM_REPO_LOCATION = 'https://github.com/apache/beam.git'
-INSTALL_COMMAND_ARGS = ["clean", "install", "-DskipTests",
-                        "-Dcheckstyle.skip=true"]
+GRADLE_INSTALL_COMMAND_ARGS = ["clean", "install", "-xcheck", "--stacktrace"]
+
+def AddRunnerArgument(command):
+  runner_name = FLAGS.beam_runner
+
+  if runner_name is None or runner_name == 'direct':
+    command.append('-DintegrationTestRunner=direct')
+
+  if runner_name == 'dataflow':
+    command.append('-DintegrationTestRunner=dataflow')
 
 
-def AddRunnerProfileMvnArgument(service_type, mvn_command,
-                                runner_profile_override):
-  runner_profile = ''
-
-  if service_type == dpb_service.DATAFLOW:
-    runner_profile = 'dataflow-runner'
-
-  if runner_profile_override is not None:
-    runner_profile = runner_profile_override
-
-  if len(runner_profile) > 0:
-    mvn_command.append('-P{}'.format(runner_profile))
-
-
-def AddRunnerOptionMvnArgument(service_type, beam_args, runner_option_override):
+def AddRunnerPipelineOption(beam_pipeline_options):
+  runner_name = FLAGS.beam_runner
+  runner_option_override = FLAGS.beam_runner_option
   runner_pipeline_option = ''
 
-  if service_type == dpb_service.DATAFLOW:
+  if runner_name == 'dataflow':
     runner_pipeline_option = ('"--runner=TestDataflowRunner"')
+
+  if runner_name == 'direct':
+    runner_pipeline_option = ('"--runner=DirectRunner"')
 
   if runner_option_override is not None:
     runner_pipeline_option = runner_option_override
 
   if len(runner_pipeline_option) > 0:
-    beam_args.append(runner_pipeline_option)
+    beam_pipeline_options.append(runner_pipeline_option)
 
 
-def AddExtraMvnProperties(mvn_command, beam_extra_mvn_properties):
-  if not beam_extra_mvn_properties:
+def AddFilesystemArgument(command):
+  filesystem_name = FLAGS.beam_filesystem
+
+  if filesystem_name == 'hdfs':
+    command.append("-Dfilesystem=hdfs")
+
+
+def AddExtraProperties(command):
+  extra_properties = FLAGS.beam_extra_properties
+
+  # TODO: For backwards compatibility only. Delete when beam_extra_mvn_properties is not used.
+  if extra_properties is None:
+    extra_properties = FLAGS.beam_extra_mvn_properties
+
+  if not extra_properties:
     return
-  if "integrationTestPipelineOptions=" in beam_extra_mvn_properties:
-    raise ValueError("integrationTestPipelineOptions must not be in beam_extra_mvn_properties")
+  if "integrationTestPipelineOptions=" in extra_properties:
+    raise ValueError("integrationTestPipelineOptions must not be in beam_extra_properties")
 
-  extra_mvn_properties = beam_extra_mvn_properties.rstrip(']').lstrip('[').split(',')
-  extra_mvn_properties = [p.rstrip('" ').lstrip('" ') for p in extra_mvn_properties]
-  for p in extra_mvn_properties:
-    mvn_command.append('-D{}'.format(p))
+  extra_properties = extra_properties.rstrip(']').lstrip('[').split(',')
+  extra_properties = [p.rstrip('" ').lstrip('" ') for p in extra_properties]
+  for p in extra_properties:
+    command.append('-D{}'.format(p))
 
 
 def InitializeBeamRepo(benchmark_spec):
@@ -130,26 +148,33 @@ def InitializeBeamRepo(benchmark_spec):
 
   vm_util.GenTempDir()
   if FLAGS.beam_location is None:
-    clone_command = [
-        FLAGS.git_binary,
-        'clone',
-        BEAM_REPO_LOCATION,
-    ]
+    git_clone_command = [FLAGS.git_binary, 'clone', BEAM_REPO_LOCATION]
     if FLAGS.beam_version:
-      clone_command.append('--branch={}'.format(FLAGS.beam_version))
-      clone_command.append('--single-branch')
-    vm_util.IssueCommand(clone_command, cwd=vm_util.GetTempDir())
+      git_clone_command.append('--branch={}'.format(FLAGS.beam_version))
+      git_clone_command.append('--single-branch')
+
+    vm_util.IssueCommand(git_clone_command, cwd=vm_util.GetTempDir())
+
   elif not os.path.exists(FLAGS.beam_location):
     raise errors.Config.InvalidValue(
-        'Directory indicated by beam_location does not exist: '
-        '{}.'.format(FLAGS.beam_location))
+      'Directory indicated by beam_location does not exist: {}.'.format(FLAGS.beam_location)
+    )
 
+  _PrebuildBeam()
+
+
+def _PrebuildBeam():
+  # Rebuild beam if it was not build earlier
   if not FLAGS.beam_prebuilt:
-    mvn_command = [FLAGS.maven_binary]
-    mvn_command.extend(INSTALL_COMMAND_ARGS)
-    AddRunnerProfileMvnArgument(benchmark_spec.dpb_service.SERVICE_TYPE,
-                                mvn_command, FLAGS.beam_runner_profile)
-    vm_util.IssueCommand(mvn_command, timeout=1500, cwd=_GetBeamDir())
+
+    build_command = [_GetGradleCommand()]
+    build_command.extend(GRADLE_INSTALL_COMMAND_ARGS)
+
+    AddRunnerArgument(build_command)
+    AddFilesystemArgument(build_command)
+    AddExtraProperties(build_command)
+
+    vm_util.IssueCommand(build_command, timeout=1500, cwd=_GetBeamDir())
 
 
 def BuildBeamCommand(benchmark_spec, classname, job_arguments):
@@ -170,7 +195,7 @@ def BuildBeamCommand(benchmark_spec, classname, job_arguments):
   base_dir = _GetBeamDir()
 
   if FLAGS.beam_sdk == BEAM_JAVA_SDK:
-    cmd = _BuildMavenCommand(benchmark_spec, classname, job_arguments)
+    cmd = _BuildGradleCommand(classname, job_arguments)
   elif FLAGS.beam_sdk == BEAM_PYTHON_SDK:
     cmd = _BuildPythonCommand(benchmark_spec, classname, job_arguments)
     base_dir = _GetBeamPythonDir()
@@ -180,8 +205,8 @@ def BuildBeamCommand(benchmark_spec, classname, job_arguments):
   return cmd, base_dir
 
 
-def _BuildMavenCommand(benchmark_spec, classname, job_arguments):
-  """ Constructs a maven command for the benchmark.
+def _BuildGradleCommand(classname, job_arguments):
+  """ Constructs a Gradle command for the benchmark.
 
   Args:
     benchmark_spec: The PKB spec for the benchmark to run.
@@ -192,43 +217,33 @@ def _BuildMavenCommand(benchmark_spec, classname, job_arguments):
     cmd: Array containing the built command.
   """
   cmd = []
-  maven_executable = FLAGS.maven_binary
 
-  if not vm_util.ExecutableOnPath(maven_executable):
+  gradle_executable = _GetGradleCommand()
+
+  if not vm_util.ExecutableOnPath(gradle_executable):
     raise errors.Setup.MissingExecutableError(
-        'Could not find required executable "%s"' % maven_executable)
-  cmd.append(maven_executable)
+      'Could not find required executable "%s"' % gradle_executable)
 
-  cmd.append('-e')
-  cmd.append('verify')
-  cmd.append('-Dit.test={}'.format(classname))
-  cmd.append('-DskipITs=false')
+  cmd.append(gradle_executable)
+  cmd.append('integrationTest')
+  cmd.append('--tests={}'.format(classname))
 
   if FLAGS.beam_it_module:
-    cmd.append('-pl')
+    cmd.append('-p')
     cmd.append(FLAGS.beam_it_module)
-
-  if FLAGS.beam_it_profile:
-    cmd.append('-P{}'.format(FLAGS.beam_it_profile))
 
   beam_args = job_arguments if job_arguments else []
 
-  # Don't add any args when the user overrides beam_runner_profile since it is
-  # expected that they know what they are doing and we can't know what args
-  # to pass since it differs by runner.
-  if (benchmark_spec.service_type == dpb_service.DATAFLOW
-      and (FLAGS.beam_runner_profile is not None and
-           len(FLAGS.beam_runner_profile) > 0)):
-    beam_args.append('"--defaultWorkerLogLevel={}"'.format(FLAGS.dpb_log_level))
-
-  AddRunnerProfileMvnArgument(benchmark_spec.service_type, cmd,
-                              FLAGS.beam_runner_profile)
-  AddRunnerOptionMvnArgument(benchmark_spec.service_type, beam_args,
-                             FLAGS.beam_runner_option)
-  AddExtraMvnProperties(cmd, FLAGS.beam_extra_mvn_properties)
+  AddRunnerArgument(cmd)
+  AddRunnerPipelineOption(beam_args)
+  AddFilesystemArgument(cmd)
+  AddExtraProperties(cmd)
 
   cmd.append("-DintegrationTestPipelineOptions="
              "[{}]".format(','.join(beam_args)))
+
+  cmd.append("--stacktrace")
+  cmd.append("--info")
 
   return cmd
 
@@ -250,7 +265,7 @@ def _BuildPythonCommand(benchmark_spec, modulename, job_arguments):
   python_executable = FLAGS.python_binary
   if not vm_util.ExecutableOnPath(python_executable):
     raise errors.Setup.MissingExecutableError(
-        'Could not find required executable "%s"' % python_executable)
+      'Could not find required executable "%s"' % python_executable)
   cmd.append(python_executable)
 
   cmd.append('setup.py')
@@ -275,10 +290,13 @@ def _BuildPythonCommand(benchmark_spec, modulename, job_arguments):
   return cmd
 
 
+def _GetGradleCommand():
+  return FLAGS.gradle_binary if FLAGS.gradle_binary else _GetBeamDir() + '/gradlew'
+
 def _GetBeamDir():
   # TODO: This is temporary, find a better way.
   return FLAGS.beam_location if FLAGS.beam_location else os.path.join(
-      vm_util.GetTempDir(), 'beam')
+    vm_util.GetTempDir(), 'beam')
 
 
 def _GetBeamPythonDir():


### PR DESCRIPTION
Since there is an ongoing maven -> gradle migration in beam, the mvn commands located in beam_benchmark_helper.py should be migrated to gradle's equivalents. 

More on that matter here: https://issues.apache.org/jira/browse/BEAM-3942. The beam's part was done, now it's time to change what's necessary in PerfKit.

@asaksena could you take a look? If you don't mind, I'd also like @DariuszAniszewski to take a look before merging this, as he also works very closely with this benchmark. 
