### PR TITLE
Add mixin for static debian11 systems

### DIFF
--- a/CHANGES.next.md
+++ b/CHANGES.next.md
@@ -27,6 +27,7 @@
 
 ### New features:
 
+-   Add support for static systems running debian11
 -   Add ibmcloud as a new provider.
 -   Add prefix/directory support for object storage service runs.
 -   Add MaskRCNN and ReXtNet-101 to the horovod benchmark.

--- a/perfkitbenchmarker/static_virtual_machine.py
+++ b/perfkitbenchmarker/static_virtual_machine.py
@@ -374,3 +374,8 @@ class Debian9BasedStaticVirtualMachine(StaticVirtualMachine,
 class Debian10BasedStaticVirtualMachine(StaticVirtualMachine,
                                         linux_virtual_machine.Debian10Mixin):
   pass
+
+
+class Debian11BasedStaticVirtualMachine(StaticVirtualMachine,
+                                        linux_virtual_machine.Debian11Mixin):
+  pass


### PR DESCRIPTION
This PR addresses the issue I opened here #3667 by adding support to PKB for static systems that run debian11 