### PR TITLE
Cassandra branch name fix

### DIFF
--- a/CHANGES.next.md
+++ b/CHANGES.next.md
@@ -589,3 +589,4 @@
   a remote command is successfully run.
 - Added flag --cluster_boot_test_rdp_port_listening to measure time until RDP
   port accepts a connection in Windows. It is True by default.
+- Fixed Cassandra branch name (GH-2025 from @marcomicera)

--- a/perfkitbenchmarker/linux_packages/cassandra.py
+++ b/perfkitbenchmarker/linux_packages/cassandra.py
@@ -41,7 +41,7 @@ from six.moves import range
 JNA_JAR_URL = ('https://maven.java.net/content/repositories/releases/'
                'net/java/dev/jna/jna/4.1.0/jna-4.1.0.jar')
 CASSANDRA_GIT_REPRO = 'https://github.com/apache/cassandra.git'
-CASSANDRA_VERSION = 'cassandra-2.1.10'
+CASSANDRA_VERSION = 'cassandra-2.1'
 CASSANDRA_YAML_TEMPLATE = 'cassandra/cassandra.yaml.j2'
 CASSANDRA_ENV_TEMPLATE = 'cassandra/cassandra-env.sh.j2'
 CASSANDRA_DIR = posixpath.join(INSTALL_DIR, 'cassandra')


### PR DESCRIPTION
[Apache Cassandra](https://github.com/apache/cassandra/branches) does not have a `'cassandra-2.1.10'` branch anymore. This causes this `git checkout` command to fail:
https://github.com/GoogleCloudPlatform/PerfKitBenchmarker/blob/2df6a1ce2008b6ba77a7961fd86310c631f9dad2/perfkitbenchmarker/linux_packages/cassandra.py#L83-L89

[`cassandra-2.1`](https://github.com/apache/cassandra/tree/cassandra-2.1) should do the job.