### PR TITLE
Respect GCE C4 Hyperdisk Requirement

### DIFF
--- a/perfkitbenchmarker/providers/gcp/gce_disk.py
+++ b/perfkitbenchmarker/providers/gcp/gce_disk.py
@@ -136,6 +136,7 @@ NVME_PD_MACHINE_FAMILIES = ['m3']
 HYPERDISK_ONLY_MACHINE_FAMILIES = [
     'c3a',
     'n4',
+    'c4',
 ]
 # Default boot disk type in pkb.
 # Console defaults to pd-balanced & gcloud defaults to pd-standard as of 11/23


### PR DESCRIPTION
Ensure PKB correctly provisions C4 instances with hyperdisk storage only, as they are hyperdisk-exclusive machines (like N4 instances).
