### PR TITLE
Add new graviton4 instance

### DIFF
--- a/perfkitbenchmarker/providers/aws/aws_virtual_machine.py
+++ b/perfkitbenchmarker/providers/aws/aws_virtual_machine.py
@@ -131,6 +131,7 @@ _MACHINE_TYPE_PREFIX_TO_ARM_ARCH = {
     'im4g': 'graviton2',
     'is4ge': 'graviton2',
     'i4g': 'graviton2',
+    'i8g': 'graviton4',
     'x2g': 'graviton2',
     'x8g': 'graviton4',
     'hpc7g': 'graviton3E',

--- a/perfkitbenchmarker/providers/aws/aws_virtual_machine.py
+++ b/perfkitbenchmarker/providers/aws/aws_virtual_machine.py
@@ -118,13 +118,13 @@ _MACHINE_TYPE_PREFIX_TO_ARM_ARCH = {
     'a1': 'cortex-a72',
     'c6g': 'graviton2',
     'c7g': 'graviton3',
+    'c8g': 'graviton4',
     'g5g': 'graviton2',
     'm6g': 'graviton2',
     'm7g': 'graviton3',
+    'm8g': 'graviton4',
     'r6g': 'graviton2',
     'r7g': 'graviton3',
-    'm8g': 'graviton4',
-    'c8g': 'graviton4',
     'r8g': 'graviton4',
     'i8g': 'graviton4',
     't4g': 'graviton2',
@@ -132,6 +132,7 @@ _MACHINE_TYPE_PREFIX_TO_ARM_ARCH = {
     'is4ge': 'graviton2',
     'i4g': 'graviton2',
     'x2g': 'graviton2',
+    'x8g': 'graviton4',
     'hpc7g': 'graviton3E',
 }
 


### PR DESCRIPTION
This pull request includes updates to the `perfkitbenchmarker/providers/aws/aws_virtual_machine.py` file to add new AWS instance types and correct the ordering of existing ones.

Updates to AWS instance types:

* Added new AWS instance types `x8g`,`i8g`  with `graviton4` processors.
* Corrected the ordering of instance types to ensure `graviton4` processors are listed correctly.
* Ref) https://aws.amazon.com/ec2/instance-types/x8g/