### PR TITLE
Kubernetes disk storageclass dup fix

### DIFF
--- a/perfkitbenchmarker/providers/kubernetes/kubernetes_disk.py
+++ b/perfkitbenchmarker/providers/kubernetes/kubernetes_disk.py
@@ -309,7 +309,6 @@ class StorageClass(resource.BaseResource):
     :return: True or False
     """
 
-    body = self._BuildBody()
     exists_cmd = [FLAGS.kubectl, '--kubeconfig=%s' % FLAGS.kubeconfig, 'get',
                   'sc', '-o=json', self.name]
 

--- a/perfkitbenchmarker/providers/kubernetes/kubernetes_disk.py
+++ b/perfkitbenchmarker/providers/kubernetes/kubernetes_disk.py
@@ -324,18 +324,18 @@ class StorageClass(resource.BaseResource):
         return False
 
   def _Create(self):
-    """Creates the PVC."""
+    """Creates the StorageClass."""
     body = self._BuildBody()
     if not self._CheckStorageClassExists():
       kubernetes_helper.CreateResource(body)
 
   def _Delete(self):
-    """Deletes the PVC."""
+    """Deletes the StorageClass."""
     body = self._BuildBody()
     kubernetes_helper.DeleteResource(body)
 
   def _BuildBody(self):
-    """Builds JSOM representing the StorageClass."""
+    """Builds JSON representing the StorageClass."""
     body = {
         'kind': 'StorageClass',
         'apiVersion': 'storage.k8s.io/v1',


### PR DESCRIPTION
Prevent duplicated StorageClass creation If the StorageClass with the same name and parameters exists

before:
```
2018-05-02 09:17:04,174 c58cf638 MainThread copy_throughput(1/1) INFO     Provisioning resources for benchmark copy_throughput
2018-05-02 09:17:04,175 c58cf638 MainThread copy_throughput(1/1) INFO     No legacy->new disk type map for provider Kubernetes
================================================================================
['/usr/local/bin/kubectl', '--kubeconfig=/k8s-custer-config/config', 'create', '-f', '/tmp/tmpTISdxQ']
['{"kind": "StorageClass", "provisioner": "kubernetes.io/glusterfs", "parameters": {"resturl": "https://sds-operator.default.svc.certascale.local:443", "clusterid": "56bc8701f71359c55d266c803095f432"}, "apiVersion": "storage.k8s.io/v1", "metadata": {"name": "pkb-c58cf638-0"}}']
================================================================================
2018-05-02 09:17:04,189 c58cf638 Thread-2 copy_throughput(1/1) INFO     Running: /usr/local/bin/kubectl --kubeconfig=/k8s-custer-config/config create -f /tmp/tmpTISdxQ
['/usr/local/bin/kubectl', '--kubeconfig=/k8s-custer-config/config', 'create', '-f', '/tmp/tmpTISdxQ']
stdout: storageclass.storage.k8s.io "pkb-c58cf638-0" created
, stderr:, retcode:0
================================================================================
['/usr/local/bin/kubectl', '--kubeconfig=/k8s-custer-config/config', 'create', '-f', '/tmp/tmpcxXDBv']
['{"kind": "PersistentVolumeClaim", "spec": {"storageClassName": "pkb-c58cf638-0", "accessModes": ["ReadWriteOnce"], "resources": {"requests": {"storage": "100Gi"}}}, "apiVersion": "v1", "metadata": {"name": "pkb-c58cf638-0-0"}}']
================================================================================
2018-05-02 09:17:18,186 c58cf638 Thread-2 copy_throughput(1/1) INFO     Running: /usr/local/bin/kubectl --kubeconfig=/k8s-custer-config/config create -f /tmp/tmpcxXDBv
['/usr/local/bin/kubectl', '--kubeconfig=/k8s-custer-config/config', 'create', '-f', '/tmp/tmpcxXDBv']
stdout: persistentvolumeclaim "pkb-c58cf638-0-0" created
, stderr:, retcode:0
================================================================================
['/usr/local/bin/kubectl', '--kubeconfig=/k8s-custer-config/config', 'create', '-f', '/tmp/tmpVcV899']
['{"kind": "StorageClass", "provisioner": "kubernetes.io/glusterfs", "parameters": {"resturl": "https://sds-operator.default.svc.certascale.local:443", "clusterid": "56bc8701f71359c55d266c803095f432"}, "apiVersion": "storage.k8s.io/v1", "metadata": {"name": "pkb-c58cf638-0"}}']
================================================================================
2018-05-02 09:17:20,024 c58cf638 Thread-2 copy_throughput(1/1) INFO     Running: /usr/local/bin/kubectl --kubeconfig=/k8s-custer-config/config create -f /tmp/tmpVcV899
2018-05-02 09:17:21,958 c58cf638 Thread-2 copy_throughput(1/1) INFO     Ran: {/usr/local/bin/kubectl --kubeconfig=/k8s-custer-config/config create -f /tmp/tmpVcV899}  ReturnCode:1
STDOUT:
STDERR: Error from server (AlreadyExists): error when creating "/tmp/tmpVcV899": storageclasses.storage.k8s.io "pkb-c58cf638-0" already exists

['/usr/local/bin/kubectl', '--kubeconfig=/k8s-custer-config/config', 'create', '-f', '/tmp/tmpVcV899']
stdout: , stderr:Error from server (AlreadyExists): error when creating "/tmp/tmpVcV899": storageclasses.storage.k8s.io "pkb-c58cf638-0" already exists
, retcode:1
2018-05-02 09:17:21,959 c58cf638 Thread-2 copy_throughput(1/1) INFO     Retrying exception running IssueRetryableCommand: Command returned a non-zero exit code.
```

after:
```
2018-05-02 12:19:06,158 c87f8d3e Thread-2 copy_throughput(1/1) INFO     StorageClass already exists.
```