### PR TITLE
Remove "default" keyword from AWS and Azure boot disk size

### DIFF
--- a/CHANGES.next.md
+++ b/CHANGES.next.md
@@ -101,4 +101,5 @@
         (to 20GB).
     -   The current defaults leave other Linux OSes at 10GB and Windows OSes at
         50GB.
+-   Remove 'default' keyword from AWS and Azure boot_disk_size
 -   Explicitly setting Netperf to Python 3.

--- a/perfkitbenchmarker/providers/aws/aws_virtual_machine.py
+++ b/perfkitbenchmarker/providers/aws/aws_virtual_machine.py
@@ -1009,7 +1009,7 @@ class AwsVirtualMachine(virtual_machine.BaseVirtualMachine):
     """
     result = super(AwsVirtualMachine, self).GetResourceMetadata()
     result['boot_disk_type'] = self.DEFAULT_ROOT_DISK_TYPE
-    result['boot_disk_size'] = self.boot_disk_size or 'default'
+    result['boot_disk_size'] = self.boot_disk_size
     if self.use_dedicated_host:
       result['num_vms_per_host'] = self.num_vms_per_host
     result['efa'] = FLAGS.aws_efa

--- a/perfkitbenchmarker/providers/azure/azure_virtual_machine.py
+++ b/perfkitbenchmarker/providers/azure/azure_virtual_machine.py
@@ -726,7 +726,7 @@ class AzureVirtualMachine(
     result = super(AzureVirtualMachine, self).GetResourceMetadata()
     result['accelerated_networking'] = self.nic.accelerated_networking
     result['boot_disk_type'] = self.os_disk.disk_type
-    result['boot_disk_size'] = self.os_disk.disk_size or 'default'
+    result['boot_disk_size'] = self.os_disk.disk_size
     if self.network.placement_group:
       result['placement_group_strategy'] = self.network.placement_group.strategy
     else:


### PR DESCRIPTION
The default value for the boot_disk_size field in the AWS and Azure providers is incompatible with the comments in their VmSpec:
```
`boot_disk_size: None or int. The size of the boot disk in GB.`
```
Instead of `None`, the default value is set to `'default'` in the metadata. This mismatch between the default value type (string) and the value when a custom size is provided (int) can cause issues when trying to insert the metadata to a database.

Tested on both AWS and Azure using the sample_benchmark, by adding the following lines in perfkitbenchmarker/linux_benchmarks/sample_benchmark.py, after the BENCHMARK_DATA dict:
```
BENCHMARK_DATA_URL = {
    'preprovisioned_data.txt':
        'https://github.com/florinpapa/preprovisioned_data/raw/master/preprovisioned_data.txt'}
```
Then, I used the following commands to start the benchmark (which worked):
```
./pkb.py --cloud=Azure --benchmarks=sample
./pkb.py --cloud=AWS --benchmarks=sample --machine_type=m5.xlarge
```