### PR TITLE
Mpi percentiles

### DIFF
--- a/perfkitbenchmarker/histogram_util.yaml
+++ b/perfkitbenchmarker/histogram_util.yaml
@@ -1,0 +1,59 @@
+# Copyright 2014 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utility for computing percentile values from a histogram"""
+
+PERCENTILES = [50, 90, 99]
+
+def _HistogramStatsCalculator(histogram, percentiles=PERCENTILES):
+  """Computes values at percentiles in a distribution as well as stddev.
+
+  Args:
+    histogram: A dict mapping values to the number of samples with that value.
+    percentiles: An array of percentiles to calculate.
+
+  Returns:
+    A dict mapping stat names to their values.
+  """
+  stats = {}
+
+  # Histogram data in list form sorted by key
+  by_value = sorted([(value, count) for value, count in histogram.items()],
+                    key=lambda x: x[0])
+  total_count = sum(histogram.values())
+
+  cur_value_index = 0  # Current index in by_value
+  cur_index = 0  # Number of values we've passed so far
+  for p in percentiles:
+    index = int(float(total_count) * float(p) / 100.0)
+    index = min(index, total_count - 1)  # Handle 100th percentile
+    for value, count in by_value[cur_value_index:]:
+      if cur_index + count > index:
+        stats['p%s' % str(p)] = by_value[cur_value_index][0]
+        break
+      else:
+        cur_index += count
+        cur_value_index += 1
+
+  # Compute stddev
+  value_sum = float(sum([value * count for value, count in histogram.items()]))
+  average = value_sum / float(total_count)
+  if total_count > 1:
+    total_of_squares = sum([
+        (value - average)**2 * count for value, count in histogram.items()
+    ])
+    stats['stddev'] = (total_of_squares / (total_count - 1))**0.5
+  else:
+    stats['stddev'] = 0
+  return stats

--- a/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
@@ -133,7 +133,7 @@ PORT_START = 20000
 REMOTE_SCRIPTS_DIR = 'netperf_test_scripts'
 REMOTE_SCRIPT = 'netperf_test.py'
 
-PERCENTILES = [50, 90, 99]
+PERCENTILES = [50, 90, 95, 99]
 
 # By default, Container-Optimized OS (COS) host firewall allows only
 # outgoing connections and incoming SSH connections. To allow incoming
@@ -345,6 +345,7 @@ def ParseNetperfOutput(stdout, metadata, benchmark_name,
     for metric_key, metric_name in [
         ('50th Percentile Latency Microseconds', 'p50'),
         ('90th Percentile Latency Microseconds', 'p90'),
+        ('95th Percentile Latency Microseconds', 'p95'),
         ('99th Percentile Latency Microseconds', 'p99'),
         ('Minimum Latency Microseconds', 'min'),
         ('Maximum Latency Microseconds', 'max'),
@@ -469,7 +470,7 @@ def RunNetperf(vm, benchmark_name, server_ip, num_streams):
     # Extract the throughput values from the samples
     throughputs = [s.value for s in throughput_samples]
     # Compute some stats on the throughput values
-    throughput_stats = sample.PercentileCalculator(throughputs, [50, 90, 99])
+    throughput_stats = sample.PercentileCalculator(throughputs, [50, 90, 95, 99])
     throughput_stats['min'] = min(throughputs)
     throughput_stats['max'] = max(throughputs)
     # Calculate aggregate throughput

--- a/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
@@ -133,7 +133,10 @@ PORT_START = 20000
 REMOTE_SCRIPTS_DIR = 'netperf_test_scripts'
 REMOTE_SCRIPT = 'netperf_test.py'
 
-PERCENTILES = [50, 90, 95, 99]
+PERCENTILES = [50, 90, 99]
+
+flag_util.DEFINE_integerlist(
+    'percentiles', [50, 90, 99], 'Latency percentiles to calculate.')
 
 # By default, Container-Optimized OS (COS) host firewall allows only
 # outgoing connections and incoming SSH connections. To allow incoming
@@ -470,7 +473,7 @@ def RunNetperf(vm, benchmark_name, server_ip, num_streams):
     # Extract the throughput values from the samples
     throughputs = [s.value for s in throughput_samples]
     # Compute some stats on the throughput values
-    throughput_stats = sample.PercentileCalculator(throughputs, [50, 90, 95, 99])
+    throughput_stats = sample.PercentileCalculator(throughputs, FLAGS.percentiles)
     throughput_stats['min'] = min(throughputs)
     throughput_stats['max'] = max(throughputs)
     # Calculate aggregate throughput
@@ -492,7 +495,7 @@ def RunNetperf(vm, benchmark_name, server_ip, num_streams):
           sample.Sample(f'{benchmark_name}_Latency_Histogram', 0, 'us',
                         hist_metadata))
       # Calculate stats on aggregate latency histogram
-      latency_stats = _HistogramStatsCalculator(latency_histogram, [50, 90, 99])
+      latency_stats = _HistogramStatsCalculator(latency_histogram, FLAGS.percentiles)
       # Create samples for the latency stats
       for stat, value in latency_stats.items():
         samples.append(


### PR DESCRIPTION
Added functionality to produce latency percentile information from MPI benchmarks like PingPong and Multi-PingPong

- moved _HistogramStatsCalculator from netperf_benchmark.py to separate utility file
- add imports for _HistogramStatsCalculator in netperf_benchmark and mpi_benchmark to produce/report user-specified latency percentiles