### PR TITLE
 Fix incorrect subnet name from vpc GCP

### DIFF
--- a/perfkitbenchmarker/providers/gcp/gce_network.py
+++ b/perfkitbenchmarker/providers/gcp/gce_network.py
@@ -903,13 +903,21 @@ class GceNetwork(network.BaseNetwork):
     self.is_existing_network = True
     self.subnet_names = []
     self.primary_subnet_name = None
+    self.network_name = None
+    
+    # Determine the network name first
+    if gcp_flags.GCE_NETWORK_NAMES.value:
+      self.network_name = gcp_flags.GCE_NETWORK_NAMES.value[0]
+    else:
+      self.network_name = self._MakeGceNetworkName()
+      self.is_existing_network = False
+      
+    # Then handle subnet names
     if network_spec.subnet_names:
       self.subnet_names = network_spec.subnet_names
-    elif gcp_flags.GCE_NETWORK_NAMES.value:
-      self.subnet_names = gcp_flags.GCE_NETWORK_NAMES.value
-    else:
-      self.subnet_names = self._MakeGceNetworkName()
-      self.is_existing_network = False
+    elif not self.is_existing_network:
+      # If we're creating a new network, use the network name as subnet name by default
+      self.subnet_names = [self.network_name]
     if not isinstance(self.subnet_names, list):
       self.subnet_names = [self.subnet_names]
     self.primary_subnet_name = self.subnet_names[0]
@@ -918,28 +926,30 @@ class GceNetwork(network.BaseNetwork):
     self.subnet_resources = []
     mode = gcp_flags.GCE_NETWORK_TYPE.value
     self.subnet_resource = None
+    # Create network resources using network_name
     if not self.is_existing_network or mode == 'legacy':
-      for name in self.subnet_names:
-        self.network_resources.append(
-            GceNetworkResource(name, mode, self.project, self.mtu)
-        )
+      self.network_resources.append(
+          GceNetworkResource(self.network_name, mode, self.project, self.mtu)
+      )
+    
+    # Create subnet resources using subnet_names within the specified network
     if (self.is_existing_network and mode != 'legacy') or (mode == 'custom'):
       subnet_region = util.GetRegionFromZone(network_spec.zone)
       for name in self.subnet_names:
         self.subnet_resources.append(
             GceSubnetResource(
-                name, name, subnet_region, self.cidr, self.project
+                name, self.network_name, subnet_region, self.cidr, self.project
             )
         )
       self.subnet_resource = GceSubnetResource(
           self.primary_subnet_name,
-          self.primary_subnet_name,
+          self.network_name,
           subnet_region,
           self.cidr,
           self.project,
       )
     self.network_resource = GceNetworkResource(
-        self.primary_subnet_name, mode, self.project, self.mtu
+        self.network_name, mode, self.project, self.mtu
     )
     # Stage FW rules.
     self.all_nets = self._GetNetworksFromSpec(


### PR DESCRIPTION
This PR fixes an issue where subnet names were incorrectly using the network name instead of being properly configured separately.
 
## Changes made:
- Modified GceNetwork class to properly handle subnet names
- Ensured network name and subnet names are managed separately
- Fixed references to subnet resources to use the correct network name
 
This change ensures that when using GCP VPC networks with custom subnets, the subnet names are correctly configured and don't default to using the network name in all places.

Test command to reproduce and verify this fix
```
source ../../venv/bin/activate
cd $HOME/projects/PerfKitBenchmarker
export LOG_FOLDER=../pkb-logs
export MACHINE_TYPE=c4d-standard-4

python3 ./pkb.py \
  --benchmarks=nginx \
  --temp_dir=$LOG_FOLDER \
  --cloud=GCP \
  --project=your-gcp-proj1 \
  --zone=us-central1-a \
  --machine_type=$MACHINE_TYPE \
  --run_uri=standalone \
  --nginx_server_machine_type=$MACHINE_TYPE \
  --nginx_upstream_server_machine_type=$MACHINE_TYPE \
  --nginx_client_machine_type=$MACHINE_TYPE \
  --nginx_content_size=1024 \
  --nginx_load_configs="32:300:32:1000,512:300:512:1000" \
  --gce_network_name=your-custom-vpc \
  --gce_subnet_name=your-custom-subnet \
  --owner=owner-name \
  --accept_licenses