### PR TITLE
Improve beam_integration_benchmark to support Python3 pipeline

### DIFF
--- a/tests/beam_benchmark_helper_test.py
+++ b/tests/beam_benchmark_helper_test.py
@@ -180,6 +180,7 @@ class BeamBenchmarkHelperTestCase(unittest.TestCase):
 
   def test_build_python_command(self):
     FLAGS.beam_python_attr = 'IT'
+    FLAGS.beam_it_module = 'sdks/python'
     FLAGS.beam_runner = 'TestRunner'
     FLAGS.beam_python_sdk_location = 'py/location.tar'
     FLAGS.beam_sdk = beam_benchmark_helper.BEAM_PYTHON_SDK
@@ -197,10 +198,12 @@ class BeamBenchmarkHelperTestCase(unittest.TestCase):
                                                              ['--args'])
       expected_cmd = [
           'gradlew',
-          'beam-sdks-python:integrationTest',
-          '-Ptests=apache_beam.py',
-          '-Pattr=IT',
-          '-PpipelineOptions=--args --runner=TestRunner --sdk_location=py/location.tar',
+          'integrationTest',
+          '-Dtests=apache_beam.py',
+          '-p',
+          'sdks/python',
+          '-Dattr=IT',
+          '-DpipelineOptions=--args "--runner=TestRunner" "--sdk_location=py/location.tar"',
           '--info',
           '--scan',
       ]


### PR DESCRIPTION
Changes in beam_integration_benchmark are to better support pipeline invocation in order to enable Python3 Beam pipeline:

- Improved Gradle command build with project path enabled.
- Change use of Gradle property `-P` to System property `-D` for better integration.
- Flag cleanup and doc string improve.