### PR TITLE
Enabling Oracle Linux 8 and Oracle Linux 9. 

### DIFF
--- a/perfkitbenchmarker/linux_virtual_machine.py
+++ b/perfkitbenchmarker/linux_virtual_machine.py
@@ -60,6 +60,7 @@ FLAGS = flags.FLAGS
 
 OS_PRETTY_NAME_REGEXP = r'PRETTY_NAME="(.*)"'
 _EPEL_URL = 'https://dl.fedoraproject.org/pub/epel/epel-release-latest-{}.noarch.rpm'
+_ORACLE_EPEL_URL = 'oracle-epel-release-el{}'
 CLEAR_BUILD_REGEXP = r'Installed version:\s*(.*)\s*'
 UPDATE_RETRIES = 5
 DEFAULT_SSH_PORT = 22
@@ -1988,6 +1989,23 @@ class Rhel9Mixin(BaseRhelMixin):
     # https://docs.fedoraproject.org/en-US/epel/#_rhel_9
     self.RemoteCommand(f'sudo dnf install -y {_EPEL_URL.format(9)}')
 
+class Oracle8Mixin(BaseRhelMixin):
+    """Class holding Oracle Linux 8 specific VM methods and attributes."""
+    OS_TYPE = os_types.ORACLE8
+    PYTHON_2_PACKAGE = None
+
+    def SetupPackageManager(self):
+        """Install EPEL."""
+        self.RemoteCommand(f'sudo dnf install -y {_ORACLE_EPEL_URL.format(8)}')
+
+class Oracle9Mixin(BaseRhelMixin):
+    """Class holding Oracle Linux 9 specific VM methods and attributes."""
+    OS_TYPE = os_types.ORACLE9
+    PYTHON_2_PACKAGE = None
+
+    def SetupPackageManager(self):
+        """Install EPEL."""
+        self.RemoteCommand(f'sudo dnf install -y {_ORACLE_EPEL_URL.format(9)}')
 
 class CentOs7Mixin(BaseRhelMixin):
   """Class holding CentOS 7 specific VM methods and attributes."""

--- a/perfkitbenchmarker/os_types.py
+++ b/perfkitbenchmarker/os_types.py
@@ -30,6 +30,8 @@ DEBIAN10_BACKPORTS = 'debian10_backports'
 DEBIAN11 = 'debian11'
 DEBIAN11_BACKPORTS = 'debian11_backports'
 JUJU = 'juju'
+ORACLE8 = 'oracle8'
+ORACLE9 = 'oracle9'
 RHEL7 = 'rhel7'
 RHEL8 = 'rhel8'
 RHEL9 = 'rhel9'
@@ -88,6 +90,8 @@ LINUX_OS_TYPES = CONTAINER_OS_TYPES + [
     DEBIAN11,
     DEBIAN11_BACKPORTS,
     JUJU,
+    ORACLE8,
+    ORACLE9,
     RHEL7,
     RHEL8,
     RHEL9,


### PR DESCRIPTION
Add and enable Oracle Linux 8 and Oracle Linux 9.
This is necessary to work with OCI provider. 
depends on #4061 

