### PR TITLE
Fix Kubernetes StorageClass deletion

### DIFF
--- a/CHANGES.next.md
+++ b/CHANGES.next.md
@@ -181,3 +181,4 @@
   stage metric.
 - Fixed bug of modifying the providers/aws/util.AWS_PREFIX value.
 - Made failures of 'aws ec2 run-instances' fail PKB quickly.
+- Fix Kubernetes StorageClass deletion

--- a/perfkitbenchmarker/kubernetes_helper.py
+++ b/perfkitbenchmarker/kubernetes_helper.py
@@ -43,7 +43,7 @@ def CreateFromFile(file_name):
 def DeleteFromFile(file_name):
   checkKubernetesFlags()
   delete_cmd = [FLAGS.kubectl, '--kubeconfig=%s' % FLAGS.kubeconfig, 'delete',
-                '-f', file_name]
+                '-f', file_name, '--ignore-not-found']
   vm_util.IssueRetryableCommand(delete_cmd)
 
 


### PR DESCRIPTION
Use _kubectl --ignore-not-found_ flag to delete resources.
In particular, this fixes _copy_throughput_ benchmark on Kubernetes which creates the same StorageClass twice and gets stuck trying to delete it the second time.