### PR TITLE
Add window size tuning parameters

### DIFF
--- a/CHANGES.next.md
+++ b/CHANGES.next.md
@@ -15,6 +15,10 @@
 
 - Add infiniband support in nccl benchmark.
 - Added AwsVpcS3Endpoint for VPC connectivity to S3.
+- Add `--tcp_max_receive_buffer` flag to set net.ipv4.tcp_rmem sysctl value
+- Add `--tcp_max_send_buffer` flag to set net.ipv4.tcp_wmem sysctl value
+- Add `--rmem_max` flag to set net.core.rmem_max sysctl value
+- Add `--wmem_max` flag to set net.core.wmem_max sysctl value
 - Add `--os_type=debian9` support for AWS and Azure Providers.
 - Add `--os_type=debian10` support for GCP, AWS and Azure Providers.
 - Add function to tune NCCL parameters.

--- a/perfkitbenchmarker/linux_virtual_machine.py
+++ b/perfkitbenchmarker/linux_virtual_machine.py
@@ -154,13 +154,13 @@ flags.DEFINE_string(
 
 flags.DEFINE_integer(
     'tcp_max_receive_buffer', None, 
-    'The maximum receive buffer for TCP socket connections. '
+    'The maximum receive buffer for TCP socket connections in bytes. '
     'Increasing this value may increase single stream TCP throughput '
     'for high latency connections')
 
 flags.DEFINE_integer(
     'tcp_max_send_buffer', None, 
-    'The maximum send buffer for TCP socket connections. '
+    'The maximum send buffer for TCP socket connections in bytes. '
     'Increasing this value may increase single stream TCP throughput '
     'for high latency connections')
 

--- a/perfkitbenchmarker/linux_virtual_machine.py
+++ b/perfkitbenchmarker/linux_virtual_machine.py
@@ -152,11 +152,6 @@ flags.DEFINE_string(
     'non-empty string will cause a reboot to occur after VM prepare. '
     'If unspecified, the kernel command line will be unmodified.')
 
-flags.DEFINE_bool(
-    'increase_tcp_window', False,
-    'A flag to increase the TCP window for all VMs on the network. '
-    'As with other sysctrls, will cause a reboot to happen.')
-
 flags.DEFINE_integer(
     'tcp_max_receive_buffer', None, 
     'The maximum receive buffer for TCP socket connections. '

--- a/perfkitbenchmarker/linux_virtual_machine.py
+++ b/perfkitbenchmarker/linux_virtual_machine.py
@@ -154,24 +154,27 @@ flags.DEFINE_string(
 
 flags.DEFINE_integer(
     'tcp_max_receive_buffer', None,
-    'The maximum receive buffer for TCP socket connections in bytes. '
+    'Changes the third component of the sysctl value net.ipv4.tcp_rmem. '
+    'This sets the maximum receive buffer for TCP socket connections in bytes. '
     'Increasing this value may increase single stream TCP throughput '
     'for high latency connections')
 
 flags.DEFINE_integer(
     'tcp_max_send_buffer', None,
-    'The maximum send buffer for TCP socket connections in bytes. '
+    'Changes the third component of the sysctl value net.ipv4.tcp_wmem. '
+    'This sets the maximum send buffer for TCP socket connections in bytes. '
     'Increasing this value may increase single stream TCP throughput '
     'for high latency connections')
 
 flags.DEFINE_integer(
     'rmem_max', None,
-    'Sets the max OS receive buffer size in bytes for all types of '
-    'connections')
+    'Sets the sysctl value net.core.rmem_max. This sets the max OS '
+    'receive buffer size in bytes for all types of connections')
 
 flags.DEFINE_integer(
     'wmem_max', None,
-    'Sets the max OS send buffer size in bytes for all types of connections')
+    'Sets the sysctl value net.core.wmem_max. This sets the max OS '
+    'send buffer size in bytes for all types of connections')
 
 
 class BaseLinuxMixin(virtual_machine.BaseOsMixin):

--- a/perfkitbenchmarker/linux_virtual_machine.py
+++ b/perfkitbenchmarker/linux_virtual_machine.py
@@ -164,6 +164,15 @@ flags.DEFINE_integer(
     'Increasing this value may increase single stream TCP throughput '
     'for high latency connections')
 
+flags.DEFINE_integer(
+    'rmem_max', None,
+    'Sets the max OS receive buffer size for all types of connections')
+
+flags.DEFINE_integer(
+    'wmem_max', None,
+    'Sets the max OS send buffer size for all types of connections')
+
+
 
 class BaseLinuxMixin(virtual_machine.BaseOsMixin):
   """Class that holds Linux related VM methods and attributes."""
@@ -468,24 +477,42 @@ class BaseLinuxMixin(virtual_machine.BaseOsMixin):
   def DoConfigureTCPWindow(self):
     """Change TCP window parameters in sysctl"""
 
-    # TCP autotuning setting.
-    # values are in bytes
+    # Return if none of these flags are set
+    if all(x is None for x in [FLAGS.tcp_max_receive_buffer,
+                               FLAGS.tcp_max_send_buffer,
+                               FLAGS.rmem_max,
+                               FLAGS.wmem_max]):
+      return
+
+    # Get current values from VM
     stdout, _ = self.RemoteCommand('cat /proc/sys/net/ipv4/tcp_rmem')
     rmem_values = stdout.split()
     stdout, _ = self.RemoteCommand('cat /proc/sys/net/ipv4/tcp_wmem')
     wmem_values = stdout.split()
+    stdout, _ = self.RemoteCommand('cat /proc/sys/net/core/rmem_max')
+    rmem_max = int(stdout)
+    stdout, _ = self.RemoteCommand('cat /proc/sys/net/core/wmem_max')
+    wmem_max = int(stdout)
 
+    # third number is max receive/send
     max_receive = rmem_values[2]
     max_send = wmem_values[2]
 
+    # if flags are set, override current values from vm
     if FLAGS.tcp_max_receive_buffer:
       max_receive = FLAGS.tcp_max_receive_buffer
     if FLAGS.tcp_max_send_buffer:
       max_send = FLAGS.tcp_max_send_buffer
+    if FLAGS.rmem_max:
+      rmem_max = FLAGS.rmem_max
+    if FLAGS.wmem_max:
+      wmem_max = FLAGS.wmem_max
 
     # Add values to metadata
     self.os_metadata['tcp_max_receive_buffer'] = max_receive
     self.os_metadata['tcp_max_send_buffer'] = max_send
+    self.os_metadata['rmem_max'] = rmem_max
+    self.os_metadata['wmem_max'] = wmem_max
 
     rmem_string = '{} {} {}'.format(rmem_values[0],
                                     rmem_values[1],
@@ -494,9 +521,11 @@ class BaseLinuxMixin(virtual_machine.BaseOsMixin):
                                     wmem_values[1],
                                     max_send)
 
-    self.ApplySysctlPersistent({
+    self._ApplySysctlPersistent({
         'net.ipv4.tcp_rmem': rmem_string,
-        'net.ipv4.tcp_wmem': wmem_string
+        'net.ipv4.tcp_wmem': wmem_string,
+        'net.core.rmem_max': rmem_max,
+        'net.core.wmem_max': wmem_max
     })
 
   def _RebootIfNecessary(self):

--- a/perfkitbenchmarker/linux_virtual_machine.py
+++ b/perfkitbenchmarker/linux_virtual_machine.py
@@ -166,12 +166,12 @@ flags.DEFINE_integer(
 
 flags.DEFINE_integer(
     'rmem_max', None,
-    'Sets the max OS receive buffer size for all types of connections')
+    'Sets the max OS receive buffer size in bytes for all types of '
+    'connections')
 
 flags.DEFINE_integer(
     'wmem_max', None,
-    'Sets the max OS send buffer size for all types of connections')
-
+    'Sets the max OS send buffer size in bytes for all types of connections')
 
 
 class BaseLinuxMixin(virtual_machine.BaseOsMixin):

--- a/perfkitbenchmarker/linux_virtual_machine.py
+++ b/perfkitbenchmarker/linux_virtual_machine.py
@@ -463,19 +463,21 @@ class BaseLinuxMixin(virtual_machine.BaseOsMixin):
     if not FLAGS.increase_tcp_window:
       return
 
-    # values are in bytes
-    # sets max OS receive buffer for all connections
-    self.ApplySysctlPersistent('net.core.rmem_max', '67108864')
-    # sets max OS send buffer for all connections
-    self.ApplySysctlPersistent('net.core.wmem_max', '67108864')
     # TCP autotuning setting.
-    # overrides the /proc/sys/net/core/rmem_default value
+    # values are in bytes
+    # net.core.rmem_max sets max OS receive buffer for all connections
+    # net.core.wmem_max sets max OS send buffer for all connections
+    # net.ipv4.tcp_rmem overrides the /proc/sys/net/core/rmem_default value
     # first value = <min receive buffer>
     # second value = <default receive buffer>
     # third value = <max receive buffer>
-    self.ApplySysctlPersistent('net.ipv4.tcp_rmem', '4096 87380 33554432')
-    # TCP autotuning setting. Same as above, but with send instead of receive
-    self.ApplySysctlPersistent('net.ipv4.tcp_wmem', '4096 87380 33554432')
+    # net.ipv4.tcp_wmem, same as above, but with send instead of receive
+    self.ApplySysctlPersistent({
+        'net.core.rmem_max': '67108864',
+        'net.core.wmem_max': '67108864',
+        'net.ipv4.tcp_rmem': '4096 87380 33554432',
+        'net.ipv4.tcp_wmem': '4096 87380 33554432'
+    })
 
   def _RebootIfNecessary(self):
     """Will reboot the VM if self._needs_reboot has been set."""


### PR DESCRIPTION
I have added in four flags to set the following sysctl settings:
        net.ipv4.tcp_rmem
        net.ipv4.tcp_wmem
        net.core.rmem_max
        net.core.wmem_max

tcp_rmem and tcp_wmem each consist of 3 values (min default max). I only added flags to change the max value, as this is what the automatic tcp window scaling in linux uses as is maximum.

rmem_max and wmem_max set the maximum send/receive buffers for non TCP connections.

Tuning these parameters are essential for achieve decent throughput over links with a high RTT