### PR TITLE
Fix Openstack provider subnet creation issue

### DIFF
--- a/perfkitbenchmarker/providers/openstack/os_virtual_machine.py
+++ b/perfkitbenchmarker/providers/openstack/os_virtual_machine.py
@@ -367,7 +367,12 @@ class OpenStackVirtualMachine(virtual_machine.BaseVirtualMachine):
                                            self.network_name)
     net_stdout, _, _ = net_cmd.Issue()
     network = json.loads(net_stdout)
-    self.subnet_id = network['subnets']
+
+    if type(network['subnets']) is list:
+        self.subnet_id = network['subnets'][0]
+    else:
+        self.subnet_id = network['subnets']
+
     subnet_cmd = os_utils.OpenStackCLICommand(self, 'subnet', 'show',
                                               self.subnet_id)
     stdout, _, _ = subnet_cmd.Issue()


### PR DESCRIPTION
Added checks for return type of `openstack network show {{ network_name }}`.

This change is meant to address this specific issue #2022 where `openstack network show {{ network_name }}` returns a `list<string>` rather than a `string`, thus breaking the openstack provider. 

This occurs with the openstack CLI 4.0.0 (although the specific version responsible for the change in return type is hard to identify in the changelogs).





