### PR TITLE
Check ycsb proportion explicitly against none.

### DIFF
--- a/CHANGES.next.md
+++ b/CHANGES.next.md
@@ -111,3 +111,4 @@
     - change private_keyfile_dir from a constant value to a FLAG
     - delete all db entries as part of Cleanup
 -   Remove 'default' keyword from AWS and Azure boot_disk_size
+-   Check ycsb proportion explicitly against none.

--- a/perfkitbenchmarker/linux_packages/ycsb.py
+++ b/perfkitbenchmarker/linux_packages/ycsb.py
@@ -1098,11 +1098,11 @@ class YCSBExecutor(object):
         parameters['hdrhistogram.output.path'] = hdr_files_dir
       if FLAGS.ycsb_requestdistribution:
         parameters['requestdistribution'] = FLAGS.ycsb_requestdistribution
-      if FLAGS.ycsb_readproportion:
+      if FLAGS.ycsb_readproportion is not None:
         parameters['readproportion'] = FLAGS.ycsb_readproportion
-      if FLAGS.ycsb_updateproportion:
+      if FLAGS.ycsb_updateproportion is not None:
         parameters['updateproportion'] = FLAGS.ycsb_updateproportion
-      if FLAGS.ycsb_scanproportion:
+      if FLAGS.ycsb_scanproportion is not None:
         parameters['scanproportion'] = FLAGS.ycsb_scanproportion
       parameters.update(kwargs)
       remote_path = posixpath.join(INSTALL_DIR,


### PR DESCRIPTION
When I set ycsb_readproportion to 0.0, it ended up not setting the readproportion on the underlying ycsb command. This is because we are using if FLAGS.ycsb_readproportion to check if the flag is set, but the flag could be set explicitly to 0.0 and still fail the check.