### PR TITLE
Cloudharmony network test update.

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/cloudharmony_network_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/cloudharmony_network_benchmark.py
@@ -277,6 +277,7 @@ def Prepare(benchmark_spec):
   client = vm_groups['client'][0]
   client.Install('cloud_harmony_network')
 
+  # Ignore complaints from using self-signed certificate
   if FLAGS.ch_network_test == 'ssl':
     client.RemoteCommand('echo insecure >> $HOME/.curlrc')
 

--- a/perfkitbenchmarker/linux_benchmarks/cloudharmony_network_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/cloudharmony_network_benchmark.py
@@ -112,9 +112,9 @@ def CheckPrerequisites(_):
   if FLAGS.ch_network_test_service_type == STORAGE and FLAGS.cloud != 'GCP':
     raise NotImplementedError('Benchmark only supports GCS object storage.')
   elif FLAGS.ch_network_test_service_type == DNS and FLAGS.ch_network_test != 'dns':
-    raise InvalidConfigurationError('If ch_network_test_service_type flag is set to dns, ch_network_test flag must also be dns')
+    raise errors.Setup.InvalidConfigurationError('If ch_network_test_service_type flag is set to dns, ch_network_test flag must also be dns')
   elif FLAGS.ch_network_test_service_type != DNS and FLAGS.ch_network_test == 'dns':
-    raise InvalidConfigurationError('If ch_network_test flag is set to dns, ch_network_test_service_type flag must also be dns')
+    raise errors.Setup.InvalidConfigurationError('If ch_network_test flag is set to dns, ch_network_test_service_type flag must also be dns')
   elif FLAGS.ch_network_test_service_type == DNS and FLAGS.cloud != 'GCP':
     raise NotImplementedError('DNS Benchmark not implemented for this cloud type')
 

--- a/perfkitbenchmarker/linux_benchmarks/cloudharmony_network_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/cloudharmony_network_benchmark.py
@@ -198,7 +198,7 @@ def _PrepareServer(vm):
         'sudo sed -i "/server_name _;/a listen [::]:443 ssl default_server;" /etc/nginx/sites-enabled/default'
     )
         
-    vm.RemoteCommand('sudo systemctl restart nginx')
+  vm.RemoteCommand('sudo systemctl restart nginx')
 
   web_probe_file = posixpath.join(vm.GetScratchDir(), 'probe.tgz')
   vm.InstallPreprovisionedPackageData(cloud_harmony_network.PACKAGE_NAME,

--- a/perfkitbenchmarker/linux_benchmarks/cloudharmony_network_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/cloudharmony_network_benchmark.py
@@ -379,7 +379,7 @@ def _Run(benchmark_spec, test):
     metadata['throughput_time'] = True
   if FLAGS.ch_network_throughput_slowest_thread:
     metadata['throughput_slowest_thread'] = True
-  if FLAGS.ch_network_test == 'dns':
+  if FLAGS.ch_network_test == DNS:
     metadata['dns_recursive'] = True
   if FLAGS.ch_network_test in ['rtt', 'ssl', 'ttfb']:
     metadata['throughput_time'] = True

--- a/perfkitbenchmarker/linux_benchmarks/cloudharmony_network_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/cloudharmony_network_benchmark.py
@@ -320,7 +320,8 @@ def _Run(benchmark_spec, test):
     # use GCP zonal internal DNS, but maybe should add domain to vm's data attributes?
     endpoints = ''
     if FLAGS.cloud == 'GCP':
-      endpoints = ' '.join([f'--test_endpoint={vm.name}.{vm.zone}.c.{vm.project}.internal' for vm in vms])
+      # endpoints = ' '.join([f'--test_endpoint={vm.name}.{vm.zone}.c.{vm.project}.internal' for vm in vms])
+      endpoints = ' '.join('--test_endpoint=google.com')
     else:
       raise NotImplementedError('DNS not implemented for this cloud type')
     _AddComputeMetadata(client, vms[0], metadata)
@@ -335,11 +336,15 @@ def _Run(benchmark_spec, test):
     metadata['throughput_slowest_thread'] = True
   if FLAGS.ch_network_test == 'dns':
     metadata['dns_recursive'] = True
+  if FLAGS.ch_network_test in ['rtt', 'ssl', 'ttfb']:
+    metadata['throughput_time'] = True
 
   metadata = cloud_harmony_util.GetCommonMetadata(metadata)
   cmd_path = posixpath.join(cloud_harmony_network.INSTALL_PATH, 'run.sh')
   outdir = vm_util.VM_TMP_DIR
   cmd = f'sudo {cmd_path} {endpoints} {metadata} --output={outdir} --verbose'
+  print("CMD")
+  print(cmd)
   client.RobustRemoteCommand(cmd)
   save_command = posixpath.join(cloud_harmony_network.INSTALL_PATH, 'save.sh')
   client.RemoteCommand(f'{save_command} {outdir}')


### PR DESCRIPTION
This PR adds support for some functionality that is in the cloudharmony network test, but does not currently work through PerfKit Benchmarker.

Add support for DNS test option. Currently this is only working for Google Cloud using zonal internal DNS.

Add support for SSL test option. This creates a self-signed certificate with the option of using ECC (prime256v1) or RSA (2048).
I could change these, or add additional options for curves and key sizes if desired. 
This also allows the --ch_network_throughput_https flag to work properly.

Fix metadata for SSL, TTFB, and RTT tests. Units were displaying Mbits/sec, when the values should have been milliseconds.

