### PR TITLE
Option to set disk size for external volume

### DIFF
--- a/perfkitbenchmarker/providers/ibmcloud/ibmcloud_disk.py
+++ b/perfkitbenchmarker/providers/ibmcloud/ibmcloud_disk.py
@@ -30,6 +30,7 @@ FLAGS = flags.FLAGS
 
 _MAX_DISK_ATTACH_SECONDS = 300
 _MAX_FIND_DEVICE_SECONDS = 120
+DEFAULT_DISK_SIZE = 1000
 
 
 class IbmCloudDisk(disk.BaseDisk):
@@ -55,6 +56,7 @@ class IbmCloudDisk(disk.BaseDisk):
     self.attached_vm = None
     self.attached_vdisk_uri = None
     self.device_path = None
+    self.data_disk_size = FLAGS.data_disk_size if FLAGS.data_disk_size is not None else DEFAULT_DISK_SIZE
 
   def _Create(self):
     """Creates an external block volume."""
@@ -64,7 +66,7 @@ class IbmCloudDisk(disk.BaseDisk):
         'zone': self.zone,
         'iops': FLAGS.ibmcloud_volume_iops,
         'profile': FLAGS.ibmcloud_volume_profile,
-        'capacity': self.disk_size
+        'capacity': self.data_disk_size
     })
     if self.encryption_key is not None:
       volcmd.flags['encryption_key'] = self.encryption_key

--- a/perfkitbenchmarker/providers/ibmcloud/ibmcloud_virtual_machine.py
+++ b/perfkitbenchmarker/providers/ibmcloud/ibmcloud_virtual_machine.py
@@ -402,6 +402,11 @@ class Ubuntu1804BasedIbmCloudVirtualMachine(
     super(Ubuntu1804BasedIbmCloudVirtualMachine, self).PrepareVMEnvironment()
 
 
+class Ubuntu2004BasedIbmCloudVirtualMachine(IbmCloudVirtualMachine,
+                                            linux_virtual_machine.Ubuntu2004Mixin):
+  IMAGE_NAME_PREFIX = 'ibm-ubuntu-20-04-'
+
+
 class RhelBasedIbmCloudVirtualMachine(IbmCloudVirtualMachine,
                                       linux_virtual_machine.BaseRhelMixin):
 

--- a/perfkitbenchmarker/providers/ibmcloud/ibmcloud_virtual_machine.py
+++ b/perfkitbenchmarker/providers/ibmcloud/ibmcloud_virtual_machine.py
@@ -359,7 +359,7 @@ class IbmCloudVirtualMachine(virtual_machine.BaseVirtualMachine):
 
   def ShouldDownloadPreprovisionedData(self, module_name, filename):
     """Returns whether or not preprovisioned data is available."""
-    return True
+    return False
 
 
 class DebianBasedIbmCloudVirtualMachine(IbmCloudVirtualMachine,
@@ -380,6 +380,11 @@ class Debian9BasedIbmCloudVirtualMachine(DebianBasedIbmCloudVirtualMachine,
 class Debian10BasedIbmCloudVirtualMachine(DebianBasedIbmCloudVirtualMachine,
                                           linux_virtual_machine.Debian10Mixin):
   IMAGE_NAME_PREFIX = 'ibm-debian-10-'
+
+
+class Debian11BasedIbmCloudVirtualMachine(DebianBasedIbmCloudVirtualMachine,
+                                          linux_virtual_machine.Debian11Mixin):
+  IMAGE_NAME_PREFIX = 'ibm-debian-11-'
 
 
 class Ubuntu1604BasedIbmCloudVirtualMachine(


### PR DESCRIPTION
Option to set disk size for external volume to override defaults,
also to support ubuntu2004.
This is for IBMCloud.