### PR TITLE
Fix a bug in which computing the boot time metrics for VMs would fail…

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/cluster_boot_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/cluster_boot_benchmark.py
@@ -51,6 +51,9 @@ def GetTimeToBoot(vms):
   Returns:
     List of Samples containing the boot time.
   """
+  if not vms:
+    return []
+
   min_create_start_time = min(vm.create_start_time for vm in vms)
 
   max_create_delay_sec = 0


### PR DESCRIPTION
… if the benchmark doesn't boot VMs.

-------------
Created by MOE: https://github.com/google/moe
MOE_MIGRATED_REVID=232339571