### PR TITLE
Updated linux_virtual_machine.py to use the single source of truth of…

### DIFF
--- a/CHANGES.next.md
+++ b/CHANGES.next.md
@@ -564,3 +564,6 @@
 - Update requirements.txt for Python 3
 - Upgrade hadoop to version 3.2.1.
 - Install the netcat-openbsd and zlib.h debian package for aerospike_ycsb.
+- Updated linux_virtual_machine.py to use the single source of truth of
+  perfkitbenchmark_keyfile path for non-static VM, expanding the use case of
+  stage-wise test, e.g., do prepare on machine A, do run stage on machine B.

--- a/perfkitbenchmarker/linux_virtual_machine.py
+++ b/perfkitbenchmarker/linux_virtual_machine.py
@@ -642,8 +642,9 @@ class BaseLinuxMixin(virtual_machine.BaseOsMixin):
         self.user_name, remote_ip, remote_path)
     scp_cmd = ['scp', '-P', str(self.ssh_port), '-pr']
     # An scp is not retried, so increase the connection timeout.
-    scp_cmd.extend(vm_util.GetSshOptions(self.ssh_private_key,
-                                         connect_timeout=30))
+    ssh_private_key = (self.ssh_private_key if self.is_static else
+                       vm_util.GetPrivateKeyPath())
+    scp_cmd.extend(vm_util.GetSshOptions(ssh_private_key, connect_timeout=30))
     if copy_to:
       scp_cmd.extend([file_path, remote_location])
     else:
@@ -734,7 +735,9 @@ class BaseLinuxMixin(virtual_machine.BaseOsMixin):
         self.internal_ip if FLAGS.ssh_via_internal_ip else self.ip_address)
     user_host = '%s@%s' % (self.user_name, ip_address)
     ssh_cmd = ['ssh', '-A', '-p', str(self.ssh_port), user_host]
-    ssh_cmd.extend(vm_util.GetSshOptions(self.ssh_private_key))
+    ssh_private_key = (self.ssh_private_key if self.is_static else
+                       vm_util.GetPrivateKeyPath())
+    ssh_cmd.extend(vm_util.GetSshOptions(ssh_private_key))
     try:
       if login_shell:
         ssh_cmd.extend(['-t', '-t', 'bash -l -c "%s"' % command])


### PR DESCRIPTION
… perfkitbenchmark_keyfile path for non-static VM, expanding the use case of stage-wise test, e.g., do prepare on machine A, do run stage on machine B.

-------------
Created by MOE: https://github.com/google/moe
MOE_MIGRATED_REVID=274387748