### PR TITLE
Netperf Latency Percentile Flag

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
@@ -101,6 +101,10 @@ flags.register_validator(
     'netperf_benchmarks',
     lambda benchmarks: benchmarks and set(benchmarks).issubset(ALL_BENCHMARKS))
 
+flag_util.DEFINE_integerlist(
+    'netperf_latency_percentiles', [50, 90, 99], 'Latency percentiles to calculate/report'
+)
+
 FLAGS = flags.FLAGS
 
 BENCHMARK_NAME = 'netperf'
@@ -575,7 +579,7 @@ def RunNetperf(vm, benchmark_name, server_ips, num_streams):
           sample.Sample(f'{benchmark_name}_Latency_Histogram', 0, 'us',
                         hist_metadata))
       # Calculate stats on aggregate latency histogram
-      latency_stats = _HistogramStatsCalculator(latency_histogram, [50, 90, 99])
+      latency_stats = _HistogramStatsCalculator(latency_histogram, FLAGS.netperf_latency_percentiles)
       # Create samples for the latency stats
       for stat, value in latency_stats.items():
         samples.append(

--- a/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
@@ -101,7 +101,7 @@ flags.register_validator(
     'netperf_benchmarks',
     lambda benchmarks: benchmarks and set(benchmarks).issubset(ALL_BENCHMARKS))
 
-flag_util.DEFINE_list(
+flags.DEFINE_list(
     'netperf_latency_percentiles', [50, 90, 99], 'Latency percentiles to calculate/report'
 )
 

--- a/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/netperf_benchmark.py
@@ -101,7 +101,7 @@ flags.register_validator(
     'netperf_benchmarks',
     lambda benchmarks: benchmarks and set(benchmarks).issubset(ALL_BENCHMARKS))
 
-flag_util.DEFINE_integerlist(
+flag_util.DEFINE_list(
     'netperf_latency_percentiles', [50, 90, 99], 'Latency percentiles to calculate/report'
 )
 


### PR DESCRIPTION
Allow users to define list of Netperf latency percentiles to calculate/report as a flag, instead of only reporting 50th, 90th, and 99th percentiles