### PR TITLE
Update iperf2

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ In its current release these are the benchmarks that are executed:
 -   `hpcc`: [Original BSD license](http://icl.cs.utk.edu/hpcc/faq/#263)
 -   [`hpcg`](https://github.com/hpcg-benchmark/hpcg/):
     [BSD 3-clause](https://github.com/hpcg-benchmark/hpcg/blob/master/LICENSE)
--   `iperf`: [BSD license](http://iperf.sourceforge.net/)
+-   `iperf`: [UIUC License](https://sourceforge.net/p/iperf2/code/ci/master/tree/doc/ui_license.html)
 -   `memtier_benchmark`:
     [GPL v2](https://github.com/RedisLabs/memtier_benchmark)
 -   `mesh_network`:

--- a/perfkitbenchmarker/linux_packages/iperf.py
+++ b/perfkitbenchmarker/linux_packages/iperf.py
@@ -31,7 +31,7 @@ def _Install(vm):
   vm.Install('build_tools')
   vm.Install('wget')
 
-  vm.RemoteCommand('wget -O %s/%s %s' % 
+  vm.RemoteCommand('wget -O %s/%s %s' %
                    (INSTALL_DIR, IPERF_TAR, IPERF_URL))
 
   vm.RemoteCommand('cd %s; tar xvf %s; cd %s; '


### PR DESCRIPTION
In reference to issue #2105
Updates iperf2 version from 2.0.4 to 2.0.13.
Installs from source, as 2.0.13 is not in package managers currently
Otherwise, functionality of the benchmark remains the same.