### PR TITLE
using image name instead of hard-coded image ID

### DIFF
--- a/perfkitbenchmarker/providers/rackspace/rackspace_virtual_machine.py
+++ b/perfkitbenchmarker/providers/rackspace/rackspace_virtual_machine.py
@@ -40,7 +40,7 @@ import tempfile
 
 from perfkitbenchmarker import errors
 from perfkitbenchmarker import flags
-from perfkitbenchmarker import linux_virtual_machine
+from perfkitbenchmarker import linux_virtual_machine as linux_vm
 from perfkitbenchmarker import virtual_machine
 from perfkitbenchmarker import vm_util
 from perfkitbenchmarker import providers
@@ -78,8 +78,8 @@ LSBLK_REGEX = (r'NAME="(.*)"\s+MODEL="(.*)"\s+SIZE="(.*)"'
                r'\s+TYPE="(.*)"\s+MOUNTPOINT="(.*)"\s+LABEL="(.*)"')
 LSBLK_PATTERN = re.compile(LSBLK_REGEX)
 
-UBUNTU_IMAGE = '09de0a66-3156-48b4-90a5-1cf25a905207'
-RHEL_IMAGE = '92f8a8b8-6019-4c27-949b-cf9910b84ffb'
+UBUNTU_IMAGE = 'Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)'
+RHEL_IMAGE = 'CentOS 7 (PVHVM)'
 
 INSTANCE_EXISTS_STATUSES = frozenset(
     ['BUILD', 'ACTIVE', 'PAUSED', 'SHUTOFF', 'ERROR'])
@@ -156,7 +156,7 @@ class RackspaceVirtualMachine(virtual_machine.BaseVirtualMachine):
   """Object representing a Rackspace Public Cloud Virtual Machine."""
 
   CLOUD = providers.RACKSPACE
-  DEFAULT_IMAGE = None
+  DEFAULT_IMAGE = 'CentOS 7 (PVHVM)'
 
   def __init__(self, vm_spec):
     """Initialize a Rackspace Virtual Machine
@@ -275,7 +275,7 @@ class RackspaceVirtualMachine(virtual_machine.BaseVirtualMachine):
       blk_flag = RenderBlockDeviceTemplate(self.image, REMOTE_BOOT_DISK_SIZE_GB)
       create_cmd.flags['block-device'] = blk_flag
     else:
-      create_cmd.flags['image-id'] = self.image
+      create_cmd.flags['image-name'] = self.image
     if FLAGS.rackspace_network_id is not None:
       create_cmd.flags['networks'] = ','.join([
           rackspace_network.PUBLIC_NET_ID, rackspace_network.SERVICE_NET_ID,
@@ -527,10 +527,18 @@ class RackspaceVirtualMachine(virtual_machine.BaseVirtualMachine):
 
 
 class DebianBasedRackspaceVirtualMachine(RackspaceVirtualMachine,
-                                         linux_virtual_machine.DebianMixin):
+                                         linux_vm.DebianMixin):
   DEFAULT_IMAGE = UBUNTU_IMAGE
 
 
 class RhelBasedRackspaceVirtualMachine(RackspaceVirtualMachine,
-                                       linux_virtual_machine.RhelMixin):
+                                       linux_vm.RhelMixin):
   DEFAULT_IMAGE = RHEL_IMAGE
+  
+class Ubuntu1604BasedGceVirtualMachine(RackspaceVirtualMachine,
+                                       linux_vm.Ubuntu1604Mixin):
+  DEFAULT_IMAGE = UBUNTU_IMAGE
+  
+
+
+


### PR DESCRIPTION
Specifying image by name instead of UUID ensures that benchmarks will run on the latest base image.