### PR TITLE
type annotations added for aerospike_benchmark.py

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/aerospike_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/aerospike_benchmark.py
@@ -187,7 +187,7 @@ aerospike:
 
 
 def GetConfig(user_config : Dict[str, Any] )  -> Dict[str, Any]:
-  config  = configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
+  config = configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
   if FLAGS.aerospike_storage_type == aerospike_server.DISK:
     config['vm_groups']['workers']['disk_count'] = 1
     if FLAGS.data_disk_type == disk.LOCAL:

--- a/perfkitbenchmarker/linux_benchmarks/aerospike_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/aerospike_benchmark.py
@@ -23,12 +23,14 @@ by the "aerospike_storage_type" and "data_disk_type" flags.
 """
 
 import functools
-
+from typing import Any, Dict, List
 from absl import flags
 from perfkitbenchmarker import background_tasks
+from perfkitbenchmarker import benchmark_spec
 from perfkitbenchmarker import configs
 from perfkitbenchmarker import disk
 from perfkitbenchmarker import errors
+from perfkitbenchmarker import sample
 from perfkitbenchmarker import vm_util
 from perfkitbenchmarker.linux_packages import aerospike_client
 from perfkitbenchmarker.linux_packages import aerospike_server
@@ -184,8 +186,8 @@ aerospike:
 """
 
 
-def GetConfig(user_config):
-  config = configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
+def GetConfig(user_config : Dict[str, Any] )  -> Dict[str, Any]:
+  config  = configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
   if FLAGS.aerospike_storage_type == aerospike_server.DISK:
     config['vm_groups']['workers']['disk_count'] = 1
     if FLAGS.data_disk_type == disk.LOCAL:
@@ -227,7 +229,7 @@ def GetConfig(user_config):
   return config
 
 
-def Prepare(benchmark_spec):
+def Prepare(benchmark_spec: benchmark_spec.BenchmarkSpec) -> None:
   """Install Aerospike server and Aerospike tools on the other.
 
   Args:
@@ -301,7 +303,7 @@ def Prepare(benchmark_spec):
   background_tasks.RunThreaded(_Load, run_params)
 
 
-def Run(benchmark_spec):
+def Run(benchmark_spec: benchmark_spec.BenchmarkSpec) -> List[sample.Sample]:
   """Runs a read/update load test on Aerospike.
 
   Args:
@@ -425,7 +427,7 @@ def Run(benchmark_spec):
   return samples
 
 
-def Cleanup(benchmark_spec):
+def Cleanup(benchmark_spec: benchmark_spec.BenchmarkSpec) -> None:
   """Cleanup Aerospike.
 
   Args:

--- a/perfkitbenchmarker/linux_benchmarks/aerospike_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/aerospike_benchmark.py
@@ -186,7 +186,7 @@ aerospike:
 """
 
 
-def GetConfig(user_config : Dict[str, Any] )  -> Dict[str, Any]:
+def GetConfig(user_config: Dict[str, Any]) -> Dict[str, Any]:
   config = configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
   if FLAGS.aerospike_storage_type == aerospike_server.DISK:
     config['vm_groups']['workers']['disk_count'] = 1
@@ -241,9 +241,7 @@ def Prepare(benchmark_spec: benchmark_spec.BenchmarkSpec) -> None:
   servers = benchmark_spec.vm_groups['workers']
   # VMs where the server is not up yet.
   servers_not_up = [
-      server
-      for server in servers
-      if not aerospike_server.IsServerUp(server)
+      server for server in servers if not aerospike_server.IsServerUp(server)
   ]
 
   seed_ips = [vm.internal_ip for vm in servers]
@@ -345,6 +343,7 @@ def Run(benchmark_spec: benchmark_spec.BenchmarkSpec) -> List[sample.Sample]:
       )
       stdout, _ = clients[client_idx].RobustRemoteCommand(run_command)
       stdout_samples.extend(aerospike_client.ParseAsbenchStdout(stdout))  # pylint: disable=cell-var-from-loop
+
     workload_types = FLAGS.aerospike_test_workload_types.split(';')
     extra_args = (
         FLAGS.aerospike_test_workload_extra_args

--- a/perfkitbenchmarker/linux_packages/openssl.py
+++ b/perfkitbenchmarker/linux_packages/openssl.py
@@ -24,3 +24,6 @@ def YumInstall(vm):
 def AptInstall(vm):
   """Installs OpenSSL on the VM."""
   vm.InstallPackages('openssl libssl-dev')
+
+def SafAptInstall(vm):
+  vm.remoteInstall

--- a/perfkitbenchmarker/linux_packages/openssl.py
+++ b/perfkitbenchmarker/linux_packages/openssl.py
@@ -24,6 +24,3 @@ def YumInstall(vm):
 def AptInstall(vm):
   """Installs OpenSSL on the VM."""
   vm.InstallPackages('openssl libssl-dev')
-
-def SafAptInstall(vm):
-  vm.remoteInstall


### PR DESCRIPTION
The following methods had their type annotations added

`GetConfig(user_config : Dict[str, Any] )  -> Dict[str, Any]` 
`Prepare(benchmark_spec: benchmark_spec.BenchmarkSpec) `
`Run(benchmark_spec: benchmark_spec.BenchmarkSpec) -> List[sample.Sample]`
`Cleanup(benchmark_spec: benchmark_spec.BenchmarkSpec) -> None`
