### PR TITLE
Implement AllowIcmp() for AWS and GCP provider.

### DIFF
--- a/CHANGES.next.md
+++ b/CHANGES.next.md
@@ -26,6 +26,10 @@
         https://aws.amazon.com/blogs/aws/update-on-amazon-linux-ami-end-of-life/
         at which point it will be removed from PKB.
     -   You can use the recommended `amazonlinux2` instead.
+-   Remove `ping_also_run_using_external_ip` from ping benchmark
+    -   You should now use the `ip_addresses` flag to specify whether to
+        test with internal IPs, external IPs or both. This brings ping
+        into alignment with how other network benchmarks function.
 
 ### New features:
 

--- a/perfkitbenchmarker/linux_benchmarks/iperf_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/iperf_benchmark.py
@@ -181,7 +181,7 @@ def Run(benchmark_spec):
                                  receiving_vm,
                                  receiving_vm.ip_address,
                                  thread_count,
-                                 'external'))
+                                 vm_util.IpAddressMetadata.EXTERNAL))
 
       # Send using internal IP addresses
       if vm_util.ShouldRunOnInternalIpAddress(sending_vm,
@@ -190,7 +190,7 @@ def Run(benchmark_spec):
                                  receiving_vm,
                                  receiving_vm.internal_ip,
                                  thread_count,
-                                 'internal'))
+                                 vm_util.IpAddressMetadata.INTERNAL))
 
   return results
 

--- a/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
@@ -498,7 +498,7 @@ def Run(benchmark_spec):
         external_ip_results = RunNetperf(client_vm, netperf_benchmark,
                                          server_vm.ip_address, num_streams)
         for external_ip_result in external_ip_results:
-          external_ip_result.metadata['ip_type'] = 'external'
+          external_ip_result.metadata['ip_type'] = vm_util.IpAddressMetadata.EXTERNAL
           external_ip_result.metadata.update(metadata)
         results.extend(external_ip_results)
 
@@ -507,7 +507,7 @@ def Run(benchmark_spec):
                                          server_vm.internal_ip, num_streams)
         for internal_ip_result in internal_ip_results:
           internal_ip_result.metadata.update(metadata)
-          internal_ip_result.metadata['ip_type'] = 'internal'
+          internal_ip_result.metadata['ip_type'] = vm_util.IpAddressMetadata.INTERNAL
         results.extend(internal_ip_results)
 
   return results

--- a/perfkitbenchmarker/linux_benchmarks/ping_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/ping_benchmark.py
@@ -103,7 +103,9 @@ def _RunPing(sending_vm, receiving_vm, receiving_ip, ip_type):
     sending_vm: The VM issuing the ping request.
     receiving_vm: The VM receiving the ping.  Needed for metadata.
     receiving_ip: The IP address to be pinged.
-    ip_type: The type of 'receiving_ip' (either 'internal' or 'external')
+    ip_type: The type of 'receiving_ip',
+        (either 'vm_util.IpAddressSubset.INTERNAL 
+         or vm_util.IpAddressSubset.EXTERNAL')
   Returns:
     A list of samples, with one sample for each metric.
   """

--- a/perfkitbenchmarker/linux_benchmarks/ping_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/ping_benchmark.py
@@ -114,7 +114,7 @@ def _RunPing(sending_vm, receiving_vm, receiving_ip, ip_type):
     logging.warn('%s is not reachable from %s', receiving_vm, sending_vm)
     return []
 
-  logging.info('Ping results (ip_type = %s):' % ip_type)
+  logging.info('Ping results (ip_type = %s):', ip_type)
   ping_cmd = 'ping -c 100 %s' % receiving_ip
   stdout, _ = sending_vm.RemoteCommand(ping_cmd, should_log=True)
   stats = re.findall('([0-9]*\\.[0-9]*)', stdout.splitlines()[-1])

--- a/perfkitbenchmarker/linux_benchmarks/ping_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/ping_benchmark.py
@@ -80,13 +80,13 @@ def Run(benchmark_spec):
       ip_type = vm_util.IpAddressMetadata.EXTERNAL
       results = results + _RunPing(sending_vm,
                                    receiving_vm,
-                                   receiving_vm.internal_ip,
+                                   receiving_vm.ip_address,
                                    ip_type)
     if vm_util.ShouldRunOnInternalIpAddress(sending_vm, receiving_vm):
       ip_type = vm_util.IpAddressMetadata.INTERNAL
       results = results + _RunPing(sending_vm,
                                    receiving_vm,
-                                   receiving_vm.ip_address,
+                                   receiving_vm.internal_ip,
                                    ip_type)
   return results
 
@@ -105,7 +105,7 @@ def _RunPing(sending_vm, receiving_vm, receiving_ip, ip_type):
   Returns:
     A list of samples, with one sample for each metric.
   """
-  if ip_type == vm_util.IpAddressSubset.INTERNAL and not sending_vm.IsReachable(receiving_vm):
+  if ip_type == vm_util.IpAddressMetadata.INTERNAL and not sending_vm.IsReachable(receiving_vm):
     logging.warn('%s is not reachable from %s', receiving_vm, sending_vm)
     return []
 

--- a/perfkitbenchmarker/linux_benchmarks/ping_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/ping_benchmark.py
@@ -103,7 +103,7 @@ def _RunPing(sending_vm, receiving_vm, receiving_ip, ip_type):
   Returns:
     A list of samples, with one sample for each metric.
   """
-  if not sending_vm.IsReachable(receiving_vm) and ip_type == 'internal':
+  if ip_type == 'internal' and not sending_vm.IsReachable(receiving_vm):
     logging.warn('%s is not reachable from %s', receiving_vm, sending_vm)
     return []
 

--- a/perfkitbenchmarker/linux_benchmarks/ping_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/ping_benchmark.py
@@ -120,7 +120,13 @@ def _RunPing(sending_vm, receiving_vm, receiving_ip, ip_type):
   stats = re.findall('([0-9]*\\.[0-9]*)', stdout.splitlines()[-1])
   assert len(stats) == len(METRICS), stats
   results = []
-  metadata = {'ip_type': ip_type,
+
+  if ip_type == vm_util.IpAddressSubset.INTERNAL:
+    ip_string = 'internal'
+  else:
+    ip_string = 'external'
+
+  metadata = {'ip_type': ip_string,
               'receiving_zone': receiving_vm.zone,
               'sending_zone': sending_vm.zone}
   for i, metric in enumerate(METRICS):

--- a/perfkitbenchmarker/linux_benchmarks/ping_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/ping_benchmark.py
@@ -103,7 +103,7 @@ def _RunPing(sending_vm, receiving_vm, receiving_ip, ip_type):
   Returns:
     A list of samples, with one sample for each metric.
   """
-  if not sending_vm.IsReachable(receiving_vm):
+  if not sending_vm.IsReachable(receiving_vm) and ip_type == 'internal':
     logging.warn('%s is not reachable from %s', receiving_vm, sending_vm)
     return []
 

--- a/perfkitbenchmarker/linux_benchmarks/ping_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/ping_benchmark.py
@@ -104,8 +104,9 @@ def _RunPing(sending_vm, receiving_vm, receiving_ip, ip_type):
     receiving_vm: The VM receiving the ping.  Needed for metadata.
     receiving_ip: The IP address to be pinged.
     ip_type: The type of 'receiving_ip',
-        (either 'vm_util.IpAddressSubset.INTERNAL 
+        (either 'vm_util.IpAddressSubset.INTERNAL
          or vm_util.IpAddressSubset.EXTERNAL')
+
   Returns:
     A list of samples, with one sample for each metric.
   """

--- a/perfkitbenchmarker/providers/aws/aws_network.py
+++ b/perfkitbenchmarker/providers/aws/aws_network.py
@@ -69,7 +69,8 @@ class AwsFirewall(network.BaseFirewall):
     Args:
       vm: The BaseVirtualMachine object to open the ICMP protocol for.
     """
-    entry = (-1, -1, vm.region, vm.group_id)
+    source = '0.0.0.0/0'
+    entry = (-1, -1, vm.region, vm.group_id, source)
     with self._lock:
       if entry in self.firewall_set:
         return
@@ -80,7 +81,7 @@ class AwsFirewall(network.BaseFirewall):
           '--group-id=%s' % vm.group_id,
           '--protocol=icmp',
           '--port=-1',
-          '--cidr=0.0.0.0/0']
+          '--cidr=%s' % source]
       util.IssueRetryableCommand(
           authorize_cmd)
       self.firewall_set.add(entry)

--- a/perfkitbenchmarker/providers/aws/aws_network.py
+++ b/perfkitbenchmarker/providers/aws/aws_network.py
@@ -71,11 +71,16 @@ class AwsFirewall(network.BaseFirewall):
       vm: The BaseVirtualMachine object to open the ICMP protocol for.
     """
     source = '0.0.0.0/0'
-    # type, code, region, group_id, cidr
-    entry = (-1, -1, vm.region, vm.group_id, source)
+
+    # region, group_id, source
+    entry = (vm.region, vm.group_id, source)
     with self._lock:
       if entry in self.firewall_icmp_set:
         return
+      # When defining ICMP firewall rules using the aws cli,
+      # port specifies the type of ICMP traffic allowed,
+      # with -1 meaning all ICMP types
+      # https://docs.aws.amazon.com/cli/latest/reference/ec2/authorize-security-group-ingress.html
       authorize_cmd = util.AWS_PREFIX + [
           'ec2',
           'authorize-security-group-ingress',

--- a/perfkitbenchmarker/providers/aws/aws_network.py
+++ b/perfkitbenchmarker/providers/aws/aws_network.py
@@ -69,7 +69,6 @@ class AwsFirewall(network.BaseFirewall):
     Args:
       vm: The BaseVirtualMachine object to open the ICMP protocol for.
     """
-    print("ALLOWING ICMP")
     entry = (-1, -1, vm.region, vm.group_id)
     with self._lock:
       if entry in self.firewall_set:

--- a/perfkitbenchmarker/providers/gcp/gce_network.py
+++ b/perfkitbenchmarker/providers/gcp/gce_network.py
@@ -586,6 +586,30 @@ class GceFirewall(network.BaseFirewall):
     for firewall_rule in six.itervalues(self.firewall_rules):
       firewall_rule.Delete()
 
+  def AllowIcmp(self, vm):
+    """Opens the ICMP protocol on the firewall.
+
+    Args:
+      vm: The BaseVirtualMachine object to open the ICMP protocol for.
+    """
+    if vm.is_static:
+      return
+    with self._lock:
+      firewall_name = ('perfkit-firewall-%s-%d-%d' %
+                       (FLAGS.run_uri, -1, -1))
+
+      key = (vm.project, -1, -1)
+      if key in self.firewall_rules:
+        return
+
+      allow = 'ICMP'
+
+      firewall_rule = GceFirewallRule(
+          firewall_name, vm.project, allow,
+          vm.network.network_resource.name)
+      self.firewall_rules[key] = firewall_rule
+      firewall_rule.Create()
+
 
 class GceNetworkSpec(network.BaseNetworkSpec):
 

--- a/perfkitbenchmarker/providers/gcp/gce_network.py
+++ b/perfkitbenchmarker/providers/gcp/gce_network.py
@@ -598,9 +598,16 @@ class GceFirewall(network.BaseFirewall):
     if vm.is_static:
       return
     with self._lock:
-      firewall_name = ('perfkit-firewall-icmp-%s-%d-%d' %
-                       (FLAGS.run_uri, -1, -1))
-      key = (vm.project, -1, -1)
+      if vm.cidr:  # Allow multiple networks per zone.
+        cidr_string = network.BaseNetwork.FormatCidrString(vm.cidr)
+        firewall_name = ('perfkit-firewall-icmp-%s-%s' %
+                         (cidr_string, FLAGS.run_uri))
+        key = (vm.project, vm.cidr)
+      else:
+        firewall_name = ('perfkit-firewall-icmp-%s' %
+                         (FLAGS.run_uri))
+        key = (vm.project)
+
       if key in self.firewall_icmp_rules:
         return
 

--- a/perfkitbenchmarker/providers/gcp/gce_network.py
+++ b/perfkitbenchmarker/providers/gcp/gce_network.py
@@ -543,6 +543,7 @@ class GceFirewall(network.BaseFirewall):
     """Initialize GCE firewall class."""
     self._lock = threading.Lock()
     self.firewall_rules = {}
+    self.firewall_icmp_rules = {}
 
   def AllowPort(self, vm, start_port, end_port=None, source_range=None):
     """Opens a port on the firewall.
@@ -585,6 +586,8 @@ class GceFirewall(network.BaseFirewall):
     """Closes all ports on the firewall."""
     for firewall_rule in six.itervalues(self.firewall_rules):
       firewall_rule.Delete()
+    for firewall_rule in six.itervalues(self.firewall_icmp_rules):
+      firewall_rule.Delete()
 
   def AllowIcmp(self, vm):
     """Opens the ICMP protocol on the firewall.
@@ -595,19 +598,17 @@ class GceFirewall(network.BaseFirewall):
     if vm.is_static:
       return
     with self._lock:
-      firewall_name = ('perfkit-firewall-%s-%d-%d' %
+      firewall_name = ('perfkit-firewall-icmp-%s-%d-%d' %
                        (FLAGS.run_uri, -1, -1))
-
       key = (vm.project, -1, -1)
-      if key in self.firewall_rules:
+      if key in self.firewall_icmp_rules:
         return
 
       allow = 'ICMP'
-
       firewall_rule = GceFirewallRule(
           firewall_name, vm.project, allow,
           vm.network.network_resource.name)
-      self.firewall_rules[key] = firewall_rule
+      self.firewall_icmp_rules[key] = firewall_rule
       firewall_rule.Create()
 
 

--- a/perfkitbenchmarker/vm_util.py
+++ b/perfkitbenchmarker/vm_util.py
@@ -142,6 +142,11 @@ flags.DEFINE_enum('background_network_ip_type', IpAddressSubset.EXTERNAL,
                   'traffic')
 
 
+class IpAddressMetadata(object):
+  INTERNAL = 'internal'
+  EXTERNAL = 'external'
+
+
 def GetTempDir():
   """Returns the tmp dir of the current run."""
   return temp_dir.GetRunDirPath()

--- a/tests/linux_benchmarks/ping_benchmark_test.py
+++ b/tests/linux_benchmarks/ping_benchmark_test.py
@@ -35,14 +35,15 @@ class TestGenerateJobFileString(unittest.TestCase):
     outfile = open(path, 'r')
     pingstdout = outfile.read()
     for vm in vm_spec.vms:
-      vm.RemoteCommand.side_effect = [(pingstdout, ' ')]
+      vm.RemoteCommand.side_effect = [(pingstdout, ' '), (pingstdout, ' ')]
     ping_benchmark.Prepare(vm_spec)
     samples = ping_benchmark.Run(vm_spec)
     ping_benchmark.Cleanup(vm_spec)
 
-    self.assertEquals(vm_spec.vms[0].RemoteCommand.call_count, 1)
-    self.assertEquals(vm_spec.vms[1].RemoteCommand.call_count, 1)
-    self.assertEquals(len(samples), 8)
+    self.assertEquals(vm_spec.vms[0].RemoteCommand.call_count, 2)
+    self.assertEquals(vm_spec.vms[1].RemoteCommand.call_count, 2)
+    self.assertEquals(len(samples), 16)
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/tutorials/inter_region_reports/README.md
+++ b/tutorials/inter_region_reports/README.md
@@ -246,7 +246,7 @@ other options for each VM.
           machine_type: [n1-standard-2]
       flags:
         cloud: GCP
-        ping_also_run_using_external_ip: True
+        ip_addresses: BOTH
     ```
 
 1.  Run the latency tests.

--- a/tutorials/inter_region_reports/data/all_region_latency.yaml
+++ b/tutorials/inter_region_reports/data/all_region_latency.yaml
@@ -12,4 +12,4 @@ ping:
       gcp_min_cpu_platform: [skylake]
   flags:
     cloud: GCP
-    ping_also_run_using_external_ip: True
+    ip_addresses: BOTH

--- a/tutorials/inter_region_reports/data/simple_region_latency.yaml
+++ b/tutorials/inter_region_reports/data/simple_region_latency.yaml
@@ -13,4 +13,4 @@ ping:
       gcp_min_cpu_platform: [skylake]
   flags:
     cloud: GCP
-    ping_also_run_using_external_ip: True
+    ip_addresses: BOTH


### PR DESCRIPTION
I found that the ping benchmark with --ping_also_run_using_external_ip=True would fail when trying to perform tests with external IP addresses.

The benchmark makes a call to AllowIcmp(), which is not implemented for multiple cloud providers. So I have implemented that function for Google Cloud and now ping tests using external IPs function as intended.

external ping tests are also failing on AWS and I'm working on a fix for those