### PR TITLE
Create an SCP benchmark

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/scp_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/scp_benchmark.py
@@ -17,25 +17,29 @@ import logging
 import time
 from typing import Any
 from absl import flags
+from perfkitbenchmarker import background_tasks
 from perfkitbenchmarker import benchmark_spec as bm_spec
 from perfkitbenchmarker import configs
-from perfkitbenchmarker import flag_util
+from perfkitbenchmarker import data
 from perfkitbenchmarker import sample
 from perfkitbenchmarker import vm_util
+
+FLAGS = flags.FLAGS
+flags.DEFINE_integer('scp_file_size_gb', 1,
+                     'Size of the file to be created for SCP transfer in GB.')
 
 BENCHMARK_NAME = 'scp'
 BENCHMARK_CONFIG = """
 scp:
-  description: Runs a sample benchmark.
+  description: Runs SCP benchmark.
   vm_groups:
     vm_1:
       vm_spec: *default_single_core
+      disk_spec: *default_500_gb
     vm_2:
       vm_spec: *default_single_core
+      disk_spec: *default_500_gb
 """
-
-# temp file
-# _FILE = '/tmp/example_vm_benchmark.txt'
 
 
 def GetConfig(user_config: dict[str, Any]) -> dict[str, Any]:
@@ -43,56 +47,117 @@ def GetConfig(user_config: dict[str, Any]) -> dict[str, Any]:
   return configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
 
 
+def GenerateSSHKey(vm):
+  """Generates a new SSH key pair on the VM."""
+  vm.RemoteCommand('ssh-keygen -t rsa -N "" -f ~/.ssh/scp_benchmark_key')
+  public_key, _ = vm.RemoteCommand('cat ~/.ssh/scp_benchmark_key.pub')
+  return public_key.strip()
+
+
+def GenerateAndExchangeSSHKeys(vm1, vm2):
+  """Exchanges SSH keys between two VMs."""
+  public_key1 = GenerateSSHKey(vm1)
+  public_key2 = GenerateSSHKey(vm2)
+  vm1.RemoteCommand(f'echo "{public_key2}" >> ~/.ssh/authorized_keys')
+  vm2.RemoteCommand(f'echo "{public_key1}" >> ~/.ssh/authorized_keys')
+
+
 def Prepare(benchmark_spec: bm_spec.BenchmarkSpec):
-  """Prepares the VMs and other resources for running the benchmark.
+  """Prepares the VMs and files to be transferred."""
+  logging.info('Preparing SCP benchmark')
 
-  This is a good place to download binaries onto the VMs, create any data files
-  needed for a benchmark run, etc.
-
-  Args:
-    benchmark_spec: The benchmark spec for this sample benchmark.
-  """
   vms = benchmark_spec.vms
   if len(vms) != 2:
     raise ValueError(
         f'scp benchmark requires exactly two machines, found {len(vms)}'
     )
 
-  # _, _ = vm.RemoteCommand(f'echo "Hello World" > {_FILE}')
-  # logging.info('Wrote "Hello World" to %s.', _FILE)
-  logging.info('[HELLO] SCP BENCHMARK - Prepare')
+  # Backup current states
+  for vm in vms:
+    vm.RemoteCommand('sysctl -a > /tmp/original_sysctl.conf')
+
+  # Generate and exchange SSH keys
+  GenerateAndExchangeSSHKeys(vms[0], vms[1])
+  
+  # Create a payload file on both VM
+  try:
+    background_tasks.RunThreaded(PrepareFileForTransfer, vms)
+  except Exception as e:
+    logging.error('Error during file preparation: %s', str(e))
+
+
+def PrepareFileForTransfer(vm):
+  """Creates a test file of specified size on the VM."""
+  logging.info('Preparing the test file')
+
+  # Create directory with appropriate permissions
+  vm.RemoteCommand('sudo mkdir -p /data_for_transfer && sudo chmod 777 /data_for_transfer')
+  # Create a random file of specified size
+  file_size_gb = FLAGS.scp_file_size_gb
+  block_size = '50M'          # 50MiB per block
+  count = file_size_gb * 20   # 1GB = 1000MiB = 20 blocks
+  vm.RemoteCommand(
+    f'dd if=/dev/urandom of=/data_for_transfer/payload.img bs={block_size} count={count} status=progress'
+  )
 
 
 def Run(benchmark_spec: bm_spec.BenchmarkSpec) -> list[sample.Sample]:
-  """Runs the benchmark and returns a dict of performance data.
+  """Runs the benchmark and returns a dict of performance data."""
+  logging.info('Running SCP benchmark')
 
-  It must be possible to run the benchmark multiple times after the Prepare
-  stage.
-
-  Args:
-    benchmark_spec: The benchmark spec for this sample benchmark.
-
-  Returns:
-    A list of performance samples.
-  """
   vms = benchmark_spec.vms
-  # stdout, _ = vm.RemoteCommand(f'cat {_FILE}')
-  # logging.info('Read %s from %s.', stdout.strip(), _FILE)
-  logging.info('[HELLO] SCP BENCHMARK - Run')
-  # This is a sample benchmark that produces no meaningful data, but we return
-  # a single sample as an example.
-  metadata = dict()
-  metadata['sample_metadata'] = 'stdout'
-  return [sample.Sample('sample_metric', 123.456, 'sec', metadata)]
+  vm1, vm2 = vms[0], vms[1]
+  results = []
+
+  def TransferFile(vm_pair):
+    source_vm, dest_vm = vm_pair
+    # clear any existing received file from previous runs
+    dest_vm.RemoteCommand('rm -f /data_for_transfer/received.img')
+
+    scp_cmd = (f'scp -o StrictHostKeyChecking=no -i ~/.ssh/scp_benchmark_key '
+               f'/data_for_transfer/payload.img '
+               f'{dest_vm.user_name}@{dest_vm.internal_ip}:/data_for_transfer/received.img')
+
+    start_time = time.time()
+    source_vm.RemoteCommand(scp_cmd)
+    end_time = time.time()
+    return end_time - start_time
+
+  # Run TransferFile on both VMs
+  thread_params = [
+    (((vm1, vm2),), {}),  # VM1 to VM2
+    (((vm2, vm1),), {})   # VM2 to VM1
+  ]
+  transfer_times = background_tasks.RunThreaded(TransferFile, thread_params)
+  transfer_time_1, transfer_time_2 = transfer_times
+  
+  metadata = {
+      'file_size_gb': FLAGS.scp_file_size_gb,
+      'vm1_zone': vm1.zone,
+      'vm2_zone': vm2.zone,
+      'vm1_machine_type': vm1.machine_type,
+      'vm2_machine_type': vm2.machine_type,
+  }
+
+  # Report individual transfer times
+  results.append(sample.Sample(
+      'SCP_Transfer_Time_VM1_to_VM2', transfer_time_1, 'seconds', metadata))
+  results.append(sample.Sample(
+      'SCP_Transfer_Time_VM2_to_VM1', transfer_time_2, 'seconds', metadata))
+
+  return results
 
 
 def Cleanup(benchmark_spec: bm_spec.BenchmarkSpec):
-  """Cleans up after the benchmark completes.
+  """Cleans up after SCP benchmark completes."""
+  vms = benchmark_spec.vms
+  
+  for vm in vms:
+    vm.RemoteCommand('rm -rf /data_for_transfer')
+    vm.RemoteCommand('rm -f ~/.ssh/scp_benchmark_key ~/.ssh/scp_benchmark_key.pub')
+    vm.RemoteCommand("sed -i '/scp_benchmark_key/d' ~/.ssh/authorized_keys")
+    # restore original state in case
+    vm.RemoteCommand('sudo sysctl -p /tmp/original_sysctl.conf')
+    vm.RemoteCommand('rm /tmp/original_sysctl.conf')
 
-  The state of the VMs should be equivalent to the state before Prepare was
-  called.
-
-  Args:
-    benchmark_spec: The benchmark spec for this sample benchmark.
-  """
   del benchmark_spec

--- a/perfkitbenchmarker/linux_benchmarks/scp_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/scp_benchmark.py
@@ -1,0 +1,98 @@
+# Copyright 2024 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""SCP files between VMs."""
+
+import logging
+import time
+from typing import Any
+from absl import flags
+from perfkitbenchmarker import benchmark_spec as bm_spec
+from perfkitbenchmarker import configs
+from perfkitbenchmarker import flag_util
+from perfkitbenchmarker import sample
+from perfkitbenchmarker import vm_util
+
+BENCHMARK_NAME = 'scp'
+BENCHMARK_CONFIG = """
+scp:
+  description: Runs a sample benchmark.
+  vm_groups:
+    vm_1:
+      vm_spec: *default_single_core
+    vm_2:
+      vm_spec: *default_single_core
+"""
+
+# temp file
+# _FILE = '/tmp/example_vm_benchmark.txt'
+
+
+def GetConfig(user_config: dict[str, Any]) -> dict[str, Any]:
+  """Returns the configuration of a benchmark."""
+  return configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
+
+
+def Prepare(benchmark_spec: bm_spec.BenchmarkSpec):
+  """Prepares the VMs and other resources for running the benchmark.
+
+  This is a good place to download binaries onto the VMs, create any data files
+  needed for a benchmark run, etc.
+
+  Args:
+    benchmark_spec: The benchmark spec for this sample benchmark.
+  """
+  vms = benchmark_spec.vms
+  if len(vms) != 2:
+    raise ValueError(
+        f'scp benchmark requires exactly two machines, found {len(vms)}'
+    )
+
+  # _, _ = vm.RemoteCommand(f'echo "Hello World" > {_FILE}')
+  # logging.info('Wrote "Hello World" to %s.', _FILE)
+  logging.info('[HELLO] SCP BENCHMARK - Prepare')
+
+
+def Run(benchmark_spec: bm_spec.BenchmarkSpec) -> list[sample.Sample]:
+  """Runs the benchmark and returns a dict of performance data.
+
+  It must be possible to run the benchmark multiple times after the Prepare
+  stage.
+
+  Args:
+    benchmark_spec: The benchmark spec for this sample benchmark.
+
+  Returns:
+    A list of performance samples.
+  """
+  vms = benchmark_spec.vms
+  # stdout, _ = vm.RemoteCommand(f'cat {_FILE}')
+  # logging.info('Read %s from %s.', stdout.strip(), _FILE)
+  logging.info('[HELLO] SCP BENCHMARK - Run')
+  # This is a sample benchmark that produces no meaningful data, but we return
+  # a single sample as an example.
+  metadata = dict()
+  metadata['sample_metadata'] = 'stdout'
+  return [sample.Sample('sample_metric', 123.456, 'sec', metadata)]
+
+
+def Cleanup(benchmark_spec: bm_spec.BenchmarkSpec):
+  """Cleans up after the benchmark completes.
+
+  The state of the VMs should be equivalent to the state before Prepare was
+  called.
+
+  Args:
+    benchmark_spec: The benchmark spec for this sample benchmark.
+  """
+  del benchmark_spec


### PR DESCRIPTION
### Summary
This PR introduces the initial implementation of the SCP benchmark for Linux as described in issue [#5234](https://github.com/GoogleCloudPlatform/PerfKitBenchmarker/issues/5234).

The SCP benchmark measures the time taken to SCP a file between two VMs. The current version focuses on the Linux implementation and is functional, while the Windows implementation will follow in a future PR or updated later in this PR.

### Detalis:
 - Added `scp_benchmark.py` in the `linux_benchmarks` directory.
 - Implemented the `BENCHMARK_NAME` and `BENCHMARK_CONFIG` constants so that the benchmark can be discovered and run by PKB.
 - Implemented `GetConfig`, `Prepare`, `Run`, and `Cleanup` functions.
   - Prepared SSH keys between VMs and created a random file on each VM for the SCP transfer test.
   - Implemented SCP transfer between VMs and measured the transfer time in both directions.
   - Results include individual SCP times from both VMs (VM1 to VM2, VM2 to VM1).

### Testing:
The benchmark was tested on Linux VMs. Example commands and results:

- `./pkb.py --benchmarks=scp --machine_type=e2-micro --data_disk_type=pd-ssd --data_disk_size=5`

```
-------------------------PerfKitBenchmarker Results Summary-------------------------
SCP:
  SCP_Transfer_Time_VM1_to_VM2         90.416951 seconds                        (file_size_gb="1" run_number="0" vm1_machine_type="e2-micro" vm1_zone="us-central1-a" vm2_machine_type="e2-micro" vm2_zone="us-central1-a" vm_1_gce_nic_type="['GVNIC']" vm_2_gce_nic_type="['GVNIC']")
  SCP_Transfer_Time_VM2_to_VM1         90.856173 seconds                        (file_size_gb="1" run_number="0" vm1_machine_type="e2-micro" vm1_zone="us-central1-a" vm2_machine_type="e2-micro" vm2_zone="us-central1-a" vm_1_gce_nic_type="['GVNIC']" vm_2_gce_nic_type="['GVNIC']")
  lscpu                                 0.000000                                (Address sizes="46 bits physical, 48 bits virtual" Architecture="x86_64" BogoMIPS="4400.36" Byte Order="Little Endian" CPU family="6" CPU op-mode(s)="32-bit, 64-bit" CPU(s)="2" Core(s) per socket="1" Flags="fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss ht syscall nx pdpe1gb rdtscp lm constant_tsc rep_good nopl xtopology nonstop_tsc cpuid tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 x2apic movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm abm 3dnowprefetch pti ssbd ibrs ibpb stibp fsgsbase tsc_adjust bmi1 hle avx2 smep bmi2 erms invpcid rtm rdseed adx smap xsaveopt arat md_clear arch_capabilities" Hypervisor vendor="KVM" L1d cache="32 KiB (1 instance)" L1i cache="32 KiB (1 instance)" L2 cache="256 KiB (1 instance)" L3 cache="55 MiB (1 instance)" Model="79" Model name="Intel(R) Xeon(R) CPU @ 2.20GHz" NUMA node(s)="1" NUMA node0 CPU(s)="0,1" On-line CPU(s) list="0,1" Socket(s)="1" Stepping="0" Thread(s) per core="2" Vendor ID="GenuineIntel" Virtualization type="full" Vulnerability Gather data sampling="Not affected" Vulnerability Itlb multihit="Not affected" Vulnerability L1tf="Mitigation; PTE Inversion" Vulnerability Mds="Mitigation; Clear CPU buffers; SMT Host state unknown" Vulnerability Meltdown="Mitigation; PTI" Vulnerability Mmio stale data="Vulnerable: Clear CPU buffers attempted, no microcode; SMT Host state unknown" Vulnerability Reg file data sampling="Not affected" Vulnerability Retbleed="Mitigation; IBRS" Vulnerability Spec rstack overflow="Not affected" Vulnerability Spec store bypass="Mitigation; Speculative Store Bypass disabled via prctl" Vulnerability Spectre v1="Mitigation; usercopy/swapgs barriers and __user pointer sanitization" Vulnerability Spectre v2="Mitigation; IBRS; IBPB conditional; STIBP conditional; RSB filling; PBRSB-eIBRS Not affected; BHI SW loop, KVM SW loop" Vulnerability Srbds="Not affected" Vulnerability Tsx async abort="Mitigation; Clear CPU buffers; SMT Host state unknown" node_name="pkb-5df88af7-0" vm_1_gce_nic_type="['GVNIC']" vm_2_gce_nic_type="['GVNIC']")
  lscpu                                 0.000000                                (Address sizes="46 bits physical, 48 bits virtual" Architecture="x86_64" BogoMIPS="4400.49" Byte Order="Little Endian" CPU family="6" CPU op-mode(s)="32-bit, 64-bit" CPU(s)="2" Core(s) per socket="1" Flags="fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss ht syscall nx pdpe1gb rdtscp lm constant_tsc rep_good nopl xtopology nonstop_tsc cpuid tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 x2apic movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm abm 3dnowprefetch pti ssbd ibrs ibpb stibp fsgsbase tsc_adjust bmi1 hle avx2 smep bmi2 erms invpcid rtm rdseed adx smap xsaveopt arat md_clear arch_capabilities" Hypervisor vendor="KVM" L1d cache="32 KiB (1 instance)" L1i cache="32 KiB (1 instance)" L2 cache="256 KiB (1 instance)" L3 cache="55 MiB (1 instance)" Model="79" Model name="Intel(R) Xeon(R) CPU @ 2.20GHz" NUMA node(s)="1" NUMA node0 CPU(s)="0,1" On-line CPU(s) list="0,1" Socket(s)="1" Stepping="0" Thread(s) per core="2" Vendor ID="GenuineIntel" Virtualization type="full" Vulnerability Gather data sampling="Not affected" Vulnerability Itlb multihit="Not affected" Vulnerability L1tf="Mitigation; PTE Inversion" Vulnerability Mds="Mitigation; Clear CPU buffers; SMT Host state unknown" Vulnerability Meltdown="Mitigation; PTI" Vulnerability Mmio stale data="Vulnerable: Clear CPU buffers attempted, no microcode; SMT Host state unknown" Vulnerability Reg file data sampling="Not affected" Vulnerability Retbleed="Mitigation; IBRS" Vulnerability Spec rstack overflow="Not affected" Vulnerability Spec store bypass="Mitigation; Speculative Store Bypass disabled via prctl" Vulnerability Spectre v1="Mitigation; usercopy/swapgs barriers and __user pointer sanitization" Vulnerability Spectre v2="Mitigation; IBRS; IBPB conditional; STIBP conditional; RSB filling; PBRSB-eIBRS Not affected; BHI SW loop, KVM SW loop" Vulnerability Srbds="Not affected" Vulnerability Tsx async abort="Mitigation; Clear CPU buffers; SMT Host state unknown" node_name="pkb-5df88af7-1" vm_1_gce_nic_type="['GVNIC']" vm_2_gce_nic_type="['GVNIC']")
  proccpu                               0.000000                                (address sizes="46 bits physical, 48 bits virtual" bogomips="4400.36" bugs="bhi cpu_meltdown l1tf mds mmio_stale_data retbleed spec_store_bypass spectre_v1 spectre_v2 swapgs taa" cache size="56320 KB" cache_alignment="64" clflush size="64" cpu MHz="2200.184" cpu cores="1" cpu family="6" cpuid level="13" flags="3dnowprefetch abm adx aes apic arat arch_capabilities avx avx2 bmi1 bmi2 clflush cmov constant_tsc cpuid cx16 cx8 de erms f16c fma fpu fsgsbase fxsr hle ht hypervisor ibpb ibrs invpcid lahf_lm lm mca mce md_clear mmx movbe msr mtrr nonstop_tsc nopl nx pae pat pcid pclmulqdq pdpe1gb pge pni popcnt pse pse36 pti rdrand rdseed rdtscp rep_good rtm sep smap smep ss ssbd sse sse2 sse4_1 sse4_2 ssse3 stibp syscall tsc tsc_adjust tsc_known_freq vme x2apic xsave xsaveopt xtopology" fpu="yes" fpu_exception="yes" microcode="0xffffffff" model="79" model name="Intel(R) Xeon(R) CPU @ 2.20GHz" node_name="pkb-5df88af7-0" power management="" proccpu="address sizes,bogomips,bugs,cache size,cache_alignment,clflush size,cpu MHz,cpu cores,cpu family,cpuid level,flags,fpu,fpu_exception,microcode,model,model name,power management,siblings,stepping,vendor_id,wp" siblings="2" stepping="0" vendor_id="GenuineIntel" vm_1_gce_nic_type="['GVNIC']" vm_2_gce_nic_type="['GVNIC']" wp="yes")
  proccpu_mapping                       0.000000                                (node_name="pkb-5df88af7-0" proc_0="apicid=0;core id=0;initial apicid=0;physical id=0" proc_1="apicid=1;core id=0;initial apicid=1;physical id=0" vm_1_gce_nic_type="['GVNIC']" vm_2_gce_nic_type="['GVNIC']")
  proccpu                               0.000000                                (address sizes="46 bits physical, 48 bits virtual" bogomips="4400.49" bugs="bhi cpu_meltdown l1tf mds mmio_stale_data retbleed spec_store_bypass spectre_v1 spectre_v2 swapgs taa" cache size="56320 KB" cache_alignment="64" clflush size="64" cpu MHz="2200.248" cpu cores="1" cpu family="6" cpuid level="13" flags="3dnowprefetch abm adx aes apic arat arch_capabilities avx avx2 bmi1 bmi2 clflush cmov constant_tsc cpuid cx16 cx8 de erms f16c fma fpu fsgsbase fxsr hle ht hypervisor ibpb ibrs invpcid lahf_lm lm mca mce md_clear mmx movbe msr mtrr nonstop_tsc nopl nx pae pat pcid pclmulqdq pdpe1gb pge pni popcnt pse pse36 pti rdrand rdseed rdtscp rep_good rtm sep smap smep ss ssbd sse sse2 sse4_1 sse4_2 ssse3 stibp syscall tsc tsc_adjust tsc_known_freq vme x2apic xsave xsaveopt xtopology" fpu="yes" fpu_exception="yes" microcode="0xffffffff" model="79" model name="Intel(R) Xeon(R) CPU @ 2.20GHz" node_name="pkb-5df88af7-1" power management="" proccpu="address sizes,bogomips,bugs,cache size,cache_alignment,clflush size,cpu MHz,cpu cores,cpu family,cpuid level,flags,fpu,fpu_exception,microcode,model,model name,power management,siblings,stepping,vendor_id,wp" siblings="2" stepping="0" vendor_id="GenuineIntel" vm_1_gce_nic_type="['GVNIC']" vm_2_gce_nic_type="['GVNIC']" wp="yes")
  proccpu_mapping                       0.000000                                (node_name="pkb-5df88af7-1" proc_0="apicid=0;core id=0;initial apicid=0;physical id=0" proc_1="apicid=1;core id=0;initial apicid=1;physical id=0" vm_1_gce_nic_type="['GVNIC']" vm_2_gce_nic_type="['GVNIC']")
  cpu_vuln                              0.000000                                (mitigation_l1tf="PTE Inversion" mitigation_mds="Clear CPU buffers; SMT Host state unknown" mitigation_meltdown="PTI" mitigation_retbleed="IBRS" mitigation_spec_store_bypass="Speculative Store Bypass disabled via prctl" mitigation_spectre_v1="usercopy/swapgs barriers and __user pointer sanitization" mitigation_spectre_v2="IBRS; IBPB: conditional; STIBP: conditional; RSB filling; PBRSB-eIBRS: Not affected; BHI: SW loop, KVM: SW loop" mitigation_tsx_async_abort="Clear CPU buffers; SMT Host state unknown" mitigations="l1tf,mds,meltdown,retbleed,spec_store_bypass,spectre_v1,spectre_v2,tsx_async_abort" notaffecteds="gather_data_sampling,itlb_multihit,reg_file_data_sampling,spec_rstack_overflow,srbds" vm_1_gce_nic_type="['GVNIC']" vm_2_gce_nic_type="['GVNIC']" vm_name="pkb-5df88af7-0" vulnerabilities="mmio_stale_data" vulnerability_mmio_stale_data="Clear CPU buffers attempted, no microcode; SMT Host state unknown")
  cpu_vuln                              0.000000                                (mitigation_l1tf="PTE Inversion" mitigation_mds="Clear CPU buffers; SMT Host state unknown" mitigation_meltdown="PTI" mitigation_retbleed="IBRS" mitigation_spec_store_bypass="Speculative Store Bypass disabled via prctl" mitigation_spectre_v1="usercopy/swapgs barriers and __user pointer sanitization" mitigation_spectre_v2="IBRS; IBPB: conditional; STIBP: conditional; RSB filling; PBRSB-eIBRS: Not affected; BHI: SW loop, KVM: SW loop" mitigation_tsx_async_abort="Clear CPU buffers; SMT Host state unknown" mitigations="l1tf,mds,meltdown,retbleed,spec_store_bypass,spectre_v1,spectre_v2,tsx_async_abort" notaffecteds="gather_data_sampling,itlb_multihit,reg_file_data_sampling,spec_rstack_overflow,srbds" vm_1_gce_nic_type="['GVNIC']" vm_2_gce_nic_type="['GVNIC']" vm_name="pkb-5df88af7-1" vulnerabilities="mmio_stale_data" vulnerability_mmio_stale_data="Clear CPU buffers attempted, no microcode; SMT Host state unknown")
  gcc_version                           0.000000                                (name="pkb-5df88af7-0" versiondump="" versioninfo="None" vm_1_gce_nic_type="['GVNIC']" vm_2_gce_nic_type="['GVNIC']")
  gcc_version                           0.000000                                (name="pkb-5df88af7-1" versiondump="" versioninfo="None" vm_1_gce_nic_type="['GVNIC']" vm_2_gce_nic_type="['GVNIC']")
  glibc_version                         0.000000                                (name="pkb-5df88af7-0" versioninfo="ldd (Ubuntu GLIBC 2.39-0ubuntu8.3) 2.39" vm_1_gce_nic_type="['GVNIC']" vm_2_gce_nic_type="['GVNIC']")
  glibc_version                         0.000000                                (name="pkb-5df88af7-1" versioninfo="ldd (Ubuntu GLIBC 2.39-0ubuntu8.3) 2.39" vm_1_gce_nic_type="['GVNIC']" vm_2_gce_nic_type="['GVNIC']")
  End to End Runtime                  453.342871 seconds                        (vm_1_gce_nic_type="['GVNIC']" vm_2_gce_nic_type="['GVNIC']")

-------------------------
For all tests: perfkitbenchmarker_version="v1.12.0-4864-g4320a71f" vm_1_/dev/loop0="67080192" vm_1_/dev/loop1="391553024" vm_1_/dev/loop2="40714240" vm_1_/dev/sda="10737418240" vm_1_/dev/sdb="5368709120" vm_1_automatic_restart="False" vm_1_boot_disk_size="10" vm_1_boot_disk_type="pd-balanced" vm_1_cloud="GCP" vm_1_cpu_arch="x86_64" vm_1_cpu_version="GenuineIntel_6_79_0" vm_1_data_disk_0_fstab_options="defaults" vm_1_data_disk_0_media="ssd" vm_1_data_disk_0_mount_options="discard" vm_1_data_disk_0_num_stripes="1" vm_1_data_disk_0_replication="zone" vm_1_data_disk_0_size="5" vm_1_data_disk_0_type="pd-ssd" vm_1_data_disk_count="1" vm_1_dedicated_host="False" vm_1_disk_filesystem_blocksize="4096" vm_1_disk_filesystem_type="ext4" vm_1_gce_network_name="pkb-network-5df88af7" vm_1_gce_network_tier="premium" vm_1_gce_shielded_secure_boot="False" vm_1_gce_subnet_name="" vm_1_image="ubuntu-2404-noble-amd64-v20241004" vm_1_image_family="ubuntu-2404-lts-amd64" vm_1_image_project="ubuntu-os-cloud" vm_1_kernel_release="6.8.0-1015-gcp" vm_1_machine_type="e2-micro" vm_1_mtu="1460" vm_1_num_cpus="2" vm_1_numa_node_count="1" vm_1_os_info="Ubuntu 24.04.1 LTS" vm_1_os_type="ubuntu2404" vm_1_placement_group_style="none" vm_1_project="ghc-perfkit" vm_1_tcp_congestion_control="cubic" vm_1_threads_per_core="2" vm_1_vm_count="1" vm_1_vm_ids="7838006806519295158" vm_1_vm_ip_addresses="35.232.201.29" vm_1_vm_names="pkb-5df88af7-0" vm_1_zone="us-central1-a" vm_2_/dev/loop0="67080192" vm_2_/dev/loop1="391553024" vm_2_/dev/loop2="40714240" vm_2_/dev/sda="10737418240" vm_2_/dev/sdb="5368709120" vm_2_automatic_restart="False" vm_2_boot_disk_size="10" vm_2_boot_disk_type="pd-balanced" vm_2_cloud="GCP" vm_2_cpu_arch="x86_64" vm_2_cpu_version="GenuineIntel_6_79_0" vm_2_data_disk_0_fstab_options="defaults" vm_2_data_disk_0_media="ssd" vm_2_data_disk_0_mount_options="discard" vm_2_data_disk_0_num_stripes="1" vm_2_data_disk_0_replication="zone" vm_2_data_disk_0_size="5" vm_2_data_disk_0_type="pd-ssd" vm_2_data_disk_count="1" vm_2_dedicated_host="False" vm_2_disk_filesystem_blocksize="4096" vm_2_disk_filesystem_type="ext4" vm_2_gce_network_name="pkb-network-5df88af7" vm_2_gce_network_tier="premium" vm_2_gce_shielded_secure_boot="False" vm_2_gce_subnet_name="" vm_2_image="ubuntu-2404-noble-amd64-v20241004" vm_2_image_family="ubuntu-2404-lts-amd64" vm_2_image_project="ubuntu-os-cloud" vm_2_kernel_release="6.8.0-1015-gcp" vm_2_machine_type="e2-micro" vm_2_mtu="1460" vm_2_num_cpus="2" vm_2_numa_node_count="1" vm_2_os_info="Ubuntu 24.04.1 LTS" vm_2_os_type="ubuntu2404" vm_2_placement_group_style="none" vm_2_project="ghc-perfkit" vm_2_tcp_congestion_control="cubic" vm_2_threads_per_core="2" vm_2_vm_count="1" vm_2_vm_ids="4144752862341967030" vm_2_vm_ip_addresses="34.170.109.125" vm_2_vm_names="pkb-5df88af7-1" vm_2_zone="us-central1-a" vm_ids="7838006806519295158,4144752862341967030" vm_ip_addresses="35.232.201.29,34.170.109.125" vm_names="pkb-5df88af7-0,pkb-5df88af7-1"
2024-10-05 01:18:26,506 5df88af7 MainThread INFO     Benchmark run statuses:
---------------------------------------
Name  UID   Status     Failed Substatus
---------------------------------------
scp   scp0  SUCCEEDED                  
---------------------------------------
```

- `./pkb.py --benchmarks=scp --machine_type=e2-micro --data_disk_type=pd-ssd --data_disk_size=20 --scp_file_size_gb=8`

```
-------------------------PerfKitBenchmarker Results Summary-------------------------
SCP:
  SCP_Transfer_Time_VM1_to_VM2        615.115628 seconds                        (file_size_gb="8" run_number="0" vm1_machine_type="e2-micro" vm1_zone="us-central1-a" vm2_machine_type="e2-micro" vm2_zone="us-central1-a" vm_1_gce_nic_type="['GVNIC']" vm_2_gce_nic_type="['GVNIC']")
  SCP_Transfer_Time_VM2_to_VM1        554.013225 seconds                        (file_size_gb="8" run_number="0" vm1_machine_type="e2-micro" vm1_zone="us-central1-a" vm2_machine_type="e2-micro" vm2_zone="us-central1-a" vm_1_gce_nic_type="['GVNIC']" vm_2_gce_nic_type="['GVNIC']")
  lscpu                                 0.000000                                (Address sizes="46 bits physical, 48 bits virtual" Architecture="x86_64" BogoMIPS="4400.40" Byte Order="Little Endian" CPU family="6" CPU op-mode(s)="32-bit, 64-bit" CPU(s)="2" Core(s) per socket="1" Flags="fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss ht syscall nx pdpe1gb rdtscp lm constant_tsc rep_good nopl xtopology nonstop_tsc cpuid tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 x2apic movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm abm 3dnowprefetch pti ssbd ibrs ibpb stibp fsgsbase tsc_adjust bmi1 hle avx2 smep bmi2 erms invpcid rtm rdseed adx smap xsaveopt arat md_clear arch_capabilities" Hypervisor vendor="KVM" L1d cache="32 KiB (1 instance)" L1i cache="32 KiB (1 instance)" L2 cache="256 KiB (1 instance)" L3 cache="55 MiB (1 instance)" Model="79" Model name="Intel(R) Xeon(R) CPU @ 2.20GHz" NUMA node(s)="1" NUMA node0 CPU(s)="0,1" On-line CPU(s) list="0,1" Socket(s)="1" Stepping="0" Thread(s) per core="2" Vendor ID="GenuineIntel" Virtualization type="full" Vulnerability Gather data sampling="Not affected" Vulnerability Itlb multihit="Not affected" Vulnerability L1tf="Mitigation; PTE Inversion" Vulnerability Mds="Mitigation; Clear CPU buffers; SMT Host state unknown" Vulnerability Meltdown="Mitigation; PTI" Vulnerability Mmio stale data="Vulnerable: Clear CPU buffers attempted, no microcode; SMT Host state unknown" Vulnerability Reg file data sampling="Not affected" Vulnerability Retbleed="Mitigation; IBRS" Vulnerability Spec rstack overflow="Not affected" Vulnerability Spec store bypass="Mitigation; Speculative Store Bypass disabled via prctl" Vulnerability Spectre v1="Mitigation; usercopy/swapgs barriers and __user pointer sanitization" Vulnerability Spectre v2="Mitigation; IBRS; IBPB conditional; STIBP conditional; RSB filling; PBRSB-eIBRS Not affected; BHI SW loop, KVM SW loop" Vulnerability Srbds="Not affected" Vulnerability Tsx async abort="Mitigation; Clear CPU buffers; SMT Host state unknown" node_name="pkb-24ddb2dc-0" vm_1_gce_nic_type="['GVNIC']" vm_2_gce_nic_type="['GVNIC']")
  lscpu                                 0.000000                                (Address sizes="46 bits physical, 48 bits virtual" Architecture="x86_64" BogoMIPS="4400.39" Byte Order="Little Endian" CPU family="6" CPU op-mode(s)="32-bit, 64-bit" CPU(s)="2" Core(s) per socket="1" Flags="fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss ht syscall nx pdpe1gb rdtscp lm constant_tsc rep_good nopl xtopology nonstop_tsc cpuid tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 x2apic movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm abm 3dnowprefetch pti ssbd ibrs ibpb stibp fsgsbase tsc_adjust bmi1 hle avx2 smep bmi2 erms invpcid rtm rdseed adx smap xsaveopt arat md_clear arch_capabilities" Hypervisor vendor="KVM" L1d cache="32 KiB (1 instance)" L1i cache="32 KiB (1 instance)" L2 cache="256 KiB (1 instance)" L3 cache="55 MiB (1 instance)" Model="79" Model name="Intel(R) Xeon(R) CPU @ 2.20GHz" NUMA node(s)="1" NUMA node0 CPU(s)="0,1" On-line CPU(s) list="0,1" Socket(s)="1" Stepping="0" Thread(s) per core="2" Vendor ID="GenuineIntel" Virtualization type="full" Vulnerability Gather data sampling="Not affected" Vulnerability Itlb multihit="Not affected" Vulnerability L1tf="Mitigation; PTE Inversion" Vulnerability Mds="Mitigation; Clear CPU buffers; SMT Host state unknown" Vulnerability Meltdown="Mitigation; PTI" Vulnerability Mmio stale data="Vulnerable: Clear CPU buffers attempted, no microcode; SMT Host state unknown" Vulnerability Reg file data sampling="Not affected" Vulnerability Retbleed="Mitigation; IBRS" Vulnerability Spec rstack overflow="Not affected" Vulnerability Spec store bypass="Mitigation; Speculative Store Bypass disabled via prctl" Vulnerability Spectre v1="Mitigation; usercopy/swapgs barriers and __user pointer sanitization" Vulnerability Spectre v2="Mitigation; IBRS; IBPB conditional; STIBP conditional; RSB filling; PBRSB-eIBRS Not affected; BHI SW loop, KVM SW loop" Vulnerability Srbds="Not affected" Vulnerability Tsx async abort="Mitigation; Clear CPU buffers; SMT Host state unknown" node_name="pkb-24ddb2dc-1" vm_1_gce_nic_type="['GVNIC']" vm_2_gce_nic_type="['GVNIC']")
  proccpu                               0.000000                                (address sizes="46 bits physical, 48 bits virtual" bogomips="4400.40" bugs="bhi cpu_meltdown l1tf mds mmio_stale_data retbleed spec_store_bypass spectre_v1 spectre_v2 swapgs taa" cache size="56320 KB" cache_alignment="64" clflush size="64" cpu MHz="2200.204" cpu cores="1" cpu family="6" cpuid level="13" flags="3dnowprefetch abm adx aes apic arat arch_capabilities avx avx2 bmi1 bmi2 clflush cmov constant_tsc cpuid cx16 cx8 de erms f16c fma fpu fsgsbase fxsr hle ht hypervisor ibpb ibrs invpcid lahf_lm lm mca mce md_clear mmx movbe msr mtrr nonstop_tsc nopl nx pae pat pcid pclmulqdq pdpe1gb pge pni popcnt pse pse36 pti rdrand rdseed rdtscp rep_good rtm sep smap smep ss ssbd sse sse2 sse4_1 sse4_2 ssse3 stibp syscall tsc tsc_adjust tsc_known_freq vme x2apic xsave xsaveopt xtopology" fpu="yes" fpu_exception="yes" microcode="0xffffffff" model="79" model name="Intel(R) Xeon(R) CPU @ 2.20GHz" node_name="pkb-24ddb2dc-0" power management="" proccpu="address sizes,bogomips,bugs,cache size,cache_alignment,clflush size,cpu MHz,cpu cores,cpu family,cpuid level,flags,fpu,fpu_exception,microcode,model,model name,power management,siblings,stepping,vendor_id,wp" siblings="2" stepping="0" vendor_id="GenuineIntel" vm_1_gce_nic_type="['GVNIC']" vm_2_gce_nic_type="['GVNIC']" wp="yes")
  proccpu_mapping                       0.000000                                (node_name="pkb-24ddb2dc-0" proc_0="apicid=0;core id=0;initial apicid=0;physical id=0" proc_1="apicid=1;core id=0;initial apicid=1;physical id=0" vm_1_gce_nic_type="['GVNIC']" vm_2_gce_nic_type="['GVNIC']")
  proccpu                               0.000000                                (address sizes="46 bits physical, 48 bits virtual" bogomips="4400.39" bugs="bhi cpu_meltdown l1tf mds mmio_stale_data retbleed spec_store_bypass spectre_v1 spectre_v2 swapgs taa" cache size="56320 KB" cache_alignment="64" clflush size="64" cpu MHz="2200.198" cpu cores="1" cpu family="6" cpuid level="13" flags="3dnowprefetch abm adx aes apic arat arch_capabilities avx avx2 bmi1 bmi2 clflush cmov constant_tsc cpuid cx16 cx8 de erms f16c fma fpu fsgsbase fxsr hle ht hypervisor ibpb ibrs invpcid lahf_lm lm mca mce md_clear mmx movbe msr mtrr nonstop_tsc nopl nx pae pat pcid pclmulqdq pdpe1gb pge pni popcnt pse pse36 pti rdrand rdseed rdtscp rep_good rtm sep smap smep ss ssbd sse sse2 sse4_1 sse4_2 ssse3 stibp syscall tsc tsc_adjust tsc_known_freq vme x2apic xsave xsaveopt xtopology" fpu="yes" fpu_exception="yes" microcode="0xffffffff" model="79" model name="Intel(R) Xeon(R) CPU @ 2.20GHz" node_name="pkb-24ddb2dc-1" power management="" proccpu="address sizes,bogomips,bugs,cache size,cache_alignment,clflush size,cpu MHz,cpu cores,cpu family,cpuid level,flags,fpu,fpu_exception,microcode,model,model name,power management,siblings,stepping,vendor_id,wp" siblings="2" stepping="0" vendor_id="GenuineIntel" vm_1_gce_nic_type="['GVNIC']" vm_2_gce_nic_type="['GVNIC']" wp="yes")
  proccpu_mapping                       0.000000                                (node_name="pkb-24ddb2dc-1" proc_0="apicid=0;core id=0;initial apicid=0;physical id=0" proc_1="apicid=1;core id=0;initial apicid=1;physical id=0" vm_1_gce_nic_type="['GVNIC']" vm_2_gce_nic_type="['GVNIC']")
  cpu_vuln                              0.000000                                (mitigation_l1tf="PTE Inversion" mitigation_mds="Clear CPU buffers; SMT Host state unknown" mitigation_meltdown="PTI" mitigation_retbleed="IBRS" mitigation_spec_store_bypass="Speculative Store Bypass disabled via prctl" mitigation_spectre_v1="usercopy/swapgs barriers and __user pointer sanitization" mitigation_spectre_v2="IBRS; IBPB: conditional; STIBP: conditional; RSB filling; PBRSB-eIBRS: Not affected; BHI: SW loop, KVM: SW loop" mitigation_tsx_async_abort="Clear CPU buffers; SMT Host state unknown" mitigations="l1tf,mds,meltdown,retbleed,spec_store_bypass,spectre_v1,spectre_v2,tsx_async_abort" notaffecteds="gather_data_sampling,itlb_multihit,reg_file_data_sampling,spec_rstack_overflow,srbds" vm_1_gce_nic_type="['GVNIC']" vm_2_gce_nic_type="['GVNIC']" vm_name="pkb-24ddb2dc-0" vulnerabilities="mmio_stale_data" vulnerability_mmio_stale_data="Clear CPU buffers attempted, no microcode; SMT Host state unknown")
  cpu_vuln                              0.000000                                (mitigation_l1tf="PTE Inversion" mitigation_mds="Clear CPU buffers; SMT Host state unknown" mitigation_meltdown="PTI" mitigation_retbleed="IBRS" mitigation_spec_store_bypass="Speculative Store Bypass disabled via prctl" mitigation_spectre_v1="usercopy/swapgs barriers and __user pointer sanitization" mitigation_spectre_v2="IBRS; IBPB: conditional; STIBP: conditional; RSB filling; PBRSB-eIBRS: Not affected; BHI: SW loop, KVM: SW loop" mitigation_tsx_async_abort="Clear CPU buffers; SMT Host state unknown" mitigations="l1tf,mds,meltdown,retbleed,spec_store_bypass,spectre_v1,spectre_v2,tsx_async_abort" notaffecteds="gather_data_sampling,itlb_multihit,reg_file_data_sampling,spec_rstack_overflow,srbds" vm_1_gce_nic_type="['GVNIC']" vm_2_gce_nic_type="['GVNIC']" vm_name="pkb-24ddb2dc-1" vulnerabilities="mmio_stale_data" vulnerability_mmio_stale_data="Clear CPU buffers attempted, no microcode; SMT Host state unknown")
  gcc_version                           0.000000                                (name="pkb-24ddb2dc-0" versiondump="" versioninfo="None" vm_1_gce_nic_type="['GVNIC']" vm_2_gce_nic_type="['GVNIC']")
  gcc_version                           0.000000                                (name="pkb-24ddb2dc-1" versiondump="" versioninfo="None" vm_1_gce_nic_type="['GVNIC']" vm_2_gce_nic_type="['GVNIC']")
  glibc_version                         0.000000                                (name="pkb-24ddb2dc-0" versioninfo="ldd (Ubuntu GLIBC 2.39-0ubuntu8.3) 2.39" vm_1_gce_nic_type="['GVNIC']" vm_2_gce_nic_type="['GVNIC']")
  glibc_version                         0.000000                                (name="pkb-24ddb2dc-1" versioninfo="ldd (Ubuntu GLIBC 2.39-0ubuntu8.3) 2.39" vm_1_gce_nic_type="['GVNIC']" vm_2_gce_nic_type="['GVNIC']")
  End to End Runtime                 1237.515663 seconds                        (vm_1_gce_nic_type="['GVNIC']" vm_2_gce_nic_type="['GVNIC']")

-------------------------
For all tests: perfkitbenchmarker_version="v1.12.0-4864-g4320a71f" vm_1_/dev/loop0="67080192" vm_1_/dev/loop1="391553024" vm_1_/dev/loop2="40714240" vm_1_/dev/sda="10737418240" vm_1_/dev/sdb="21474836480" vm_1_automatic_restart="False" vm_1_boot_disk_size="10" vm_1_boot_disk_type="pd-balanced" vm_1_cloud="GCP" vm_1_cpu_arch="x86_64" vm_1_cpu_version="GenuineIntel_6_79_0" vm_1_data_disk_0_fstab_options="defaults" vm_1_data_disk_0_media="ssd" vm_1_data_disk_0_mount_options="discard" vm_1_data_disk_0_num_stripes="1" vm_1_data_disk_0_replication="zone" vm_1_data_disk_0_size="20" vm_1_data_disk_0_type="pd-ssd" vm_1_data_disk_count="1" vm_1_dedicated_host="False" vm_1_disk_filesystem_blocksize="4096" vm_1_disk_filesystem_type="ext4" vm_1_gce_network_name="pkb-network-24ddb2dc" vm_1_gce_network_tier="premium" vm_1_gce_shielded_secure_boot="False" vm_1_gce_subnet_name="" vm_1_image="ubuntu-2404-noble-amd64-v20241004" vm_1_image_family="ubuntu-2404-lts-amd64" vm_1_image_project="ubuntu-os-cloud" vm_1_kernel_release="6.8.0-1015-gcp" vm_1_machine_type="e2-micro" vm_1_mtu="1460" vm_1_num_cpus="2" vm_1_numa_node_count="1" vm_1_os_info="Ubuntu 24.04.1 LTS" vm_1_os_type="ubuntu2404" vm_1_placement_group_style="none" vm_1_project="ghc-perfkit" vm_1_tcp_congestion_control="cubic" vm_1_threads_per_core="2" vm_1_vm_count="1" vm_1_vm_ids="501754407804548257" vm_1_vm_ip_addresses="34.28.163.98" vm_1_vm_names="pkb-24ddb2dc-0" vm_1_zone="us-central1-a" vm_2_/dev/loop0="67080192" vm_2_/dev/loop1="391553024" vm_2_/dev/loop2="40714240" vm_2_/dev/sda="10737418240" vm_2_/dev/sdb="21474836480" vm_2_automatic_restart="False" vm_2_boot_disk_size="10" vm_2_boot_disk_type="pd-balanced" vm_2_cloud="GCP" vm_2_cpu_arch="x86_64" vm_2_cpu_version="GenuineIntel_6_79_0" vm_2_data_disk_0_fstab_options="defaults" vm_2_data_disk_0_media="ssd" vm_2_data_disk_0_mount_options="discard" vm_2_data_disk_0_num_stripes="1" vm_2_data_disk_0_replication="zone" vm_2_data_disk_0_size="20" vm_2_data_disk_0_type="pd-ssd" vm_2_data_disk_count="1" vm_2_dedicated_host="False" vm_2_disk_filesystem_blocksize="4096" vm_2_disk_filesystem_type="ext4" vm_2_gce_network_name="pkb-network-24ddb2dc" vm_2_gce_network_tier="premium" vm_2_gce_shielded_secure_boot="False" vm_2_gce_subnet_name="" vm_2_image="ubuntu-2404-noble-amd64-v20241004" vm_2_image_family="ubuntu-2404-lts-amd64" vm_2_image_project="ubuntu-os-cloud" vm_2_kernel_release="6.8.0-1015-gcp" vm_2_machine_type="e2-micro" vm_2_mtu="1460" vm_2_num_cpus="2" vm_2_numa_node_count="1" vm_2_os_info="Ubuntu 24.04.1 LTS" vm_2_os_type="ubuntu2404" vm_2_placement_group_style="none" vm_2_project="ghc-perfkit" vm_2_tcp_congestion_control="cubic" vm_2_threads_per_core="2" vm_2_vm_count="1" vm_2_vm_ids="6176868509040850081" vm_2_vm_ip_addresses="34.31.17.105" vm_2_vm_names="pkb-24ddb2dc-1" vm_2_zone="us-central1-a" vm_ids="501754407804548257,6176868509040850081" vm_ip_addresses="34.28.163.98,34.31.17.105" vm_names="pkb-24ddb2dc-0,pkb-24ddb2dc-1"
2024-10-05 00:57:15,328 24ddb2dc MainThread INFO     Benchmark run statuses:
---------------------------------------
Name  UID   Status     Failed Substatus
---------------------------------------
scp   scp0  SUCCEEDED                  
---------------------------------------
```

### Pending Items:
- Further testing with different configurations. (I didn't test with many different configs given the quota limit. There might be some corner cases uncovered.)
- Implement the Windows counterpart of the SCP benchmark.
   - Install and configure WinSCP on Windows VMs, and adjust the SCP commands accordingly.

---

Seeking feedback! & Thanks again for your helpful guidance on the GHC open source day!