### PR TITLE
Use absl's parameterized.named_parameters instead of expand.

### DIFF
--- a/CHANGES.next.md
+++ b/CHANGES.next.md
@@ -29,3 +29,5 @@
     centos8, amazonlinux2)
 -   Correctly install pip rhel8,centos8 all os types.
 -   Fixed a bug in leftover entity deletion logic.
+-   Use absl parameterized test case.
+

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -32,5 +32,4 @@ flake8>=2.1.0
 psutil>=5.6.6
 gcs-oauth2-boto-plugin
 azure-storage<=0.20.3
-parameterized>=0.6.1
 freezegun

--- a/tests/aws_test.py
+++ b/tests/aws_test.py
@@ -18,9 +18,8 @@ import json
 import os.path
 import unittest
 from absl import flags
+from absl.testing import parameterized
 import mock
-
-from parameterized import parameterized
 
 from perfkitbenchmarker import benchmark_spec
 from perfkitbenchmarker import context
@@ -494,10 +493,10 @@ class AwsVirtualMachineTestCase(pkb_common_test_case.PkbCommonTestCase):
     util.IssueRetryableCommand.assert_not_called()
     self.vm.network.is_static = False
 
-  @parameterized.expand([
-      (True, 'network-interfaces', 'associate-public-ip-address'),
-      (False, 'associate-public-ip-address', 'network-interfaces'),
-  ])
+  @parameterized.named_parameters(
+      ('use_efa', True, 'network-interfaces', 'associate-public-ip-address'),
+      ('no_efa', False, 'associate-public-ip-address', 'network-interfaces'),
+  )
   def testElasticNetwork(self, use_efa, should_find, should_not_find):
     # with EFA the "--associate-public-ip-address" flag is not used, instead
     # putting that attribute into --network-interfaces

--- a/tests/linux_benchmarks/netperf_benchmark_test.py
+++ b/tests/linux_benchmarks/netperf_benchmark_test.py
@@ -17,8 +17,8 @@ import json
 import os
 import unittest
 from absl import flags
+from absl.testing import parameterized
 import mock
-import parameterized
 
 from perfkitbenchmarker import benchmark_spec
 from perfkitbenchmarker import errors
@@ -33,7 +33,7 @@ FLAGS = flags.FLAGS
 FLAGS.mark_as_parsed()
 
 
-class NetperfBenchmarkTestCase(unittest.TestCase):
+class NetperfBenchmarkTestCase(parameterized.TestCase, unittest.TestCase):
 
   maxDiff = None
 
@@ -146,15 +146,16 @@ class NetperfBenchmarkTestCase(unittest.TestCase):
       self.assertIsInstance(result[i][3], dict)
       self.assertDictContainsSubset(meta, result[i][3])
 
-  @parameterized.parameterized.expand([
-      'MIGRATED TCP STREAM TEST from 0.0.0.0 (0.0.0.0) port 0 AF_INET to '
-      '10.0.0.137 () port 20157 AF_INET : histogram\nrecv_response_timed_n: no'
-      ' response received. errno 110 counter 0\n',
-      'MIGRATED TCP STREAM TEST from 0.0.0.0 (0.0.0.0) port 0 AF_INET to '
-      '10.0.0.172 () port 20169 AF_INET : histogram\ncatcher: timer popped '
-      'with times_up != 0\nrecv_response_timed_n: no response received. errno '
-      '4 counter -1\n'
-  ])
+  @parameterized.named_parameters(
+      ('no_times_up',
+       'MIGRATED TCP STREAM TEST from 0.0.0.0 (0.0.0.0) port 0 AF_INET to '
+       '10.0.0.137 () port 20157 AF_INET : histogram\nrecv_response_timed_n: no'
+       ' response received. errno 110 counter 0\n'),
+      ('has_times_up',
+       'MIGRATED TCP STREAM TEST from 0.0.0.0 (0.0.0.0) port 0 AF_INET to '
+       '10.0.0.172 () port 20169 AF_INET : histogram\ncatcher: timer popped '
+       'with times_up != 0\nrecv_response_timed_n: no response received. errno '
+       '4 counter -1\n'))
   def testParseNetperfOutputError(self, output):
     with self.assertRaises(
         errors.Benchmarks.KnownIntermittentError) as e:

--- a/tests/linux_packages/epel_release_test.py
+++ b/tests/linux_packages/epel_release_test.py
@@ -14,8 +14,8 @@
 """Tests for perfkitbenchmarker.linux_packages.epel_release."""
 
 import unittest
+from absl.testing import parameterized
 import mock
-from parameterized import parameterized
 
 from perfkitbenchmarker import linux_virtual_machine
 from perfkitbenchmarker import os_types
@@ -85,12 +85,13 @@ class EpelReleaseTest(pkb_common_test_case.PkbCommonTestCase):
     epel_release.YumInstall(vm)
     vm.RemoteCommand.assert_called_once()
 
-  @parameterized.expand([
-      (_REPOLIST_NO_EPEL, ('base/7/x86_64', 'updates/7/x86_64'), False),
-      (_REPOLIST_WITH_EPEL, ('epel/x86_64', 'base/7/x86_64',
-                             'updates/7/x86_64'), True),
-      (_REPOLIST_WITH_EPEL_REMOTE, ('epel/x86_64',), True),
-  ])
+  @parameterized.named_parameters(
+      ('NoEpelRepo', _REPOLIST_NO_EPEL,
+       ('base/7/x86_64', 'updates/7/x86_64'), False),
+      ('HasEpelRepo', _REPOLIST_WITH_EPEL,
+       ('epel/x86_64', 'base/7/x86_64', 'updates/7/x86_64'), True),
+      ('HasRemoteEpelRepo', _REPOLIST_WITH_EPEL_REMOTE, ('epel/x86_64',), True),
+  )
   def testRepoList(self, repo_response, repo_ids, repo_enabled):
     vm = Vm(os_types.CENTOS7, [repo_response, repo_response])
     self.assertEqual(epel_release.Repolist(vm), frozenset(repo_ids))

--- a/tests/pkb_common_test_case.py
+++ b/tests/pkb_common_test_case.py
@@ -19,6 +19,7 @@ import subprocess
 from absl import flags
 from absl.testing import absltest
 from absl.testing import flagsaver
+from absl.testing import parameterized
 
 import mock
 
@@ -104,7 +105,7 @@ class TestGceVirtualMachine(TestOsMixin, gce_virtual_machine.GceVirtualMachine):
   pass
 
 
-class PkbCommonTestCase(absltest.TestCase):
+class PkbCommonTestCase(parameterized.TestCase, absltest.TestCase):
   """Test case class for PKB.
 
   Contains common functions shared by PKB test cases.

--- a/tests/providers/aws/aws_placement_group_test.py
+++ b/tests/providers/aws/aws_placement_group_test.py
@@ -9,9 +9,8 @@ import json
 import unittest
 import uuid
 from absl import flags
+from absl.testing import parameterized
 import mock
-
-from parameterized import parameterized
 
 from perfkitbenchmarker import placement_group
 from perfkitbenchmarker import providers
@@ -109,9 +108,10 @@ class AwsPlacementGroupTest(pkb_common_test_case.PkbCommonTestCase):
     self.assertEqual(REGION, pg.region)
     self.assertEqual(STRATEGY, pg.strategy)
 
-  @parameterized.expand([(EXISTS_NONE_RESPONSE, False),
-                         (EXISTS_ONE_RESPONSE, True),
-                         (EXISTS_TWO_RESPONSE, None, True)])
+  @parameterized.named_parameters(
+      ('EXISTS_NONE_RESPONSE', EXISTS_NONE_RESPONSE, False),
+      ('EXISTS_ONE_RESPONSE', EXISTS_ONE_RESPONSE, True),
+      ('EXISTS_TWO_RESPONSE', EXISTS_TWO_RESPONSE, None, True))
   def testExists(self, response, exists_value, throws_exception=False):
     self.mock_cmd.side_effect = [AwsResponse(response)]
     pg = CreateAwsPlacementGroup()

--- a/tests/providers/azure/azure_virtual_machine_test.py
+++ b/tests/providers/azure/azure_virtual_machine_test.py
@@ -1,9 +1,8 @@
 # Lint as: python3
 """Tests for perfkitbenchmarker.tests.providers.azure.azure_virtual_machine."""
 import unittest
+from absl.testing import parameterized
 import mock
-
-from parameterized import parameterized
 
 from perfkitbenchmarker import errors
 from perfkitbenchmarker import vm_util
@@ -37,15 +36,14 @@ class AzureVirtualMachineTest(pkb_common_test_case.PkbCommonTestCase):
         mock.patch.object(vm_util, 'IssueCommand'))
     self.enter_context(mock.patch.object(util, 'GetResourceTags'))
 
-  @parameterized.expand([
-      ('', 'Error Code: QuotaExceeded', 1),
-      ('',
+  @parameterized.named_parameters(
+      ('QuotaExceeded', '', 'Error Code: QuotaExceeded', 1),
+      ('CoreQuotaExceeded', '',
        'Operation could not be completed as it results in exceeding approved '
        'standardEv3Family Cores quota', 1),
-      ('',
+      ('CoreQuotaExceededDifferentWording', '',
        'The operation could not be completed as it results in exceeding quota '
-       'limit of standardEv3Family Cores', 1)
-  ])
+       'limit of standardEv3Family Cores', 1))
   def testQuotaExceeded(self, _, stderror, retcode):
     spec = azure_virtual_machine.AzureVmSpec(
         _COMPONENT, machine_type='test_machine_type', zone='testing')

--- a/tests/windows_packages/ntttcp_test.py
+++ b/tests/windows_packages/ntttcp_test.py
@@ -17,7 +17,7 @@
 import os
 import unittest
 from absl import flags
-import parameterized
+from absl.testing import parameterized
 
 from perfkitbenchmarker import sample
 from perfkitbenchmarker import test_util
@@ -29,7 +29,8 @@ FLAGS.mark_as_parsed()
 NtttcpConf = ntttcp.NtttcpConf
 
 
-class NtttcpBenchmarkTestCase(unittest.TestCase, test_util.SamplesTestMixin):
+class NtttcpBenchmarkTestCase(parameterized.TestCase, unittest.TestCase,
+                              test_util.SamplesTestMixin):
 
   def getDataContents(self, file_name):
     path = os.path.join(os.path.dirname(__file__), '..', 'data', file_name)
@@ -258,11 +259,11 @@ class NtttcpBenchmarkTestCase(unittest.TestCase, test_util.SamplesTestMixin):
     conf_list = ntttcp.ParseConfigList()
     self.assertListEqual(conf_list, expected_list)
 
-  @parameterized.parameterized.expand(
-      [('MissingVal', ['True:7:800:INTERNAL:1', 'False::2:EXTERNAL:2']),
-       ('Misspell', ['rue:7:800:INTERNAL:3', 'True:44:1001:EXTERNAL:4']),
-       ('WrongOrder', ['True:7:INTERNAL:800:1', '44:True:1001:EXTERNAL:6'])])
-  def testMalformedConfig(self, name, conf):
+  @parameterized.named_parameters(
+      ('MissingVal', ['True:7:800:INTERNAL:1', 'False::2:EXTERNAL:2']),
+      ('Misspell', ['rue:7:800:INTERNAL:3', 'True:44:1001:EXTERNAL:4']),
+      ('WrongOrder', ['True:7:INTERNAL:800:1', '44:True:1001:EXTERNAL:6']))
+  def testMalformedConfig(self, conf):
     with self.assertRaises(flags.IllegalFlagValueError):
       ntttcp.FLAGS.ntttcp_config_list = conf
 


### PR DESCRIPTION
Use absl's parameterized.named_parameters instead of expand.
