### PR TITLE
Update AliCloud support and documentation

### DIFF
--- a/CHANGES.next.md
+++ b/CHANGES.next.md
@@ -29,6 +29,8 @@
 - Raise IssueCommandError by default when vm_util.IssueCommand return code is
   non-zero.  Previous behavior can be emulated by setting
   `raise_on_failure=False`.
+- Fix AliCloud support by using the newer aliyun (instead of aliyuncli) cmd
+  line utility
 - Changed support for reusing buckets for Azure blob service benchmarking. The
   storage account and resource group are now named based on the bucket name so
   that subsequent runs can use the same bucket.
@@ -577,8 +579,6 @@
 - Unifying metadata creation on cluster boot.
 - Added support for CoreOS Container Linux in GCP, AWS, and Azure Providers.
   Support is currently limited to the cluster_boot benchmark.
-- Fix AliCloud support by using the newer aliyun (instead of aliyuncli) cmd
-  line utility
 - PkbCommonTestCase extends absltest.TestCase for py3 test backports.
 - Update tox python version.
 - Remove the remote file before pushing a local file to the remote place. This

--- a/CHANGES.next.md
+++ b/CHANGES.next.md
@@ -577,6 +577,8 @@
 - Unifying metadata creation on cluster boot.
 - Added support for CoreOS Container Linux in GCP, AWS, and Azure Providers.
   Support is currently limited to the cluster_boot benchmark.
+- Fix AliCloud support by using the newer aliyun (instead of aliyuncli) cmd
+  line utility
 - PkbCommonTestCase extends absltest.TestCase for py3 test backports.
 - Update tox python version.
 - Remove the remote file before pushing a local file to the remote place. This

--- a/CHANGES.next.md
+++ b/CHANGES.next.md
@@ -30,7 +30,7 @@
   non-zero.  Previous behavior can be emulated by setting
   `raise_on_failure=False`.
 - Fix AliCloud support by using the newer aliyun (instead of aliyuncli) cmd
-  line utility
+  line utility and removing Paramiko dependency
 - Changed support for reusing buckets for Azure blob service benchmarking. The
   storage account and resource group are now named based on the bucket name so
   that subsequent runs can use the same bucket.

--- a/README.md
+++ b/README.md
@@ -409,82 +409,24 @@ $ azure provider register Microsoft.Network
 ```
 
 ### Install AliCloud CLI and setup authentication
-Make sure you have installed pip (see the section above).
 
-Run the following command to install `aliyuncli` (omit the `sudo` on Windows)
+1. Download Linux installer from [Aliyun Github](https://github.com/aliyun/aliyun-cli).
+Follow instructions from Readme to install for your OS.
 
-1. Install python development tools:
-
-   In Debian or Ubuntu:
+2. Verify that aliyun CLI is working as expected:
 
    ```bash
-   $ sudo apt-get install -y python-dev
+   $ aliyun ecs help
    ```
 
-   In CentOS:
-
-   ```bash
-   $ sudo yum install python-devel
-   ```
-
-2. Install aliyuncli tool and python SDK for ECS:
-
-   ```bash
-   $ sudo pip install -r perfkitbenchmarker/providers/alicloud/requirements.txt
-   ```
-   In some CentOS version, you may need:
-
-   ```bash
-   $ sudo yum install libffi-devel.x86_64
-   $ sudo yum install openssl-devel.x86_64
-   $ sudo pip install 'colorama<=0.3.3'
-   ```
-
-   To check if AliCloud is installed:
-
-   ```bash
-   $ aliyuncli --help
-   ```
-
-   Check if `aliyuncli ecs` command is ready:
-
-   ```bash
-   $ aliyuncli ecs help
-   ```
-
-   If you see the "usage" message, you should follow step 3.
-   Otherwise, jump to step 4.
-
-3. Dealing with an exception when it runs on some specific version of Ubuntu.
-   Get the python lib path: `/usr/lib/python2.7/dist-packages`
-
-   ```bash
-   $ python
-   > from distutils.sysconfig import get_python_lib
-   > get_python_lib()
-   '/usr/lib/python2.7/dist-packages'
-   ```
-
-   Copy to the right directory (for Python 2.7.X):
-
-   ```bash
-   $ sudo cp -r /usr/local/lib/python2.7/dist-packages/aliyun* /usr/lib/python2.7/dist-packages/
-   ```
-
-   Check again:
-
-   ```bash
-   $ aliyuncli ecs help
-   ```
-
-4. Navigate to the [AliCloud console](https://home.console.alicloud.com/#/) to create access credentials:
+3. Navigate to the [AliCloud console](https://home.console.alicloud.com/#/) to create access credentials:
    * Login first
    * Click on "AccessKeys" (top right)
    * Click on "Create Access Key", copy and store the "Access Key ID" and "Access Key Secret" to a safe place.
    * Configure the CLI using the Access Key ID and Access Key Secret from the previous step
 
    ```bash
-   $ aliyuncli configure
+   $ aliyun configure
    ```
 
 ### DigitalOcean configuration and credentials

--- a/perfkitbenchmarker/configs/default_config_constants.yaml
+++ b/perfkitbenchmarker/configs/default_config_constants.yaml
@@ -15,8 +15,8 @@ default_single_core: &default_single_core
     zone: us-east-1
     image: null
   AliCloud:
-    machine_type: ecs.s2.large
-    zone: us-west-1a
+    machine_type: ecs.g5.large
+    zone: cn-beijing-g
     image: null
   DigitalOcean:
     machine_type: 2gb
@@ -67,6 +67,10 @@ default_dual_core: &default_dual_core
     machine_type:
       cpus: 2
       memory: 4.0GiB
+  AliCloud:
+    machine_type: ecs.g5.xlarge
+    zone: cn-beijing-g
+    image: null
 
 # TODO(nlavine): update the disk types below as more providers are
 # updated for the disk types refactor.

--- a/perfkitbenchmarker/disk.py
+++ b/perfkitbenchmarker/disk.py
@@ -57,6 +57,7 @@ FLAGS = flags.FLAGS
 STANDARD = 'standard'
 REMOTE_SSD = 'remote_ssd'
 PIOPS = 'piops'  # Provisioned IOPS (SSD) in AWS and Alicloud
+REMOTE_ESSD = 'remote_essd'  # Enhanced Cloud SSD in Alicloud
 
 # 'local' refers to disks that come attached to VMs. It is the only
 # "universal" disk type that is not associated with a provider. It

--- a/perfkitbenchmarker/providers/alicloud/ali_virtual_machine.py
+++ b/perfkitbenchmarker/providers/alicloud/ali_virtual_machine.py
@@ -287,7 +287,8 @@ class AliVirtualMachine(virtual_machine.BaseVirtualMachine):
 
     # Create user and add SSH key
     public_key = AliCloudKeyFileManager.GetPublicKey()
-    user_data = util.ADD_USER_TEMPLATE.format(self.user_name, public_key)
+    user_data = util.ADD_USER_TEMPLATE.format(user_name=self.user_name,
+                                              public_key=public_key)
     logging.debug('encoding startup script: %s' % user_data)
     create_cmd.extend(['--UserData', six.ensure_str(
         base64.b64encode(user_data.encode('utf-8')))])

--- a/perfkitbenchmarker/providers/alicloud/ali_virtual_machine.py
+++ b/perfkitbenchmarker/providers/alicloud/ali_virtual_machine.py
@@ -22,6 +22,7 @@ import json
 import threading
 import logging
 import base64
+import six
 
 from perfkitbenchmarker import flags
 from perfkitbenchmarker import virtual_machine
@@ -288,7 +289,8 @@ class AliVirtualMachine(virtual_machine.BaseVirtualMachine):
     public_key = AliCloudKeyFileManager.GetPublicKey()
     user_data = util.ADD_USER_TEMPLATE.format(self.user_name, public_key)
     logging.debug('encoding startup script: %s' % user_data)
-    create_cmd.extend(['--UserData', base64.b64encode(user_data)])
+    create_cmd.extend(['--UserData', six.ensure_str(
+        base64.b64encode(user_data.encode('utf-8')))])
 
     create_cmd = util.GetEncodedCmd(create_cmd)
     stdout, _ = vm_util.IssueRetryableCommand(create_cmd)

--- a/perfkitbenchmarker/providers/alicloud/flags.py
+++ b/perfkitbenchmarker/providers/alicloud/flags.py
@@ -25,13 +25,16 @@ flags.DEFINE_string('ali_io_optimized', None,
                     'None which means no IO optimized '
                     '"optimized" means use IO optimized. If you '
                     'choose optimized, you must specify the system disk type')
-flags.DEFINE_string('ali_system_disk_type', 'cloud',
-                    'System disk catogory for AliCloud. The default is '
+flags.DEFINE_string('ali_system_disk_type', 'cloud_ssd',
+                    'System disk category for AliCloud. The default is '
                     '"cloud" for General cloud disk, '
                     '"cloud_ssd" for cloud ssd disk, '
+                    '"cloud_essd" for enhanced cloud ssd disk, '
                     '"cloud_efficiency" for efficiency cloud disk, '
                     '"ephemeral_ssd" for local ssd disk')
+flags.DEFINE_integer('ali_system_disk_size', 50,
+                     'System disk size in GB. Default is 50 GB.')
 flags.DEFINE_boolean('ali_use_vpc', True,
                      'Use VPC to create networks')
-flags.DEFINE_integer('ali_eip_address_bandwidth', 5,
+flags.DEFINE_integer('ali_eip_address_bandwidth', 100,
                      'The rate limit of the EIP in Mbps.')

--- a/perfkitbenchmarker/providers/alicloud/requirements.txt
+++ b/perfkitbenchmarker/providers/alicloud/requirements.txt
@@ -13,6 +13,4 @@
 # limitations under the License.
 
 # Requirements for running PerfKit Benchmarker on AliCloud.
-aliyuncli>=2.1
-aliyun-python-sdk-ecs>=0.1.4
 paramiko>=1.15

--- a/perfkitbenchmarker/providers/alicloud/requirements.txt
+++ b/perfkitbenchmarker/providers/alicloud/requirements.txt
@@ -13,4 +13,3 @@
 # limitations under the License.
 
 # Requirements for running PerfKit Benchmarker on AliCloud.
-paramiko>=1.15

--- a/perfkitbenchmarker/providers/alicloud/util.py
+++ b/perfkitbenchmarker/providers/alicloud/util.py
@@ -37,13 +37,13 @@ REGION_HZ = 'cn-hangzhou'
 
 
 ADD_USER_TEMPLATE = '''#!/bin/bash
-echo "{0} ALL = NOPASSWD: ALL" >> /etc/sudoers
-useradd {0} --home /home/{0} --shell /bin/bash -m
-mkdir /home/{0}/.ssh
-echo "{1}" >> /home/{0}/.ssh/authorized_keys
-chown -R {0}:{0} /home/{0}/.ssh
-chmod 700 /home/{0}/.ssh
-chmod 600 /home/{0}/.ssh/authorized_keys
+echo "{user_name} ALL = NOPASSWD: ALL" >> /etc/sudoers
+useradd {user_name} --home /home/{user_name} --shell /bin/bash -m
+mkdir /home/{user_name}/.ssh
+echo "{public_key}" >> /home/{user_name}/.ssh/authorized_keys
+chown -R {user_name}:{user_name} /home/{user_name}/.ssh
+chmod 700 /home/{user_name}/.ssh
+chmod 600 /home/{user_name}/.ssh/authorized_keys
 '''
 
 

--- a/perfkitbenchmarker/providers/alicloud/util.py
+++ b/perfkitbenchmarker/providers/alicloud/util.py
@@ -22,10 +22,6 @@ import shlex
 import string
 import random
 import os
-try:
-    import paramiko
-except ImportError:
-    paramiko = None
 
 from perfkitbenchmarker import flags
 from perfkitbenchmarker import vm_util

--- a/perfkitbenchmarker/providers/alicloud/util.py
+++ b/perfkitbenchmarker/providers/alicloud/util.py
@@ -75,7 +75,7 @@ def AddTags(resource_id, resource_type, region, **kwargs):
       '--RegionId', region,
       '--ResourceId', resource_id,
       '--ResourceType', resource_type]
-  for index, (key, value) in enumerate(kwargs.iteritems()):
+  for index, (key, value) in enumerate(six.iteritems(kwargs)):
     tag_cmd.extend(['--Tag.{0}.Key'.format(index + 1), str(key),
                     '--Tag.{0}.Value'.format(index + 1), str(value)])
   vm_util.IssueRetryableCommand(tag_cmd)
@@ -149,7 +149,7 @@ def AddPubKeyToHost(host_ip, password, keyfile, username):
 
 
 def GeneratePassword(length=PASSWD_LEN):
-  digit_len = int(length / 2)
+  digit_len = length // 2
   letter_len = length - digit_len
   return ''.join(random.sample(string.letters, digit_len)) + \
          ''.join(random.sample(string.digits, letter_len))


### PR DESCRIPTION
Update Alicloud support to use the newer cmd line tool `aliyun` instead of `aliyuncli`.

Tested this with fio:
```
$ ./pkb.py --cloud=AliCloud --benchmarks=fio --zone=cn-beijing-g --os_type=ubuntu1804 --benchmark_config_file=fio_ali.yaml
$ cat fio_ali.yaml
worker: &worker
  AliCloud:
    machine_type: ecs.g5.4xlarge
    zone: cn-beijing-f


worker_disk: &worker_disk
  AliCloud:
    disk_type: remote_ssd
    disk_size: 100
    mount_point: /scratch

fio:
  vm_groups:
     default:
       vm_spec: *worker
       disk_spec: *worker_disk
       vm_count: 1
```