### PR TITLE
Add GCE AMD Rome Support

### DIFF
--- a/perfkitbenchmarker/providers/gcp/flags.py
+++ b/perfkitbenchmarker/providers/gcp/flags.py
@@ -209,6 +209,7 @@ flags.DEFINE_enum(
         'broadwell',
         'skylake',
         'cascadelake',
+        'rome',
         'milan',
         'icelake',
     ],


### PR DESCRIPTION
Adding the ability to influence the GCE scheduler to deploy GCE instances using AMD Rome (available with the N2D family).