### PR TITLE
Azure skip availability set creation

### DIFF
--- a/CHANGES.next.md
+++ b/CHANGES.next.md
@@ -152,6 +152,7 @@
 - Records two new samples for /proc/cpuinfo data.
 - Added support for specifying a number of vms per host for Azure & AWS Dedicated Hosting.
   Simply add flag `num_vms_per_host=<#>` to use. Benchmark fails if the # of vms per host specified exceeds the memory capacity of the host.
+- Added support for skipping the creation of Azure availability sets with the --azure_availability_set=False flag (fixes #1863)
 - Added support for AWS EFA networking with --aws_efa=True flag.
 - Added NCCL benchmark for GPU networking.
 

--- a/perfkitbenchmarker/providers/azure/azure_network.py
+++ b/perfkitbenchmarker/providers/azure/azure_network.py
@@ -457,7 +457,8 @@ class AzureNetwork(network.BaseNetwork):
     self.location = util.GetLocationFromZone(self.zone)
     # With dedicated hosting and/or an availability zone, an availability set
     # cannot be created
-    if FLAGS.dedicated_hosts or util.GetAvailabilityZoneFromZone(self.zone):
+    if FLAGS.dedicated_hosts or util.GetAvailabilityZoneFromZone(self.zone) or \
+       not FLAGS.azure_availability_set:
       self.avail_set = None
     else:
       avail_set_name = '%s-%s' % (self.resource_group.name, self.zone)

--- a/perfkitbenchmarker/providers/azure/azure_network.py
+++ b/perfkitbenchmarker/providers/azure/azure_network.py
@@ -457,8 +457,8 @@ class AzureNetwork(network.BaseNetwork):
     self.location = util.GetLocationFromZone(self.zone)
     # With dedicated hosting and/or an availability zone, an availability set
     # cannot be created
-    if FLAGS.dedicated_hosts or util.GetAvailabilityZoneFromZone(self.zone) or \
-       not FLAGS.azure_availability_set:
+    if (FLAGS.dedicated_hosts or util.GetAvailabilityZoneFromZone(self.zone) or
+       not FLAGS.azure_availability_set):
       self.avail_set = None
     else:
       avail_set_name = '%s-%s' % (self.resource_group.name, self.zone)

--- a/perfkitbenchmarker/providers/azure/flags.py
+++ b/perfkitbenchmarker/providers/azure/flags.py
@@ -78,3 +78,8 @@ flags.DEFINE_integer(
 flags.DEFINE_enum('azure_redis_size',
                   'C3', VALID_CACHE_SIZES,
                   'Azure redis cache size to use.')
+
+flags.DEFINE_boolean('azure_availability_set', True,
+                     'If True, create an availability set and place virtual '
+                     'machines in it. If False, do not create availability '
+                     'set.')


### PR DESCRIPTION
This change adds the `--azure_availability_set` flag, which controls whether an availability set is created. By default, the flag is set to `True`, but it can be manually set to `False` in order to skip availability set creation, if needed.

Fixes https://github.com/GoogleCloudPlatform/PerfKitBenchmarker/issues/1863.

Tested with mongodb_ycsb, as reported in the issue:
```
./pkb.py --cloud=Azure --benchmarks=mongodb_ycsb --benchmark_config_file=ycsb_config.yml --azure_availability_set=False

cat ycsb_config.yml
server: &server
    Azure:
        machine_type: Standard_L32s
        zone: eastus2
disk: &disk
    Azure:
        disk_type: local
        mount_point: /scratch
client: &client
    Azure:
        machine_type: Standard_F72s_v2
        zone: eastus2
mongodb_ycsb:
    vm_groups:
        workers:
            os_type: ubuntu1604
            vm_spec: *server
            disk_spec: *disk
            vm_count: 1
        clients:
            os_type: ubuntu1604
            vm_spec: *client
```