### PR TITLE
VPN support

### DIFF
--- a/perfkitbenchmarker/benchmark_spec.py
+++ b/perfkitbenchmarker/benchmark_spec.py
@@ -697,11 +697,6 @@ class BenchmarkSpec(object):
 
     if self.vpn_service:
       self.vpn_service.Delete()
-      self.vpn_service = None
-      self.vpns = {}  # dict of vpn's
-      self.vpn_gws = {}  # dict of vpn gw's
-      self.vpn_gws_lock = threading.Lock()
-      self.vpns_lock = threading.Lock()
 
     self.deleted = True
 

--- a/perfkitbenchmarker/benchmark_spec.py
+++ b/perfkitbenchmarker/benchmark_spec.py
@@ -529,8 +529,7 @@ class BenchmarkSpec(object):
     """Create the VPNService object."""
     if self.config.vpn_service is None:
       return
-    vpn_service_spec = self.config.vpn_service
-    self.vpn_service = vpn_service.VPNService(vpn_service_spec)
+    self.vpn_service = vpn_service.VPNService(self.config.vpn_service)
 
   def Prepare(self):
     targets = [(vm.PrepareBackgroundWorkload, (), {}) for vm in self.vms]

--- a/perfkitbenchmarker/benchmark_spec.py
+++ b/perfkitbenchmarker/benchmark_spec.py
@@ -163,8 +163,8 @@ class BenchmarkSpec(object):
 
     self.vpn_service = None
     self.vpns = {}  # dict of vpn's
-    self.vpn_gws = {}  # dict of vpn gw's
-    self.vpn_gws_lock = threading.Lock()
+    self.vpn_gateways = {}  # dict of vpn gw's
+    self.vpn_gateways_lock = threading.Lock()
     self.vpns_lock = threading.Lock()
 
     # Modules can't be pickled, but functions can, so we store the functions

--- a/perfkitbenchmarker/benchmark_spec.py
+++ b/perfkitbenchmarker/benchmark_spec.py
@@ -49,6 +49,8 @@ from perfkitbenchmarker import stages
 from perfkitbenchmarker import static_virtual_machine as static_vm
 from perfkitbenchmarker import virtual_machine
 from perfkitbenchmarker import vm_util
+from perfkitbenchmarker import vpn_service
+
 import six
 from six.moves import range
 import six.moves._thread
@@ -158,6 +160,12 @@ class BenchmarkSpec(object):
         self.config.vm_groups if self.config.relational_db is None else
         relational_db.VmsToBoot(self.config.relational_db.vm_groups))
     self.vpc_peering = self.config.vpc_peering
+
+    self.vpn_service = None
+    self.vpns = {}  # dict of vpn's
+    self.vpngws = {}  # dict of vpn gw's
+    self.vpngws_lock = threading.Lock()
+    self.vpns_lock = threading.Lock()
 
     # Modules can't be pickled, but functions can, so we store the functions
     # necessary to run the benchmark.
@@ -517,6 +525,13 @@ class BenchmarkSpec(object):
                           'service'.format(name, spark_service.PKB_MANAGED))
         self.vms_to_boot[name] = spec
 
+  def ConstructVPNService(self):
+    """Create the VPNService object."""
+    if self.config.vpn_service is None:
+      return
+    vpn_service_spec = self.config.vpn_service
+    self.vpn_service = vpn_service.VPNService(vpn_service_spec)
+
   def Prepare(self):
     targets = [(vm.PrepareBackgroundWorkload, (), {}) for vm in self.vms]
     vm_util.RunParallelThreads(targets, len(targets))
@@ -617,6 +632,8 @@ class BenchmarkSpec(object):
           if network.__class__.__name__ == 'AwsNetwork':
             self.edw_service.cluster_subnet_group.subnet_id = network.subnet.id
       self.edw_service.Create()
+    if self.vpn_service:
+      self.vpn_service.Create()
 
   def Delete(self):
     if self.deleted:
@@ -677,6 +694,14 @@ class BenchmarkSpec(object):
       except Exception:
         logging.exception('Got an exception deleting networks. '
                           'Attempting to continue tearing down.')
+
+    if self.vpn_service:
+      self.vpn_service.Delete()
+      self.vpn_service = None
+      self.vpns = {}  # dict of vpn's
+      self.vpngws = {}  # dict of vpn gw's
+      self.vpngws_lock = threading.Lock()
+      self.vpns_lock = threading.Lock()
 
     self.deleted = True
 

--- a/perfkitbenchmarker/benchmark_spec.py
+++ b/perfkitbenchmarker/benchmark_spec.py
@@ -163,8 +163,8 @@ class BenchmarkSpec(object):
 
     self.vpn_service = None
     self.vpns = {}  # dict of vpn's
-    self.vpngws = {}  # dict of vpn gw's
-    self.vpngws_lock = threading.Lock()
+    self.vpn_gws = {}  # dict of vpn gw's
+    self.vpn_gws_lock = threading.Lock()
     self.vpns_lock = threading.Lock()
 
     # Modules can't be pickled, but functions can, so we store the functions
@@ -699,8 +699,8 @@ class BenchmarkSpec(object):
       self.vpn_service.Delete()
       self.vpn_service = None
       self.vpns = {}  # dict of vpn's
-      self.vpngws = {}  # dict of vpn gw's
-      self.vpngws_lock = threading.Lock()
+      self.vpn_gws = {}  # dict of vpn gw's
+      self.vpn_gws_lock = threading.Lock()
       self.vpns_lock = threading.Lock()
 
     self.deleted = True

--- a/perfkitbenchmarker/configs/benchmark_config_spec.py
+++ b/perfkitbenchmarker/configs/benchmark_config_spec.py
@@ -1287,8 +1287,8 @@ class _CloudRedisDecoder(option_decoders.TypeVerifier):
 
 class _VPNServiceSpec(spec.BaseSpec):
   """Spec needed to configure a vpn tunnel between two vm_groups.
-    Since vpn_gw may be across cloud providers we only create tunnel when
-    vpn_gw's are up and known
+    Since vpn_gateway may be across cloud providers we only create tunnel when
+    vpn_gateway's are up and known
   """
   def __init__(self, component_full_name, flag_values=None, **kwargs):
     super(_VPNServiceSpec, self).__init__(

--- a/perfkitbenchmarker/configs/benchmark_config_spec.py
+++ b/perfkitbenchmarker/configs/benchmark_config_spec.py
@@ -1284,8 +1284,110 @@ class _CloudRedisDecoder(option_decoders.TypeVerifier):
     return result
 
 
+
+class _VPNServiceSpec(spec.BaseSpec):
+  """Spec needed to configure a vpn tunnel between two vm_groups.
+    Since vpn_gw may be across cloud providers we only create tunnel when
+    vpn_gw's are up and known
+  """
+  def __init__(self, component_full_name, flag_values=None, **kwargs):
+    super(_VPNServiceSpec, self).__init__(
+        component_full_name, flag_values=flag_values, **kwargs)
+    if not self.name:
+      self.name = 'pkb-vpn-svc-{0}'.format(flag_values.run_uri)
+
+  @classmethod
+  def _GetOptionDecoderConstructions(cls):
+    """Gets decoder classes and constructor args for each configurable option.
+
+    Returns:
+      dict. Maps option name string to a (ConfigOptionDecoder class, dict) pair.
+      The pair specifies a decoder class and its __init__() keyword arguments to
+      construct in order to decode the named option.
+    """
+    result = super(_VPNServiceSpec, cls)._GetOptionDecoderConstructions()
+    result.update({
+        'shared_key': (option_decoders.StringDecoder, {
+            'default': None,
+            'none_ok': True}),
+        'name': (option_decoders.StringDecoder, {
+            'default': None,
+            'none_ok': True}),
+        'tunnel_count': (option_decoders.IntDecoder, {
+            'default': 1,
+            'none_ok': True}),
+        'gateway_count': (option_decoders.IntDecoder, {
+            'default': 1,
+            'none_ok': True}),
+        'routing_type': (option_decoders.StringDecoder, {
+            'default': 'static',
+            'none_ok': True}),
+        'ike_version': (option_decoders.IntDecoder, {
+            'default': 1,
+            'none_ok': True}),
+    })
+    return result
+
+  @classmethod
+  def _ApplyFlags(cls, config_values, flag_values):
+    """Modifies config options based on runtime flag values.
+
+    Args:
+      config_values: dict mapping config option names to provided values. May
+          be modified by this function.
+      flag_values: flags.FlagValues. Runtime flags that may override the
+          provided config values.
+    """
+    super(_VPNServiceSpec, cls)._ApplyFlags(config_values, flag_values)
+    if flag_values['vpn_service_tunnel_count'].present:
+      config_values['tunnel_count'] = flag_values.vpn_service_tunnel_count
+    if flag_values['vpn_service_gateway_count'].present:
+      config_values['gateway_count'] = flag_values.vpn_service_gateway_count
+    if flag_values['vpn_service_name'].present:
+      config_values['name'] = flag_values.vpn_service_name
+    if flag_values['vpn_service_shared_key'].present:
+      config_values['shared_key'] = flag_values.vpn_service_shared_key
+    if flag_values['vpn_service_routing_type'].present:
+      config_values['routing_type'] = flag_values.vpn_service_routing_type
+    if flag_values['vpn_service_ike_version'].present:
+      config_values['ike_version'] = flag_values.vpn_service_ike_version
+
+
+class _VPNServiceDecoder(option_decoders.TypeVerifier):
+  """Validate the vpn_service dictionary of a benchmark config object.
+  """
+
+  def __init__(self, **kwargs):
+    super(_VPNServiceDecoder, self).__init__(valid_types=(dict,), **kwargs)
+
+  def Decode(self, value, component_full_name, flag_values):
+    """Verify vpn_service dict of a benchmark config object.
+
+    Args:
+      value: dict. Config dictionary
+      component_full_name: string.  Fully qualified name of the configurable
+        component containing the config option.
+      flag_values: flags.FlagValues.  Runtime flag values to be propagated to
+        BaseSpec constructors.
+
+    Returns:
+      _VPNService built from the config passed in in value.
+
+    Raises:
+      errors.Config.InvalidateValue upon invalid input value.
+    """
+    vpn_service_config = super(
+        _VPNServiceDecoder, self).Decode(value, component_full_name,
+                                         flag_values)
+    result = _VPNServiceSpec(
+        self._GetOptionFullName(component_full_name), flag_values,
+        **vpn_service_config)
+    return result
+
+
 class _AppGroupSpec(spec.BaseSpec):
   """Configurable options of a AppService group."""
+
 
   @classmethod
   def _GetOptionDecoderConstructions(cls):
@@ -1480,6 +1582,9 @@ class BenchmarkConfigSpec(spec.BaseSpec):
             'default': None
         }),
         'cloud_redis': (_CloudRedisDecoder, {
+            'default': None
+        }),
+        'vpn_service': (_VPNServiceDecoder, {
             'default': None
         }),
         'app_groups': (_AppGroupsDecoder, {

--- a/perfkitbenchmarker/configs/benchmark_config_spec.py
+++ b/perfkitbenchmarker/configs/benchmark_config_spec.py
@@ -1130,7 +1130,7 @@ class _SparkServiceDecoder(option_decoders.TypeVerifier):
     Returns:
       _SparkServiceSpec Build from the config passed in in value.
     Raises:
-      errors.Config.InvalidateValue upon invalid input value.
+      errors.Config.InvalidValue upon invalid input value.
     """
     spark_service_config = super(_SparkServiceDecoder, self).Decode(
         value, component_full_name, flag_values)
@@ -1160,7 +1160,7 @@ class _RelationalDbDecoder(option_decoders.TypeVerifier):
       _RelationalDbService built from the config passed in in value.
 
     Raises:
-      errors.Config.InvalidateValue upon invalid input value.
+      errors.Config.InvalidValue upon invalid input value.
     """
     relational_db_config = super(_RelationalDbDecoder,
                                  self).Decode(value, component_full_name,
@@ -1191,7 +1191,7 @@ class _TpuGroupsDecoder(option_decoders.TypeVerifier):
       _Tpu built from the config passed in in value.
 
     Raises:
-      errors.Config.InvalidateValue upon invalid input value.
+      errors.Config.InvalidValue upon invalid input value.
     """
     tpu_group_configs = super(_TpuGroupsDecoder, self).Decode(
         value, component_full_name, flag_values)
@@ -1273,7 +1273,7 @@ class _CloudRedisDecoder(option_decoders.TypeVerifier):
       _CloudRedis built from the config passed in in value.
 
     Raises:
-      errors.Config.InvalidateValue upon invalid input value.
+      errors.Config.InvalidValue upon invalid input value.
     """
     cloud_redis_config = super(
         _CloudRedisDecoder, self).Decode(value, component_full_name,
@@ -1282,7 +1282,6 @@ class _CloudRedisDecoder(option_decoders.TypeVerifier):
         self._GetOptionFullName(component_full_name), flag_values,
         **cloud_redis_config)
     return result
-
 
 
 class _VPNServiceSpec(spec.BaseSpec):
@@ -1374,7 +1373,7 @@ class _VPNServiceDecoder(option_decoders.TypeVerifier):
       _VPNService built from the config passed in in value.
 
     Raises:
-      errors.Config.InvalidateValue upon invalid input value.
+      errors.Config.InvalidValue upon invalid input value.
     """
     vpn_service_config = super(
         _VPNServiceDecoder, self).Decode(value, component_full_name,
@@ -1387,7 +1386,6 @@ class _VPNServiceDecoder(option_decoders.TypeVerifier):
 
 class _AppGroupSpec(spec.BaseSpec):
   """Configurable options of a AppService group."""
-
 
   @classmethod
   def _GetOptionDecoderConstructions(cls):
@@ -1441,7 +1439,7 @@ class _AppGroupsDecoder(option_decoders.TypeVerifier):
      dict mapping app group name string to _AppGroupSpec.
 
     Raises:
-      errors.Config.InvalidateValue upon invalid input value.
+      errors.Config.InvalidValue upon invalid input value.
     """
     app_group_configs = super(_AppGroupsDecoder, self).Decode(
         value, component_full_name, flag_values)
@@ -1475,7 +1473,7 @@ class _AppServiceDecoder(option_decoders.TypeVerifier):
       AppService object built from config.
 
     Raises:
-      errors.Config.InvalidateValue upon invalid input value.
+      errors.Config.InvalidValue upon invalid input value.
     """
     config = super(_AppServiceDecoder, self).Decode(
         value, component_full_name, flag_values)

--- a/perfkitbenchmarker/network.py
+++ b/perfkitbenchmarker/network.py
@@ -20,6 +20,8 @@ others in the
 same project.
 """
 
+import abc
+
 from enum import Enum
 
 from perfkitbenchmarker import context
@@ -114,39 +116,20 @@ class BaseVpnGateway(object):
     """
     self.zone = zone
     self.cidr = cidr
-    self.require_target_to_init = False  # True if we need taget Gateway up front (AWS)
+    self.require_target_to_init = False  # True if we need target Gateway up front (AWS)
 
-  @classmethod
-  def GetVpnGateway(cls):
-    """Returns a BaseVpnGateway.
-    This method is used instead of directly calling the class's constructor.
-    It creates BaseVpnGateway instances and registers them.
-    If a BaseVpnGateway object has already been registered, that object
-    will be returned rather than creating a new one. This enables multiple
-    VMs to call this method and all share the same BaseVPN object.
-    """
-    if cls.CLOUD is None:
-      raise errors.Error('VPN Gateways should have CLOUD attributes.')
-    benchmark_spec = context.GetThreadBenchmarkSpec()
-    if benchmark_spec is None:
-      raise errors.Error('GetVPN called in a thread without a '
-                         'BenchmarkSpec.')
-    with benchmark_spec.vpn_gateways_lock:
-      key = cls.CLOUD
-      if key not in benchmark_spec.vpn_gateways:
-        benchmark_spec.vpn_gateways[key] = cls()
-      return benchmark_spec.vpn_gateways[key]
-
+  @abc.abstractmethod
   def IsTunnelConfigured(self, tunnel_config):
-    """ Returns True if the tunnel_config is complete.
+    """Returns True if the tunnel_config is complete.
 
     Args:
      tunnel_config: The tunnel_config of the tunnel to check.
     Returns:
        boolean.
     """
-    pass
+    raise NotImplementedError()
 
+  @abc.abstractmethod
   def IsTunnelReady(self, tunnel_id):
     """Returns True if the tunnel is ready.
 
@@ -156,8 +139,9 @@ class BaseVpnGateway(object):
     Returns:
       boolean.
     """
-    pass
+    raise NotImplementedError()
 
+  @abc.abstractmethod
   def ConfigureTunnel(self, tunnel_config):
     """Updates the tunnel_config object with new information.
 
@@ -170,15 +154,17 @@ class BaseVpnGateway(object):
     Args:
       tunnel_config: The tunnel_config object of the tunnel to configure.
     """
-    pass
+    raise NotImplementedError()
 
+  @abc.abstractmethod
   def Create(self):
     """Creates the actual VPN Gateway."""
-    pass
+    raise NotImplementedError()
 
+  @abc.abstractmethod
   def Delete(self):
       """Deletes the actual VPN Gateway."""
-      pass
+      raise NotImplementedError()
 
 
 class BaseNetwork(object):

--- a/perfkitbenchmarker/network.py
+++ b/perfkitbenchmarker/network.py
@@ -103,7 +103,7 @@ class BaseNetworkSpec(object):
 
 
 class BaseVpnGateway(object):
-  """An object representing the Base VPN GW."""
+  """An object representing the Base VPN Gateway."""
   CLOUD = None
 
   def __init__(self, zone=None, cidr=None):
@@ -114,7 +114,7 @@ class BaseVpnGateway(object):
     """
     self.zone = zone
     self.cidr = cidr
-    self.require_target_to_init = False  # True if we need taget GW up front (AWS)
+    self.require_target_to_init = False  # True if we need taget Gateway up front (AWS)
 
   @classmethod
   def GetVpnGateway(cls):
@@ -126,7 +126,7 @@ class BaseVpnGateway(object):
     VMs to call this method and all share the same BaseVPN object.
     """
     if cls.CLOUD is None:
-      raise errors.Error('VPN GWs should have CLOUD attributes.')
+      raise errors.Error('VPN Gateways should have CLOUD attributes.')
     benchmark_spec = context.GetThreadBenchmarkSpec()
     if benchmark_spec is None:
       raise errors.Error('GetVPN called in a thread without a '
@@ -173,11 +173,11 @@ class BaseVpnGateway(object):
     pass
 
   def Create(self):
-    """Creates the actual VPN GW."""
+    """Creates the actual VPN Gateway."""
     pass
 
   def Delete(self):
-      """Deletes the actual VPN GW."""
+      """Deletes the actual VPN Gateway."""
       pass
 
 

--- a/perfkitbenchmarker/network.py
+++ b/perfkitbenchmarker/network.py
@@ -126,16 +126,16 @@ class BaseVPNGW(object):
     VMs to call this method and all share the same BaseVPN object.
     """
     if cls.CLOUD is None:
-      raise errors.Error('VPNGWs should have CLOUD attributes.')
+      raise errors.Error('VPN GWs should have CLOUD attributes.')
     benchmark_spec = context.GetThreadBenchmarkSpec()
     if benchmark_spec is None:
       raise errors.Error('GetVPN called in a thread without a '
                          'BenchmarkSpec.')
-    with benchmark_spec.vpngws_lock:
+    with benchmark_spec.vpn_gws_lock:
       key = cls.CLOUD
-      if key not in benchmark_spec.vpngws:
-        benchmark_spec.vpngws[key] = cls()
-      return benchmark_spec.vpngws[key]
+      if key not in benchmark_spec.vpn_gws:
+        benchmark_spec.vpn_gws[key] = cls()
+      return benchmark_spec.vpn_gws[key]
 
   def IsTunnelConfigured(self):
     pass
@@ -144,11 +144,11 @@ class BaseVPNGW(object):
     pass
 
   def Create(self):
-    """Creates the actual VPNGW."""
+    """Creates the actual VPN GW."""
     pass
 
   def Delete(self):
-      """Deletes the actual VPNGW."""
+      """Deletes the actual VPN GW."""
       pass
 
 

--- a/perfkitbenchmarker/network.py
+++ b/perfkitbenchmarker/network.py
@@ -137,10 +137,39 @@ class BaseVPNGW(object):
         benchmark_spec.vpn_gateways[key] = cls()
       return benchmark_spec.vpn_gateways[key]
 
-  def IsTunnelConfigured(self):
+  def IsTunnelConfigured(self, tunnel_config):
+    """ Returns True if the tunnel_config is complete.
+
+    Args:
+     tunnel_config: The tunnel_config of the tunnel to check.
+    Returns:
+       boolean.
+    """
+    pass
+
+  def IsTunnelReady(self, tunnel_id):
+    """Returns True if the tunnel is ready.
+
+    Args:
+      tunnel_id: The id of the tunnel to check.
+
+    Returns:
+      boolean.
+    """
     pass
 
   def ConfigureTunnel(self, tunnel_config):
+    """Updates the tunnel_config object with new information.
+
+    Each provider may require different information to setup a VPN tunnel,
+    and all information needed to configure the tunnel may not be available
+    up front. Incremental updates to tunnel_config are made by calling this
+    function on each endpoint until either both endpoint tunnels are configured
+    or no more updates can be made.
+
+    Args:
+      tunnel_config: The tunnel_config object of the tunnel to configure.
+    """
     pass
 
   def Create(self):

--- a/perfkitbenchmarker/network.py
+++ b/perfkitbenchmarker/network.py
@@ -102,6 +102,56 @@ class BaseNetworkSpec(object):
     return '%s(%r)' % (self.__class__, self.__dict__)
 
 
+class BaseVPNGW(object):
+  """An object representing the Base VPN GW."""
+  CLOUD = None
+
+  def __init__(self, zone=None, cidr=None):
+    """Initializes the BaseVPNGW.
+
+    Args:
+      zone: The zone in which to create the VPNGW.
+    """
+    self.zone = zone
+    self.cidr = cidr
+    self.require_target_to_init = False  # True if we need taget GW up front (AWS)
+
+  @classmethod
+  def GetVPNGW(cls):
+    """Returns a BaseVPNGW.
+    This method is used instead of directly calling the class's constructor.
+    It creates BaseVPNGW instances and registers them.
+    If a BaseVPNGW object has already been registered, that object
+    will be returned rather than creating a new one. This enables multiple
+    VMs to call this method and all share the same BaseVPN object.
+    """
+    if cls.CLOUD is None:
+      raise errors.Error('VPNGWs should have CLOUD attributes.')
+    benchmark_spec = context.GetThreadBenchmarkSpec()
+    if benchmark_spec is None:
+      raise errors.Error('GetVPN called in a thread without a '
+                         'BenchmarkSpec.')
+    with benchmark_spec.vpngws_lock:
+      key = cls.CLOUD
+      if key not in benchmark_spec.vpngws:
+        benchmark_spec.vpngws[key] = cls()
+      return benchmark_spec.vpngws[key]
+
+  def IsTunnelConfigured(self):
+    pass
+
+  def ConfigureTunnel(self, tunnel_config):
+    pass
+
+  def Create(self):
+    """Creates the actual VPNGW."""
+    pass
+
+  def Delete(self):
+      """Deletes the actual VPNGW."""
+      pass
+
+
 class BaseNetwork(object):
   """Object representing a Base Network."""
 

--- a/perfkitbenchmarker/network.py
+++ b/perfkitbenchmarker/network.py
@@ -131,11 +131,11 @@ class BaseVPNGW(object):
     if benchmark_spec is None:
       raise errors.Error('GetVPN called in a thread without a '
                          'BenchmarkSpec.')
-    with benchmark_spec.vpn_gws_lock:
+    with benchmark_spec.vpn_gateways_lock:
       key = cls.CLOUD
-      if key not in benchmark_spec.vpn_gws:
-        benchmark_spec.vpn_gws[key] = cls()
-      return benchmark_spec.vpn_gws[key]
+      if key not in benchmark_spec.vpn_gateways:
+        benchmark_spec.vpn_gateways[key] = cls()
+      return benchmark_spec.vpn_gateways[key]
 
   def IsTunnelConfigured(self):
     pass

--- a/perfkitbenchmarker/network.py
+++ b/perfkitbenchmarker/network.py
@@ -102,26 +102,26 @@ class BaseNetworkSpec(object):
     return '%s(%r)' % (self.__class__, self.__dict__)
 
 
-class BaseVPNGW(object):
+class BaseVpnGateway(object):
   """An object representing the Base VPN GW."""
   CLOUD = None
 
   def __init__(self, zone=None, cidr=None):
-    """Initializes the BaseVPNGW.
+    """Initializes the BaseVpnGateway.
 
     Args:
-      zone: The zone in which to create the VPNGW.
+      zone: The zone in which to create the VpnGateway.
     """
     self.zone = zone
     self.cidr = cidr
     self.require_target_to_init = False  # True if we need taget GW up front (AWS)
 
   @classmethod
-  def GetVPNGW(cls):
-    """Returns a BaseVPNGW.
+  def GetVpnGateway(cls):
+    """Returns a BaseVpnGateway.
     This method is used instead of directly calling the class's constructor.
-    It creates BaseVPNGW instances and registers them.
-    If a BaseVPNGW object has already been registered, that object
+    It creates BaseVpnGateway instances and registers them.
+    If a BaseVpnGateway object has already been registered, that object
     will be returned rather than creating a new one. This enables multiple
     VMs to call this method and all share the same BaseVPN object.
     """

--- a/perfkitbenchmarker/pkb.py
+++ b/perfkitbenchmarker/pkb.py
@@ -330,6 +330,9 @@ flags.DEFINE_boolean(
 flags.DEFINE_string(
     'skip_pending_runs_file', None,
     'If file exists, any pending runs will be not be executed.')
+flags.DEFINE_boolean(
+    'use_vpn', False,
+    'Creates VPN tunnels between vm_groups')
 flags.DEFINE_integer(
     'after_prepare_sleep_time', 0,
     'The time in seconds to sleep after the prepare phase. This can be useful '
@@ -624,6 +627,7 @@ def DoProvisionPhase(spec, timer):
   spec.ConstructCapacityReservations()
   spec.ConstructTpu()
   spec.ConstructEdwService()
+  spec.ConstructVPNService()
   spec.ConstructNfsService()
   spec.ConstructSmbService()
   # Pickle the spec before we try to create anything so we can clean

--- a/perfkitbenchmarker/providers/gcp/gce_network.py
+++ b/perfkitbenchmarker/providers/gcp/gce_network.py
@@ -53,7 +53,7 @@ class GceVPNGW(network.BaseVPNGW):
     self.tunnels = {}
     self.routes = {}
     self.ip_resource = None
-    self.vpn_gw_resource = GceVPNGWResource(name, network_name, region, cidr, project)
+    self.vpn_gateway_resource = GceVPNGWResource(name, network_name, region, cidr, project)
 
     self.name = name
     self.network_name = network_name
@@ -73,9 +73,9 @@ class GceVPNGW(network.BaseVPNGW):
       raise errors.Error('GetNetwork called in a thread without a '
                          'BenchmarkSpec.')
     key = self.name
-    with benchmark_spec.vpn_gws_lock:
-      if key not in benchmark_spec.vpn_gws:
-        benchmark_spec.vpn_gws[key] = self
+    with benchmark_spec.vpn_gateways_lock:
+      if key not in benchmark_spec.vpn_gateways:
+        benchmark_spec.vpn_gateways[key] = self
 
   def ConfigureTunnel(self, tunnel_config):
     network.BaseVPNGW.ConfigureTunnel(self, tunnel_config)
@@ -151,14 +151,14 @@ class GceVPNGW(network.BaseVPNGW):
     target_endpoint = [k for k in tunnel_config.endpoints.keys() if k not in self.name][0]
     project = tunnel_config.endpoints[self.name]['project']
     region = tunnel_config.endpoints[self.name]['region']
-    vpn_gw_id = self.name
+    vpn_gateway_id = self.name
     target_ip = tunnel_config.endpoints[target_endpoint]['ip_address']
     psk = tunnel_config.psk
     ike_version = tunnel_config.ike_version
     suffix = tunnel_config.suffix
     name = 'tun-' + self.name + '-' + suffix
     if name not in self.tunnels:
-      self.tunnels[name] = GceStaticTunnel(project, region, name, vpn_gw_id, target_ip, ike_version, psk)
+      self.tunnels[name] = GceStaticTunnel(project, region, name, vpn_gateway_id, target_ip, ike_version, psk)
       self.tunnels[name].Create()
       tunnel_config.endpoints[self.name]['tunnel_id'] = name
 
@@ -216,8 +216,8 @@ class GceVPNGW(network.BaseVPNGW):
                          'BenchmarkSpec.')
     if self.created:
       return
-    if self.vpn_gw_resource:
-      self.vpn_gw_resource.Create()
+    if self.vpn_gateway_resource:
+      self.vpn_gateway_resource.Create()
 
     self.created = True
 
@@ -238,8 +238,8 @@ class GceVPNGW(network.BaseVPNGW):
       for route in self.routes:
         self.routes[route].Delete()
 
-    if self.vpn_gw_resource:
-      self.vpn_gw_resource.Delete()
+    if self.vpn_gateway_resource:
+      self.vpn_gateway_resource.Delete()
 
     self.created = False
 
@@ -315,12 +315,12 @@ class GceIPAddress(resource.BaseResource):
 class GceStaticTunnel(resource.BaseResource):
   """An object representing a GCE Tunnel."""
 
-  def __init__(self, project, region, name, vpn_gw_id, target_ip, ike_version, psk):
+  def __init__(self, project, region, name, vpn_gateway_id, target_ip, ike_version, psk):
     super(GceStaticTunnel, self).__init__()
     self.project = project
     self.region = region
     self.name = name
-    self.vpn_gw_id = vpn_gw_id
+    self.vpn_gateway_id = vpn_gateway_id
     self.target_ip = target_ip
     self.ike_version = ike_version
     self.psk = psk
@@ -329,7 +329,7 @@ class GceStaticTunnel(resource.BaseResource):
     """Creates the Tunnel."""
     cmd = util.GcloudCommand(self, 'compute', 'vpn-tunnels', 'create', self.name)
     cmd.flags['peer-address'] = self.target_ip
-    cmd.flags['target-vpn-gateway'] = self.vpn_gw_id
+    cmd.flags['target-vpn-gateway'] = self.vpn_gateway_id
     cmd.flags['ike-version'] = self.ike_version
     cmd.flags['local-traffic-selector'] = '0.0.0.0/0'
     cmd.flags['remote-traffic-selector'] = '0.0.0.0/0'
@@ -401,15 +401,15 @@ class GceRoute(resource.BaseResource):
 class GceForwardingRule(resource.BaseResource):
   """An object representing a GCE Forwarding Rule."""
 
-  def __init__(self, name, protocol, src_vpn_gw, port=None):
+  def __init__(self, name, protocol, src_vpn_gateway, port=None):
     super(GceForwardingRule, self).__init__()
     self.name = name
     self.protocol = protocol
     self.port = port
-    self.target_name = src_vpn_gw.name
-    self.target_ip = src_vpn_gw.ip_address
-    self.src_region = src_vpn_gw.region
-    self.project = src_vpn_gw.project
+    self.target_name = src_vpn_gateway.name
+    self.target_ip = src_vpn_gateway.ip_address
+    self.src_region = src_vpn_gateway.region
+    self.project = src_vpn_gateway.project
 
   def __eq__(self, other):
     """Defines equality to make comparison easy."""
@@ -648,7 +648,7 @@ class GceNetwork(network.BaseNetwork):
   def __init__(self, network_spec):
     super(GceNetwork, self).__init__(network_spec)
     self.project = network_spec.project
-    self.vpn_gw = {}
+    self.vpn_gateway = {}
 
     #  Figuring out the type of network here.
     #  Precedence: User Managed > MULTI > SINGLE > DEFAULT
@@ -696,10 +696,10 @@ class GceNetwork(network.BaseNetwork):
     # Add VPNGWs to the network.
     if FLAGS.use_vpn:
       for gwnum in range(0, FLAGS.vpn_service_gateway_count):
-        vpn_gw_name = 'vpngw-%s-%s-%s' % (
+        vpn_gateway_name = 'vpngw-%s-%s-%s' % (
             util.GetRegionFromZone(network_spec.zone), gwnum, FLAGS.run_uri)
-        self.vpn_gw[vpn_gw_name] = GceVPNGW(
-            vpn_gw_name, name, util.GetRegionFromZone(network_spec.zone),
+        self.vpn_gateway[vpn_gateway_name] = GceVPNGW(
+            vpn_gateway_name, name, util.GetRegionFromZone(network_spec.zone),
             network_spec.cidr, self.project)
 
   def _GetNetworksFromSpec(self, network_spec):
@@ -817,16 +817,16 @@ class GceNetwork(network.BaseNetwork):
       if self.external_nets_rules:
         for rule in self.external_nets_rules:
           self.external_nets_rules[rule].Create()
-      if getattr(self, 'vpn_gw', False):
-        for gw in self.vpn_gw:
-          self.vpn_gw[gw].Create()
+      if getattr(self, 'vpn_gateway', False):
+        for gw in self.vpn_gateway:
+          self.vpn_gateway[gw].Create()
 
   def Delete(self):
     """Deletes the actual network."""
     if not FLAGS.gce_network_name:
-      if getattr(self, 'vpn_gw', False):
-        for gw in self.vpn_gw:
-          self.vpn_gw[gw].Delete()
+      if getattr(self, 'vpn_gateway', False):
+        for gw in self.vpn_gateway:
+          self.vpn_gateway[gw].Delete()
       if self.default_firewall_rule.created:
         self.default_firewall_rule.Delete()
       if self.external_nets_rules:

--- a/perfkitbenchmarker/providers/gcp/gce_network.py
+++ b/perfkitbenchmarker/providers/gcp/gce_network.py
@@ -44,6 +44,7 @@ ALLOW_ALL = 'tcp:1-65535,udp:1-65535,icmp'
 
 
 class GceVPNGW(network.BaseVPNGW):
+  """Object representing a GCE VPN Gateway"""
   CLOUD = providers.GCP
 
   def __init__(self, name, network_name, region, cidr, project):
@@ -78,6 +79,11 @@ class GceVPNGW(network.BaseVPNGW):
         benchmark_spec.vpn_gateways[key] = self
 
   def ConfigureTunnel(self, tunnel_config):
+    """Updates tunnel config with new information.
+    
+    Args:
+      tunnel_config: The tunnel configuration for this VPN.
+    """
     network.BaseVPNGW.ConfigureTunnel(self, tunnel_config)
     logging.info('Configuring Tunnel with params:')
     logging.info(tunnel_config)
@@ -145,9 +151,23 @@ class GceVPNGW(network.BaseVPNGW):
     tunnel_config.endpoints[self.name]['is_configured'] = True
 
   def IsTunnelReady(self, tunnel_id):
+    """Returns True if the tunnel is up and ready for traffic.
+
+    Args:
+      tunnel_id: The id of the tunnel to check.
+
+    Returns:
+      boolean.
+
+    """
     return self.tunnels[tunnel_id].IsReady()
 
   def _SetupTunnel(self, tunnel_config):
+    """Register a new GCE VPN tunnel for this endpoint.
+
+    Args:
+      tunnel_config: VPN tunnel configuration.
+    """
     target_endpoint = [k for k in tunnel_config.endpoints.keys() if k not in self.name][0]
     project = tunnel_config.endpoints[self.name]['project']
     region = tunnel_config.endpoints[self.name]['region']
@@ -164,7 +184,8 @@ class GceVPNGW(network.BaseVPNGW):
 
   def _SetupForwarding(self, tunnel_config):
     """Create IPSec forwarding rules
-    Forwards ESP protocol, and UDP 500/4500 for tunnel setup
+
+    Forwards ESP protocol, and UDP 500/4500 for tunnel setup.
 
     Args:
       source_gw: The BaseVPN object to add forwarding rules to.
@@ -245,6 +266,7 @@ class GceVPNGW(network.BaseVPNGW):
 
 
 class GceVPNGWResource(resource.BaseResource):
+  """Object representing a GCE VPN Gateway Resource."""
 
   def __init__(self, name, network_name, region, cidr, project):
     super(GceVPNGWResource, self).__init__()
@@ -276,6 +298,7 @@ class GceVPNGWResource(resource.BaseResource):
 
 
 class GceIPAddress(resource.BaseResource):
+  """Object representing a GCE IP address."""
 
   def __init__(self, project, region, name):
     super(GceIPAddress, self).__init__()

--- a/perfkitbenchmarker/providers/gcp/gce_network.py
+++ b/perfkitbenchmarker/providers/gcp/gce_network.py
@@ -88,7 +88,6 @@ class GceVpnGateway(network.BaseVpnGateway):
     Args:
       tunnel_config: The tunnel configuration for this VPN.
     """
-    # network.BaseVpnGateway.ConfigureTunnel(self, tunnel_config)
     logging.debug('Configuring Tunnel with params:')
     logging.debug(tunnel_config)
 
@@ -232,7 +231,7 @@ class GceVpnGateway(network.BaseVpnGateway):
 
     route_name = 'route-' + self.name + '-' + suffix
     if route_name not in self.routes:
-      self.routes[route_name] = GceRoute(route_name, dest_cidr, self.network_name, next_hop_tun, self.region, self.project, self.region)
+      self.routes[route_name] = GceRoute(route_name, dest_cidr, self.network_name, next_hop_tun, self.region, self.project)
       self.routes[route_name].Create()
 
   def Create(self):
@@ -323,7 +322,7 @@ class GceIPAddress(resource.BaseResource):
     cmd.flags['region'] = self.region
     cmd.flags['format'] = 'value(address)'
     stdout, _, _ = cmd.Issue()
-    self.ip_address = stdout.encode('ascii', 'ignore').rstrip().decode()
+    self.ip_address = stdout.rstrip()
 
   def _Delete(self):
     """ Deletes a public IP for the VPN gateway """
@@ -388,7 +387,7 @@ class GceStaticTunnel(resource.BaseResource):
 class GceRoute(resource.BaseResource):
   """An object representing a GCE Route."""
 
-  def __init__(self, route_name, dest_cidr, network_name, next_hop_tun, next_hop_region, project, region):
+  def __init__(self, route_name, dest_cidr, network_name, next_hop_tun, next_hop_region, project):
     super(GceRoute, self).__init__()
     self.name = route_name
     self.dest_cidr = dest_cidr
@@ -396,7 +395,6 @@ class GceRoute(resource.BaseResource):
     self.next_hop_tun = next_hop_tun
     self.network_name = network_name
     self.project = project
-    self.region = region
 
   def _Create(self):
     """Creates the Route."""

--- a/perfkitbenchmarker/providers/gcp/gce_network.py
+++ b/perfkitbenchmarker/providers/gcp/gce_network.py
@@ -85,13 +85,13 @@ class GceVPNGW(network.BaseVPNGW):
     # update tunnel_config if needed
     if self.name not in tunnel_config.endpoints:
       logging.info('tunnel_config: This endpoint isnt registered yet... %s' % self.name)
-      tunnel_config.endpoints[self.name] = {}
-      tunnel_config.endpoints[self.name]['is_configured'] = False
-      tunnel_config.endpoints[self.name]['cidr'] = self.cidr
-      tunnel_config.endpoints[self.name]['project'] = self.project
-      tunnel_config.endpoints[self.name]['network_name'] = self.network_name
-      tunnel_config.endpoints[self.name]['region'] = self.region
-      tunnel_config.endpoints[self.name]['require_target_to_init'] = self.require_target_to_init
+      tunnel_config.endpoints[self.name] = {'is_configured': False,
+                                            'cidr': self.cidr,
+                                            'project': self.project,
+                                            'network_name':  self.network_name,
+                                            'region': self.region,
+                                            'require_target_to_init': self.require_target_to_init,
+                                            }
 
     # attach public IP to this GW if doesnt exist
     # and update tunnel_config if needed

--- a/perfkitbenchmarker/providers/gcp/gce_network.py
+++ b/perfkitbenchmarker/providers/gcp/gce_network.py
@@ -94,7 +94,7 @@ class GceVpnGateway(network.BaseVpnGateway):
 
     # update tunnel_config if needed
     if self.name not in tunnel_config.endpoints:
-      logging.info('tunnel_config: This endpoint isnt registered yet... %s' % self.name)
+      logging.debug('tunnel_config: This endpoint isnt registered yet... %s' % self.name)
       tunnel_config.endpoints[self.name] = {'is_configured': False,
                                             'cidr': self.cidr,
                                             'project': self.project,
@@ -113,7 +113,7 @@ class GceVpnGateway(network.BaseVpnGateway):
           self.ip_resource.Create()
         self.ip_address = self.ip_resource.ip_address
       if 'ip_address' not in tunnel_config.endpoints[self.name]:
-        logging.info('tunnel_config: Configuring IP for %s' % self.name)
+        logging.debug('tunnel_config: Configuring IP for %s' % self.name)
         tunnel_config.endpoints[self.name]['ip_address'] = self.ip_address
 
     # configure forwarding
@@ -122,12 +122,12 @@ class GceVpnGateway(network.BaseVpnGateway):
       if len(self.forwarding_rules) == 3:
         logging.debug('tunnel_config: Forwarding already configured, skipping')
       else:
-        logging.info('tunnel_config: Setting up forwarding')
+        logging.debug('tunnel_config: Setting up forwarding')
         self._SetupForwarding(tunnel_config)
 
     # Abort if we don't have a target info configured yet
     if len(tunnel_config.endpoints) < 2:
-      logging.info('tunnel_config: Only found %d endpoints... waiting for target to configure' % len(tunnel_config.endpoints))
+      logging.debug('tunnel_config: Only found %d endpoints... waiting for target to configure' % len(tunnel_config.endpoints))
       return
 
     # Get target endpoint config key
@@ -136,7 +136,7 @@ class GceVpnGateway(network.BaseVpnGateway):
     # configure tunnel resources
     # requires: target_ip_address, IKE version (default 1),
     if 'ip_address' not in tunnel_config.endpoints[target_endpoint]:
-      logging.info('tunnel_config: Target IP needed... waiting for target to configure')
+      logging.debug('tunnel_config: Target IP needed... waiting for target to configure')
       return
     if not hasattr(tunnel_config, 'psk'):
       logging.debug('tunnel_config: PSK not provided... setting to runid')
@@ -147,7 +147,7 @@ class GceVpnGateway(network.BaseVpnGateway):
     # requires: next_hop_tunnel_id, target_cidr,
     dest_cidr = tunnel_config.endpoints[target_endpoint].get('cidr')
     if not dest_cidr or not dest_cidr.strip():
-      logging.info('tunnel_config: destination CIDR needed... waiting for target to configure')
+      logging.debug('tunnel_config: destination CIDR needed... waiting for target to configure')
       return
     self._SetupRouting(
         tunnel_config.suffix,

--- a/perfkitbenchmarker/vpn_service.py
+++ b/perfkitbenchmarker/vpn_service.py
@@ -246,6 +246,7 @@ class VPNService(resource.BaseResource):
      # get all gw pairs then filter out the non matching tunnel id's
     vpn_gw_pairs = itertools.combinations(vpn_gws, 2)
     r = re.compile(r"(?P<gw_prefix>.*-.*-.*)?-(?P<gw_tnum>[0-9])-(?P<run_id>.*)")
-    # function = lambda x: r.search(x[0]).group('gw_tnum') == r.search(x[1]).group('gw_tnum')
-    function = lambda x: r.search(x[0]).group('gw_prefix') != r.search(x[1]).group('gw_prefix')
-    return list(filter(function, vpn_gw_pairs))
+    def filterGateways(gateway_pair):
+      return r.search(gateway_pair[0]).group('gw_prefix') != r.search(
+          gateway_pair[1]).group('gw_prefix')
+    return list(filter(filterGateways, vpn_gw_pairs))

--- a/perfkitbenchmarker/vpn_service.py
+++ b/perfkitbenchmarker/vpn_service.py
@@ -77,7 +77,7 @@ class VPN(object):
     if benchmark_spec is None:
       raise errors.Error('GetVPN called in a thread without a '
                          'BenchmarkSpec.')
-    with benchmark_spec.vpn_gws_lock:
+    with benchmark_spec.vpn_gateways_lock:
       key = self.getKeyFromGWPair(gwpair, suffix)
       if key not in benchmark_spec.vpns:
         self.Create(gwpair, suffix)
@@ -87,14 +87,14 @@ class VPN(object):
   def ConfigureTunnel(self):
 
     benchmark_spec = context.GetThreadBenchmarkSpec()
-    vpn_gw_0 = benchmark_spec.vpn_gws[self.GWPair[0]]
-    vpn_gw_1 = benchmark_spec.vpn_gws[self.GWPair[1]]
+    vpn_gateway_0 = benchmark_spec.vpn_gateways[self.GWPair[0]]
+    vpn_gateway_1 = benchmark_spec.vpn_gateways[self.GWPair[1]]
 
-    assert not (vpn_gw_0.require_target_to_init and vpn_gw_1.require_target_to_init), 'Cant connect 2 passive VPN GWs'
+    assert not (vpn_gateway_0.require_target_to_init and vpn_gateway_1.require_target_to_init), 'Cant connect 2 passive VPN GWs'
 
     while not self.isTunnelConfigured():
-        vpn_gw_0.ConfigureTunnel(self.tunnel_config)
-        vpn_gw_1.ConfigureTunnel(self.tunnel_config)
+        vpn_gateway_0.ConfigureTunnel(self.tunnel_config)
+        vpn_gateway_1.ConfigureTunnel(self.tunnel_config)
 
     tunnel_status = self.isTunnelReady()
     logging.info('Tunnel is ready?: %s ' % tunnel_status)
@@ -115,7 +115,7 @@ class VPN(object):
     timeout = time.time() + 60 * 5  # give up after 5 mins
     while(not ready and time.time() < timeout):
       logging.info('Tunnel endpoints configured. Waiting for tunnel...')
-      ready = benchmark_spec.vpn_gws[self.GWPair[0]].IsTunnelReady(self.tunnel_config.endpoints[self.GWPair[0]]['tunnel_id']) and benchmark_spec.vpn_gws[self.GWPair[1]].IsTunnelReady(self.tunnel_config.endpoints[self.GWPair[1]]['tunnel_id'])
+      ready = benchmark_spec.vpn_gateways[self.GWPair[0]].IsTunnelReady(self.tunnel_config.endpoints[self.GWPair[0]]['tunnel_id']) and benchmark_spec.vpn_gateways[self.GWPair[1]].IsTunnelReady(self.tunnel_config.endpoints[self.GWPair[1]]['tunnel_id'])
       time.sleep(5)
 
     return ready
@@ -212,10 +212,10 @@ class VPNService(resource.BaseResource):
                          'BenchmarkSpec.')
 
 
-    self.vpn_gw_pairs = self.GetVPNGWPairs(benchmark_spec.vpn_gws)
+    self.vpn_gateway_pairs = self.GetVPNGWPairs(benchmark_spec.vpn_gateways)
 
 
-    for gwpair in self.vpn_gw_pairs:
+    for gwpair in self.vpn_gateway_pairs:
       # creates the vpn if it doesn't exist and registers in bm_spec.vpns
       suffix = self.GetNewSuffix()
       vpn_id = VPN().getKeyFromGWPair(gwpair, suffix)
@@ -240,13 +240,13 @@ class VPNService(resource.BaseResource):
                   }
     return basic_data
 
-  def GetVPNGWPairs(self, vpn_gws):
+  def GetVPNGWPairs(self, vpn_gateways):
     # vpngw-us-west1-0-28ed049a <-> vpngw-us-central1-0-28ed049a # yes
     # vpngw-us-west1-0-28ed049a <-> vpngw-us-central1-1-28ed049a # no
      # get all gw pairs then filter out the non matching tunnel id's
-    vpn_gw_pairs = itertools.combinations(vpn_gws, 2)
+    vpn_gateway_pairs = itertools.combinations(vpn_gateways, 2)
     r = re.compile(r"(?P<gw_prefix>.*-.*-.*)?-(?P<gw_tnum>[0-9])-(?P<run_id>.*)")
     def filterGateways(gateway_pair):
       return r.search(gateway_pair[0]).group('gw_prefix') != r.search(
           gateway_pair[1]).group('gw_prefix')
-    return list(filter(filterGateways, vpn_gw_pairs))
+    return list(filter(filterGateways, vpn_gateway_pairs))

--- a/perfkitbenchmarker/vpn_service.py
+++ b/perfkitbenchmarker/vpn_service.py
@@ -17,7 +17,7 @@ This module contains the main VPNService class, which manages the VPN lifecycle,
 the VPN class, which manages the VPN tunnel lifecycle between two endpoints, and
 the TunnelConfig class, which maintains the parameters needed to configure a
 tunnel between two endpoints. Related: perfkitbenchmarker.network
-module includes the BaseVPNGW class to manage VPN gateway endpoints.
+module includes the BaseVpnGateway class to manage VPN gateway endpoints.
 """
 
 import itertools
@@ -94,7 +94,7 @@ class VPN(object):
     """Gets a VPN object for the gateway_pair or creates one if none exists
 
     Args:
-    gateway_pair: a tuple of two VPNGWs
+    gateway_pair: a tuple of two VpnGateways
     """
 
     benchmark_spec = context.GetThreadBenchmarkSpec()
@@ -257,7 +257,7 @@ class VPNService(resource.BaseResource):
     return result
 
   def _Create(self):
-    """Creates VPN objects for VPNGW pairs."""
+    """Creates VPN objects for VpnGateway pairs."""
 
     benchmark_spec = context.GetThreadBenchmarkSpec()
     if benchmark_spec is None:
@@ -265,7 +265,7 @@ class VPNService(resource.BaseResource):
                          'BenchmarkSpec.')
 
 
-    self.vpn_gateway_pairs = self.GetVPNGWPairs(benchmark_spec.vpn_gateways)
+    self.vpn_gateway_pairs = self.GetVpnGatewayPairs(benchmark_spec.vpn_gateways)
 
 
     for gateway_pair in self.vpn_gateway_pairs:
@@ -300,7 +300,7 @@ class VPNService(resource.BaseResource):
                   }
     return basic_data
 
-  def GetVPNGWPairs(self, vpn_gateways):
+  def GetVpnGatewayPairs(self, vpn_gateways):
     """Returns pairs of gateways to create VPNs between.
 
     Currently creates a pair between all non-matching region endpoints (mesh).

--- a/perfkitbenchmarker/vpn_service.py
+++ b/perfkitbenchmarker/vpn_service.py
@@ -153,7 +153,7 @@ class VPN(object):
     if len(self.tunnel_config.endpoints) == 2:
       if (self.tunnel_config.endpoints[self.GatewayPair[0]]['is_configured'] and
           self.tunnel_config.endpoints[self.GatewayPair[1]]['is_configured']):
-        logging.info('Tunnel is configured.')
+        logging.debug('Tunnel is configured.')
         is_tunnel_configured = True
     return is_tunnel_configured
 
@@ -165,7 +165,7 @@ class VPN(object):
       boolean.
     """
     benchmark_spec = context.GetThreadBenchmarkSpec()
-    logging.info('Tunnel endpoints configured. Waiting for tunnel...')
+    logging.debug('Tunnel endpoints configured. Waiting for tunnel...')
     ready = (benchmark_spec.vpn_gateways[self.GatewayPair[0]].IsTunnelReady(
         self.tunnel_config.endpoints[self.GatewayPair[0]]['tunnel_id']) and
         benchmark_spec.vpn_gateways[self.GatewayPair[1]].IsTunnelReady(

--- a/perfkitbenchmarker/vpn_service.py
+++ b/perfkitbenchmarker/vpn_service.py
@@ -1,0 +1,251 @@
+# Copyright 2017 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import threading
+
+from perfkitbenchmarker import errors, context, resource, flags
+import itertools
+import re
+# from itertools import ifilter
+import time
+import logging
+import json
+import uuid
+
+flags.DEFINE_integer('vpn_service_tunnel_count', None,
+                     'Number of tunnels to create for each VPNGW pair.')
+flags.DEFINE_integer('vpn_service_gateway_count', None,
+                     'Number of VPN GWs to create for each VPNGW pair.')
+flags.DEFINE_string('vpn_service_name', None,
+                    'If set, use this name for VPN Service.')
+flags.DEFINE_string('vpn_service_shared_key', None,
+                    'If set, use this PSK for VPNs.')
+flags.DEFINE_string('vpn_service_routing_type', None,
+                    'static or dynamic(BGP)')
+flags.DEFINE_integer('vpn_service_ike_version', None, 'IKE version')
+
+FLAGS = flags.FLAGS
+
+
+def GetVPNServiceClass():
+  """Gets the VPNService class.
+
+  Args:
+
+  Returns:
+    Implementation class
+  """
+  return resource.GetResourceClass(VPNService)
+
+
+class VPN(object):
+  """An object representing the VPN."""
+
+  def __init__(self, *args, **kwargs):
+      return object.__init__(self, *args, **kwargs)
+
+  def getKeyFromGWPair(self, gwpair, suffix=''):
+    key = 'vpn' + ''.join(gw for gw in gwpair) + suffix + FLAGS.run_uri
+    return key
+
+  def Create(self, gwpair, suffix=''):
+    self.GWPair = gwpair
+    self.name = self.getKeyFromGWPair(gwpair)
+    self.tunnel_config = TunnelConfig(name=self.name, suffix=suffix)
+
+  def Delete(self):
+    pass
+
+  def GetVPN(self, gwpair, suffix=''):
+    """Gets a VPN object for the gwpair or creates one if none exists
+
+    Args:
+    gwpair: a tuple of two VPNGWs
+    """
+
+    benchmark_spec = context.GetThreadBenchmarkSpec()
+    if benchmark_spec is None:
+      raise errors.Error('GetVPN called in a thread without a '
+                         'BenchmarkSpec.')
+    with benchmark_spec.vpngws_lock:
+      key = self.getKeyFromGWPair(gwpair, suffix)
+      if key not in benchmark_spec.vpns:
+        self.Create(gwpair, suffix)
+        benchmark_spec.vpns[key] = self
+      return benchmark_spec.vpns[key]
+
+  def ConfigureTunnel(self):
+
+    benchmark_spec = context.GetThreadBenchmarkSpec()
+    vpngw0 = benchmark_spec.vpngws[self.GWPair[0]]
+    vpngw1 = benchmark_spec.vpngws[self.GWPair[1]]
+
+    assert not (vpngw0.require_target_to_init and vpngw1.require_target_to_init), 'Cant connect 2 passive VPN GWs'
+
+    while not self.isTunnelConfigured():
+        vpngw0.ConfigureTunnel(self.tunnel_config)
+        vpngw1.ConfigureTunnel(self.tunnel_config)
+
+    tunnel_status = self.isTunnelReady()
+    logging.info('Tunnel is ready?: %s ' % tunnel_status)
+
+  def isTunnelConfigured(self):
+    is_tunnel_configured = False
+    if len(self.tunnel_config.endpoints) == 2:
+      if self.tunnel_config.endpoints[self.GWPair[0]]['is_configured'] and self.tunnel_config.endpoints[self.GWPair[1]]['is_configured']:
+        logging.info('Tunnel is configured.')
+        is_tunnel_configured = True
+    return is_tunnel_configured
+
+  # tunnel should be up now, just wait for all clear
+  # blocking here for now
+  def isTunnelReady(self):
+    benchmark_spec = context.GetThreadBenchmarkSpec()
+    ready = False
+    timeout = time.time() + 60 * 5  # give up after 5 mins
+    while(not ready and time.time() < timeout):
+      logging.info('Tunnel endpoints configured. Waiting for tunnel...')
+      ready = benchmark_spec.vpngws[self.GWPair[0]].IsTunnelReady(self.tunnel_config.endpoints[self.GWPair[0]]['tunnel_id']) and benchmark_spec.vpngws[self.GWPair[1]].IsTunnelReady(self.tunnel_config.endpoints[self.GWPair[1]]['tunnel_id'])
+      time.sleep(5)
+
+    return ready
+
+
+class TunnelConfig(object):
+  """Object to hold all parms needed to configure a tunnel.
+
+  tunnel_config =
+  { tunnel_name = ''
+    routing = ''
+    psk = ''
+    endpoints = [ep1={...}, ep2={...}
+    }
+
+  endpoint =
+  { name = ''
+    ip = ''
+    cidr = ''
+    require_target_to_init = t/f
+    tunnel_id = ''
+
+  }
+  }
+
+  """
+
+  _tunnelconfig_lock = threading.Lock()
+
+  def __init__(self, **kwargs):
+    super(TunnelConfig, self).__init__()
+    self.tunnel_name = kwargs.get('tunnel_name', 'unnamed_tunnel')  # uniquely id this tunnel
+    self.endpoints = {}
+    self.routing = kwargs.get('routing', 'static')  # @TODO dynamic(bgp)
+    self.ike_version = kwargs.get('ike_version', '1')
+    self.psk = kwargs.get('psk', 'key' + FLAGS.run_uri)
+    self.suffix = kwargs.get('suffix', '')
+
+  def set(self, **kwargs):
+    with self._tunnelconfig_lock:
+      for key in kwargs:
+          setattr(self, key, kwargs[key])
+
+  def __str__(self):
+    return str(json.dumps(self.__dict__))
+
+
+class VPNService(resource.BaseResource):
+  RESOURCE_TYPE = 'BaseVPNService'
+  REQUIRED_ATTRS = ['SERVICE']
+
+  def __init__(self, spec):
+    """Initialize the VPN Service object.
+
+    Args:
+      vpn_service_spec: spec of the vpn service.
+    """
+    super(VPNService, self).__init__()
+    self.name = spec.name
+    self.tunnel_count = spec.tunnel_count
+    self.gateway_count = FLAGS.vpn_service_gateway_count
+    self.routing = spec.routing_type
+    self.ike_version = spec.ike_version
+    self.psk = FLAGS.run_uri
+    self.spec = spec
+    self.vpns = {}
+
+  def GetResourceMetadata(self):
+    """Returns a dictionary of metadata about the resource."""
+
+    if not self.created:
+      return {}
+    result = self.metadata.copy()
+    if self.routing is not None:
+      result['vpn_service_routing_type'] = self.routing
+    if self.ike_version is not None:
+      result['vpn_service_ike_version'] = self.ike_version
+    if self.tunnel_count is not None:
+      result['vpn_service_tunnel_count'] = self.tunnel_count
+    if self.gateway_count is not None:
+      result['gateway_count'] = self.gateway_count
+    # if self.psk is not None:  # probably don't want to publish this.
+    #   result['vpn_service_shared_key'] = self.psk
+
+    return result
+
+  def _Create(self):
+    """Creates VPN objects for VPNGW pairs.
+    """
+
+    benchmark_spec = context.GetThreadBenchmarkSpec()
+    if benchmark_spec is None:
+      raise errors.Error('CreateVPN Service. called in a thread without a '
+                         'BenchmarkSpec.')
+
+
+    self.vpngw_pairs = self.GetVPNGWPairs(benchmark_spec.vpngws)
+
+
+    for gwpair in self.vpngw_pairs:
+      # creates the vpn if it doesn't exist and registers in bm_spec.vpns
+      suffix = self.GetNewSuffix()
+      vpn_id = VPN().getKeyFromGWPair(gwpair, suffix)
+      self.vpns[vpn_id] = VPN().GetVPN(gwpair, suffix)
+      self.vpns[vpn_id].ConfigureTunnel()
+
+  def _Delete(self):
+    pass
+
+  def GetNewSuffix(self):
+    # Names for tunnels, fr's, routes, etc need to be unique
+    return format(uuid.uuid4().fields[1], 'x')
+
+  def GetMetadata(self):
+    """Return a dictionary of the metadata for VPNs created."""
+    basic_data = {'vpn_service_name': self.name,
+                  'vpn_service_routing_type': self.routing,
+                  'vpn_service_ike_version': self.ike_version,
+                  'vpn_service_tunnel_count': self.tunnel_count,
+                  'vpn_service_gateway_count': self.gateway_count,
+                  # 'vpn_service_psk': self.psk,
+                  }
+    return basic_data
+
+  def GetVPNGWPairs(self, vpngws):
+    # vpngw-us-west1-0-28ed049a <-> vpngw-us-central1-0-28ed049a # yes
+    # vpngw-us-west1-0-28ed049a <-> vpngw-us-central1-1-28ed049a # no
+     # get all gw pairs then filter out the non matching tunnel id's
+    vpngw_pairs = itertools.combinations(vpngws, 2)
+    r = re.compile(r"(?P<gw_prefix>.*-.*-.*)?-(?P<gw_tnum>[0-9])-(?P<run_id>.*)")
+    # function = lambda x: r.search(x[0]).group('gw_tnum') == r.search(x[1]).group('gw_tnum')
+    function = lambda x: r.search(x[0]).group('gw_prefix') != r.search(x[1]).group('gw_prefix')
+    return filter(function, vpngw_pairs)

--- a/perfkitbenchmarker/vpn_service.py
+++ b/perfkitbenchmarker/vpn_service.py
@@ -42,16 +42,19 @@ flags.DEFINE_string('vpn_service_name', None,
                     'If set, use this name for VPN Service.')
 flags.DEFINE_string('vpn_service_shared_key', None,
                     'If set, use this PSK for VPNs.')
-flags.DEFINE_string('vpn_service_routing_type', None, 'static or dynamic(BGP)')
 flags.DEFINE_integer('vpn_service_ike_version', None, 'IKE version')
-
-FLAGS = flags.FLAGS
 
 
 class VPN_ROUTING_TYPE(Enum):
-  DEFAULT = None
   STATIC = 'static'
   DYNAMIC = 'dynamic'
+
+flags.DEFINE_enum(
+    'vpn_service_routing_type', None,
+    [VPN_ROUTING_TYPE.STATIC.value, VPN_ROUTING_TYPE.DYNAMIC.value],
+    'static or dynamic(BGP)')
+
+FLAGS = flags.FLAGS
 
 
 def GetVPNServiceClass():
@@ -204,7 +207,7 @@ class TunnelConfig(object):
     super(TunnelConfig, self).__init__()
     self.tunnel_name = kwargs.get('tunnel_name', 'unnamed_tunnel')
     self.endpoints = {}
-    self.routing = kwargs.get('routing', VPN_ROUTING_TYPE.DEFAULT.value)
+    self.routing = kwargs.get('routing', None)
     self.ike_version = kwargs.get('ike_version', 2)
     self.shared_key = kwargs.get('shared_key', 'key' + FLAGS.run_uri)
     self.suffix = kwargs.get('suffix', '')

--- a/perfkitbenchmarker/vpn_service.py
+++ b/perfkitbenchmarker/vpn_service.py
@@ -61,7 +61,7 @@ class VPN(object):
   def Create(self, gwpair, suffix=''):
     self.GWPair = gwpair
     self.name = self.getKeyFromGWPair(gwpair)
-    self.tunnel_config = TunnelConfig(name=self.name, suffix=suffix)
+    self.tunnel_config = TunnelConfig(tunnel_name=self.name, suffix=suffix)
 
   def Delete(self):
     pass
@@ -248,4 +248,4 @@ class VPNService(resource.BaseResource):
     r = re.compile(r"(?P<gw_prefix>.*-.*-.*)?-(?P<gw_tnum>[0-9])-(?P<run_id>.*)")
     # function = lambda x: r.search(x[0]).group('gw_tnum') == r.search(x[1]).group('gw_tnum')
     function = lambda x: r.search(x[0]).group('gw_prefix') != r.search(x[1]).group('gw_prefix')
-    return filter(function, vpn_gw_pairs)
+    return list(filter(function, vpn_gw_pairs))

--- a/tests/vpn_service_test.py
+++ b/tests/vpn_service_test.py
@@ -118,7 +118,7 @@ class VpnServiceTestCase(BaseVPNServiceTest):
     self.assertTrue(hasattr(pspec, 'vpn_gateways'))
     self.assertTrue(pspec.vpn_gateways is not None)
 
-  def testGetVPNGWPairs(self):
+  def testGetVPNGatewayPairs(self):
     vpn_gateways = {'vpngw-us-west1-0-None': None,
                     'vpngw-us-west1-1-None': None,
                     'vpngw-us-central1-0-None': None,
@@ -127,11 +127,11 @@ class VpnServiceTestCase(BaseVPNServiceTest):
     FLAGS.vpn_service_gateway_count = 1
     spec = self._CreateBenchmarkSpecFromYaml(DEFAULT_CFG)
     spec.ConstructVPNService()
-    pairs = spec.vpn_service.GetVPNGWPairs(vpn_gateways)
+    pairs = spec.vpn_service.GetVpnGatewayPairs(vpn_gateways)
     self.assertEqual(len(pairs), 4)
     # test unpickled values
     pspec = pickle.loads(pickle.dumps(spec))
-    ppairs = pspec.vpn_service.GetVPNGWPairs(vpn_gateways)
+    ppairs = pspec.vpn_service.GetVpnGatewayPairs(vpn_gateways)
     self.assertEqual(len(ppairs), 4)
 
 

--- a/tests/vpn_service_test.py
+++ b/tests/vpn_service_test.py
@@ -1,0 +1,176 @@
+# Copyright 2020 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for vpn service"""
+import pickle
+import sys
+
+from perfkitbenchmarker import benchmark_spec
+from perfkitbenchmarker import configs
+from perfkitbenchmarker import flags
+from perfkitbenchmarker import linux_benchmarks
+from perfkitbenchmarker import providers
+from perfkitbenchmarker.configs import benchmark_config_spec
+from perfkitbenchmarker.vpn_service import TunnelConfig
+from tests import pkb_common_test_case
+
+FLAGS = flags.FLAGS
+
+PROJECT = 'mock_project'
+CLOUD = providers.GCP
+BENCHMARK_NAME = 'iperf'
+URI = 'uri45678'
+
+DEFAULT_CFG = """
+# VPN iperf config.
+iperf:
+  description: Run iperf over vpn
+  flags:
+    iperf_sending_thread_count: 5
+    use_vpn: True
+    vpn_service_gateway_count: 1
+  vpn_service:
+    tunnel_count: 1
+    ike_version: 2
+    routing_type: static
+  vm_groups:
+    vm_1:
+      cloud: GCP
+      cidr: 10.0.1.0/24
+      vm_spec:
+        GCP:
+            zone: us-west1-b
+            machine_type: n1-standard-4
+    vm_2:
+      cloud: GCP
+      cidr: 192.168.1.0/24
+      vm_spec:
+        GCP:
+            zone: us-central1-c
+            machine_type: n1-standard-4
+"""
+
+
+class BaseVPNServiceTest(pkb_common_test_case.PkbCommonTestCase):
+
+  def setUp(self):
+    super(BaseVPNServiceTest, self).setUp()
+    if not sys.warnoptions:  # https://bugs.python.org/issue33154
+      import warnings
+      warnings.simplefilter("ignore", ResourceWarning)
+
+  def _CreateBenchmarkSpecFromYaml(self, yaml_string,
+                                   benchmark_name=BENCHMARK_NAME):
+    config = configs.LoadConfig(yaml_string, {}, benchmark_name)
+    return self._CreateBenchmarkSpecFromConfigDict(config, benchmark_name)
+
+  def _CreateBenchmarkSpecFromConfigDict(self, config_dict, benchmark_name):
+    config_spec = benchmark_config_spec.BenchmarkConfigSpec(benchmark_name,
+                                                            flag_values=FLAGS,
+                                                            **config_dict)
+    benchmark_module = next((b for b in linux_benchmarks.BENCHMARKS if
+                             b.BENCHMARK_NAME == benchmark_name))
+    return benchmark_spec.BenchmarkSpec(benchmark_module, config_spec, URI)
+
+  def extractDictAFromB(self, A, B):  # assertDictContainsSubset deprecated
+    return dict([(k, B[k]) for k in A.keys() if k in B.keys()])
+
+
+class VpnServiceTestCase(BaseVPNServiceTest):
+
+  def testVpnServiceConfig(self):
+    FLAGS.use_vpn = True
+    FLAGS.vpn_service_gateway_count = 1
+    spec = self._CreateBenchmarkSpecFromYaml(DEFAULT_CFG)
+    spec.ConstructVPNService()
+    spec.ConstructVirtualMachines()
+    #  test global flags
+    self.assertTrue(spec.config.flags['use_vpn'])
+    self.assertEqual(spec.config.flags['vpn_service_gateway_count'], 1)
+    # test vpn_service flags
+    self.assertTrue(hasattr(spec, 'vpn_service'))
+    self.assertTrue(spec.vpn_service is not None)
+    self.assertEqual(spec.vpn_service.tunnel_count, 1)
+    self.assertEqual(spec.vpn_service.ike_version, 2)
+    self.assertEqual(spec.vpn_service.routing, 'static')
+    # test benchmark_spec attributes
+    self.assertTrue(hasattr(spec, 'vpn_gateways'))
+    self.assertTrue(spec.vpn_gateways is not None)
+    # test unpickled values for above
+    pspec = pickle.loads(pickle.dumps(spec))
+    self.assertTrue(pspec.config.flags['use_vpn'])
+    self.assertEqual(pspec.config.flags['vpn_service_gateway_count'], 1)
+    self.assertTrue(hasattr(pspec, 'vpn_service'))
+    self.assertTrue(pspec.vpn_service is not None)
+    self.assertEqual(pspec.vpn_service.tunnel_count, 1)
+    self.assertEqual(pspec.vpn_service.ike_version, 2)
+    self.assertEqual(pspec.vpn_service.routing, 'static')
+    self.assertTrue(hasattr(pspec, 'vpn_gateways'))
+    self.assertTrue(pspec.vpn_gateways is not None)
+
+  def testGetVPNGWPairs(self):
+    vpn_gateways = {'vpngw-us-west1-0-None': None,
+                    'vpngw-us-west1-1-None': None,
+                    'vpngw-us-central1-0-None': None,
+                    'vpngw-us-central1-1-None': None, }
+    FLAGS.use_vpn = True
+    FLAGS.vpn_service_gateway_count = 1
+    spec = self._CreateBenchmarkSpecFromYaml(DEFAULT_CFG)
+    spec.ConstructVPNService()
+    pairs = spec.vpn_service.GetVPNGWPairs(vpn_gateways)
+    self.assertEqual(len(pairs), 4)
+    # test unpickled values
+    pspec = pickle.loads(pickle.dumps(spec))
+    ppairs = pspec.vpn_service.GetVPNGWPairs(vpn_gateways)
+    self.assertEqual(len(ppairs), 4)
+
+
+class TunnelConfigTestCase(BaseVPNServiceTest):
+
+  def testTunnelConfigHash(self):
+    FLAGS.run_uri = URI
+    ep1 = {
+        'name': 'ep1',
+        'ip': '1.2.3.4',
+        'cidr': '1.2.3.4/5',
+        'require_target_to_init': False,
+        'tunnel_id': '12345',
+    }
+    ep2 = {
+        'name': 'ep2',
+        'ip': '9.8.7.6',
+        'cidr': '9.8.7.6/5',
+        'require_target_to_init': False,
+        'tunnel_id': '98765',
+    }
+
+    endpoints = [ep1, ep2]
+
+    conf = {
+        'tunnel_name': 'tun1',
+        'ike_version': '3',
+        'routing': 'static',
+        'psk': 'private',
+        'endpoints': endpoints
+    }
+
+    tunnel_config = TunnelConfig()
+    tunnel_config2 = TunnelConfig()
+
+    hash1 = tunnel_config.hash()
+    hash2 = tunnel_config2.hash()
+    self.assertEqual(hash1, hash2)
+
+    tunnel_config.setConfig(**conf)
+    hash3 = tunnel_config.hash()
+    self.assertNotEqual(hash1, hash3)

--- a/tests/vpn_service_test.py
+++ b/tests/vpn_service_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for vpn service"""
+from absl.testing import flagsaver
 import pickle
 import sys
 
@@ -88,9 +89,8 @@ class BaseVPNServiceTest(pkb_common_test_case.PkbCommonTestCase):
 
 class VpnServiceTestCase(BaseVPNServiceTest):
 
+  @flagsaver.flagsaver(use_vpn=True, vpn_service_gateway_count=1)
   def testVpnServiceConfig(self):
-    FLAGS.use_vpn = True
-    FLAGS.vpn_service_gateway_count = 1
     spec = self._CreateBenchmarkSpecFromYaml(DEFAULT_CFG)
     spec.ConstructVPNService()
     spec.ConstructVirtualMachines()
@@ -118,13 +118,12 @@ class VpnServiceTestCase(BaseVPNServiceTest):
     self.assertTrue(hasattr(pspec, 'vpn_gateways'))
     self.assertTrue(pspec.vpn_gateways is not None)
 
+  @flagsaver.flagsaver(use_vpn=True, vpn_service_gateway_count=1)
   def testGetVPNGatewayPairs(self):
     vpn_gateways = {'vpngw-us-west1-0-None': None,
                     'vpngw-us-west1-1-None': None,
                     'vpngw-us-central1-0-None': None,
                     'vpngw-us-central1-1-None': None, }
-    FLAGS.use_vpn = True
-    FLAGS.vpn_service_gateway_count = 1
     spec = self._CreateBenchmarkSpecFromYaml(DEFAULT_CFG)
     spec.ConstructVPNService()
     pairs = spec.vpn_service.GetVpnGatewayPairs(vpn_gateways)
@@ -137,8 +136,8 @@ class VpnServiceTestCase(BaseVPNServiceTest):
 
 class TunnelConfigTestCase(BaseVPNServiceTest):
 
+  @flagsaver.flagsaver(run_uri=URI)
   def testTunnelConfigHash(self):
-    FLAGS.run_uri = URI
     ep1 = {
         'name': 'ep1',
         'ip': '1.2.3.4',


### PR DESCRIPTION
- Adds support for running network benchmarks across a VPN. 
- Includes GCP implementation with static routes.

Example config:
```
iperf:
  description: Run iperf over vpn
  flags:
    iperf_sending_thread_count: 20
    use_vpn: True
    vpn_service_gateway_count: 1
  vpn_service:
    tunnel_count: 1
    ike_version: 2
    routing_type: static
  vm_groups:
    vm_1:
      cloud: GCP
      cidr: 10.0.1.0/24
      vm_spec:
        GCP:
            zone: us-west1-b
            machine_type: n1-standard-4
    vm_2:
      cloud: GCP
      cidr: 192.168.1.0/24
      vm_spec:
        GCP:
            zone: us-central1-c
            machine_type: n1-standard-4
```