### PR TITLE
Cloudharmony network benchmark uplink test fix

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/cloudharmony_network_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/cloudharmony_network_benchmark.py
@@ -141,7 +141,7 @@ def _PrepareServer(vm):
   vm.Install(NGINX)
 
   # Required to make uplink test function properly
-  vm.RemoteCommand('sudo sed -i "/server_name _;/a error_page  405 =200 $uri;" /etc/nginx/sites-enabled/default')
+  vm.RemoteCommand('sudo sed -i "/server_name _;/a error_page  405 =200 \$uri;" /etc/nginx/sites-enabled/default')
   vm.RemoteCommand('sudo sed -i "/server_name _;/a client_max_body_size 100M;" /etc/nginx/sites-enabled/default')
   vm.RemoteCommand('sudo systemctl restart nginx')
 

--- a/perfkitbenchmarker/linux_benchmarks/cloudharmony_network_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/cloudharmony_network_benchmark.py
@@ -141,9 +141,9 @@ def _PrepareServer(vm):
   vm.Install(NGINX)
 
   # Required to make uplink test function properly
-  vm.RemoteCommand("sudo sed -i '/server_name _;/a error_page  405 =200 $uri;' /etc/nginx/sites-enabled/default")
-  vm.RemoteCommand("sudo sed -i '/server_name _;/a client_max_body_size 100M;' /etc/nginx/sites-enabled/default")
-  vm.RemoteCommand("sudo systemctl restart nginx")
+  vm.RemoteCommand('sudo sed -i "/server_name _;/a error_page  405 =200 $uri;" /etc/nginx/sites-enabled/default')
+  vm.RemoteCommand('sudo sed -i "/server_name _;/a client_max_body_size 100M;" /etc/nginx/sites-enabled/default')
+  vm.RemoteCommand('sudo systemctl restart nginx')
 
   web_probe_file = posixpath.join(vm.GetScratchDir(), 'probe.tgz')
   vm.InstallPreprovisionedPackageData(cloud_harmony_network.PACKAGE_NAME,

--- a/perfkitbenchmarker/linux_benchmarks/cloudharmony_network_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/cloudharmony_network_benchmark.py
@@ -139,6 +139,12 @@ def _PrepareServer(vm):
     vm: the server virtual machine.
   """
   vm.Install(NGINX)
+
+  # Required to make uplink test function properly
+  vm.RemoteCommand("sudo sed -i '/server_name _;/a error_page  405 =200 $uri;' /etc/nginx/sites-enabled/default")
+  vm.RemoteCommand("sudo sed -i '/server_name _;/a client_max_body_size 100M;' /etc/nginx/sites-enabled/default")
+  vm.RemoteCommand("sudo systemctl restart nginx")
+
   web_probe_file = posixpath.join(vm.GetScratchDir(), 'probe.tgz')
   vm.InstallPreprovisionedPackageData(cloud_harmony_network.PACKAGE_NAME,
                                       [cloud_harmony_network.WEB_PROBE_TAR],


### PR DESCRIPTION
These changes to the nginx server configuration make the uplink test function properly.
I set a static max size of 100 Mbits, but I could change this to being based on the --ch_network_throughput_size flag