### PR TITLE
Add support for CoreOS Container Linux in GCP, AWS, and Azure Providers

### DIFF
--- a/CHANGES.next.md
+++ b/CHANGES.next.md
@@ -571,3 +571,7 @@
   stage-wise test, e.g., do prepare on machine A, do run stage on machine B.
 - Added --scp_connect_timeout and --ssh_connect_timeout flag to replace the
   hard-coded values at the call sites of vm_util.GetSshOptions.
+- Added support for Container Optimized OS in the GCP Provider. Support is
+  currently limited to the cluster_boot benchmark.
+- Added support for CoreOS Container Linux in GCP, AWS, and Azure Providers.
+  Support is currently limited to the cluster_boot benchmark.

--- a/perfkitbenchmarker/linux_virtual_machine.py
+++ b/perfkitbenchmarker/linux_virtual_machine.py
@@ -1347,7 +1347,7 @@ class Centos7Mixin(RhelMixin):
 class ContainerOptimizedOsMixin(BaseContainerLinuxMixin):
   """Class holding COS specific VM methods and attributes."""
   OS_TYPE = os_types.COS
-  BASE_OS_TYPE = os_types.COS
+  BASE_OS_TYPE = os_types.CORE_OS
 
   def PrepareVMEnvironment(self):
     super(ContainerOptimizedOsMixin, self).PrepareVMEnvironment()
@@ -1356,6 +1356,12 @@ class ContainerOptimizedOsMixin(BaseContainerLinuxMixin):
     # TODO(user): Support reboots
     self.RemoteCommand('sudo mount -o remount,exec /home')
     self.RemoteCommand('sudo mount -o remount,exec /tmp')
+
+
+class CoreOsMixin(BaseContainerLinuxMixin):
+  """Class holding CoreOS Container Linux specific VM methods and attributes."""
+  OS_TYPE = os_types.CORE_OS
+  BASE_OS_TYPE = os_types.CORE_OS
 
 
 class DebianMixin(BaseLinuxMixin):

--- a/perfkitbenchmarker/os_types.py
+++ b/perfkitbenchmarker/os_types.py
@@ -19,6 +19,7 @@ AMAZONLINUX2 = 'amazonlinux2'
 CENTOS7 = 'centos7'
 CLEAR = 'clear'
 COS = 'cos'
+CORE_OS = 'core_os'
 DEBIAN = 'debian'
 DEBIAN9 = 'debian9'
 JUJU = 'juju'
@@ -38,6 +39,7 @@ LINUX_OS_TYPES = [
     AMAZONLINUX2,
     CENTOS7,
     CLEAR,
+    CORE_OS,
     COS,
     DEBIAN,
     DEBIAN9,
@@ -57,7 +59,7 @@ WINDOWS_OS_TYPES = [
     WINDOWS2019,
 ]
 ALL = LINUX_OS_TYPES + WINDOWS_OS_TYPES
-BASE_OS_TYPES = [CLEAR, COS, DEBIAN, RHEL, WINDOWS]
+BASE_OS_TYPES = [CLEAR, CORE_OS, DEBIAN, RHEL, WINDOWS]
 
 flags.DEFINE_enum(
     'os_type', UBUNTU1604, ALL,

--- a/perfkitbenchmarker/providers/aws/aws_virtual_machine.py
+++ b/perfkitbenchmarker/providers/aws/aws_virtual_machine.py
@@ -922,6 +922,18 @@ class ClearBasedAwsVirtualMachine(AwsVirtualMachine,
     self.user_name = FLAGS.aws_user_name if user_name_set else 'clear'
 
 
+class CoreOsBasedAwsVirtualMachine(AwsVirtualMachine,
+                                   linux_virtual_machine.CoreOsMixin):
+  IMAGE_NAME_FILTER = 'CoreOS-stable-*-hvm*'
+  # Note AMIs can also be found distributed by CoreOS in 595879546273
+  IMAGE_OWNER = '679593333241'  # For marketplace images.
+
+  def __init__(self, vm_spec):
+    super(CoreOsBasedAwsVirtualMachine, self).__init__(vm_spec)
+    user_name_set = FLAGS['aws_user_name'].present
+    self.user_name = FLAGS.aws_user_name if user_name_set else 'core'
+
+
 class DebianBasedAwsVirtualMachine(AwsVirtualMachine,
                                    linux_virtual_machine.DebianMixin):
   """Class with configuration for AWS Debian virtual machines."""

--- a/perfkitbenchmarker/providers/azure/azure_virtual_machine.py
+++ b/perfkitbenchmarker/providers/azure/azure_virtual_machine.py
@@ -717,6 +717,11 @@ class CentosBasedAzureVirtualMachine(AzureVirtualMachine,
     self.python_pip_package_config = 'python2-pip'
 
 
+class CoreOsBasedAzureVirtualMachine(AzureVirtualMachine,
+                                     linux_virtual_machine.CoreOsMixin):
+  IMAGE_URN = 'CoreOS:CoreOS:Stable:latest'
+
+
 class WindowsAzureVirtualMachine(AzureVirtualMachine,
                                  windows_virtual_machine.WindowsMixin):
   """Class supporting Windows Azure virtual machines."""

--- a/perfkitbenchmarker/providers/gcp/gce_virtual_machine.py
+++ b/perfkitbenchmarker/providers/gcp/gce_virtual_machine.py
@@ -838,6 +838,11 @@ class ContainerOptimizedOsBasedGceVirtualMachine(
   DEFAULT_IMAGE_PROJECT = 'cos-cloud'
 
 
+class CoreOsBasedGceVirtualMachine(GceVirtualMachine, linux_vm.CoreOsMixin):
+  DEFAULT_IMAGE_FAMILY = 'coreos-stable'
+  DEFAULT_IMAGE_PROJECT = 'coreos-cloud'
+
+
 class Ubuntu1404BasedGceVirtualMachine(GceVirtualMachine,
                                        linux_vm.Ubuntu1404Mixin):
   DEFAULT_IMAGE_FAMILY = 'ubuntu-1404-lts'


### PR DESCRIPTION
Support is currently limited to the cluster_boot benchmark.

-------------
Created by MOE: https://github.com/google/moe
MOE_MIGRATED_REVID=276363846