### PR TITLE
Implement support for Clear Linux

### DIFF
--- a/CHANGES.next.md
+++ b/CHANGES.next.md
@@ -133,6 +133,7 @@
 - Added a benchmark to run spark application on a cluster that computes an approximation to pi.
 - Added a benchmark to run spark io workload on a cluster that provisions a database and queries it.
 - Added flag --record_lscpu=True to record lscpu data as its own metric "lscpu"
+- Added support for the Clear Linux OS type for AWS and static VMs (e.g. --os-type=clear)
 - Added flag --aws_placement_group_style to allow different AWS placement groups options for ec2 VM benchmarks.
 
 ### Enhancements:

--- a/perfkitbenchmarker/linux_packages/mdadm.py
+++ b/perfkitbenchmarker/linux_packages/mdadm.py
@@ -32,4 +32,4 @@ def AptInstall(vm):
 
 
 def SwupdInstall(vm):
-  vm.Install('storage-utils')
+  vm.InstallPackages('storage-utils')

--- a/perfkitbenchmarker/linux_packages/pip.py
+++ b/perfkitbenchmarker/linux_packages/pip.py
@@ -51,6 +51,13 @@ def YumInstall(vm):
   Install(vm, package_name)
 
 
+def SwupdInstall(vm):
+  """Installs the pip package on the VM,"""
+  vm.InstallPackages("which")
+  package_name = "python-basic"
+  Install(vm, package_name)
+
+
 def Uninstall(vm):
   """Uninstalls the pip package on the VM."""
   vm.RemoteCommand('pip freeze | grep --fixed-strings --line-regexp '

--- a/perfkitbenchmarker/linux_packages/python.py
+++ b/perfkitbenchmarker/linux_packages/python.py
@@ -24,4 +24,9 @@ def YumInstall(vm):
 
 def AptInstall(vm):
   """Installs the package on the VM."""
-  vm.InstallPackages('python2.7')
+  vm.InstallPackages('python python2.7')
+
+
+def SwupdInstall(vm):
+  """Installs the package on the VM"""
+  vm.InstallPackages('python-basic')

--- a/perfkitbenchmarker/linux_packages/python.py
+++ b/perfkitbenchmarker/linux_packages/python.py
@@ -19,6 +19,9 @@
 def YumInstall(vm):
   """Installs the package on the VM."""
   package_name = getattr(vm, 'python_package_config', 'python-2.7.5')
+  # try to install "python" by default
+  if package_name != 'python':
+    package_name = 'python ' + package_name
   vm.InstallPackages(package_name)
 
 

--- a/perfkitbenchmarker/linux_virtual_machine.py
+++ b/perfkitbenchmarker/linux_virtual_machine.py
@@ -1121,11 +1121,11 @@ class ClearMixin(BaseLinuxMixin):
     self.RemoteCommand('sudo rm /etc/sudoers.d/pkb')
 
   def SnapshotPackages(self):
-    """Grabs a snapshot of the currently installed packages."""
+    """See base class."""
     self.RemoteCommand('sudo swupd bundle-list > {0}/bundle_list'.format(linux_packages.INSTALL_DIR))
 
   def RestorePackages(self):
-    """Restores the currently installed bundles to those snapshotted."""
+    """See base class."""
     self.RemoteCommand(
         'sudo swupd bundle-list | grep --fixed-strings --line-regexp --invert-match --file '
         '{0}/bundle_list | xargs --no-run-if-empty sudo swupd bundle-remove'.format(linux_packages.INSTALL_DIR),
@@ -1139,10 +1139,6 @@ class ClearMixin(BaseLinuxMixin):
   def InstallPackages(self, packages):
     """Installs packages using the swupd bundle manager."""
     self.RemoteCommand('sudo swupd bundle-add {0}'.format(packages))
-
-  def InstallPackageGroup(self, package_group):
-    """Installs a 'package group' using the yum package manager."""
-    self.RemoteCommand('sudo swupd bundle-add "{0}"'.format(package_group))
 
   def Install(self, package_name):
     """Installs a PerfKit package on the VM."""
@@ -1167,26 +1163,17 @@ class ClearMixin(BaseLinuxMixin):
       package.Uninstall(self)
 
   def GetPathToConfig(self, package_name):
-    """Returns the path to the config file for PerfKit packages.
-
-    This function is mostly useful when config files locations
-    don't match across distributions (such as mysql). Packages don't
-    need to implement it if this is not the case.
-    """
+    """See base class"""
     package = linux_packages.PACKAGES[package_name]
     return package.SwupdGetPathToConfig(self)
 
   def GetServiceName(self, package_name):
-    """Returns the service name of a PerfKit package.
-
-    This function is mostly useful when service names don't
-    match across distributions (such as mongodb). Packages don't
-    need to implement it if this is not the case.
-    """
+    """See base class"""
     package = linux_packages.PACKAGES[package_name]
     return package.SwupdGetServiceName(self)
 
   def GetOsInfo(self):
+    """See base class"""
     stdout, _ = self.RemoteCommand('swupd info | grep Installed')
     return "Clear Linux build: {0}".format(regex_util.ExtractGroup(CLEAR_BUILD_REGEXP, stdout))
 

--- a/perfkitbenchmarker/os_types.py
+++ b/perfkitbenchmarker/os_types.py
@@ -17,6 +17,7 @@ from perfkitbenchmarker import flags
 
 AMAZONLINUX2 = 'amazonlinux2'
 CENTOS7 = 'centos7'
+CLEAR = 'clear'
 DEBIAN = 'debian'
 DEBIAN9 = 'debian9'
 JUJU = 'juju'
@@ -35,6 +36,7 @@ WINDOWS2019 = 'windows2019'
 LINUX_OS_TYPES = [
     AMAZONLINUX2,
     CENTOS7,
+    CLEAR,
     DEBIAN,
     DEBIAN9,
     JUJU,
@@ -53,7 +55,7 @@ WINDOWS_OS_TYPES = [
     WINDOWS2019,
 ]
 ALL = LINUX_OS_TYPES + WINDOWS_OS_TYPES
-BASE_OS_TYPES = [DEBIAN, RHEL, WINDOWS]
+BASE_OS_TYPES = [CLEAR, DEBIAN, RHEL, WINDOWS]
 
 flags.DEFINE_enum(
     'os_type', UBUNTU1604, ALL,

--- a/perfkitbenchmarker/providers/aws/aws_virtual_machine.py
+++ b/perfkitbenchmarker/providers/aws/aws_virtual_machine.py
@@ -903,6 +903,17 @@ class AwsVirtualMachine(virtual_machine.BaseVirtualMachine):
     return result
 
 
+class ClearBasedAwsVirtualMachine(AwsVirtualMachine,
+                                  linux_virtual_machine.ClearMixin):
+  IMAGE_NAME_FILTER = 'clear/images/*/clear-*'
+  IMAGE_OWNER = '679593333241'  # For marketplace images.
+
+  def __init__(self, vm_spec):
+    super(ClearBasedAwsVirtualMachine, self).__init__(vm_spec)
+    user_name_set = FLAGS['aws_user_name'].present
+    self.user_name = FLAGS.aws_user_name if user_name_set else 'clear'
+
+
 class DebianBasedAwsVirtualMachine(AwsVirtualMachine,
                                    linux_virtual_machine.DebianMixin):
   """Class with configuration for AWS Debian virtual machines."""

--- a/perfkitbenchmarker/static_virtual_machine.py
+++ b/perfkitbenchmarker/static_virtual_machine.py
@@ -202,6 +202,7 @@ class StaticVirtualMachine(virtual_machine.BaseVirtualMachine):
         os_types.WINDOWS: required_keys | frozenset(['password']),
         os_types.DEBIAN: linux_required_keys,
         os_types.RHEL: linux_required_keys,
+        os_types.CLEAR: linux_required_keys,
         os_types.UBUNTU_CONTAINER: linux_required_keys,
     }
 
@@ -304,6 +305,11 @@ class ContainerizedStaticVirtualMachine(
 
 class DebianBasedStaticVirtualMachine(StaticVirtualMachine,
                                       linux_virtual_machine.DebianMixin):
+  pass
+
+
+class ClearBasedStaticVirtualMachine(StaticVirtualMachine,
+                                     linux_virtual_machine.ClearMixin):
   pass
 
 


### PR DESCRIPTION
This diff implements support for Clear Linux (`--os_type=clear`) in PerfKitBenchmarker.

I have tested this with sample_benchmark, by adding the following lines in `perfkitbenchmarker/linux_benchmarks/sample_benchmark.py`, after the BENCHMARK_DATA dict:
```
BENCHMARK_DATA_URL = {
    'preprovisioned_data.txt':
        'https://github.com/florinpapa/preprovisioned_data/raw/master/preprovisioned_data.txt'}
```
Then, I used this command to run the benchmark:
```
./pkb.py --cloud=AWS --benchmarks=sample --image=ami-0e6e70a1c30534bd2 --os_type=clear --machine_type=m5.4xlarge --zone=us-west-2a
```