### PR TITLE
Fix file not found error when run zip tool

### DIFF
--- a/tools/zip/zip.py
+++ b/tools/zip/zip.py
@@ -26,7 +26,7 @@ def main(argv):
     sys.exit('Usage: %s <outfile>' % argv[0])
   zip_file_path = argv[1]
 
-  version = subprocess.check_output(('pkb.py', '--version')).rstrip()
+  version = subprocess.check_output((os.path.join(os.getcwd(), 'pkb.py'), '--version')).rstrip()
 
   with zipfile.ZipFile(zip_file_path, 'w') as zip_file:
     for dir_path, _, file_names in os.walk('perfkitbenchmarker'):


### PR DESCRIPTION
Right now, when run zip tool follow the README file, get the following errors. This PR is to fix the problem

$ python tools/zip/zip.py xytest.zip
Traceback (most recent call last):
  File "tools/zip/zip.py", line 44, in <module>
    main(sys.argv)
  File "tools/zip/zip.py", line 29, in main
    version = subprocess.check_output(('pkb.py', '--version')).rstrip()
  File "/usr/lib/python3.6/subprocess.py", line 356, in check_output
    **kwargs).stdout
  File "/usr/lib/python3.6/subprocess.py", line 423, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/usr/lib/python3.6/subprocess.py", line 729, in __init__
    restore_signals, start_new_session)
  File "/usr/lib/python3.6/subprocess.py", line 1364, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'pkb.py': 'pkb.py'