### PR TITLE
Default Docker image for cluster_boot on Kubernetes

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/cluster_boot_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/cluster_boot_benchmark.py
@@ -41,6 +41,8 @@ cluster_boot:
           machine_type: n1-standard-2
           zone: us-central1-a
           boot_disk_type: pd-ssd
+        Kubernetes:
+          image: null
       vm_count: null
 """
 


### PR DESCRIPTION
When launching `cluster_boot` on Kubernetes without specifying the image to be used, this error pops up:
```
perfkitbenchmarker.errors.MissingOption: cluster_boot.vm_groups.default.cloud is "Kubernetes", but cluster_boot.vm_groups.default.vm_spec does not contain a configuration for "Kubernetes".
```
This fix sets the default image to `null` in the default `cluster_boot` configuration for Kubernetes, causing PKB to use [its default Docker image](https://github.com/GoogleCloudPlatform/PerfKitBenchmarker/blob/master/perfkitbenchmarker/data/docker/pkb/ubuntu16/Dockerfile) (`ubuntu:16.04`).