### PR TITLE
Update Linux kernel version in kernel compile benchmark

### DIFF
--- a/perfkitbenchmarker/data/kernel_compile.config
+++ b/perfkitbenchmarker/data/kernel_compile.config
@@ -1,5 +1,5 @@
 #
-# Linux/x86 4.4.25 Kernel Configuration
+# Linux/x86 4.4.35 Kernel Configuration
 #
 # Generated somewhat ad-hoc starting with my desktop's 3.13 kernel config, then
 # running 'make oldconfig' and holding down <Enter>. However, the config

--- a/perfkitbenchmarker/linux_packages/kernel_compile.py
+++ b/perfkitbenchmarker/linux_packages/kernel_compile.py
@@ -16,9 +16,10 @@ import os
 
 from perfkitbenchmarker import linux_packages
 
-URL = 'https://www.kernel.org/pub/linux/kernel/v4.x/linux-4.4.25.tar.gz'
-TARBALL = 'linux-4.4.25.tar.gz'
-UNTAR_DIR = 'linux-4.4.25'
+LINUX_VERSION = '4.4.35'
+URL = 'https://www.kernel.org/pub/linux/kernel/v4.x/linux-%s.tar.gz' %(LINUX_VERSION)
+TARBALL = 'linux-%s.tar.gz' %(LINUX_VERSION)
+UNTAR_DIR = 'linux-%s' %(LINUX_VERSION)
 KERNEL_TARBALL = os.path.join(linux_packages.INSTALL_DIR, TARBALL)
 
 


### PR DESCRIPTION
Hello,

I am testing pkb benchmarks on static vms.

On Ubuntu 18.04 setups with gcc version 7.5.0, the kernel_compile_benchmark fails with:

STDERR: arch/x86/Makefile:133: stack-protector enabled but compiler support broken
Makefile:668: Cannot use CONFIG_CC_STACKPROTECTOR_REGULAR: -fstack-protector not supported by compiler

The kernel version used for this benchmark is 4.4.25. Looking through versions and diffs, the 4.4.35 version is the closest that builds without issues.

The commits that seem to resolve the issue are:
mainline [82031ea29e454b574bc6f49a33683a693ca5d907](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=82031ea29e454b574bc6f49a33683a693ca5d907)
stable [3a868dde1824d4eca277df490d2be99355320095](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=3a868dde1824d4eca277df490d2be99355320095)

Probably more testing is needed with other setups.

Thanks,
Emmanouil Maroudas