### PR TITLE
Don't override exception during publication of failed run sample.

### DIFF
--- a/CHANGES.next.md
+++ b/CHANGES.next.md
@@ -378,3 +378,5 @@
 - Install NCCL when installing Tensorflow with GPU support.
 - Update AzureBlobStorageService to persist for max of `--timeout_minutes` and `--persistent_timeout_minutes`.
 - Add --project flag to GoogleCloudStorageService MakeBucket command.
+- Fix virtual_machine.GetResourceMetadata() so that it does not try to gather
+  metadata from a VM that has not been provisioned yet.

--- a/perfkitbenchmarker/virtual_machine.py
+++ b/perfkitbenchmarker/virtual_machine.py
@@ -352,6 +352,8 @@ class BaseVirtualMachine(resource.BaseResource):
     Returns:
       dict mapping string property key to value.
     """
+    if not self.created:
+      return {}
     result = self.metadata.copy()
     result.update({
         'image': self.image,

--- a/tests/gce_virtual_machine_test.py
+++ b/tests/gce_virtual_machine_test.py
@@ -1,4 +1,4 @@
-# Copyright 2018 PerfKitBenchmarker Authors. All rights reserved.
+# Copyright 2019 PerfKitBenchmarker Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -166,6 +166,7 @@ class GceVirtualMachineTestCase(pkb_common_test_case.PkbCommonTestCase):
     spec = gce_virtual_machine.GceVmSpec(
         _COMPONENT, machine_type='test_machine_type', project='p')
     vm = gce_virtual_machine.GceVirtualMachine(spec)
+    vm.created = True
     self.assertDictContainsSubset(
         {'dedicated_host': False, 'machine_type': 'test_machine_type',
          'project': 'p'},
@@ -177,6 +178,7 @@ class GceVirtualMachineTestCase(pkb_common_test_case.PkbCommonTestCase):
         _COMPONENT, machine_type='test_machine_type', preemptible=True,
         project='p')
     vm = gce_virtual_machine.GceVirtualMachine(spec)
+    vm.created = True
     self.assertDictContainsSubset(
         {'dedicated_host': False, 'machine_type': 'test_machine_type',
          'preemptible': True, 'project': 'p'},
@@ -187,6 +189,7 @@ class GceVirtualMachineTestCase(pkb_common_test_case.PkbCommonTestCase):
     spec = gce_virtual_machine.GceVmSpec(_COMPONENT, machine_type={
         'cpus': 1, 'memory': '1.0GiB'}, project='p')
     vm = gce_virtual_machine.GceVirtualMachine(spec)
+    vm.created = True
     self.assertDictContainsSubset(
         {'cpus': 1, 'memory_mib': 1024, 'project': 'p',
          'dedicated_host': False},
@@ -198,6 +201,7 @@ class GceVirtualMachineTestCase(pkb_common_test_case.PkbCommonTestCase):
         preemptible=True,
         project='fakeproject')
     vm = gce_virtual_machine.GceVirtualMachine(spec)
+    vm.created = True
     self.assertDictContainsSubset({
         'cpus': 1, 'memory_mib': 1024, 'project': 'fakeproject',
         'dedicated_host': False, 'preemptible': True}, vm.GetResourceMetadata())
@@ -210,6 +214,7 @@ class GceVirtualMachineTestCase(pkb_common_test_case.PkbCommonTestCase):
         gpu_type='k80',
         project='fakeproject')
     vm = gce_virtual_machine.GceVirtualMachine(spec)
+    vm.created = True
     self.assertDictContainsSubset({
         'cpus': 1, 'memory_mib': 1024, 'project': 'fakeproject',
         'dedicated_host': False, 'gpu_count': 2, 'gpu_type': 'k80'
@@ -261,6 +266,7 @@ class GceVirtualMachineOsTypesTestCase(pkb_common_test_case.PkbCommonTestCase):
     with PatchCriticalObjects(self._CreateFakeReturnValues()) as issue_command:
       vm = vm_class(self.spec)
       vm._Create()
+      vm.created = True
       command_string = ' '.join(issue_command.call_args[0][0])
 
       self.assertEqual(issue_command.call_count, 1)
@@ -278,6 +284,7 @@ class GceVirtualMachineOsTypesTestCase(pkb_common_test_case.PkbCommonTestCase):
         self._CreateFakeReturnValues(fake_image)) as issue_command:
       vm = vm_class(self.spec)
       vm._Create()
+      vm.created = True
       command_string = ' '.join(issue_command.call_args[0][0])
 
       self.assertEqual(issue_command.call_count, 1)
@@ -299,6 +306,7 @@ class GceVirtualMachineOsTypesTestCase(pkb_common_test_case.PkbCommonTestCase):
         self._CreateFakeReturnValues(fake_image)) as issue_command:
       vm = vm_class(self.spec)
       vm._Create()
+      vm.created = True
       command_string = ' '.join(issue_command.call_args[0][0])
 
       self.assertEqual(issue_command.call_count, 1)
@@ -320,6 +328,7 @@ class GceVirtualMachineOsTypesTestCase(pkb_common_test_case.PkbCommonTestCase):
         self._CreateFakeReturnValues(fake_image)) as issue_command:
       vm = vm_class(self.spec)
       vm._Create()
+      vm.created = True
       command_string = ' '.join(issue_command.call_args[0][0])
 
       self.assertEqual(issue_command.call_count, 1)
@@ -343,6 +352,7 @@ class GceVirtualMachineOsTypesTestCase(pkb_common_test_case.PkbCommonTestCase):
     with PatchCriticalObjects(self._CreateFakeReturnValues()) as issue_command:
       vm = vm_class(spec)
       vm._Create()
+      vm.created = True
       command_string = ' '.join(issue_command.call_args[0][0])
 
       self.assertEqual(issue_command.call_count, 1)
@@ -368,6 +378,7 @@ class GceVirtualMachineOsTypesTestCase(pkb_common_test_case.PkbCommonTestCase):
     with PatchCriticalObjects(self._CreateFakeReturnValues()) as issue_command:
       vm = vm_class(spec)
       vm._Create()
+      vm.created = True
       command_string = ' '.join(issue_command.call_args[0][0])
 
       self.assertEqual(issue_command.call_count, 1)


### PR DESCRIPTION
During the creation of failed run samples, PKB tries to gather metadata from a number of resources (including VMs), even if they were not provisioned yet. This was causing PKB to try to obtain the number of CPUs from non-existent VMs, causing superfluous logging in addition to overwriting the exception that caused the failure in the first place.
This change fixes this (for VMs at least) by checking if the VM is created before attempting to add metadata.
Tested:
Tested manually by specifying an invalid zone. The root exception is now preserved (before this CL it was overwritten by an SSH error by the VM trying to SSH to its non-existent IP address).

-------------
Created by MOE: https://github.com/google/moe
MOE_MIGRATED_REVID=230410874