### PR TITLE
Add MSS flag to netperf benchmark

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
@@ -284,9 +284,6 @@ def ParseNetperfOutput(stdout, metadata, benchmark_name,
     logging.error(message)
     raise errors.Benchmarks.KnownIntermittentError(message)
 
-  print("RESULTS")
-  print(results)
-
   # Update the metadata with some additional infos
   meta_keys = [('Confidence Iterations Run', 'confidence_iter'),
                ('Throughput Confidence Width (%)', 'confidence_width_percent')]

--- a/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
@@ -291,7 +291,7 @@ def ParseNetperfOutput(stdout, metadata, benchmark_name,
     meta_keys.extend([
         ('Local Transport Retransmissions', 'netperf_retransmissions'),
         ('Remote Transport Retransmissions', 'netserver_retransmissions'),
-        ('Transport MSS bytes', 'netperf_effective_mss')
+        ('Transport MSS bytes', 'netperf_mss')
     ])
 
   metadata.update({meta_key: results[netperf_key]
@@ -407,7 +407,7 @@ def RunNetperf(vm, benchmark_name, server_ip, num_streams):
   if FLAGS.netperf_mss and 'TCP' in benchmark_name.upper():
     netperf_cmd += (' -G {mss}b'.format(
                       mss=FLAGS.netperf_mss))
-    metadata['netperf_requested_mss'] = FLAGS.netperf_mss
+    metadata['netperf_mss_requested'] = FLAGS.netperf_mss
 
   # Run all of the netperf processes and collect their stdout
   # TODO(dlott): Analyze process start delta of netperf processes on the remote

--- a/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
@@ -407,6 +407,7 @@ def RunNetperf(vm, benchmark_name, server_ip, num_streams):
   if FLAGS.netperf_mss and 'TCP' in benchmark_name.upper():
     netperf_cmd += (' -G {mss}b'.format(
                       mss=FLAGS.netperf_mss))
+    metadata['netperf_requested_mss'] = FLAGS.netperf_mss
 
   # Run all of the netperf processes and collect their stdout
   # TODO(dlott): Analyze process start delta of netperf processes on the remote

--- a/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
@@ -76,7 +76,8 @@ flags.DEFINE_integer('netperf_mss', None,
                      'Sets the Maximum Segment Size (in bytes) for netperf TCP tests to use. '
                      'The effective MSS will be slightly smaller than the value specified here. '
                      'If you try to set an MSS higher than the current MTU, '
-                     'the MSS will be set to the highest possible value for that MTU.')
+                     'the MSS will be set to the highest possible value for that MTU. '
+                     'If you try to set the MSS lower than 88 bytes, the default MSS will be used')
 
 ALL_BENCHMARKS = ['TCP_RR', 'TCP_CRR', 'TCP_STREAM', 'UDP_RR', 'UDP_STREAM']
 flags.DEFINE_list('netperf_benchmarks', ALL_BENCHMARKS,
@@ -401,6 +402,10 @@ def RunNetperf(vm, benchmark_name, server_ip, num_streams):
                         thinktime=FLAGS.netperf_thinktime,
                         thinktime_array_size=FLAGS.netperf_thinktime_array_size,
                         thinktime_run_length=FLAGS.netperf_thinktime_run_length)
+
+  if FLAGS.netperf_mss and 'TCP' in benchmark_name.upper():
+    netperf_cmd += (' -G {mss}b'.format(
+                      mss=FLAGS.netperf_mss))
 
   # Run all of the netperf processes and collect their stdout
   # TODO(dlott): Analyze process start delta of netperf processes on the remote

--- a/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
@@ -72,6 +72,11 @@ flags.DEFINE_integer('netperf_udp_stream_send_size_in_bytes', 1024,
 # of 16K so that we can achieve the "link rate".
 flags.DEFINE_integer('netperf_tcp_stream_send_size_in_bytes', 131072,
                      'Send size to use for TCP_STREAM tests (netperf -m flag)')
+flags.DEFINE_integer('netperf_mss', None,
+                     'Sets the Maximum Segment Size (in bytes) to use. The effective MSS '
+                     'will be slightly smaller than the value specified here. '
+                     'If you try to set an MSS higher than the current MTU, '
+                     'the MSS will be set to the highest possible value for that MTU.')
 
 ALL_BENCHMARKS = ['TCP_RR', 'TCP_CRR', 'TCP_STREAM', 'UDP_RR', 'UDP_STREAM']
 flags.DEFINE_list('netperf_benchmarks', ALL_BENCHMARKS,

--- a/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
@@ -109,7 +109,7 @@ OUTPUT_SELECTOR = (
     'THROUGHPUT,THROUGHPUT_UNITS,P50_LATENCY,P90_LATENCY,'
     'P99_LATENCY,STDDEV_LATENCY,MIN_LATENCY,MAX_LATENCY,'
     'CONFIDENCE_ITERATION,THROUGHPUT_CONFID,'
-    'LOCAL_TRANSPORT_RETRANS,REMOTE_TRANSPORT_RETRANS',
+    'LOCAL_TRANSPORT_RETRANS,REMOTE_TRANSPORT_RETRANS,'
     'TRANSPORT_MSS')
 
 # Command ports are even (id*2), data ports are odd (id*2 + 1)
@@ -284,6 +284,9 @@ def ParseNetperfOutput(stdout, metadata, benchmark_name,
     logging.error(message)
     raise errors.Benchmarks.KnownIntermittentError(message)
 
+  print("RESULTS")
+  print(results)
+
   # Update the metadata with some additional infos
   meta_keys = [('Confidence Iterations Run', 'confidence_iter'),
                ('Throughput Confidence Width (%)', 'confidence_width_percent')]
@@ -291,6 +294,7 @@ def ParseNetperfOutput(stdout, metadata, benchmark_name,
     meta_keys.extend([
         ('Local Transport Retransmissions', 'netperf_retransmissions'),
         ('Remote Transport Retransmissions', 'netserver_retransmissions'),
+        ('Transport MSS bytes', 'netperf_effective_mss')
     ])
 
   metadata.update({meta_key: results[netperf_key]

--- a/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
@@ -73,8 +73,8 @@ flags.DEFINE_integer('netperf_udp_stream_send_size_in_bytes', 1024,
 flags.DEFINE_integer('netperf_tcp_stream_send_size_in_bytes', 131072,
                      'Send size to use for TCP_STREAM tests (netperf -m flag)')
 flags.DEFINE_integer('netperf_mss', None,
-                     'Sets the Maximum Segment Size (in bytes) to use. The effective MSS '
-                     'will be slightly smaller than the value specified here. '
+                     'Sets the Maximum Segment Size (in bytes) for netperf TCP tests to use. '
+                     'The effective MSS will be slightly smaller than the value specified here. '
                      'If you try to set an MSS higher than the current MTU, '
                      'the MSS will be set to the highest possible value for that MTU.')
 
@@ -108,7 +108,8 @@ OUTPUT_SELECTOR = (
     'THROUGHPUT,THROUGHPUT_UNITS,P50_LATENCY,P90_LATENCY,'
     'P99_LATENCY,STDDEV_LATENCY,MIN_LATENCY,MAX_LATENCY,'
     'CONFIDENCE_ITERATION,THROUGHPUT_CONFID,'
-    'LOCAL_TRANSPORT_RETRANS,REMOTE_TRANSPORT_RETRANS')
+    'LOCAL_TRANSPORT_RETRANS,REMOTE_TRANSPORT_RETRANS',
+    'TRANSPORT_MSS')
 
 # Command ports are even (id*2), data ports are odd (id*2 + 1)
 PORT_START = 20000

--- a/tests/data/netperf_results.json
+++ b/tests/data/netperf_results.json
@@ -1,52 +1,52 @@
 [
   [
     "MIGRATED TCP REQUEST/RESPONSE TEST from 0.0.0.0 (0.0.0.0) port 20001 AF_INET to 104.154.50.86 () port 20001 AF_INET : +/-2.500% @ 99% conf.  : first burst 0",
-    "Throughput,Throughput Units,Throughput Confidence Width (%),Confidence Iterations Run,Stddev Latency Microseconds,50th Percentile Latency Microseconds,90th Percentile Latency Microseconds,99th Percentile Latency Microseconds,Minimum Latency Microseconds,Maximum Latency Microseconds,Local Transport Retransmissions,Remote Transport Retransmissions",
-    "1405.50,Trans/s,2.522,4,783.80,683,735,841,600,900,0,0"
+    "Throughput,Throughput Units,Throughput Confidence Width (%),Confidence Iterations Run,Stddev Latency Microseconds,50th Percentile Latency Microseconds,90th Percentile Latency Microseconds,99th Percentile Latency Microseconds,Minimum Latency Microseconds,Maximum Latency Microseconds,Local Transport Retransmissions,Remote Transport Retransmissions,Transport MSS bytes",
+    "1405.50,Trans/s,2.522,4,783.80,683,735,841,600,900,0,0,1408"
   ],
   [
     "MIGRATED TCP REQUEST/RESPONSE TEST from 0.0.0.0 (0.0.0.0) port 20001 AF_INET to 10.240.31.117 () port 20001 AF_INET : +/-2.500% @ 99% conf.  : first burst 0",
-    "Throughput,Throughput Units,Throughput Confidence Width (%),Confidence Iterations Run,Stddev Latency Microseconds,50th Percentile Latency Microseconds,90th Percentile Latency Microseconds,99th Percentile Latency Microseconds,Minimum Latency Microseconds,Maximum Latency Microseconds,Local Transport Retransmissions,Remote Transport Retransmissions",
-    "3545.77,Trans/s,2.186,3,189.82,274,309,371,200,400,0,0"
+    "Throughput,Throughput Units,Throughput Confidence Width (%),Confidence Iterations Run,Stddev Latency Microseconds,50th Percentile Latency Microseconds,90th Percentile Latency Microseconds,99th Percentile Latency Microseconds,Minimum Latency Microseconds,Maximum Latency Microseconds,Local Transport Retransmissions,Remote Transport Retransmissions,Transport MSS bytes",
+    "3545.77,Trans/s,2.186,3,189.82,274,309,371,200,400,0,0,1408"
   ],
   [
     "MIGRATED TCP Connect/Request/Response TEST from 0.0.0.0 (0.0.0.0) port 20001 AF_INET to 104.154.50.86 () port 20001 AF_INET : +/-2.500% @ 99% conf.",
-    "Throughput,Throughput Units,Throughput Confidence Width (%),Confidence Iterations Run,Stddev Latency Microseconds,50th Percentile Latency Microseconds,90th Percentile Latency Microseconds,99th Percentile Latency Microseconds,Minimum Latency Microseconds,Maximum Latency Microseconds,Local Transport Retransmissions,Remote Transport Retransmissions",
-    "343.35,Trans/s,11.837,20,8147.88,2048,2372,30029,2000,35000,0,0"
+    "Throughput,Throughput Units,Throughput Confidence Width (%),Confidence Iterations Run,Stddev Latency Microseconds,50th Percentile Latency Microseconds,90th Percentile Latency Microseconds,99th Percentile Latency Microseconds,Minimum Latency Microseconds,Maximum Latency Microseconds,Local Transport Retransmissions,Remote Transport Retransmissions,Transport MSS bytes",
+    "343.35,Trans/s,11.837,20,8147.88,2048,2372,30029,2000,35000,0,0,1408"
   ],
   [
     "MIGRATED TCP Connect/Request/Response TEST from 0.0.0.0 (0.0.0.0) port 20001 AF_INET to 10.240.31.117 () port 20001 AF_INET : +/-2.500% @ 99% conf.",
-    "Throughput,Throughput Units,Throughput Confidence Width (%),Confidence Iterations Run,Stddev Latency Microseconds,50th Percentile Latency Microseconds,90th Percentile Latency Microseconds,99th Percentile Latency Microseconds,Minimum Latency Microseconds,Maximum Latency Microseconds,Local Transport Retransmissions,Remote Transport Retransmissions",
-    "1078.07,Trans/s,7.512,20,551.07,871,996,2224,800,2500,0,0"
+    "Throughput,Throughput Units,Throughput Confidence Width (%),Confidence Iterations Run,Stddev Latency Microseconds,50th Percentile Latency Microseconds,90th Percentile Latency Microseconds,99th Percentile Latency Microseconds,Minimum Latency Microseconds,Maximum Latency Microseconds,Local Transport Retransmissions,Remote Transport Retransmissions,Transport MSS bytes",
+    "1078.07,Trans/s,7.512,20,551.07,871,996,2224,800,2500,0,0,1408"
   ],
   [
     "MIGRATED TCP STREAM TEST from 0.0.0.0 (0.0.0.0) port 20001 AF_INET to 104.154.50.86 () port 20001 AF_INET : +/-2.500% @ 99% conf.",
-    "Throughput,Throughput Units,Throughput Confidence Width (%),Confidence Iterations Run,Stddev Latency Microseconds,50th Percentile Latency Microseconds,90th Percentile Latency Microseconds,99th Percentile Latency Microseconds,Minimum Latency Microseconds,Maximum Latency Microseconds,Local Transport Retransmissions,Remote Transport Retransmissions",
-    "1187.94,10^6bits/s,10.100,20,1084.37,2,6,3374,1,3500,0,0"
+    "Throughput,Throughput Units,Throughput Confidence Width (%),Confidence Iterations Run,Stddev Latency Microseconds,50th Percentile Latency Microseconds,90th Percentile Latency Microseconds,99th Percentile Latency Microseconds,Minimum Latency Microseconds,Maximum Latency Microseconds,Local Transport Retransmissions,Remote Transport Retransmissions,Transport MSS bytes",
+    "1187.94,10^6bits/s,10.100,20,1084.37,2,6,3374,1,3500,0,0,1408"
   ],
   [
     "MIGRATED TCP STREAM TEST from 0.0.0.0 (0.0.0.0) port 20001 AF_INET to 10.240.31.117 () port 20001 AF_INET : +/-2.500% @ 99% conf.",
-    "Throughput,Throughput Units,Throughput Confidence Width (%),Confidence Iterations Run,Stddev Latency Microseconds,50th Percentile Latency Microseconds,90th Percentile Latency Microseconds,99th Percentile Latency Microseconds,Minimum Latency Microseconds,Maximum Latency Microseconds,Local Transport Retransmissions,Remote Transport Retransmissions",
-    "1973.37,10^6bits/s,4.995,7,694.10,2,4,20,1,30,0,0"
+    "Throughput,Throughput Units,Throughput Confidence Width (%),Confidence Iterations Run,Stddev Latency Microseconds,50th Percentile Latency Microseconds,90th Percentile Latency Microseconds,99th Percentile Latency Microseconds,Minimum Latency Microseconds,Maximum Latency Microseconds,Local Transport Retransmissions,Remote Transport Retransmissions,Transport MSS bytes",
+    "1973.37,10^6bits/s,4.995,7,694.10,2,4,20,1,30,0,0,1408"
   ],
   [
     "MIGRATED UDP REQUEST/RESPONSE TEST from 0.0.0.0 (0.0.0.0) port 20001 AF_INET to 104.154.50.86 () port 20001 AF_INET : +/-2.500% @ 99% conf.  : first burst 0",
     "Throughput,Throughput Units,Throughput Confidence Width (%),Confidence Iterations Run,Stddev Latency Microseconds,50th Percentile Latency Microseconds,90th Percentile Latency Microseconds,99th Percentile Latency Microseconds,Minimum Latency Microseconds,Maximum Latency Microseconds,Local Transport Retransmissions,Remote Transport Retransmissions",
-    "1359.71,Trans/s,4.911,13,808.44,700,757,891,600,1000,0,0"
+    "1359.71,Trans/s,4.911,13,808.44,700,757,891,600,1000,0,0,-1"
   ],
   [
     "MIGRATED UDP REQUEST/RESPONSE TEST from 0.0.0.0 (0.0.0.0) port 20001 AF_INET to 10.240.31.117 () port 20001 AF_INET : +/-2.500% @ 99% conf.  : first burst 0",
     "Throughput,Throughput Units,Throughput Confidence Width (%),Confidence Iterations Run,Stddev Latency Microseconds,50th Percentile Latency Microseconds,90th Percentile Latency Microseconds,99th Percentile Latency Microseconds,Minimum Latency Microseconds,Maximum Latency Microseconds,Local Transport Retransmissions,Remote Transport Retransmissions",
-    "3313.49,Trans/s,7.546,20,214.64,295,330,406,200,500,0,0"
+    "3313.49,Trans/s,7.546,20,214.64,295,330,406,200,500,0,0,-1"
   ],
   [
     "MIGRATED UDP STREAM TEST from 0.0.0.0 (0.0.0.0) port 0 AF_INET to 104.198.67.251 () port 20001 AF_INET : +/-2.500% @ 99% conf.",
     "Throughput,Throughput Units,50th Percentile Latency Microseconds,90th Percentile Latency Microseconds,99th Percentile Latency Microseconds,Stddev Latency Microseconds,Minimum Latency Microseconds,Maximum Latency Microseconds,Confidence Iterations Run,Throughput Confidence Width (%),Local Transport Retransmissions,Remote Transport Retransmissions",
-    "1102.42,10^6bits/s,3,3,11,46.14,1,15144,1,-1.000,-1,-1"
+    "1102.42,10^6bits/s,3,3,11,46.14,1,15144,1,-1.000,-1,-1,-1"
   ],
     [
     "MIGRATED UDP STREAM TEST from 0.0.0.0 (0.0.0.0) port 0 AF_INET to 104.198.67.251 () port 20001 AF_INET : +/-2.500% @ 99% conf.",
     "Throughput,Throughput Units,50th Percentile Latency Microseconds,90th Percentile Latency Microseconds,99th Percentile Latency Microseconds,Stddev Latency Microseconds,Minimum Latency Microseconds,Maximum Latency Microseconds,Confidence Iterations Run,Throughput Confidence Width (%),Local Transport Retransmissions,Remote Transport Retransmissions",
-    "1802.72,10^6bits/s,3,3,11,46.14,1,15144,1,-1.000,-1,-1"
+    "1802.72,10^6bits/s,3,3,11,46.14,1,15144,1,-1.000,-1,-1,-1"
   ]
 ]


### PR DESCRIPTION
Adds ability to change MSS in netperf TCP benchmarks using netperf's -G benchmark specific flag

If you want, I can also go through this file and change all the .formats to fstrings, to bring it up to date with other benchmarks