### PR TITLE
Change old style strings to f strings 

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
@@ -388,10 +388,9 @@ def RunNetperf(vm, benchmark_name, server_ip, num_streams):
     metadata['netperf_send_size_in_bytes'] = FLAGS.netperf_udp_stream_send_size_in_bytes
 
   elif benchmark_name.upper() == 'TCP_STREAM':
-    netperf_cmd += (' -m {send_size} -M {send_size} '.format(
-        send_size=FLAGS.netperf_tcp_stream_send_size_in_bytes))
-    metadata[
-        'netperf_send_size_in_bytes'] = FLAGS.netperf_tcp_stream_send_size_in_bytes
+    send_size = FLAGS.netperf_tcp_stream_send_size_in_bytes
+    netperf_cmd += f' -m {send_size} -M {send_size} '
+    metadata['netperf_send_size_in_bytes'] = FLAGS.netperf_tcp_stream_send_size_in_bytes
 
   if FLAGS.netperf_thinktime != 0:
     netperf_cmd += (f' -X {FLAGS.netperf_thinktime},{FLAGS.netperf_thinktime_array_size},'

--- a/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
@@ -398,7 +398,7 @@ def RunNetperf(vm, benchmark_name, server_ip, num_streams):
                     f'{FLAGS.netperf_thinktime_run_length} ')
 
   if FLAGS.netperf_mss and 'TCP' in benchmark_name.upper():
-    netperf_cmd += (' -G {mss}b'.format(mss=FLAGS.netperf_mss))
+    netperf_cmd += f' -G {FLAGS.netperf_mss}b'
     metadata['netperf_mss_requested'] = FLAGS.netperf_mss
 
   # Run all of the netperf processes and collect their stdout

--- a/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
@@ -167,7 +167,7 @@ def Prepare(benchmark_spec):
 
   # Copy remote test script to client
   path = data.ResourcePath(os.path.join(REMOTE_SCRIPTS_DIR, REMOTE_SCRIPT))
-  logging.info(f'Uploading {path} to {vms[0]}')
+  logging.info('Uploading %s to %s', path, vms[0])
   vms[0].PushFile(path, REMOTE_SCRIPT)
   vms[0].RemoteCommand(f'sudo chmod 777 {REMOTE_SCRIPT}')
 
@@ -187,8 +187,8 @@ def _SetupHostFirewall(benchmark_spec):
   if vm_util.ShouldRunOnExternalIpAddress():
     ip_addrs.append(client_vm.ip_address)
 
-  logging.info(f'setting up host firewall on {server_vm.name} '
-               f'running {server_vm.image} for client at {ip_addrs}')
+  logging.info('setting up host firewall on %s running %s for client at %s',
+               server_vm.name, server_vm.image, ip_addrs)
   cmd = 'sudo iptables -A INPUT -p %s -s %s -j ACCEPT'
   for protocol in 'tcp', 'udp':
     for ip_addr in ip_addrs:
@@ -376,9 +376,13 @@ def RunNetperf(vm, benchmark_name, server_ip, num_streams):
               'sending_thread_count': num_streams,
               'max_iter': FLAGS.netperf_max_iter or 1}
 
-  netperf_cmd = (f'{netperf.NETPERF_PATH} -p {{command_port}} -j {verbosity} '
-                 f'-t {benchmark_name} -H {server_ip} -l {FLAGS.netperf_test_length} {confidence}'
-                 f' -- '
+  netperf_cmd = (f'{netperf.NETPERF_PATH} '
+                 f'-p {{command_port}} '
+                 f'-j {verbosity} '
+                 f'-t {benchmark_name} '
+                 f'-H {server_ip} '
+                 f'-l {FLAGS.netperf_test_length} {confidence}'
+                  ' -- '
                  f'-P ,{{data_port}} '
                  f'-o {OUTPUT_SELECTOR}')
 
@@ -393,7 +397,9 @@ def RunNetperf(vm, benchmark_name, server_ip, num_streams):
     metadata['netperf_send_size_in_bytes'] = FLAGS.netperf_tcp_stream_send_size_in_bytes
 
   if FLAGS.netperf_thinktime != 0:
-    netperf_cmd += (f' -X {FLAGS.netperf_thinktime},{FLAGS.netperf_thinktime_array_size},'
+    netperf_cmd += (' -X '
+                    f'{FLAGS.netperf_thinktime},'
+                    f'{FLAGS.netperf_thinktime_array_size},'
                     f'{FLAGS.netperf_thinktime_run_length} ')
 
   if FLAGS.netperf_mss and 'TCP' in benchmark_name.upper():
@@ -485,7 +491,7 @@ def Run(benchmark_spec):
   vms = benchmark_spec.vms
   client_vm = vms[0]  # Client aka "sending vm"
   server_vm = vms[1]  # Server aka "receiving vm"
-  logging.info(f'netperf running on {client_vm}')
+  logging.info('netperf running on %s', client_vm)
   results = []
   metadata = {
       'sending_zone': client_vm.zone,

--- a/perfkitbenchmarker/linux_benchmarks/netperf_pps_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/netperf_pps_benchmark.py
@@ -147,27 +147,26 @@ def RunNetperfAggregate(vm, server_ips):
   """
 
   # setup remote hosts file
-  vm.RemoteCommand(f"cd {netperf.NETPERF_EXAMPLE_DIR} && rm remote_hosts")
+  vm.RemoteCommand(f'cd {netperf.NETPERF_EXAMPLE_DIR} && rm remote_hosts')
   ip_num = 0
   for ip in server_ips:
-    vm.RemoteCommand(f"cd {netperf.NETPERF_EXAMPLE_DIR} && "
-                     f"echo 'REMOTE_HOSTS[{ip_num}]={ip}' >> remote_hosts")
+    vm.RemoteCommand(f"echo 'REMOTE_HOSTS[{ip_num}]={ip}' >> "
+                     f"{netperf.NETPERF_EXAMPLE_DIR}/remote_hosts")
     ip_num += 1
 
-  vm.RemoteCommand(f"cd {netperf.NETPERF_EXAMPLE_DIR} && "
-                   f"echo 'NUM_REMOTE_HOSTS={len(server_ips)}' >> remote_hosts")
-  vm.RemoteCommand(f"cd {netperf.NETPERF_EXAMPLE_DIR} && export PATH=$PATH:.")
+  vm.RemoteCommand(f"echo 'NUM_REMOTE_HOSTS={len(server_ips)}' >> "
+                   f"{netperf.NETPERF_EXAMPLE_DIR}/remote_hosts")
 
   # allow script to be executed and run script
   stdout, stderr = vm.RemoteCommand(f"cd {netperf.NETPERF_EXAMPLE_DIR} && "
-                                    "export PATH=$PATH:. && chmod "
-                                    "+x runemomniaggdemo.sh && "
+                                    "export PATH=$PATH:. && "
+                                    "chmod +x runemomniaggdemo.sh && "
                                     "./runemomniaggdemo.sh",
                                     ignore_failure=True, should_log=True,
                                     login_shell=False, timeout=1200)
 
   # print out netperf_tps.log to log
-  stdout_1, stderr_1 = vm.RemoteCommand(f"cd {netperf.NETPERF_EXAMPLE_DIR} && cat netperf_tps.log",
+  stdout_1, stderr_1 = vm.RemoteCommand(f'cat {netperf.NETPERF_EXAMPLE_DIR}/netperf_tps.log',
                                         ignore_failure=True, should_log=True,
                                         login_shell=False, timeout=1200)
 
@@ -175,8 +174,8 @@ def RunNetperfAggregate(vm, server_ips):
   logging.info(stderr_1)
 
   # do post processing step
-  proc_stdout, proc_stderr = vm.RemoteCommand(f"cd {netperf.NETPERF_EXAMPLE_DIR} && ./post_proc.py "
-                                              "--intervals netperf_tps.log",
+  proc_stdout, proc_stderr = vm.RemoteCommand(f'cd {netperf.NETPERF_EXAMPLE_DIR} && ./post_proc.py '
+                                              '--intervals netperf_tps.log',
                                               ignore_failure=True)
 
   samples = ParseNetperfAggregateOutput(proc_stdout)

--- a/perfkitbenchmarker/linux_benchmarks/netperf_pps_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/netperf_pps_benchmark.py
@@ -147,30 +147,27 @@ def RunNetperfAggregate(vm, server_ips):
   """
 
   # setup remote hosts file
-  vm.RemoteCommand("cd %s && rm remote_hosts"
-                   % (netperf.NETPERF_EXAMPLE_DIR))
+  vm.RemoteCommand(f"cd {netperf.NETPERF_EXAMPLE_DIR} && rm remote_hosts")
   ip_num = 0
   for ip in server_ips:
-    vm.RemoteCommand("cd %s && echo 'REMOTE_HOSTS[%d]=%s' >> remote_hosts"
-                     % (netperf.NETPERF_EXAMPLE_DIR, ip_num, ip))
+    vm.RemoteCommand(f"cd {netperf.NETPERF_EXAMPLE_DIR} && "
+                     f"echo 'REMOTE_HOSTS[{ip_num}]={ip}' >> remote_hosts")
     ip_num += 1
 
-  vm.RemoteCommand("cd %s && echo 'NUM_REMOTE_HOSTS=%d' >> remote_hosts"
-                   % (netperf.NETPERF_EXAMPLE_DIR, len(server_ips)))
-  vm.RemoteCommand('cd %s && export PATH=$PATH:.'
-                   % (netperf.NETPERF_EXAMPLE_DIR))
+  vm.RemoteCommand(f"cd {netperf.NETPERF_EXAMPLE_DIR} && "
+                   f"echo 'NUM_REMOTE_HOSTS={len(server_ips)}' >> remote_hosts")
+  vm.RemoteCommand(f"cd {netperf.NETPERF_EXAMPLE_DIR} && export PATH=$PATH:.")
 
   # allow script to be executed and run script
-  stdout, stderr = vm.RemoteCommand("cd %s && export PATH=$PATH:. && chmod "
+  stdout, stderr = vm.RemoteCommand(f"cd {netperf.NETPERF_EXAMPLE_DIR} && "
+                                    "export PATH=$PATH:. && chmod "
                                     "+x runemomniaggdemo.sh && "
-                                    "./runemomniaggdemo.sh"
-                                    % (netperf.NETPERF_EXAMPLE_DIR),
+                                    "./runemomniaggdemo.sh",
                                     ignore_failure=True, should_log=True,
                                     login_shell=False, timeout=1200)
 
   # print out netperf_tps.log to log
-  stdout_1, stderr_1 = vm.RemoteCommand("cd %s && cat netperf_tps.log" %
-                                        (netperf.NETPERF_EXAMPLE_DIR),
+  stdout_1, stderr_1 = vm.RemoteCommand(f"cd {netperf.NETPERF_EXAMPLE_DIR} && cat netperf_tps.log",
                                         ignore_failure=True, should_log=True,
                                         login_shell=False, timeout=1200)
 
@@ -178,11 +175,9 @@ def RunNetperfAggregate(vm, server_ips):
   logging.info(stderr_1)
 
   # do post processing step
-  proc_stdout, proc_stderr = vm.RemoteCommand("cd %s && ./post_proc.py "
-                                              "--intervals netperf_tps.log"
-                                              % (netperf.NETPERF_EXAMPLE_DIR),
+  proc_stdout, proc_stderr = vm.RemoteCommand(f"cd {netperf.NETPERF_EXAMPLE_DIR} && ./post_proc.py "
+                                              "--intervals netperf_tps.log",
                                               ignore_failure=True)
-
 
   samples = ParseNetperfAggregateOutput(proc_stdout)
 

--- a/perfkitbenchmarker/linux_benchmarks/ping_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/ping_benchmark.py
@@ -55,8 +55,7 @@ def Prepare(benchmark_spec):  # pylint: disable=unused-argument
   """
   if len(benchmark_spec.vms) != 2:
     raise ValueError(
-        'Ping benchmark requires exactly two machines, found {0}'
-        .format(len(benchmark_spec.vms)))
+        f'Ping benchmark requires exactly two machines, found {len(benchmark_spec.vms)}')
   if vm_util.ShouldRunOnExternalIpAddress():
     vms = benchmark_spec.vms
     for vm in vms:
@@ -107,11 +106,11 @@ def _RunPing(sending_vm, receiving_vm, receiving_ip, ip_type):
   """
   if (ip_type == vm_util.IpAddressMetadata.INTERNAL and
       not sending_vm.IsReachable(receiving_vm)):
-    logging.warn('%s is not reachable from %s', receiving_vm, sending_vm)
+    logging.warn(f'{receiving_vm} is not reachable from {sending_vm}')
     return []
 
-  logging.info('Ping results (ip_type = %s):', ip_type)
-  ping_cmd = 'ping -c 100 %s' % receiving_ip
+  logging.info(f'Ping results (ip_type = {ip_type}):')
+  ping_cmd = f'ping -c 100 {receiving_ip}'
   stdout, _ = sending_vm.RemoteCommand(ping_cmd, should_log=True)
   stats = re.findall('([0-9]*\\.[0-9]*)', stdout.splitlines()[-1])
   assert len(stats) == len(METRICS), stats

--- a/perfkitbenchmarker/linux_benchmarks/ping_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/ping_benchmark.py
@@ -106,10 +106,10 @@ def _RunPing(sending_vm, receiving_vm, receiving_ip, ip_type):
   """
   if (ip_type == vm_util.IpAddressMetadata.INTERNAL and
       not sending_vm.IsReachable(receiving_vm)):
-    logging.warn(f'{receiving_vm} is not reachable from {sending_vm}')
+    logging.warn('%s is not reachable from %s', receiving_vm, sending_vm)
     return []
 
-  logging.info(f'Ping results (ip_type = {ip_type}):')
+  logging.info('Ping results (ip_type = %s):', ip_type)
   ping_cmd = f'ping -c 100 {receiving_ip}'
   stdout, _ = sending_vm.RemoteCommand(ping_cmd, should_log=True)
   stats = re.findall('([0-9]*\\.[0-9]*)', stdout.splitlines()[-1])

--- a/perfkitbenchmarker/linux_packages/netperf.py
+++ b/perfkitbenchmarker/linux_packages/netperf.py
@@ -32,9 +32,8 @@ flags.DEFINE_integer(
     'benchmark produces.')
 FLAGS = flags.FLAGS
 NETPERF_TAR = 'netperf-2.7.0.tar.gz'
-NETPERF_URL = 'https://github.com/HewlettPackard/netperf/archive/%s' % (
-              NETPERF_TAR)
-NETPERF_DIR = '%s/netperf-netperf-2.7.0' % linux_packages.INSTALL_DIR
+NETPERF_URL = f'https://github.com/HewlettPackard/netperf/archive/{NETPERF_TAR}'
+NETPERF_DIR = f'{linux_packages.INSTALL_DIR}/netperf-netperf-2.7.0'
 
 NETPERF_SRC_DIR = NETPERF_DIR + '/src'
 NETSERVER_PATH = NETPERF_SRC_DIR + '/netserver'
@@ -50,25 +49,22 @@ def _Install(vm):
   vm.Install('build_tools')
 
   _CopyTar(vm)
-  vm.RemoteCommand('cd %s && tar xvzf %s' %
-                   (linux_packages.INSTALL_DIR, NETPERF_TAR))
+  vm.RemoteCommand(f'cd {linux_packages.INSTALL_DIR} && tar xvzf {NETPERF_TAR}')
   # Modify netperf to print out all buckets in its histogram rather than
   # aggregating, edit runemomniaggdemo script, and apply fix to
   # allow it to compile with --enable-demo flag correctly
   vm.PushDataFile('netperf.patch', NETLIB_PATCH)
 
-  vm.RemoteCommand('cd %s && patch -l -p1 < netperf.patch' %
-                   NETPERF_DIR)
+  vm.RemoteCommand(f'cd {NETPERF_DIR} && patch -l -p1 < netperf.patch')
 
-  vm.RemoteCommand('cd %s && CFLAGS=-DHIST_NUM_OF_BUCKET=%s '
+  vm.RemoteCommand(f'cd {NETPERF_DIR} && '
+                   f'CFLAGS=-DHIST_NUM_OF_BUCKET={FLAGS.netperf_histogram_buckets} '
                    './configure --enable-burst '
                    '--enable-demo --enable-histogram '
-                   '&& make && sudo make install' %
-                   (NETPERF_DIR, FLAGS.netperf_histogram_buckets))
+                   '&& make && sudo make install')
 
-  vm.RemoteCommand('cd %s && chmod +x runemomniaggdemo.sh'
-                   '&& chmod +x find_max_burst.sh'
-                   % (NETPERF_EXAMPLE_DIR))
+  vm.RemoteCommand(f'cd {NETPERF_EXAMPLE_DIR} && chmod +x runemomniaggdemo.sh'
+                   '&& chmod +x find_max_burst.sh')
 
   # Set keepalive to a low value to ensure that the control connection
   # is not closed by the cloud networking infrastructure.
@@ -98,8 +94,7 @@ def _CopyTar(vm):
     vm.PushDataFile(NETPERF_TAR, remote_path=(linux_packages.INSTALL_DIR + '/'))
   except data.ResourceNotFound:
     vm.Install('curl')
-    vm.RemoteCommand('curl %s -L -o %s/%s' %
-                     (NETPERF_URL, linux_packages.INSTALL_DIR, NETPERF_TAR))
+    vm.RemoteCommand(f'curl {NETPERF_URL} -L -o {linux_packages.INSTALL_DIR}/{NETPERF_TAR}')
 
 
 def YumInstall(vm):


### PR DESCRIPTION
Changed older style strings to f strings for ping, netperf, and netperf_pps benchmarks
I also changed netperf_pps.py to netperf_pps_benchmark.py to make it consistent with all of the other files