### PR TITLE
shorten tempdir suffix

### DIFF
--- a/perfkitbenchmarker/temp_dir.py
+++ b/perfkitbenchmarker/temp_dir.py
@@ -30,7 +30,7 @@ if six.PY2:
 else:
   import functools
 
-_PERFKITBENCHMARKER = 'perfkitbenchmarker'
+_PERFKITBENCHMARKER = 'pkb'
 _RUNS = 'runs'
 _VERSIONS = 'versions'
 


### PR DESCRIPTION
tl;dr: tempdir paths are too long on macos, which breaks SSH. See #2233 for details.

This solution works on my machine but it might not be the ideal fix. I don't know enough about macos internals to suggest a better solution, though.