### PR TITLE
The spark service resource supports a new flag (spark_service_log_lev…

### DIFF
--- a/CHANGES.next.md
+++ b/CHANGES.next.md
@@ -179,6 +179,7 @@
 - Add default tags like timeout_utc to GCE.
 - Add validation to all the TPU tests.
 - Add number of Train/Eval TPU shards in metadata.
+- The spark service resource supports a new flag (spark_service_log_level), to control the log level and generated output.
 
 ### Bug fixes and maintenance updates:
 - Moved GPU-related specs from GceVmSpec to BaseVmSpec

--- a/perfkitbenchmarker/providers/gcp/gcp_dataproc.py
+++ b/perfkitbenchmarker/providers/gcp/gcp_dataproc.py
@@ -133,10 +133,11 @@ class GcpDataproc(spark_service.BaseSparkService):
 
     # Dataproc gives as stdout an object describing job execution.
     # Its stderr contains a mix of the stderr of the job, and the
-    # stdout of the job.  We set the driver log level to FATAL
+    # stdout of the job.  We can set the driver log level to FATAL
     # to suppress those messages, and we can then separate, hopefully
     # the job standard out from the log messages.
-    cmd.flags['driver-log-levels'] = 'root=FATAL'
+    cmd.flags['driver-log-levels'] = 'root={}'.format(
+        FLAGS.spark_service_log_level)
     if job_arguments:
       cmd.additional_flags = ['--'] + job_arguments
     stdout, stderr, retcode = cmd.Issue(timeout=None)

--- a/perfkitbenchmarker/spark_service.py
+++ b/perfkitbenchmarker/spark_service.py
@@ -38,6 +38,9 @@ from perfkitbenchmarker import vm_util
 flags.DEFINE_string('spark_static_cluster_id', None,
                     'If set, the name of the Spark cluster, assumed to be '
                     'ready.')
+flags.DEFINE_enum('spark_service_log_level', 'INFO', ['DEBUG', 'INFO', 'FATAL'],
+                  'Supported log levels when submitting jobs to spark service'
+                  ' clusters.')
 
 
 # Cloud to use for pkb-created Spark service.


### PR DESCRIPTION
…el), to control the log level and generated output.

-------------
Created by MOE: https://github.com/google/moe
MOE_MIGRATED_REVID=213711079