### PR TITLE
Specify regular write mode for NamedTemporaryFile when authorizing no…

### DIFF
--- a/perfkitbenchmarker/providers/aws/elastic_container_service.py
+++ b/perfkitbenchmarker/providers/aws/elastic_container_service.py
@@ -265,7 +265,7 @@ class EksCluster(container_service.KubernetesCluster):
 
   def _AuthorizeNodes(self):
     """Allow the nodes to be added to the cluster."""
-    with vm_util.NamedTemporaryFile() as tf:
+    with vm_util.NamedTemporaryFile(mode='w') as tf:
       tf.write(_CONFIG_MAP.format(
           node_instance_role=self.eks_workers.node_instance_role))
       tf.close()


### PR DESCRIPTION
…des when creating an AWS container cluster since what's being written is a string.

-------------
Created by MOE: https://github.com/google/moe
MOE_MIGRATED_REVID=267189465