### PR TITLE
small fixes for GCP group-placement creation & intel repo installation

### DIFF
--- a/perfkitbenchmarker/linux_packages/intel_repo.py
+++ b/perfkitbenchmarker/linux_packages/intel_repo.py
@@ -100,10 +100,16 @@ def YumInstall(vm):
 
   # Disable GPG check as recommended by:
   # https://cloud.google.com/compute/docs/troubleshooting/known-issues#known_issues_for_linux_vm_instances
-  vm.RemoteCommand(
-      'sudo sed -i "s/repo_gpgcheck=1/repo_gpgcheck=0/g"'
-      ' /etc/yum.repos.d/intelproducts.repo'
-  )
+  if UseOneApi(): # account for different .repo when using OneAPI install
+    vm.RemoteCommand(
+        'sudo sed -i "s/repo_gpgcheck=1/repo_gpgcheck=0/g"'
+        ' /etc/yum.repos.d/oneAPI.repo'
+    )
+  else:
+    vm.RemoteCommand(
+        'sudo sed -i "s/repo_gpgcheck=1/repo_gpgcheck=0/g"'
+        ' /etc/yum.repos.d/intelproducts.repo'
+    )
   # the /etc/yum.repos.d/intelproducts.repo file has the gpgkey listed as the
   # _YUM_REPO_KEY, confirm that it is the same as our local copy
   vm.RemoteCommand(_YUM_DOWNLOAD_KEY_CMD)

--- a/perfkitbenchmarker/providers/gcp/gce_placement_group.py
+++ b/perfkitbenchmarker/providers/gcp/gce_placement_group.py
@@ -122,11 +122,21 @@ class GcePlacementGroup(placement_group.BasePlacementGroup):
         'group-placement',
         self.name,
     )
-    if (
-        self.style == CLUSTERED
-        or gcp_flags.GCE_PLACEMENT_GROUP_MAX_DISTANCE.value
-    ):
-      # Only alpha API supported for CLUSTERED and max-distance.
+    # alpha API for CLUSTERED
+    # beta API for max-distance
+    # https://cloud.google.com/sdk/gcloud/reference/alpha/compute/resource-policies/create/group-placement
+    # https://cloud.google.com/sdk/gcloud/reference/beta/compute/resource-policies/create/group-placement
+    if gcp_flags.GCE_PLACEMENT_GROUP_MAX_DISTANCE.value:
+      cmd = gcp_util.GcloudCommand(
+          self,
+          'beta',
+          'compute',
+          'resource-policies',
+          'create',
+          'group-placement',
+          self.name,
+      )
+    if self.style == CLUSTERED:
       cmd = gcp_util.GcloudCommand(
           self,
           'alpha',


### PR DESCRIPTION
## GCP group-placement bug

Currently, setting the `gce_placement_group_max_distance` flag with `placement_group_style=COLLOCATED`, as recommended in https://cloud.google.com/compute/docs/instances/use-compact-placement-policies#create-compact-policy, results in following error
```
perfkitbenchmarker.errors.Resource.CreationError: Failed to create placement group: ERROR: (gcloud.alpha.compute.resource-policies.create.group-placement) Could not fetch resource:
 - Required 'Alpha Access' permission for 'Compute API'
```
Current implementation uses alpha API creation command if `gce_placement_group_max_distance` flag is set when beta command can/should be used
https://cloud.google.com/sdk/gcloud/reference/alpha/compute/resource-policies/create/group-placement
https://cloud.google.com/sdk/gcloud/reference/beta/compute/resource-policies/create/group-placement

This change adds separate checks for when `gce_placement_group_max_distance` flag is set or `placement_group_style=CLUSTERED` and uses Alpha or Beta commands as appropriate

## Intel Repo bug

Currently, attempting to use a newer intelmpi_version, such as setting `intelmpi_version=2021.11.0`, results in following error
`STDOUT: STDERR: sed: can't read /etc/yum.repos.d/intelproducts.repo: No such file or directory`

Current implementation attempts to fix GPG related issue by disabling a GPG check. However, newer Intel Repo installations (2021.X.X+) use OneAPI, resulting in different .repo files

'regular' installation produces a intelproducts.repo
OneAPI installation produces a oneAPI.repo

This change checks if OneAPI was used, and disables the GPG check for the appropriate .repo file