### PR TITLE
update README to azure cli 2.0 instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ Follow the instructions at https://docs.microsoft.com/en-us/cli/azure/install-az
 on Linux, run the following commands:
 
 ```bash
-$ curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+$ curl -L https://aka.ms/InstallAzureCli | bash
 $ az login
 ```
 Test that `azure` is installed correctly:

--- a/README.md
+++ b/README.md
@@ -381,31 +381,27 @@ $ aws configure
 
 ### Windows Azure CLI and credentials
 
-You first need to install node.js and NPM.  This version of Perfkit Benchmarker
-is known to be compatible with Azure CLI version 0.10.4, and will likely work
-with any version newer than that.
+This version of Perfkit Benchmarker is known to be compatible with Azure CLI 
+version 2.0.75, and will likely work with any version newer than that.
 
-Go [here](https://nodejs.org/download/), and follow the setup instructions.
-
-Next, run the following (omit the `sudo` on Windows):
+Follow the instructions at https://docs.microsoft.com/en-us/cli/azure/install-azure-cli or 
+on Linux, run the following commands:
 
 ```bash
-$ sudo npm install azure-cli -g
-$ azure login
+$ curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+$ az login
 ```
 Test that `azure` is installed correctly:
 
 ```bash
-$ azure vm list
+$ az vm list
 ```
 
-Finally, make sure Azure is in Resource Management mode and that your account is
-authorized to allocate VMs and networks from Azure:
+Finally, make sure that your account is authorized to allocate VMs and networks from Azure:
 
 ```bash
-$ azure config mode arm
-$ azure provider register Microsoft.Compute
-$ azure provider register Microsoft.Network
+$ az provider register -n Microsoft.Compute
+$ az provider register -n Microsoft.Network
 ```
 
 ### Install AliCloud CLI and setup authentication


### PR DESCRIPTION
I've updated the README to reflect that PerfKitBenchmarker has been upgraded to use the azure cli 2.0 since this pull request: #1359 

The old azure cli uses the 'azure' command and the azure cli 2.0+ uses the 'az' command

The old cli no longer works with pkb, as the [azure provider uses the command for the new cli](https://github.com/GoogleCloudPlatform/PerfKitBenchmarker/blob/master/perfkitbenchmarker/providers/azure/__init__.py) 

I have tested this both with the master branch and with the latest release