### PR TITLE
add custom subnet support

### DIFF
--- a/perfkitbenchmarker/benchmark_spec.py
+++ b/perfkitbenchmarker/benchmark_spec.py
@@ -127,7 +127,7 @@ class BenchmarkSpec(object):
     self.sequence_number = BenchmarkSpec.total_benchmarks
     self.vms = []
     self.networks = {}
-    self.custom_subnets = {k: v.cidr for (k, v) in self.config.vm_groups.items()}
+    self.custom_subnets = {k: {'cloud': v.cloud, 'cidr': v.cidr} for (k, v) in self.config.vm_groups.items()}
     self.firewalls = {}
     self.networks_lock = threading.Lock()
     self.firewalls_lock = threading.Lock()

--- a/perfkitbenchmarker/benchmark_spec.py
+++ b/perfkitbenchmarker/benchmark_spec.py
@@ -127,6 +127,7 @@ class BenchmarkSpec(object):
     self.sequence_number = BenchmarkSpec.total_benchmarks
     self.vms = []
     self.networks = {}
+    self.custom_subnets = {k: v.cidr for (k, v) in self.config.vm_groups.items()}
     self.firewalls = {}
     self.networks_lock = threading.Lock()
     self.firewalls_lock = threading.Lock()
@@ -358,6 +359,8 @@ class BenchmarkSpec(object):
         group_spec.vm_spec.zone = zone_list[self._zone_index]
         self._zone_index = (self._zone_index + 1
                             if self._zone_index < len(zone_list) - 1 else 0)
+      if group_spec.cidr:  # apply cidr range to all vms in vm_group
+        group_spec.vm_spec.cidr = group_spec.cidr
       vm = self._CreateVirtualMachine(group_spec.vm_spec, os_type, cloud)
       if disk_spec and not vm.is_static:
         if disk_spec.disk_type == disk.LOCAL and disk_count is None:
@@ -509,6 +512,7 @@ class BenchmarkSpec(object):
     # first when sorted.
     networks = [self.networks[key]
                 for key in sorted(six.iterkeys(self.networks))]
+
     vm_util.RunThreaded(lambda net: net.Create(), networks)
     if self.container_registry:
       self.container_registry.Create()

--- a/perfkitbenchmarker/configs/benchmark_config_spec.py
+++ b/perfkitbenchmarker/configs/benchmark_config_spec.py
@@ -752,6 +752,7 @@ class _VmGroupSpec(spec.BaseSpec):
     vm_spec: BaseVmSpec. Configuration for provisioned VMs in this group.
     placement_group_name: string. Name of placement group
         that VM group belongs to.
+    cidr: subnet each vm in this group belongs to
   """
 
   def __init__(self, component_full_name, flag_values=None, **kwargs):
@@ -813,6 +814,9 @@ class _VmGroupSpec(spec.BaseSpec):
         'vm_count': (option_decoders.IntDecoder, {
             'default': _DEFAULT_VM_COUNT,
             'min': 0
+        }),
+        'cidr': (option_decoders.StringDecoder, {
+            'default': None
         }),
         'vm_spec': (option_decoders.PerCloudConfigDecoder, {}),
         'placement_group_name': (option_decoders.StringDecoder, {

--- a/perfkitbenchmarker/network.py
+++ b/perfkitbenchmarker/network.py
@@ -139,23 +139,25 @@ class BaseNetwork(object):
 
   @staticmethod
   def FormatCidrString(cidr_raw):
-    """Format CIDR for use in resource name.
+    """Format CIDR string for use in resource name.
+
+    Removes or replaces illegal characters from CIDR.
     eg '10.128.0.0/9' -> '10-128-0-0-9'
 
     Args:
       cidr_raw: The unformatted CIDR string.
+    Returns:
+      A CIDR string suitable for use in resource names.
+    Raises:
+      Error: Invalid CIDR format
     """
 
     DELIM = r'-'  # Safe delimiter for most providers
     int_regex = r'[0-9]+'
-    # try:
     octets_mask = regex_util.ExtractAllMatches(int_regex, str(cidr_raw))
-    if len(octets_mask) != 5:
-      raise errors.Error('Invalid CIDR format: "{0}"'.format(octets_mask))
+    if len(octets_mask) != 5:  # expecting 4 octets plus 1 prefix mask.
+      raise errors.Error('Invalid CIDR format: "{0}"'.format(cidr_raw))
     return DELIM.join(octets_mask)
-    # except:
-    #   # @TODO add address validation. Just punt for now.
-    #   return cidr_raw
 
   @classmethod
   def GetNetworkFromNetworkSpec(cls, spec):
@@ -176,8 +178,7 @@ class BaseNetwork(object):
                          'BenchmarkSpec.')
     key = cls._GetKeyFromNetworkSpec(spec)
 
-    #  Grab the list of other networks so we can setup firewalls, forwarding,
-    #  etc.
+    #  Grab the list of other networks to setup firewalls, forwarding, etc.
     if not hasattr(spec, 'custom_subnets'):
       spec.__setattr__('custom_subnets', benchmark_spec.custom_subnets)
 

--- a/perfkitbenchmarker/network.py
+++ b/perfkitbenchmarker/network.py
@@ -131,7 +131,7 @@ class BaseNetwork(object):
 
   @staticmethod
   def FormatCidrString(cidr_raw):
-    """ Format CIDR for use in resource names
+    """ Format CIDR for use in resource name.
 
     eg '10.128.0.0/9' -> '10-128-0-0-9'
 
@@ -141,7 +141,12 @@ class BaseNetwork(object):
 
     DELIM = r'-'  # Safe delimiter for most providers
     int_regex = r'[0-9]+'
-    return DELIM.join(regex_util.ExtractAllMatches(int_regex, str(cidr_raw)))
+    try:
+      return DELIM.join(regex_util.ExtractAllMatches(int_regex, str(cidr_raw)))
+    except:
+      # @TODO add address validation. Just punt for now.
+      return cidr_raw
+
 
   @classmethod
   def GetNetworkFromNetworkSpec(cls, spec):
@@ -165,7 +170,6 @@ class BaseNetwork(object):
     #  Grab the list of other networks so we can setup firewalls, forwarding, etc.
     if not hasattr(spec, 'custom_subnets'):
       spec.__setattr__('custom_subnets', benchmark_spec.custom_subnets)
-
 
     with benchmark_spec.networks_lock:
       if key not in benchmark_spec.networks:

--- a/perfkitbenchmarker/network.py
+++ b/perfkitbenchmarker/network.py
@@ -139,8 +139,7 @@ class BaseNetwork(object):
 
   @staticmethod
   def FormatCidrString(cidr_raw):
-    """ Format CIDR for use in resource name.
-
+    """Format CIDR for use in resource name.
     eg '10.128.0.0/9' -> '10-128-0-0-9'
 
     Args:
@@ -149,12 +148,14 @@ class BaseNetwork(object):
 
     DELIM = r'-'  # Safe delimiter for most providers
     int_regex = r'[0-9]+'
-    try:
-      return DELIM.join(regex_util.ExtractAllMatches(int_regex, str(cidr_raw)))
-    except:
-      # @TODO add address validation. Just punt for now.
-      return cidr_raw
-
+    # try:
+    octets_mask = regex_util.ExtractAllMatches(int_regex, str(cidr_raw))
+    if len(octets_mask) != 5:
+      raise errors.Error('Invalid CIDR format: "{0}"'.format(octets_mask))
+    return DELIM.join(octets_mask)
+    # except:
+    #   # @TODO add address validation. Just punt for now.
+    #   return cidr_raw
 
   @classmethod
   def GetNetworkFromNetworkSpec(cls, spec):
@@ -175,7 +176,8 @@ class BaseNetwork(object):
                          'BenchmarkSpec.')
     key = cls._GetKeyFromNetworkSpec(spec)
 
-    #  Grab the list of other networks so we can setup firewalls, forwarding, etc.
+    #  Grab the list of other networks so we can setup firewalls, forwarding,
+    #  etc.
     if not hasattr(spec, 'custom_subnets'):
       spec.__setattr__('custom_subnets', benchmark_spec.custom_subnets)
 

--- a/perfkitbenchmarker/network.py
+++ b/perfkitbenchmarker/network.py
@@ -20,9 +20,17 @@ others in the
 same project.
 """
 
+from enum import Enum
+
 from perfkitbenchmarker import context
 from perfkitbenchmarker import errors
 from perfkitbenchmarker import regex_util
+
+
+class NetType(Enum):
+  DEFAULT = 'default'
+  SINGLE = 'single'
+  MULTI = 'multi'
 
 
 class BaseFirewall(object):

--- a/perfkitbenchmarker/network.py
+++ b/perfkitbenchmarker/network.py
@@ -156,7 +156,7 @@ class BaseNetwork(object):
     int_regex = r'[0-9]+'
     octets_mask = regex_util.ExtractAllMatches(int_regex, str(cidr_raw))
     if len(octets_mask) != 5:  # expecting 4 octets plus 1 prefix mask.
-      raise errors.Error('Invalid CIDR format: "{0}"'.format(cidr_raw))
+      raise errors.ValueError('Invalid CIDR format: "{0}"'.format(cidr_raw))
     return DELIM.join(octets_mask)
 
   @classmethod

--- a/perfkitbenchmarker/providers/gcp/gce_network.py
+++ b/perfkitbenchmarker/providers/gcp/gce_network.py
@@ -24,7 +24,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import copy
 import json
 import threading
 
@@ -32,7 +31,6 @@ from perfkitbenchmarker import errors
 from perfkitbenchmarker import flags
 from perfkitbenchmarker import network
 from perfkitbenchmarker import providers
-from perfkitbenchmarker import regex_util
 from perfkitbenchmarker import resource
 
 from perfkitbenchmarker.providers.gcp import util
@@ -246,13 +244,13 @@ class GceNetwork(network.BaseNetwork):
 
     #  Figuring out the type of network here.
     #  Precedence: User Managed > CIDR (multi) > gce_subnet flag (single) > Auto (default)
-    self.net_type = 'default'  # Default network 'auto' mode. Single VPC with subnets in all regions
+    self.net_type = network.NetType.DEFAULT.value  # Default network 'auto' mode. Single VPC with subnets in all regions
     self.cidr = NETWORK_RANGE
     if FLAGS.gce_subnet_region:  # Overrides auto network when set. Creates one VPC network in single region.
-      self.net_type = 'single'
+      self.net_type = network.NetType.SINGLE.value
       self.cidr = FLAGS.gce_subnet_addr
     if network_spec.cidr:  # Creates multiple VPC networks when set.
-      self.net_type = 'multi'
+      self.net_type = network.NetType.MULTI.value
       self.cidr = network_spec.cidr
 
     name = self._MakeGceNetworkName()
@@ -330,7 +328,7 @@ class GceNetwork(network.BaseNetwork):
 
     name = 'pkb-network-%s' % _uri  # Assume the default network naming
 
-    if _net_type in ('single', 'multi'):  # GCE network names must be unique
+    if _net_type in (network.NetType.SINGLE.value, network.NetType.MULTI.value):  # GCE network names must be unique
       name = 'pkb-network-%s-%s-%s' % (_net_type, self.FormatCidrString(_cidr), _uri)
 
     return name

--- a/perfkitbenchmarker/providers/gcp/gce_network.py
+++ b/perfkitbenchmarker/providers/gcp/gce_network.py
@@ -290,8 +290,10 @@ class GceNetwork(network.BaseNetwork):
     The default network is either specified as a single region with the gce_subnet_region and gce_subnet_addr flags,
         or assigned to an auto created /20 in each region if no flags are passed.
 
-    :param network_spec:
-    :return: list[String]
+    Args:
+      network_spec: The network spec for the network.
+    Returns:
+      set(String): A set of CIDRs used by this benchmark.
     """
     nets = set()
     gce_default_subnet = FLAGS.gce_subnet_addr if FLAGS.gce_subnet_region else NETWORK_RANGE
@@ -312,10 +314,12 @@ class GceNetwork(network.BaseNetwork):
     Build the current network's name string.
     Uses current instance properties if none provided.
     Must match regex: r'(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)'
-    :param net_type:
-    :param cidr:
-    :param uri:
-    :return: String gce_network_name
+    Args:
+      net_type: One of ['default', 'single', 'multi']
+      cidr: The CIDR range of this network.
+      uri: A network suffix (if different than FLAGS.run_uri)
+    Returns:
+      String The name of this network.
     """
     if FLAGS.gce_network_name:  # Return user managed network name if defined.
       return FLAGS.gce_network_name
@@ -335,13 +339,14 @@ class GceNetwork(network.BaseNetwork):
     """
     Build a firewall name string.
     Firewall rule names must be unique within a project so we include source and destination nets to disambiguate.
-    :param net_type: default|single|multi
-    :param src_cidr: source network
-    :param dst_cidr: target network
-    :param port_range_lo: low port to open
-    :param port_range_hi: high port to open in range.
-    :param uri: run_uri
-    :return:
+    Args:
+      net_type: One of ['default', 'single', 'multi']
+      src_cidr: The CIDR range of this network.
+      dst_cidr: The CIDR range of the remote network.
+      port_range_lo: The low port to open
+      port_range_hi: The high port to open in range.
+      uri: A firewall suffix (if different than FLAGS.run_uri)
+    Returns: The name of this firewall rule.
     """
 
     _net_type = self.net_type if not net_type else net_type

--- a/perfkitbenchmarker/providers/gcp/gce_network.py
+++ b/perfkitbenchmarker/providers/gcp/gce_network.py
@@ -329,16 +329,16 @@ class GceNetwork(network.BaseNetwork):
     if FLAGS.gce_network_name:  # Return user managed network name if defined.
       return FLAGS.gce_network_name
 
-    _net_type = self.net_type if not net_type else net_type
-    _cidr = self.cidr if not cidr else cidr
-    _uri = FLAGS.run_uri if not uri else uri
+    net_type = net_type or self.net_type
+    cidr = cidr or self.cidr
+    uri = uri or FLAGS.run_uri
 
-    name = 'pkb-network-%s' % _uri  # Assume the default network naming.
+    name = 'pkb-network-%s' % uri  # Assume the default network naming.
 
-    if _net_type in (network.NetType.SINGLE.value,
+    if net_type in (network.NetType.SINGLE.value,
                      network.NetType.MULTI.value):
       name = 'pkb-network-%s-%s-%s' % (
-          _net_type, self.FormatCidrString(_cidr), _uri)
+          net_type, self.FormatCidrString(cidr), uri)
 
     return name
 
@@ -357,21 +357,21 @@ class GceNetwork(network.BaseNetwork):
       uri: A firewall suffix (if different than FLAGS.run_uri)
     Returns: The name of this firewall rule.
     """
+    net_type = net_type or self.net_type
+    uri = uri or FLAGS.run_uri
+    src_cidr = src_cidr or self.cidr
+    dst_cidr = dst_cidr or self.cidr
 
-    _net_type = self.net_type if not net_type else net_type
-    _uri = FLAGS.run_uri if not uri else uri
-    _src_cidr = self.cidr if not src_cidr else src_cidr
-    _dst_cidr = self.cidr if not dst_cidr else dst_cidr
-    _prefix = None if _src_cidr == _dst_cidr else 'perfkit-firewall'
-    _src_cidr = 'internal' if _src_cidr == _dst_cidr else self.FormatCidrString(
-        _src_cidr)
-    _dst_cidr = self.FormatCidrString(_dst_cidr)
-    _port_lo = port_range_lo
-    _port_hi = None if port_range_lo == port_range_hi else port_range_hi
+    prefix = None if src_cidr == dst_cidr else 'perfkit-firewall'
+    src_cidr = 'internal' if src_cidr == dst_cidr else self.FormatCidrString(
+        src_cidr)
+    dst_cidr = self.FormatCidrString(dst_cidr)
+    port_lo = port_range_lo
+    port_hi = None if port_range_lo == port_range_hi else port_range_hi
 
     firewall_name = '-'.join(str(i) for i in (
-        _prefix, _net_type, _src_cidr, _dst_cidr,
-        _port_lo, _port_hi, _uri) if i)
+        prefix, net_type, src_cidr, dst_cidr,
+        port_lo, port_hi, uri) if i)
 
     return firewall_name
 

--- a/perfkitbenchmarker/providers/gcp/gce_network.py
+++ b/perfkitbenchmarker/providers/gcp/gce_network.py
@@ -255,8 +255,8 @@ class GceNetwork(network.BaseNetwork):
 
     name = self._MakeGceNetworkName()
 
-    subnet_region = FLAGS.gce_subnet_region if not network_spec.cidr else \
-        util.GetRegionFromZone(network_spec.zone)
+    subnet_region = (FLAGS.gce_subnet_region if not network_spec.cidr else
+                     util.GetRegionFromZone(network_spec.zone))
     mode = 'auto' if subnet_region is None else 'custom'
     self.network_resource = GceNetworkResource(name, mode, self.project)
     if subnet_region is None:
@@ -300,8 +300,8 @@ class GceNetwork(network.BaseNetwork):
       A set of CIDR strings used by this benchmark.
     """
     nets = set()
-    gce_default_subnet = FLAGS.gce_subnet_addr if FLAGS.gce_subnet_region \
-        else NETWORK_RANGE
+    gce_default_subnet = (FLAGS.gce_subnet_addr if FLAGS.gce_subnet_region
+                          else NETWORK_RANGE)
 
     if network_spec.custom_subnets:
       for (k, v) in network_spec.custom_subnets.items():

--- a/perfkitbenchmarker/providers/gcp/gce_network.py
+++ b/perfkitbenchmarker/providers/gcp/gce_network.py
@@ -336,7 +336,7 @@ class GceNetwork(network.BaseNetwork):
     name = 'pkb-network-%s' % uri  # Assume the default network naming.
 
     if net_type in (network.NetType.SINGLE.value,
-                     network.NetType.MULTI.value):
+                    network.NetType.MULTI.value):
       name = 'pkb-network-%s-%s-%s' % (
           net_type, self.FormatCidrString(cidr), uri)
 

--- a/perfkitbenchmarker/virtual_machine.py
+++ b/perfkitbenchmarker/virtual_machine.py
@@ -127,6 +127,7 @@ class BaseVmSpec(spec.BaseSpec):
 
   Attributes:
     zone: The region / zone the in which to launch the VM.
+    cidr: The CIDR subnet range in which to launch the VM.
     machine_type: The provider-specific instance type (e.g. n1-standard-8).
     gpu_count: None or int. Number of gpus to attach to the VM.
     gpu_type: None or string. Type of gpus to attach to the VM.
@@ -227,6 +228,8 @@ class BaseVmSpec(spec.BaseSpec):
         'gpu_count': (option_decoders.IntDecoder, {'min': 1, 'default': None}),
         'zone': (option_decoders.StringDecoder, {'none_ok': True,
                                                  'default': None}),
+        'cidr': (option_decoders.StringDecoder, {'none_ok': True,
+                                                 'default': None}),
         'use_dedicated_host': (option_decoders.BooleanDecoder,
                                {'default': False}),
         'num_vms_per_host': (option_decoders.IntDecoder,
@@ -264,6 +267,7 @@ class BaseVirtualMachine(resource.BaseResource):
     user_name: Account name for login. the contents of 'ssh_public_key' should
       be in .ssh/authorized_keys for this user.
     zone: The region / zone the VM was launched in.
+    cidr: The CIDR range the VM was launched in.
     disk_specs: list of BaseDiskSpec objects. Specifications for disks attached
       to the VM.
     scratch_disks: list of BaseDisk objects. Scratch disks attached to the VM.
@@ -304,6 +308,7 @@ class BaseVirtualMachine(resource.BaseResource):
     self.disable_interrupt_moderation = vm_spec.disable_interrupt_moderation
     self.disable_rss = vm_spec.disable_rss
     self.zone = vm_spec.zone
+    self.cidr = vm_spec.cidr
     self.machine_type = vm_spec.machine_type
     self.gpu_count = vm_spec.gpu_count
     self.gpu_type = vm_spec.gpu_type
@@ -425,6 +430,8 @@ class BaseVirtualMachine(resource.BaseResource):
         'zone': self.zone,
         'cloud': self.CLOUD,
     })
+    if self.cidr is not None:
+      result['cidr'] = self.cidr
     if self.machine_type is not None:
       result['machine_type'] = self.machine_type
     if self.use_dedicated_host is not None:

--- a/tests/gce_virtual_machine_test.py
+++ b/tests/gce_virtual_machine_test.py
@@ -666,7 +666,7 @@ class GceNetworkTest(pkb_common_test_case.PkbCommonTestCase):
   def testGetNetwork(self):
     project = 'myproject'
     zone = 'us-east1-a'
-    vm = mock.Mock(zone=zone, project=project)
+    vm = mock.Mock(zone=zone, project=project, cidr=None)
     net = gce_network.GceNetwork.GetNetwork(vm)
     self.assertEqual(project, net.project)
     self.assertEqual(zone, net.zone)

--- a/tests/providers/gcp/gcp_network_test.py
+++ b/tests/providers/gcp/gcp_network_test.py
@@ -435,7 +435,7 @@ class TestGceNetworkNames(BaseGceNetworkTest):
     vm = mock.Mock(zone=zone, project=project, cidr=cidr)
     net = gce_network.GceNetwork.GetNetwork(vm)
 
-    dst_cidr = '123.567.901/13'
+    dst_cidr = '123.567.9.1/13'
     lo_port = 49152
     hi_port = 65535
     fw_name = net._MakeGceFWRuleName(
@@ -446,7 +446,7 @@ class TestGceNetworkNames(BaseGceNetworkTest):
     _prefix = 'perfkit-firewall'
     _net_type = 'multi'
     _src_cidr_string = '1-2-3-4-56'
-    _dst_cidr_string = '123-567-901-13'
+    _dst_cidr_string = '123-567-9-1-13'
     _src_port = '49152'
     _dst_port = '65535'
     _uri = _URI
@@ -492,7 +492,7 @@ class TestGceNetwork(BaseGceNetworkTest):
   def testGetNetwork(self):
     project = 'myproject'
     zone = 'us-east1-a'
-    vm = mock.Mock(zone=zone, project=project)
+    vm = mock.Mock(zone=zone, project=project, cidr=None)
     net = gce_network.GceNetwork.GetNetwork(vm)
     self.assertEqual(project, net.project)
     self.assertEqual(zone, net.zone)

--- a/tests/providers/gcp/gcp_network_test.py
+++ b/tests/providers/gcp/gcp_network_test.py
@@ -1,0 +1,507 @@
+# Copyright 2018 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for perfkitbenchmarker.providers.gcp.gce_network."""
+
+import contextlib
+# import copy
+# import json
+# import re
+# import unittest
+# import yaml
+
+import mock
+
+from perfkitbenchmarker import benchmark_spec
+from perfkitbenchmarker import configs
+# from perfkitbenchmarker import context
+from perfkitbenchmarker import errors
+from perfkitbenchmarker import flags
+from perfkitbenchmarker import linux_benchmarks
+from perfkitbenchmarker import vm_util
+from perfkitbenchmarker.configs import benchmark_config_spec
+from perfkitbenchmarker.providers.gcp import gce_network
+# from perfkitbenchmarker.providers.gcp import gce_virtual_machine
+from perfkitbenchmarker.providers.gcp import util
+from tests import pkb_common_test_case
+from six.moves import builtins
+
+FLAGS = flags.FLAGS
+
+_PROJECT = 'project'
+_CLOUD = 'GCP'
+_BENCHMARK_NAME = 'iperf'
+_URI = 'uri45678'
+_COMPONENT = 'test_component'
+
+_CFG_DEFAULT_DEFAULT = """
+iperf:
+  vm_groups:
+    vm_1:
+      cloud: GCP
+      vm_spec:
+        GCP:
+            zone: us-west1-b
+            machine_type: n1-standard-4
+    vm_2:
+      cloud: GCP
+      vm_spec:
+        GCP:
+            zone: us-central1-c
+            machine_type: n1-standard-4
+"""
+
+_CFG_MULTI_MULTI = """
+iperf:
+  vm_groups:
+    vm_1:
+      cloud: GCP
+      cidr: 10.0.1.0/24
+      vm_spec:
+        GCP:
+            zone: us-west1-b
+            machine_type: n1-standard-4
+    vm_2:
+      cloud: GCP
+      cidr: 192.168.1.0/24
+      vm_spec:
+        GCP:
+            zone: us-central1-c
+            machine_type: n1-standard-4
+"""
+
+_CFG_DEFAULT_MULTI = """
+iperf:
+  vm_groups:
+    vm_1:
+      cloud: GCP
+      vm_spec:
+        GCP:
+            zone: us-west1-b
+            machine_type: n1-standard-4
+    vm_2:
+      cloud: GCP
+      cidr: 192.168.1.0/24
+      vm_spec:
+        GCP:
+            zone: us-central1-c
+            machine_type: n1-standard-4
+"""
+
+_CFG_SAME_ZONE_AND_CIDR = """
+iperf:
+  vm_groups:
+    vm_1:
+      cloud: GCP
+      cidr: 10.0.1.0/24
+      vm_spec:
+        GCP:
+            zone: us-west1-b
+            machine_type: n1-standard-4
+    vm_2:
+      cloud: GCP
+      cidr: 10.0.1.0/24
+      vm_spec:
+        GCP:
+            zone: us-west1-b
+            machine_type: n1-standard-4
+"""
+
+_CFG_SAME_ZONE_DIFF_CIDR = """
+iperf:
+  vm_groups:
+    vm_1:
+      cloud: GCP
+      cidr: 10.0.1.0/24
+      vm_spec:
+        GCP:
+            zone: us-west1-b
+            machine_type: n1-standard-4
+    vm_2:
+      cloud: GCP
+      cidr: 10.0.2.0/24
+      vm_spec:
+        GCP:
+            zone: us-west1-b
+            machine_type: n1-standard-4
+"""
+
+_REGEX_GCE_NET_NAMES = r'(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)'
+_REGEX_GCE_FW_NAMES = r'(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)'
+
+
+class BaseGceNetworkTest(pkb_common_test_case.PkbCommonTestCase):
+
+    def setUp(self):
+        super(BaseGceNetworkTest, self).setUp()
+
+    def _CreateBenchmarkSpecFromYaml(self, yaml_string, benchmark_name=_BENCHMARK_NAME):
+        config = configs.LoadConfig(yaml_string, {}, benchmark_name)
+        return self._CreateBenchmarkSpecFromConfigDict(config, benchmark_name)
+
+    def _CreateBenchmarkSpecFromConfigDict(self, config_dict, benchmark_name):
+        config_spec = benchmark_config_spec.BenchmarkConfigSpec(
+            benchmark_name, flag_values=FLAGS, **config_dict)
+        benchmark_module = next((b for b in linux_benchmarks.BENCHMARKS
+                                 if b.BENCHMARK_NAME == benchmark_name))
+        return benchmark_spec.BenchmarkSpec(benchmark_module, config_spec, _URI)
+
+
+class TestGceNetworkConfig(BaseGceNetworkTest):
+
+    def setUp(self):
+        super(TestGceNetworkConfig, self).setUp()
+
+    def testLoadDefaultConfig(self):
+        spec = self._CreateBenchmarkSpecFromYaml(_CFG_DEFAULT_DEFAULT)
+        spec.ConstructVirtualMachines()
+
+        self.assertDictContainsSubset({'cidr': None}, spec.custom_subnets['vm_1'])
+        self.assertDictContainsSubset({'cidr': None}, spec.custom_subnets['vm_2'])
+        self.assertLen(spec.networks, 1)
+        for k in spec.networks.keys():
+            self.assertItemsEqual(['10.0.0.0/8'], spec.networks[k].all_nets)
+
+    def testLoadDefaultConfigWithFlags(self):
+        FLAGS.gce_subnet_region = 'us-north1-b'
+        FLAGS.gce_subnet_addr = '1.2.3.4/33'
+
+        spec = self._CreateBenchmarkSpecFromYaml(_CFG_DEFAULT_DEFAULT)
+        spec.ConstructVirtualMachines()
+
+        self.assertDictContainsSubset({'cidr': None}, spec.custom_subnets['vm_1'])
+        self.assertDictContainsSubset({'cidr': None}, spec.custom_subnets['vm_2'])
+        self.assertLen(spec.networks, 1)
+        for k in spec.networks.keys():
+            self.assertItemsEqual(['1.2.3.4/33'], spec.networks[k].all_nets)
+
+    def testLoadCustomConfig(self):
+        spec = self._CreateBenchmarkSpecFromYaml(_CFG_MULTI_MULTI)
+        spec.ConstructVirtualMachines()
+
+        self.assertDictContainsSubset({'cidr': '10.0.1.0/24'}, spec.custom_subnets['vm_1'])
+        self.assertDictContainsSubset({'cidr': '192.168.1.0/24'}, spec.custom_subnets['vm_2'])
+        self.assertLen(spec.networks, 2)
+        for k in spec.networks.keys():
+            self.assertItemsEqual(['192.168.1.0/24', '10.0.1.0/24'], spec.networks[k].all_nets)
+
+    def testLoadCustomConfigWithFlags(self):
+        FLAGS.gce_subnet_region = 'us-north1-b'
+        FLAGS.gce_subnet_addr = '1.2.3.4/33'
+
+        spec = self._CreateBenchmarkSpecFromYaml(_CFG_MULTI_MULTI)
+        spec.ConstructVirtualMachines()
+
+        self.assertDictContainsSubset({'cidr': '10.0.1.0/24'}, spec.custom_subnets['vm_1'])
+        self.assertDictContainsSubset({'cidr': '192.168.1.0/24'}, spec.custom_subnets['vm_2'])
+        self.assertLen(spec.networks, 2)
+        for k in spec.networks.keys():
+            self.assertItemsEqual(['192.168.1.0/24', '10.0.1.0/24'], spec.networks[k].all_nets)
+
+    def testLoadMixedConfig(self):
+        spec = self._CreateBenchmarkSpecFromYaml(_CFG_DEFAULT_MULTI)
+        spec.ConstructVirtualMachines()
+
+        self.assertDictContainsSubset({'cidr': None}, spec.custom_subnets['vm_1'])
+        self.assertDictContainsSubset({'cidr': '192.168.1.0/24'}, spec.custom_subnets['vm_2'])
+        self.assertLen(spec.networks, 2)
+        for k in spec.networks.keys():
+            self.assertItemsEqual(['10.0.0.0/8', '192.168.1.0/24'], spec.networks[k].all_nets)
+
+    def testLoadMixedConfigWithFlags(self):
+        FLAGS.gce_subnet_region = 'us-north1-b'
+        FLAGS.gce_subnet_addr = '1.2.3.4/33'
+
+        spec = self._CreateBenchmarkSpecFromYaml(_CFG_DEFAULT_MULTI)
+        spec.ConstructVirtualMachines()
+
+        self.assertDictContainsSubset({'cidr': None}, spec.custom_subnets['vm_1'])
+        self.assertDictContainsSubset({'cidr': '192.168.1.0/24'}, spec.custom_subnets['vm_2'])
+        self.assertLen(spec.networks, 2)
+        for k in spec.networks.keys():
+            self.assertItemsEqual(['1.2.3.4/33', '192.168.1.0/24'], spec.networks[k].all_nets)
+
+    def testLoadSameZoneCidrConfig(self):
+        spec = self._CreateBenchmarkSpecFromYaml(_CFG_SAME_ZONE_AND_CIDR)
+        spec.ConstructVirtualMachines()
+
+        self.assertDictContainsSubset({'cidr': '10.0.1.0/24'}, spec.custom_subnets['vm_1'])
+        self.assertDictContainsSubset({'cidr': '10.0.1.0/24'}, spec.custom_subnets['vm_2'])
+        self.assertLen(spec.networks, 1)
+        for k in spec.networks.keys():
+            self.assertItemsEqual(['10.0.1.0/24'], spec.networks[k].all_nets)
+
+    def testLoadSameZoneDiffCidrConfig(self):
+        spec = self._CreateBenchmarkSpecFromYaml(_CFG_SAME_ZONE_DIFF_CIDR)
+        spec.ConstructVirtualMachines()
+
+        self.assertDictContainsSubset({'cidr': '10.0.1.0/24'}, spec.custom_subnets['vm_1'])
+        self.assertDictContainsSubset({'cidr': '10.0.2.0/24'}, spec.custom_subnets['vm_2'])
+        self.assertLen(spec.networks, 2)
+        for k in spec.networks.keys():
+            self.assertItemsEqual(['10.0.1.0/24', '10.0.2.0/24'], spec.networks[k].all_nets)
+
+
+class TestGceNetworkNames(BaseGceNetworkTest):
+
+    def setUp(self):
+        super(TestGceNetworkNames, self).setUp()
+        # need a benchmarkspec in the context to run
+        FLAGS.run_uri = _URI
+        config_spec = benchmark_config_spec.BenchmarkConfigSpec(
+            'cluster_boot', flag_values=FLAGS)
+        benchmark_spec.BenchmarkSpec(mock.Mock(), config_spec, 'uid')
+
+    ########
+    # Network Names
+    ########
+    def testGetDefaultNetworkName(self):
+        project = _PROJECT
+        zone = 'us-north1-b'
+        cidr = None
+        # long_cidr = '123.567.901/13'  # @TODO net_utils for address sanity checks
+        vm = mock.Mock(zone=zone, project=project, cidr=cidr)
+        net = gce_network.GceNetwork.GetNetwork(vm)
+        net_name = net._MakeGceNetworkName()
+
+        _net_type = 'default'
+        _cidr_string = None
+        _uri = _URI
+        expected_netname = '-'.join(
+            i for i in ('pkb-network', _net_type, _cidr_string, _uri) if i and i not in ('default'))
+
+        self.assertEqual(expected_netname, net_name)  # pkb-network-uri45678 (default)
+        self.assertRegexpMatches(net_name, _REGEX_GCE_NET_NAMES)
+
+    def testGetSingleNetworkName(self):
+        FLAGS.gce_subnet_region = 'us-south1-c'
+        FLAGS.gce_subnet_addr = '2.2.3.4/33'
+
+        project = _PROJECT
+        zone = 'us-north1-b'
+        cidr = None
+        vm = mock.Mock(zone=zone, project=project, cidr=cidr)
+        net = gce_network.GceNetwork.GetNetwork(vm)
+        net_name = net._MakeGceNetworkName()
+
+        _net_type = 'single'
+        _cidr_string = '2-2-3-4-33'
+        _uri = _URI
+        expected_netname = '-'.join(
+            i for i in ('pkb-network', _net_type, _cidr_string, _uri) if i and i not in ('default'))
+
+        self.assertEqual(expected_netname, net_name)  # pkb-network-single-2-2-3-4-33-uri45678 (single)
+        self.assertRegexpMatches(net_name, _REGEX_GCE_NET_NAMES)
+
+    def testGetMultiNetworkName(self):
+        project = _PROJECT
+        zone = 'us-north1-b'
+        cidr = '1.2.3.4/56'
+        vm = mock.Mock(zone=zone, project=project, cidr=cidr)
+        net = gce_network.GceNetwork.GetNetwork(vm)
+        net_name = net._MakeGceNetworkName()
+
+        _net_type = 'multi'
+        _cidr_string = '1-2-3-4-56'
+        _uri = _URI
+        expected_netname = '-'.join(
+            i for i in ('pkb-network', _net_type, _cidr_string, _uri) if i and i not in ('default'))
+
+        self.assertEqual(expected_netname, net_name)  # pkb-network-multi-1-2-3-4-56-uri45678 (multi)
+        self.assertRegexpMatches(net_name, _REGEX_GCE_NET_NAMES)
+
+    ########
+    # FireWall Names
+    ########
+    def testGetDefaultFWName(self):
+        project = _PROJECT
+        zone = 'us-north1-b'
+        cidr = None
+        vm = mock.Mock(zone=zone, project=project, cidr=cidr)
+        net = gce_network.GceNetwork.GetNetwork(vm)
+        fw_name = net._MakeGceFWRuleName()
+
+        _net_type = 'default'
+        _src_cidr_string = 'internal'
+        _dst_cidr_string = '10-0-0-0-8'
+        _src_port = None
+        _dst_port = None
+        _uri = _URI
+        expected_name = '-'.join(
+            i for i in (_net_type, _src_cidr_string, _dst_cidr_string, _src_port, _dst_port, _uri) if i)
+
+        self.assertEqual(expected_name, fw_name)
+        self.assertRegexpMatches(fw_name, _REGEX_GCE_FW_NAMES)
+
+    def testGetSingleFWName(self):
+        FLAGS.gce_subnet_region = 'us-south1-c'
+        FLAGS.gce_subnet_addr = '2.2.3.4/33'
+
+        project = _PROJECT
+        zone = 'us-north1-b'
+        cidr = None
+        lo_port = None
+        hi_port = None
+        vm = mock.Mock(zone=zone, project=project, cidr=cidr)
+        net = gce_network.GceNetwork.GetNetwork(vm)
+        fw_name = net._MakeGceFWRuleName(
+            net_type=None, src_cidr=None, dst_cidr=None, port_range_lo=lo_port, port_range_hi=hi_port, uri=None)
+
+        _net_type = 'single'
+        _src_cidr_string = 'internal'
+        _dst_cidr_string = '2-2-3-4-33'
+        _src_port = None
+        _dst_port = None
+        _uri = _URI
+        expected_name = '-'.join(
+            i for i in (_net_type, _src_cidr_string, _dst_cidr_string, _src_port, _dst_port, _uri) if i)
+
+        self.assertEqual(expected_name, fw_name)  # single-internal-2-2-3-4-33-uri45678
+        self.assertRegexpMatches(fw_name, _REGEX_GCE_FW_NAMES)
+
+    def testGetMultiFWNameWithPorts(self):
+        project = _PROJECT
+        zone = 'us-north1-b'
+        cidr = '1.2.3.4/56'
+        # cidr = None
+        vm = mock.Mock(zone=zone, project=project, cidr=cidr)
+        net = gce_network.GceNetwork.GetNetwork(vm)
+
+        dst_cidr = None
+        lo_port = 49152
+        hi_port = 65535
+        fw_name = net._MakeGceFWRuleName(
+            net_type=None, src_cidr=None, dst_cidr=dst_cidr, port_range_lo=lo_port, port_range_hi=hi_port, uri=None)
+
+        _prefix = None
+        _net_type = 'multi'
+        _src_cidr_string = 'internal'
+        _dst_cidr_string = '1-2-3-4-56'
+        _src_port = '49152'
+        _dst_port = '65535'
+        _uri = _URI
+        expected_name = '-'.join(
+            i for i in (_prefix, _net_type, _src_cidr_string, _dst_cidr_string, _src_port, _dst_port, _uri) if i)
+
+        self.assertEqual(expected_name, fw_name)  # multi-internal-1-2-3-4-56-49152-65535-uri45678
+        self.assertRegexpMatches(fw_name, _REGEX_GCE_FW_NAMES)
+
+    def testGetMultiFWNameWithPortsDst(self):
+        project = _PROJECT
+        zone = 'us-north1-b'
+        cidr = '1.2.3.4/56'
+        vm = mock.Mock(zone=zone, project=project, cidr=cidr)
+        net = gce_network.GceNetwork.GetNetwork(vm)
+
+        dst_cidr = '123.567.901/13'
+        lo_port = 49152
+        hi_port = 65535
+        fw_name = net._MakeGceFWRuleName(
+            net_type=None, src_cidr=None, dst_cidr=dst_cidr, port_range_lo=lo_port, port_range_hi=hi_port, uri=None)
+
+        _prefix = 'perfkit-firewall'
+        _net_type = 'multi'
+        _src_cidr_string = '1-2-3-4-56'
+        _dst_cidr_string = '123-567-901-13'
+        _src_port = '49152'
+        _dst_port = '65535'
+        _uri = _URI
+        expected_name = '-'.join(
+            i for i in (_prefix, _net_type, _src_cidr_string, _dst_cidr_string, _src_port, _dst_port, _uri) if i)
+
+        self.assertEqual(expected_name, fw_name)  # perfkit-firewall-multi-1-2-3-4-56-123-567-901-13-49152-65535-uri45678
+        self.assertRegexpMatches(fw_name, _REGEX_GCE_FW_NAMES)
+
+
+#  found in tests/gce_virtual_machine_test.py
+@contextlib.contextmanager
+def PatchCriticalObjects(retvals=None):
+    """A context manager that patches a few critical objects with mocks."""
+
+    def ReturnVal(*unused_arg, **unused_kwargs):
+        del unused_arg
+        del unused_kwargs
+        return ('', '', 0) if retvals is None else retvals.pop(0)
+
+    with mock.patch(
+            vm_util.__name__ + '.IssueCommand',
+            side_effect=ReturnVal) as issue_command, mock.patch(
+        builtins.__name__ + '.open'), mock.patch(
+        vm_util.__name__ +
+        '.NamedTemporaryFile'), mock.patch(util.__name__ +
+                                           '.GetDefaultProject'):
+        yield issue_command
+
+
+class TestGceNetwork(BaseGceNetworkTest):
+
+    def setUp(self):
+        super(TestGceNetwork, self).setUp()
+        # need a benchmarkspec in the context to run
+        config_spec = benchmark_config_spec.BenchmarkConfigSpec(
+            'cluster_boot', flag_values=FLAGS)
+        benchmark_spec.BenchmarkSpec(mock.Mock(), config_spec, 'uid')
+
+    def testGetNetwork(self):
+        project = 'myproject'
+        zone = 'us-east1-a'
+        vm = mock.Mock(zone=zone, project=project)
+        net = gce_network.GceNetwork.GetNetwork(vm)
+        self.assertEqual(project, net.project)
+        self.assertEqual(zone, net.zone)
+
+
+class GceFirewallRuleTest(pkb_common_test_case.PkbCommonTestCase):
+
+    @mock.patch('time.sleep', side_effect=lambda _: None)
+    def testGceFirewallRuleSuccessfulAfterRateLimited(self, mock_cmd):
+        fake_rets = [('stdout', 'Rate Limit Exceeded', 1),
+                     ('stdout', 'some warning perhaps', 0)]
+        with PatchCriticalObjects(fake_rets) as issue_command:
+            fr = gce_network.GceFirewallRule('name', 'project', 'allow',
+                                             'network_name')
+            fr._Create()
+            self.assertEqual(issue_command.call_count, 2)
+
+    @mock.patch('time.sleep', side_effect=lambda _: None)
+    def testGceFirewallRuleGenericErrorAfterRateLimited(self, mock_cmd):
+        fake_rets = [('stdout', 'Rate Limit Exceeded', 1),
+                     ('stdout', 'Rate Limit Exceeded', 1),
+                     ('stdout', 'some random firewall error', 1)]
+        with PatchCriticalObjects(fake_rets) as issue_command:
+            with self.assertRaises(errors.VmUtil.IssueCommandError):
+                fr = gce_network.GceFirewallRule('name', 'project', 'allow',
+                                                 'network_name')
+                fr._Create()
+            self.assertEqual(issue_command.call_count, 3)
+
+    @mock.patch('time.sleep', side_effect=lambda _: None)
+    def testGceFirewallRuleAlreadyExistsAfterRateLimited(self, mock_cmd):
+        fake_rets = [('stdout', 'Rate Limit Exceeded', 1),
+                     ('stdout', 'Rate Limit Exceeded', 1),
+                     ('stdout', 'firewall already exists', 1)]
+        with PatchCriticalObjects(fake_rets) as issue_command:
+            fr = gce_network.GceFirewallRule('name', 'project', 'allow',
+                                             'network_name')
+            fr._Create()
+            self.assertEqual(issue_command.call_count, 3)
+
+    @mock.patch('time.sleep', side_effect=lambda _: None)
+    def testGceFirewallRuleGenericError(self, mock_cmd):
+        fake_rets = [('stdout', 'some random firewall error', 1)]
+        with PatchCriticalObjects(fake_rets) as issue_command:
+            with self.assertRaises(errors.VmUtil.IssueCommandError):
+                fr = gce_network.GceFirewallRule('name', 'project', 'allow',
+                                                 'network_name')
+                fr._Create()
+            self.assertEqual(issue_command.call_count, 1)

--- a/tests/providers/gcp/gcp_network_test.py
+++ b/tests/providers/gcp/gcp_network_test.py
@@ -145,7 +145,9 @@ class BaseGceNetworkTest(pkb_common_test_case.PkbCommonTestCase):
 
   def _CreateBenchmarkSpecFromConfigDict(self, config_dict, benchmark_name):
     config_spec = benchmark_config_spec.BenchmarkConfigSpec(
-      benchmark_name, flag_values=FLAGS, **config_dict)
+        benchmark_name,
+        flag_values=FLAGS,
+        **config_dict)
     benchmark_module = next((b for b in linux_benchmarks.BENCHMARKS
                              if b.BENCHMARK_NAME == benchmark_name))
     return benchmark_spec.BenchmarkSpec(benchmark_module, config_spec, _URI)
@@ -268,7 +270,7 @@ class TestGceNetworkNames(BaseGceNetworkTest):
     # need a benchmarkspec in the context to run
     FLAGS.run_uri = _URI
     config_spec = benchmark_config_spec.BenchmarkConfigSpec(
-      'cluster_boot', flag_values=FLAGS)
+        'cluster_boot', flag_values=FLAGS)
     benchmark_spec.BenchmarkSpec(mock.Mock(), config_spec, 'uid')
 
   ########
@@ -287,8 +289,8 @@ class TestGceNetworkNames(BaseGceNetworkTest):
     _cidr_string = None
     _uri = _URI
     expected_netname = '-'.join(
-      i for i in ('pkb-network', _net_type, _cidr_string, _uri) if
-      i and i not in ('default'))
+        i for i in ('pkb-network', _net_type, _cidr_string, _uri) if
+        i and i not in ('default'))
 
     self.assertEqual(expected_netname,
                      net_name)  # pkb-network-uri45678 (default)
@@ -309,8 +311,8 @@ class TestGceNetworkNames(BaseGceNetworkTest):
     _cidr_string = '2-2-3-4-33'
     _uri = _URI
     expected_netname = '-'.join(
-      i for i in ('pkb-network', _net_type, _cidr_string, _uri) if
-      i and i not in ('default'))
+        i for i in ('pkb-network', _net_type, _cidr_string, _uri) if
+        i and i not in ('default'))
 
     self.assertEqual(expected_netname,
                      net_name)  # pkb-network-single-2-2-3-4-33-uri45678 (single)
@@ -328,8 +330,8 @@ class TestGceNetworkNames(BaseGceNetworkTest):
     _cidr_string = '1-2-3-4-56'
     _uri = _URI
     expected_netname = '-'.join(
-      i for i in ('pkb-network', _net_type, _cidr_string, _uri) if
-      i and i not in ('default'))
+        i for i in ('pkb-network', _net_type, _cidr_string, _uri) if
+        i and i not in ('default'))
 
     self.assertEqual(expected_netname,
                      net_name)  # pkb-network-multi-1-2-3-4-56-uri45678 (multi)
@@ -353,10 +355,11 @@ class TestGceNetworkNames(BaseGceNetworkTest):
     _dst_port = None
     _uri = _URI
     expected_name = '-'.join(
-      i for i in (
-        _net_type, _src_cidr_string, _dst_cidr_string, _src_port, _dst_port,
-        _uri)
-      if i)
+        i for i in (
+            _net_type, _src_cidr_string, _dst_cidr_string, _src_port,
+            _dst_port,
+            _uri)
+        if i)
 
     self.assertEqual(expected_name, fw_name)
     self.assertRegexpMatches(fw_name, _REGEX_GCE_FW_NAMES)
@@ -373,8 +376,8 @@ class TestGceNetworkNames(BaseGceNetworkTest):
     vm = mock.Mock(zone=zone, project=project, cidr=cidr)
     net = gce_network.GceNetwork.GetNetwork(vm)
     fw_name = net._MakeGceFWRuleName(
-      net_type=None, src_cidr=None, dst_cidr=None, port_range_lo=lo_port,
-      port_range_hi=hi_port, uri=None)
+        net_type=None, src_cidr=None, dst_cidr=None, port_range_lo=lo_port,
+        port_range_hi=hi_port, uri=None)
 
     _net_type = 'single'
     _src_cidr_string = 'internal'
@@ -383,10 +386,11 @@ class TestGceNetworkNames(BaseGceNetworkTest):
     _dst_port = None
     _uri = _URI
     expected_name = '-'.join(
-      i for i in (
-        _net_type, _src_cidr_string, _dst_cidr_string, _src_port, _dst_port,
-        _uri)
-      if i)
+        i for i in (
+            _net_type, _src_cidr_string, _dst_cidr_string, _src_port,
+            _dst_port,
+            _uri)
+        if i)
 
     self.assertEqual(expected_name,
                      fw_name)  # single-internal-2-2-3-4-33-uri45678
@@ -404,8 +408,9 @@ class TestGceNetworkNames(BaseGceNetworkTest):
     lo_port = 49152
     hi_port = 65535
     fw_name = net._MakeGceFWRuleName(
-      net_type=None, src_cidr=None, dst_cidr=dst_cidr, port_range_lo=lo_port,
-      port_range_hi=hi_port, uri=None)
+        net_type=None, src_cidr=None, dst_cidr=dst_cidr,
+        port_range_lo=lo_port,
+        port_range_hi=hi_port, uri=None)
 
     _prefix = None
     _net_type = 'multi'
@@ -415,9 +420,9 @@ class TestGceNetworkNames(BaseGceNetworkTest):
     _dst_port = '65535'
     _uri = _URI
     expected_name = '-'.join(
-      i for i in (
-        _prefix, _net_type, _src_cidr_string, _dst_cidr_string, _src_port,
-        _dst_port, _uri) if i)
+        i for i in (
+            _prefix, _net_type, _src_cidr_string, _dst_cidr_string, _src_port,
+            _dst_port, _uri) if i)
 
     self.assertEqual(expected_name,
                      fw_name)  # multi-internal-1-2-3-4-56-49152-65535-uri45678
@@ -434,8 +439,9 @@ class TestGceNetworkNames(BaseGceNetworkTest):
     lo_port = 49152
     hi_port = 65535
     fw_name = net._MakeGceFWRuleName(
-      net_type=None, src_cidr=None, dst_cidr=dst_cidr, port_range_lo=lo_port,
-      port_range_hi=hi_port, uri=None)
+        net_type=None, src_cidr=None, dst_cidr=dst_cidr,
+        port_range_lo=lo_port,
+        port_range_hi=hi_port, uri=None)
 
     _prefix = 'perfkit-firewall'
     _net_type = 'multi'
@@ -445,9 +451,9 @@ class TestGceNetworkNames(BaseGceNetworkTest):
     _dst_port = '65535'
     _uri = _URI
     expected_name = '-'.join(
-      i for i in (
-        _prefix, _net_type, _src_cidr_string, _dst_cidr_string, _src_port,
-        _dst_port, _uri) if i)
+        i for i in (
+            _prefix, _net_type, _src_cidr_string, _dst_cidr_string, _src_port,
+            _dst_port, _uri) if i)
 
     self.assertEqual(expected_name,
                      fw_name)  # perfkit-firewall-multi-1-2-3-4-56-123-567-901-13-49152-65535-uri45678
@@ -467,10 +473,10 @@ def PatchCriticalObjects(retvals=None):
   with mock.patch(
       vm_util.__name__ + '.IssueCommand',
       side_effect=ReturnVal) as issue_command, mock.patch(
-    builtins.__name__ + '.open'), mock.patch(
-    vm_util.__name__ +
-    '.NamedTemporaryFile'), mock.patch(util.__name__ +
-                                       '.GetDefaultProject'):
+      builtins.__name__ + '.open'), mock.patch(
+      vm_util.__name__ +
+      '.NamedTemporaryFile'), mock.patch(util.__name__ +
+                                         '.GetDefaultProject'):
     yield issue_command
 
 
@@ -480,7 +486,7 @@ class TestGceNetwork(BaseGceNetworkTest):
     super(TestGceNetwork, self).setUp()
     # need a benchmarkspec in the context to run
     config_spec = benchmark_config_spec.BenchmarkConfigSpec(
-      'cluster_boot', flag_values=FLAGS)
+        'cluster_boot', flag_values=FLAGS)
     benchmark_spec.BenchmarkSpec(mock.Mock(), config_spec, 'uid')
 
   def testGetNetwork(self):

--- a/tests/providers/gcp/gcp_network_test.py
+++ b/tests/providers/gcp/gcp_network_test.py
@@ -1,4 +1,4 @@
-# Copyright 2018 PerfKitBenchmarker Authors. All rights reserved.
+# Copyright 2019 PerfKitBenchmarker Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,24 +14,17 @@
 """Tests for perfkitbenchmarker.providers.gcp.gce_network."""
 
 import contextlib
-# import copy
-# import json
-# import re
-# import unittest
-# import yaml
 
 import mock
 
 from perfkitbenchmarker import benchmark_spec
 from perfkitbenchmarker import configs
-# from perfkitbenchmarker import context
 from perfkitbenchmarker import errors
 from perfkitbenchmarker import flags
 from perfkitbenchmarker import linux_benchmarks
 from perfkitbenchmarker import vm_util
 from perfkitbenchmarker.configs import benchmark_config_spec
 from perfkitbenchmarker.providers.gcp import gce_network
-# from perfkitbenchmarker.providers.gcp import gce_virtual_machine
 from perfkitbenchmarker.providers.gcp import util
 from tests import pkb_common_test_case
 from six.moves import builtins
@@ -142,366 +135,404 @@ _REGEX_GCE_FW_NAMES = r'(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)'
 
 class BaseGceNetworkTest(pkb_common_test_case.PkbCommonTestCase):
 
-    def setUp(self):
-        super(BaseGceNetworkTest, self).setUp()
+  def setUp(self):
+    super(BaseGceNetworkTest, self).setUp()
 
-    def _CreateBenchmarkSpecFromYaml(self, yaml_string, benchmark_name=_BENCHMARK_NAME):
-        config = configs.LoadConfig(yaml_string, {}, benchmark_name)
-        return self._CreateBenchmarkSpecFromConfigDict(config, benchmark_name)
+  def _CreateBenchmarkSpecFromYaml(self, yaml_string,
+                                   benchmark_name=_BENCHMARK_NAME):
+    config = configs.LoadConfig(yaml_string, {}, benchmark_name)
+    return self._CreateBenchmarkSpecFromConfigDict(config, benchmark_name)
 
-    def _CreateBenchmarkSpecFromConfigDict(self, config_dict, benchmark_name):
-        config_spec = benchmark_config_spec.BenchmarkConfigSpec(
-            benchmark_name, flag_values=FLAGS, **config_dict)
-        benchmark_module = next((b for b in linux_benchmarks.BENCHMARKS
-                                 if b.BENCHMARK_NAME == benchmark_name))
-        return benchmark_spec.BenchmarkSpec(benchmark_module, config_spec, _URI)
+  def _CreateBenchmarkSpecFromConfigDict(self, config_dict, benchmark_name):
+    config_spec = benchmark_config_spec.BenchmarkConfigSpec(
+      benchmark_name, flag_values=FLAGS, **config_dict)
+    benchmark_module = next((b for b in linux_benchmarks.BENCHMARKS
+                             if b.BENCHMARK_NAME == benchmark_name))
+    return benchmark_spec.BenchmarkSpec(benchmark_module, config_spec, _URI)
 
 
 class TestGceNetworkConfig(BaseGceNetworkTest):
 
-    def setUp(self):
-        super(TestGceNetworkConfig, self).setUp()
+  def setUp(self):
+    super(TestGceNetworkConfig, self).setUp()
 
-    def testLoadDefaultConfig(self):
-        spec = self._CreateBenchmarkSpecFromYaml(_CFG_DEFAULT_DEFAULT)
-        spec.ConstructVirtualMachines()
+  def testLoadDefaultConfig(self):
+    spec = self._CreateBenchmarkSpecFromYaml(_CFG_DEFAULT_DEFAULT)
+    spec.ConstructVirtualMachines()
 
-        self.assertDictContainsSubset({'cidr': None}, spec.custom_subnets['vm_1'])
-        self.assertDictContainsSubset({'cidr': None}, spec.custom_subnets['vm_2'])
-        self.assertLen(spec.networks, 1)
-        for k in spec.networks.keys():
-            self.assertItemsEqual(['10.0.0.0/8'], spec.networks[k].all_nets)
+    self.assertDictContainsSubset({'cidr': None}, spec.custom_subnets['vm_1'])
+    self.assertDictContainsSubset({'cidr': None}, spec.custom_subnets['vm_2'])
+    self.assertLen(spec.networks, 1)
+    for k in spec.networks.keys():
+      self.assertItemsEqual(['10.0.0.0/8'], spec.networks[k].all_nets)
 
-    def testLoadDefaultConfigWithFlags(self):
-        FLAGS.gce_subnet_region = 'us-north1-b'
-        FLAGS.gce_subnet_addr = '1.2.3.4/33'
+  def testLoadDefaultConfigWithFlags(self):
+    FLAGS.gce_subnet_region = 'us-north1-b'
+    FLAGS.gce_subnet_addr = '1.2.3.4/33'
 
-        spec = self._CreateBenchmarkSpecFromYaml(_CFG_DEFAULT_DEFAULT)
-        spec.ConstructVirtualMachines()
+    spec = self._CreateBenchmarkSpecFromYaml(_CFG_DEFAULT_DEFAULT)
+    spec.ConstructVirtualMachines()
 
-        self.assertDictContainsSubset({'cidr': None}, spec.custom_subnets['vm_1'])
-        self.assertDictContainsSubset({'cidr': None}, spec.custom_subnets['vm_2'])
-        self.assertLen(spec.networks, 1)
-        for k in spec.networks.keys():
-            self.assertItemsEqual(['1.2.3.4/33'], spec.networks[k].all_nets)
+    self.assertDictContainsSubset({'cidr': None}, spec.custom_subnets['vm_1'])
+    self.assertDictContainsSubset({'cidr': None}, spec.custom_subnets['vm_2'])
+    self.assertLen(spec.networks, 1)
+    for k in spec.networks.keys():
+      self.assertItemsEqual(['1.2.3.4/33'], spec.networks[k].all_nets)
 
-    def testLoadCustomConfig(self):
-        spec = self._CreateBenchmarkSpecFromYaml(_CFG_MULTI_MULTI)
-        spec.ConstructVirtualMachines()
+  def testLoadCustomConfig(self):
+    spec = self._CreateBenchmarkSpecFromYaml(_CFG_MULTI_MULTI)
+    spec.ConstructVirtualMachines()
 
-        self.assertDictContainsSubset({'cidr': '10.0.1.0/24'}, spec.custom_subnets['vm_1'])
-        self.assertDictContainsSubset({'cidr': '192.168.1.0/24'}, spec.custom_subnets['vm_2'])
-        self.assertLen(spec.networks, 2)
-        for k in spec.networks.keys():
-            self.assertItemsEqual(['192.168.1.0/24', '10.0.1.0/24'], spec.networks[k].all_nets)
+    self.assertDictContainsSubset({'cidr': '10.0.1.0/24'},
+                                  spec.custom_subnets['vm_1'])
+    self.assertDictContainsSubset({'cidr': '192.168.1.0/24'},
+                                  spec.custom_subnets['vm_2'])
+    self.assertLen(spec.networks, 2)
+    for k in spec.networks.keys():
+      self.assertItemsEqual(['192.168.1.0/24', '10.0.1.0/24'],
+                            spec.networks[k].all_nets)
 
-    def testLoadCustomConfigWithFlags(self):
-        FLAGS.gce_subnet_region = 'us-north1-b'
-        FLAGS.gce_subnet_addr = '1.2.3.4/33'
+  def testLoadCustomConfigWithFlags(self):
+    FLAGS.gce_subnet_region = 'us-north1-b'
+    FLAGS.gce_subnet_addr = '1.2.3.4/33'
 
-        spec = self._CreateBenchmarkSpecFromYaml(_CFG_MULTI_MULTI)
-        spec.ConstructVirtualMachines()
+    spec = self._CreateBenchmarkSpecFromYaml(_CFG_MULTI_MULTI)
+    spec.ConstructVirtualMachines()
 
-        self.assertDictContainsSubset({'cidr': '10.0.1.0/24'}, spec.custom_subnets['vm_1'])
-        self.assertDictContainsSubset({'cidr': '192.168.1.0/24'}, spec.custom_subnets['vm_2'])
-        self.assertLen(spec.networks, 2)
-        for k in spec.networks.keys():
-            self.assertItemsEqual(['192.168.1.0/24', '10.0.1.0/24'], spec.networks[k].all_nets)
+    self.assertDictContainsSubset({'cidr': '10.0.1.0/24'},
+                                  spec.custom_subnets['vm_1'])
+    self.assertDictContainsSubset({'cidr': '192.168.1.0/24'},
+                                  spec.custom_subnets['vm_2'])
+    self.assertLen(spec.networks, 2)
+    for k in spec.networks.keys():
+      self.assertItemsEqual(['192.168.1.0/24', '10.0.1.0/24'],
+                            spec.networks[k].all_nets)
 
-    def testLoadMixedConfig(self):
-        spec = self._CreateBenchmarkSpecFromYaml(_CFG_DEFAULT_MULTI)
-        spec.ConstructVirtualMachines()
+  def testLoadMixedConfig(self):
+    spec = self._CreateBenchmarkSpecFromYaml(_CFG_DEFAULT_MULTI)
+    spec.ConstructVirtualMachines()
 
-        self.assertDictContainsSubset({'cidr': None}, spec.custom_subnets['vm_1'])
-        self.assertDictContainsSubset({'cidr': '192.168.1.0/24'}, spec.custom_subnets['vm_2'])
-        self.assertLen(spec.networks, 2)
-        for k in spec.networks.keys():
-            self.assertItemsEqual(['10.0.0.0/8', '192.168.1.0/24'], spec.networks[k].all_nets)
+    self.assertDictContainsSubset({'cidr': None}, spec.custom_subnets['vm_1'])
+    self.assertDictContainsSubset({'cidr': '192.168.1.0/24'},
+                                  spec.custom_subnets['vm_2'])
+    self.assertLen(spec.networks, 2)
+    for k in spec.networks.keys():
+      self.assertItemsEqual(['10.0.0.0/8', '192.168.1.0/24'],
+                            spec.networks[k].all_nets)
 
-    def testLoadMixedConfigWithFlags(self):
-        FLAGS.gce_subnet_region = 'us-north1-b'
-        FLAGS.gce_subnet_addr = '1.2.3.4/33'
+  def testLoadMixedConfigWithFlags(self):
+    FLAGS.gce_subnet_region = 'us-north1-b'
+    FLAGS.gce_subnet_addr = '1.2.3.4/33'
 
-        spec = self._CreateBenchmarkSpecFromYaml(_CFG_DEFAULT_MULTI)
-        spec.ConstructVirtualMachines()
+    spec = self._CreateBenchmarkSpecFromYaml(_CFG_DEFAULT_MULTI)
+    spec.ConstructVirtualMachines()
 
-        self.assertDictContainsSubset({'cidr': None}, spec.custom_subnets['vm_1'])
-        self.assertDictContainsSubset({'cidr': '192.168.1.0/24'}, spec.custom_subnets['vm_2'])
-        self.assertLen(spec.networks, 2)
-        for k in spec.networks.keys():
-            self.assertItemsEqual(['1.2.3.4/33', '192.168.1.0/24'], spec.networks[k].all_nets)
+    self.assertDictContainsSubset({'cidr': None}, spec.custom_subnets['vm_1'])
+    self.assertDictContainsSubset({'cidr': '192.168.1.0/24'},
+                                  spec.custom_subnets['vm_2'])
+    self.assertLen(spec.networks, 2)
+    for k in spec.networks.keys():
+      self.assertItemsEqual(['1.2.3.4/33', '192.168.1.0/24'],
+                            spec.networks[k].all_nets)
 
-    def testLoadSameZoneCidrConfig(self):
-        spec = self._CreateBenchmarkSpecFromYaml(_CFG_SAME_ZONE_AND_CIDR)
-        spec.ConstructVirtualMachines()
+  def testLoadSameZoneCidrConfig(self):
+    spec = self._CreateBenchmarkSpecFromYaml(_CFG_SAME_ZONE_AND_CIDR)
+    spec.ConstructVirtualMachines()
 
-        self.assertDictContainsSubset({'cidr': '10.0.1.0/24'}, spec.custom_subnets['vm_1'])
-        self.assertDictContainsSubset({'cidr': '10.0.1.0/24'}, spec.custom_subnets['vm_2'])
-        self.assertLen(spec.networks, 1)
-        for k in spec.networks.keys():
-            self.assertItemsEqual(['10.0.1.0/24'], spec.networks[k].all_nets)
+    self.assertDictContainsSubset({'cidr': '10.0.1.0/24'},
+                                  spec.custom_subnets['vm_1'])
+    self.assertDictContainsSubset({'cidr': '10.0.1.0/24'},
+                                  spec.custom_subnets['vm_2'])
+    self.assertLen(spec.networks, 1)
+    for k in spec.networks.keys():
+      self.assertItemsEqual(['10.0.1.0/24'], spec.networks[k].all_nets)
 
-    def testLoadSameZoneDiffCidrConfig(self):
-        spec = self._CreateBenchmarkSpecFromYaml(_CFG_SAME_ZONE_DIFF_CIDR)
-        spec.ConstructVirtualMachines()
+  def testLoadSameZoneDiffCidrConfig(self):
+    spec = self._CreateBenchmarkSpecFromYaml(_CFG_SAME_ZONE_DIFF_CIDR)
+    spec.ConstructVirtualMachines()
 
-        self.assertDictContainsSubset({'cidr': '10.0.1.0/24'}, spec.custom_subnets['vm_1'])
-        self.assertDictContainsSubset({'cidr': '10.0.2.0/24'}, spec.custom_subnets['vm_2'])
-        self.assertLen(spec.networks, 2)
-        for k in spec.networks.keys():
-            self.assertItemsEqual(['10.0.1.0/24', '10.0.2.0/24'], spec.networks[k].all_nets)
+    self.assertDictContainsSubset({'cidr': '10.0.1.0/24'},
+                                  spec.custom_subnets['vm_1'])
+    self.assertDictContainsSubset({'cidr': '10.0.2.0/24'},
+                                  spec.custom_subnets['vm_2'])
+    self.assertLen(spec.networks, 2)
+    for k in spec.networks.keys():
+      self.assertItemsEqual(['10.0.1.0/24', '10.0.2.0/24'],
+                            spec.networks[k].all_nets)
 
 
 class TestGceNetworkNames(BaseGceNetworkTest):
 
-    def setUp(self):
-        super(TestGceNetworkNames, self).setUp()
-        # need a benchmarkspec in the context to run
-        FLAGS.run_uri = _URI
-        config_spec = benchmark_config_spec.BenchmarkConfigSpec(
-            'cluster_boot', flag_values=FLAGS)
-        benchmark_spec.BenchmarkSpec(mock.Mock(), config_spec, 'uid')
+  def setUp(self):
+    super(TestGceNetworkNames, self).setUp()
+    # need a benchmarkspec in the context to run
+    FLAGS.run_uri = _URI
+    config_spec = benchmark_config_spec.BenchmarkConfigSpec(
+      'cluster_boot', flag_values=FLAGS)
+    benchmark_spec.BenchmarkSpec(mock.Mock(), config_spec, 'uid')
 
-    ########
-    # Network Names
-    ########
-    def testGetDefaultNetworkName(self):
-        project = _PROJECT
-        zone = 'us-north1-b'
-        cidr = None
-        # long_cidr = '123.567.901/13'  # @TODO net_utils for address sanity checks
-        vm = mock.Mock(zone=zone, project=project, cidr=cidr)
-        net = gce_network.GceNetwork.GetNetwork(vm)
-        net_name = net._MakeGceNetworkName()
+  ########
+  # Network Names
+  ########
+  def testGetDefaultNetworkName(self):
+    project = _PROJECT
+    zone = 'us-north1-b'
+    cidr = None
+    # long_cidr = '123.567.901/13'  # @TODO net_utils for address sanity checks
+    vm = mock.Mock(zone=zone, project=project, cidr=cidr)
+    net = gce_network.GceNetwork.GetNetwork(vm)
+    net_name = net._MakeGceNetworkName()
 
-        _net_type = 'default'
-        _cidr_string = None
-        _uri = _URI
-        expected_netname = '-'.join(
-            i for i in ('pkb-network', _net_type, _cidr_string, _uri) if i and i not in ('default'))
+    _net_type = 'default'
+    _cidr_string = None
+    _uri = _URI
+    expected_netname = '-'.join(
+      i for i in ('pkb-network', _net_type, _cidr_string, _uri) if
+      i and i not in ('default'))
 
-        self.assertEqual(expected_netname, net_name)  # pkb-network-uri45678 (default)
-        self.assertRegexpMatches(net_name, _REGEX_GCE_NET_NAMES)
+    self.assertEqual(expected_netname,
+                     net_name)  # pkb-network-uri45678 (default)
+    self.assertRegexpMatches(net_name, _REGEX_GCE_NET_NAMES)
 
-    def testGetSingleNetworkName(self):
-        FLAGS.gce_subnet_region = 'us-south1-c'
-        FLAGS.gce_subnet_addr = '2.2.3.4/33'
+  def testGetSingleNetworkName(self):
+    FLAGS.gce_subnet_region = 'us-south1-c'
+    FLAGS.gce_subnet_addr = '2.2.3.4/33'
 
-        project = _PROJECT
-        zone = 'us-north1-b'
-        cidr = None
-        vm = mock.Mock(zone=zone, project=project, cidr=cidr)
-        net = gce_network.GceNetwork.GetNetwork(vm)
-        net_name = net._MakeGceNetworkName()
+    project = _PROJECT
+    zone = 'us-north1-b'
+    cidr = None
+    vm = mock.Mock(zone=zone, project=project, cidr=cidr)
+    net = gce_network.GceNetwork.GetNetwork(vm)
+    net_name = net._MakeGceNetworkName()
 
-        _net_type = 'single'
-        _cidr_string = '2-2-3-4-33'
-        _uri = _URI
-        expected_netname = '-'.join(
-            i for i in ('pkb-network', _net_type, _cidr_string, _uri) if i and i not in ('default'))
+    _net_type = 'single'
+    _cidr_string = '2-2-3-4-33'
+    _uri = _URI
+    expected_netname = '-'.join(
+      i for i in ('pkb-network', _net_type, _cidr_string, _uri) if
+      i and i not in ('default'))
 
-        self.assertEqual(expected_netname, net_name)  # pkb-network-single-2-2-3-4-33-uri45678 (single)
-        self.assertRegexpMatches(net_name, _REGEX_GCE_NET_NAMES)
+    self.assertEqual(expected_netname,
+                     net_name)  # pkb-network-single-2-2-3-4-33-uri45678 (single)
+    self.assertRegexpMatches(net_name, _REGEX_GCE_NET_NAMES)
 
-    def testGetMultiNetworkName(self):
-        project = _PROJECT
-        zone = 'us-north1-b'
-        cidr = '1.2.3.4/56'
-        vm = mock.Mock(zone=zone, project=project, cidr=cidr)
-        net = gce_network.GceNetwork.GetNetwork(vm)
-        net_name = net._MakeGceNetworkName()
+  def testGetMultiNetworkName(self):
+    project = _PROJECT
+    zone = 'us-north1-b'
+    cidr = '1.2.3.4/56'
+    vm = mock.Mock(zone=zone, project=project, cidr=cidr)
+    net = gce_network.GceNetwork.GetNetwork(vm)
+    net_name = net._MakeGceNetworkName()
 
-        _net_type = 'multi'
-        _cidr_string = '1-2-3-4-56'
-        _uri = _URI
-        expected_netname = '-'.join(
-            i for i in ('pkb-network', _net_type, _cidr_string, _uri) if i and i not in ('default'))
+    _net_type = 'multi'
+    _cidr_string = '1-2-3-4-56'
+    _uri = _URI
+    expected_netname = '-'.join(
+      i for i in ('pkb-network', _net_type, _cidr_string, _uri) if
+      i and i not in ('default'))
 
-        self.assertEqual(expected_netname, net_name)  # pkb-network-multi-1-2-3-4-56-uri45678 (multi)
-        self.assertRegexpMatches(net_name, _REGEX_GCE_NET_NAMES)
+    self.assertEqual(expected_netname,
+                     net_name)  # pkb-network-multi-1-2-3-4-56-uri45678 (multi)
+    self.assertRegexpMatches(net_name, _REGEX_GCE_NET_NAMES)
 
-    ########
-    # FireWall Names
-    ########
-    def testGetDefaultFWName(self):
-        project = _PROJECT
-        zone = 'us-north1-b'
-        cidr = None
-        vm = mock.Mock(zone=zone, project=project, cidr=cidr)
-        net = gce_network.GceNetwork.GetNetwork(vm)
-        fw_name = net._MakeGceFWRuleName()
+  ########
+  # FireWall Names
+  ########
+  def testGetDefaultFWName(self):
+    project = _PROJECT
+    zone = 'us-north1-b'
+    cidr = None
+    vm = mock.Mock(zone=zone, project=project, cidr=cidr)
+    net = gce_network.GceNetwork.GetNetwork(vm)
+    fw_name = net._MakeGceFWRuleName()
 
-        _net_type = 'default'
-        _src_cidr_string = 'internal'
-        _dst_cidr_string = '10-0-0-0-8'
-        _src_port = None
-        _dst_port = None
-        _uri = _URI
-        expected_name = '-'.join(
-            i for i in (_net_type, _src_cidr_string, _dst_cidr_string, _src_port, _dst_port, _uri) if i)
+    _net_type = 'default'
+    _src_cidr_string = 'internal'
+    _dst_cidr_string = '10-0-0-0-8'
+    _src_port = None
+    _dst_port = None
+    _uri = _URI
+    expected_name = '-'.join(
+      i for i in (
+        _net_type, _src_cidr_string, _dst_cidr_string, _src_port, _dst_port,
+        _uri)
+      if i)
 
-        self.assertEqual(expected_name, fw_name)
-        self.assertRegexpMatches(fw_name, _REGEX_GCE_FW_NAMES)
+    self.assertEqual(expected_name, fw_name)
+    self.assertRegexpMatches(fw_name, _REGEX_GCE_FW_NAMES)
 
-    def testGetSingleFWName(self):
-        FLAGS.gce_subnet_region = 'us-south1-c'
-        FLAGS.gce_subnet_addr = '2.2.3.4/33'
+  def testGetSingleFWName(self):
+    FLAGS.gce_subnet_region = 'us-south1-c'
+    FLAGS.gce_subnet_addr = '2.2.3.4/33'
 
-        project = _PROJECT
-        zone = 'us-north1-b'
-        cidr = None
-        lo_port = None
-        hi_port = None
-        vm = mock.Mock(zone=zone, project=project, cidr=cidr)
-        net = gce_network.GceNetwork.GetNetwork(vm)
-        fw_name = net._MakeGceFWRuleName(
-            net_type=None, src_cidr=None, dst_cidr=None, port_range_lo=lo_port, port_range_hi=hi_port, uri=None)
+    project = _PROJECT
+    zone = 'us-north1-b'
+    cidr = None
+    lo_port = None
+    hi_port = None
+    vm = mock.Mock(zone=zone, project=project, cidr=cidr)
+    net = gce_network.GceNetwork.GetNetwork(vm)
+    fw_name = net._MakeGceFWRuleName(
+      net_type=None, src_cidr=None, dst_cidr=None, port_range_lo=lo_port,
+      port_range_hi=hi_port, uri=None)
 
-        _net_type = 'single'
-        _src_cidr_string = 'internal'
-        _dst_cidr_string = '2-2-3-4-33'
-        _src_port = None
-        _dst_port = None
-        _uri = _URI
-        expected_name = '-'.join(
-            i for i in (_net_type, _src_cidr_string, _dst_cidr_string, _src_port, _dst_port, _uri) if i)
+    _net_type = 'single'
+    _src_cidr_string = 'internal'
+    _dst_cidr_string = '2-2-3-4-33'
+    _src_port = None
+    _dst_port = None
+    _uri = _URI
+    expected_name = '-'.join(
+      i for i in (
+        _net_type, _src_cidr_string, _dst_cidr_string, _src_port, _dst_port,
+        _uri)
+      if i)
 
-        self.assertEqual(expected_name, fw_name)  # single-internal-2-2-3-4-33-uri45678
-        self.assertRegexpMatches(fw_name, _REGEX_GCE_FW_NAMES)
+    self.assertEqual(expected_name,
+                     fw_name)  # single-internal-2-2-3-4-33-uri45678
+    self.assertRegexpMatches(fw_name, _REGEX_GCE_FW_NAMES)
 
-    def testGetMultiFWNameWithPorts(self):
-        project = _PROJECT
-        zone = 'us-north1-b'
-        cidr = '1.2.3.4/56'
-        # cidr = None
-        vm = mock.Mock(zone=zone, project=project, cidr=cidr)
-        net = gce_network.GceNetwork.GetNetwork(vm)
+  def testGetMultiFWNameWithPorts(self):
+    project = _PROJECT
+    zone = 'us-north1-b'
+    cidr = '1.2.3.4/56'
+    # cidr = None
+    vm = mock.Mock(zone=zone, project=project, cidr=cidr)
+    net = gce_network.GceNetwork.GetNetwork(vm)
 
-        dst_cidr = None
-        lo_port = 49152
-        hi_port = 65535
-        fw_name = net._MakeGceFWRuleName(
-            net_type=None, src_cidr=None, dst_cidr=dst_cidr, port_range_lo=lo_port, port_range_hi=hi_port, uri=None)
+    dst_cidr = None
+    lo_port = 49152
+    hi_port = 65535
+    fw_name = net._MakeGceFWRuleName(
+      net_type=None, src_cidr=None, dst_cidr=dst_cidr, port_range_lo=lo_port,
+      port_range_hi=hi_port, uri=None)
 
-        _prefix = None
-        _net_type = 'multi'
-        _src_cidr_string = 'internal'
-        _dst_cidr_string = '1-2-3-4-56'
-        _src_port = '49152'
-        _dst_port = '65535'
-        _uri = _URI
-        expected_name = '-'.join(
-            i for i in (_prefix, _net_type, _src_cidr_string, _dst_cidr_string, _src_port, _dst_port, _uri) if i)
+    _prefix = None
+    _net_type = 'multi'
+    _src_cidr_string = 'internal'
+    _dst_cidr_string = '1-2-3-4-56'
+    _src_port = '49152'
+    _dst_port = '65535'
+    _uri = _URI
+    expected_name = '-'.join(
+      i for i in (
+        _prefix, _net_type, _src_cidr_string, _dst_cidr_string, _src_port,
+        _dst_port, _uri) if i)
 
-        self.assertEqual(expected_name, fw_name)  # multi-internal-1-2-3-4-56-49152-65535-uri45678
-        self.assertRegexpMatches(fw_name, _REGEX_GCE_FW_NAMES)
+    self.assertEqual(expected_name,
+                     fw_name)  # multi-internal-1-2-3-4-56-49152-65535-uri45678
+    self.assertRegexpMatches(fw_name, _REGEX_GCE_FW_NAMES)
 
-    def testGetMultiFWNameWithPortsDst(self):
-        project = _PROJECT
-        zone = 'us-north1-b'
-        cidr = '1.2.3.4/56'
-        vm = mock.Mock(zone=zone, project=project, cidr=cidr)
-        net = gce_network.GceNetwork.GetNetwork(vm)
+  def testGetMultiFWNameWithPortsDst(self):
+    project = _PROJECT
+    zone = 'us-north1-b'
+    cidr = '1.2.3.4/56'
+    vm = mock.Mock(zone=zone, project=project, cidr=cidr)
+    net = gce_network.GceNetwork.GetNetwork(vm)
 
-        dst_cidr = '123.567.901/13'
-        lo_port = 49152
-        hi_port = 65535
-        fw_name = net._MakeGceFWRuleName(
-            net_type=None, src_cidr=None, dst_cidr=dst_cidr, port_range_lo=lo_port, port_range_hi=hi_port, uri=None)
+    dst_cidr = '123.567.901/13'
+    lo_port = 49152
+    hi_port = 65535
+    fw_name = net._MakeGceFWRuleName(
+      net_type=None, src_cidr=None, dst_cidr=dst_cidr, port_range_lo=lo_port,
+      port_range_hi=hi_port, uri=None)
 
-        _prefix = 'perfkit-firewall'
-        _net_type = 'multi'
-        _src_cidr_string = '1-2-3-4-56'
-        _dst_cidr_string = '123-567-901-13'
-        _src_port = '49152'
-        _dst_port = '65535'
-        _uri = _URI
-        expected_name = '-'.join(
-            i for i in (_prefix, _net_type, _src_cidr_string, _dst_cidr_string, _src_port, _dst_port, _uri) if i)
+    _prefix = 'perfkit-firewall'
+    _net_type = 'multi'
+    _src_cidr_string = '1-2-3-4-56'
+    _dst_cidr_string = '123-567-901-13'
+    _src_port = '49152'
+    _dst_port = '65535'
+    _uri = _URI
+    expected_name = '-'.join(
+      i for i in (
+        _prefix, _net_type, _src_cidr_string, _dst_cidr_string, _src_port,
+        _dst_port, _uri) if i)
 
-        self.assertEqual(expected_name, fw_name)  # perfkit-firewall-multi-1-2-3-4-56-123-567-901-13-49152-65535-uri45678
-        self.assertRegexpMatches(fw_name, _REGEX_GCE_FW_NAMES)
+    self.assertEqual(expected_name,
+                     fw_name)  # perfkit-firewall-multi-1-2-3-4-56-123-567-901-13-49152-65535-uri45678
+    self.assertRegexpMatches(fw_name, _REGEX_GCE_FW_NAMES)
 
 
 #  found in tests/gce_virtual_machine_test.py
 @contextlib.contextmanager
 def PatchCriticalObjects(retvals=None):
-    """A context manager that patches a few critical objects with mocks."""
+  """A context manager that patches a few critical objects with mocks."""
 
-    def ReturnVal(*unused_arg, **unused_kwargs):
-        del unused_arg
-        del unused_kwargs
-        return ('', '', 0) if retvals is None else retvals.pop(0)
+  def ReturnVal(*unused_arg, **unused_kwargs):
+    del unused_arg
+    del unused_kwargs
+    return ('', '', 0) if retvals is None else retvals.pop(0)
 
-    with mock.patch(
-            vm_util.__name__ + '.IssueCommand',
-            side_effect=ReturnVal) as issue_command, mock.patch(
-        builtins.__name__ + '.open'), mock.patch(
-        vm_util.__name__ +
-        '.NamedTemporaryFile'), mock.patch(util.__name__ +
-                                           '.GetDefaultProject'):
-        yield issue_command
+  with mock.patch(
+      vm_util.__name__ + '.IssueCommand',
+      side_effect=ReturnVal) as issue_command, mock.patch(
+    builtins.__name__ + '.open'), mock.patch(
+    vm_util.__name__ +
+    '.NamedTemporaryFile'), mock.patch(util.__name__ +
+                                       '.GetDefaultProject'):
+    yield issue_command
 
 
 class TestGceNetwork(BaseGceNetworkTest):
 
-    def setUp(self):
-        super(TestGceNetwork, self).setUp()
-        # need a benchmarkspec in the context to run
-        config_spec = benchmark_config_spec.BenchmarkConfigSpec(
-            'cluster_boot', flag_values=FLAGS)
-        benchmark_spec.BenchmarkSpec(mock.Mock(), config_spec, 'uid')
+  def setUp(self):
+    super(TestGceNetwork, self).setUp()
+    # need a benchmarkspec in the context to run
+    config_spec = benchmark_config_spec.BenchmarkConfigSpec(
+      'cluster_boot', flag_values=FLAGS)
+    benchmark_spec.BenchmarkSpec(mock.Mock(), config_spec, 'uid')
 
-    def testGetNetwork(self):
-        project = 'myproject'
-        zone = 'us-east1-a'
-        vm = mock.Mock(zone=zone, project=project)
-        net = gce_network.GceNetwork.GetNetwork(vm)
-        self.assertEqual(project, net.project)
-        self.assertEqual(zone, net.zone)
+  def testGetNetwork(self):
+    project = 'myproject'
+    zone = 'us-east1-a'
+    vm = mock.Mock(zone=zone, project=project)
+    net = gce_network.GceNetwork.GetNetwork(vm)
+    self.assertEqual(project, net.project)
+    self.assertEqual(zone, net.zone)
 
 
 class GceFirewallRuleTest(pkb_common_test_case.PkbCommonTestCase):
 
-    @mock.patch('time.sleep', side_effect=lambda _: None)
-    def testGceFirewallRuleSuccessfulAfterRateLimited(self, mock_cmd):
-        fake_rets = [('stdout', 'Rate Limit Exceeded', 1),
-                     ('stdout', 'some warning perhaps', 0)]
-        with PatchCriticalObjects(fake_rets) as issue_command:
-            fr = gce_network.GceFirewallRule('name', 'project', 'allow',
-                                             'network_name')
-            fr._Create()
-            self.assertEqual(issue_command.call_count, 2)
+  @mock.patch('time.sleep', side_effect=lambda _: None)
+  def testGceFirewallRuleSuccessfulAfterRateLimited(self, mock_cmd):
+    fake_rets = [('stdout', 'Rate Limit Exceeded', 1),
+                 ('stdout', 'some warning perhaps', 0)]
+    with PatchCriticalObjects(fake_rets) as issue_command:
+      fr = gce_network.GceFirewallRule('name', 'project', 'allow',
+                                       'network_name')
+      fr._Create()
+      self.assertEqual(issue_command.call_count, 2)
 
-    @mock.patch('time.sleep', side_effect=lambda _: None)
-    def testGceFirewallRuleGenericErrorAfterRateLimited(self, mock_cmd):
-        fake_rets = [('stdout', 'Rate Limit Exceeded', 1),
-                     ('stdout', 'Rate Limit Exceeded', 1),
-                     ('stdout', 'some random firewall error', 1)]
-        with PatchCriticalObjects(fake_rets) as issue_command:
-            with self.assertRaises(errors.VmUtil.IssueCommandError):
-                fr = gce_network.GceFirewallRule('name', 'project', 'allow',
-                                                 'network_name')
-                fr._Create()
-            self.assertEqual(issue_command.call_count, 3)
+  @mock.patch('time.sleep', side_effect=lambda _: None)
+  def testGceFirewallRuleGenericErrorAfterRateLimited(self, mock_cmd):
+    fake_rets = [('stdout', 'Rate Limit Exceeded', 1),
+                 ('stdout', 'Rate Limit Exceeded', 1),
+                 ('stdout', 'some random firewall error', 1)]
+    with PatchCriticalObjects(fake_rets) as issue_command:
+      with self.assertRaises(errors.VmUtil.IssueCommandError):
+        fr = gce_network.GceFirewallRule('name', 'project', 'allow',
+                                         'network_name')
+        fr._Create()
+      self.assertEqual(issue_command.call_count, 3)
 
-    @mock.patch('time.sleep', side_effect=lambda _: None)
-    def testGceFirewallRuleAlreadyExistsAfterRateLimited(self, mock_cmd):
-        fake_rets = [('stdout', 'Rate Limit Exceeded', 1),
-                     ('stdout', 'Rate Limit Exceeded', 1),
-                     ('stdout', 'firewall already exists', 1)]
-        with PatchCriticalObjects(fake_rets) as issue_command:
-            fr = gce_network.GceFirewallRule('name', 'project', 'allow',
-                                             'network_name')
-            fr._Create()
-            self.assertEqual(issue_command.call_count, 3)
+  @mock.patch('time.sleep', side_effect=lambda _: None)
+  def testGceFirewallRuleAlreadyExistsAfterRateLimited(self, mock_cmd):
+    fake_rets = [('stdout', 'Rate Limit Exceeded', 1),
+                 ('stdout', 'Rate Limit Exceeded', 1),
+                 ('stdout', 'firewall already exists', 1)]
+    with PatchCriticalObjects(fake_rets) as issue_command:
+      fr = gce_network.GceFirewallRule('name', 'project', 'allow',
+                                       'network_name')
+      fr._Create()
+      self.assertEqual(issue_command.call_count, 3)
 
-    @mock.patch('time.sleep', side_effect=lambda _: None)
-    def testGceFirewallRuleGenericError(self, mock_cmd):
-        fake_rets = [('stdout', 'some random firewall error', 1)]
-        with PatchCriticalObjects(fake_rets) as issue_command:
-            with self.assertRaises(errors.VmUtil.IssueCommandError):
-                fr = gce_network.GceFirewallRule('name', 'project', 'allow',
-                                                 'network_name')
-                fr._Create()
-            self.assertEqual(issue_command.call_count, 1)
+  @mock.patch('time.sleep', side_effect=lambda _: None)
+  def testGceFirewallRuleGenericError(self, mock_cmd):
+    fake_rets = [('stdout', 'some random firewall error', 1)]
+    with PatchCriticalObjects(fake_rets) as issue_command:
+      with self.assertRaises(errors.VmUtil.IssueCommandError):
+        fr = gce_network.GceFirewallRule('name', 'project', 'allow',
+                                         'network_name')
+        fr._Create()
+      self.assertEqual(issue_command.call_count, 1)


### PR DESCRIPTION
- adds `--cidr` flag for vm_group level subnets
- adds GCP provider implementation
usage:

```
copy_throughput:
  description: Get cp and scp performance between vms.
  vm_groups:
    vm_1:
      cidr: 10.0.1.0/24
```

```
# iperf config with custom subnets.
iperf:
  description: Run iperf on custom cidr
  vm_groups:
    vm_1:
      cloud: GCP
      cidr: 10.0.1.0/24
      vm_spec:
        GCP:
            zone: us-west1-b
            machine_type: n1-standard-4
    vm_2:
      cloud: GCP
      cidr: 192.168.1.0/24
      vm_spec:
        GCP:
            zone: us-central1-c
            machine_type: n1-standard-4
```

