### PR TITLE
logging fix

### DIFF
--- a/perfkitbenchmarker/configs/auto_registry.py
+++ b/perfkitbenchmarker/configs/auto_registry.py
@@ -54,7 +54,7 @@ def GetRegisteredClass(
         for (key, value) in registry.items()
         if key[0] == base_class.__name__
     }
-    logging.info(NO_SUBCLASS_DEFINED_ERROR, (base_class.__name__, kwargs))
+    logging.info(NO_SUBCLASS_DEFINED_ERROR, base_class.__name__, kwargs)
     logging.warning(
         'Did you mean one of these other classes that were registered for this '
         'base class? Possibilities: %s',


### PR DESCRIPTION
I think the tuple was erroneous because it lead to `TypeError: not enough arguments for format string` because the message string has two arguments.