### PR TITLE
Quick fix beam_integration_benchmark in Gradle command build

### DIFF
--- a/perfkitbenchmarker/beam_benchmark_helper.py
+++ b/perfkitbenchmarker/beam_benchmark_helper.py
@@ -225,11 +225,11 @@ def _BuildGradleCommand(classname, job_arguments):
         'Could not find required executable "%s"' % gradle_executable)
 
   cmd.append(gradle_executable)
+  AddTaskArgument(cmd, 'integrationTest', FLAGS.beam_it_module)
   cmd.append('--tests={}'.format(classname))
 
   beam_args = job_arguments if job_arguments else []
 
-  AddTaskArgument(cmd, 'integrationTest', FLAGS.beam_it_module)
   AddRunnerArgument(cmd, FLAGS.beam_runner)
   AddRunnerPipelineOption(beam_args, FLAGS.beam_runner,
                           FLAGS.beam_runner_option)

--- a/tests/beam_benchmark_helper_test.py
+++ b/tests/beam_benchmark_helper_test.py
@@ -238,8 +238,8 @@ class BeamBenchmarkHelperTestCase(unittest.TestCase):
                                                              ['--args'])
       expected_cmd = [
           'gradlew',
-          '--tests=org.apache.beam.sdk.java',
           ':sdks:java:integrationTest',
+          '--tests=org.apache.beam.sdk.java',
           '-DintegrationTestRunner=dataflow',
           '-Dfilesystem=hdfs',
           '-Dextra_key=extra_value',


### PR DESCRIPTION
This fixes Gradle command which is to run Java pipeline. 

The correct way run Gradle is having task name next to Gradle wrapper followed by flags. E.g. `./gradlew :task:name --test=test-name -Dflag=value`

@yuyantingzero Can you help to review? Thanks!