### PR TITLE
Attach an ACR to an existing AKS cluster

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/google/pyink
+    rev: 24.10.1
+    hooks:
+      - id: pyink
+        # It is recommended to specify the latest version of Python
+        # supported by your project here, or alternatively use
+        # pre-commit's default_language_version, see
+        # https://pre-commit.com/#top_level-default_language_version
+        language_version: python3.12
+        args: [--pyink-indentation=2]

--- a/perfkitbenchmarker/benchmark_spec.py
+++ b/perfkitbenchmarker/benchmark_spec.py
@@ -293,8 +293,9 @@ class BenchmarkSpec:
 
   def ConstructResources(self):
     """Constructs the resources for the benchmark."""
-    self.ConstructContainerCluster()
+    # Container Registry needs to go first, because it might be attched to cluster
     self.ConstructContainerRegistry()
+    self.ConstructContainerCluster()
     # dpb service needs to go first, because it adds some vms.
     self.ConstructDpbService()
     self.ConstructCluster()
@@ -325,6 +326,7 @@ class BenchmarkSpec:
     """Create the container cluster."""
     if self.config.container_cluster is None:
       return
+    self.SetContainerRegistry()
     cloud = self.config.container_cluster.cloud
     cluster_type = self.config.container_cluster.type
     providers.LoadProvider(cloud)
@@ -360,6 +362,16 @@ class BenchmarkSpec:
         self.config.container_registry
     )
     self.resources.append(self.container_registry)
+
+  def SetContainerRegistry(self):
+    """Sets the constructed container registry name."""
+
+    if self.container_registry:
+        self.container_registry_name = self.container_registry.name
+        logging.info('Container registry name: %s', self.container_registry_name)
+    else:
+        self.container_registry_name = None
+        logging.warning('No container registry constructed')
 
   def ConstructDpbService(self):
     """Create the dpb_service object and create groups for its vms."""

--- a/perfkitbenchmarker/benchmark_spec.py
+++ b/perfkitbenchmarker/benchmark_spec.py
@@ -326,7 +326,9 @@ class BenchmarkSpec:
     """Create the container cluster."""
     if self.config.container_cluster is None:
       return
-    self.SetContainerRegistry()
+    if self.config.container_cluster is None:
+        return
+
     cloud = self.config.container_cluster.cloud
     cluster_type = self.config.container_cluster.type
     providers.LoadProvider(cloud)
@@ -334,8 +336,10 @@ class BenchmarkSpec:
         cloud, cluster_type
     )
     self.container_cluster = container_cluster_class(
-        self.config.container_cluster
+        self.config.container_cluster,
+        self.container_registry
     )
+    self.resources.append(self.container_registry)
     self.resources.append(self.container_cluster)
 
   def ConstructCluster(self):
@@ -362,16 +366,6 @@ class BenchmarkSpec:
         self.config.container_registry
     )
     self.resources.append(self.container_registry)
-
-  def SetContainerRegistry(self):
-    """Sets the constructed container registry name."""
-
-    if self.container_registry:
-        self.container_registry_name = self.container_registry.name
-        logging.info('Container registry name: %s', self.container_registry_name)
-    else:
-        self.container_registry_name = None
-        logging.warning('No container registry constructed')
 
   def ConstructDpbService(self):
     """Create the dpb_service object and create groups for its vms."""

--- a/perfkitbenchmarker/benchmark_spec.py
+++ b/perfkitbenchmarker/benchmark_spec.py
@@ -326,8 +326,6 @@ class BenchmarkSpec:
     """Create the container cluster."""
     if self.config.container_cluster is None:
       return
-    if self.config.container_cluster is None:
-        return
 
     cloud = self.config.container_cluster.cloud
     cluster_type = self.config.container_cluster.type
@@ -336,10 +334,12 @@ class BenchmarkSpec:
         cloud, cluster_type
     )
     self.container_cluster = container_cluster_class(
-        self.config.container_cluster,
-        self.container_registry
+        self.config.container_cluster
     )
-    self.resources.append(self.container_registry)
+
+    if self.container_registry:
+      self.container_cluster.SetContainerRegistry(self.container_registry)
+
     self.resources.append(self.container_cluster)
 
   def ConstructCluster(self):

--- a/perfkitbenchmarker/container_service.py
+++ b/perfkitbenchmarker/container_service.py
@@ -681,14 +681,10 @@ def GetContainerClusterClass(
       BaseContainerCluster, CLOUD=cloud, CLUSTER_TYPE=cluster_type
   )
 
-def SetContainerRegistry(self):
-    """Sets the constructed container registry name."""
-    if self.container_registry:
-        self.container_registry_name = self.container_registry.name
-        logging.info('Container registry name: %s', self.container_registry_name)
-    else:
-        self.container_registry_name = None
-        logging.warning('No container registry constructed')
+def SetContainerRegistry(self, container_registry):
+    """Sets the container registry for the cluster."""
+    self.container_registry = container_registry
+    logging.info("Container registry set: %s", self.container_registry.name)
 
 
 class KubernetesPod:

--- a/perfkitbenchmarker/container_service.py
+++ b/perfkitbenchmarker/container_service.py
@@ -506,7 +506,7 @@ class BaseContainerCluster(resource.BaseResource):
     )
     self.services: dict[str, KubernetesContainerService] = {}
     self._extra_samples: list[sample.Sample] = []
-    self.container_registry = getattr(cluster_spec, 'container_registry', None)
+    self.container_registry: BaseContainerRegistry | None = None
 
   @property
   def num_nodes(self) -> int:
@@ -515,6 +515,11 @@ class BaseContainerCluster(resource.BaseResource):
   @property
   def zone(self) -> str:
     return self.default_nodepool.zone
+  
+  def SetContainerRegistry(self, container_registry):
+    """Sets the container registry for the cluster."""
+    self.container_registry = container_registry
+    logging.info("Container registry set: %s", self.container_registry.name)
 
   def _InitializeDefaultNodePool(
       self,
@@ -601,9 +606,6 @@ class BaseContainerCluster(resource.BaseResource):
           'min_size': self.min_nodes,
       })
 
-    if self.container_registry:
-        metadata['container_registry'] = self.container_registry
-
     return metadata
 
   def DeployContainer(self, name, container_spec):
@@ -680,11 +682,6 @@ def GetContainerClusterClass(
   return resource.GetResourceClass(
       BaseContainerCluster, CLOUD=cloud, CLUSTER_TYPE=cluster_type
   )
-
-def SetContainerRegistry(self, container_registry):
-    """Sets the container registry for the cluster."""
-    self.container_registry = container_registry
-    logging.info("Container registry set: %s", self.container_registry.name)
 
 
 class KubernetesPod:

--- a/perfkitbenchmarker/container_service.py
+++ b/perfkitbenchmarker/container_service.py
@@ -519,7 +519,6 @@ class BaseContainerCluster(resource.BaseResource):
   def SetContainerRegistry(self, container_registry):
     """Sets the container registry for the cluster."""
     self.container_registry = container_registry
-    logging.info("Container registry set: %s", self.container_registry.name)
 
   def _InitializeDefaultNodePool(
       self,

--- a/perfkitbenchmarker/container_service.py
+++ b/perfkitbenchmarker/container_service.py
@@ -506,6 +506,7 @@ class BaseContainerCluster(resource.BaseResource):
     )
     self.services: dict[str, KubernetesContainerService] = {}
     self._extra_samples: list[sample.Sample] = []
+    self.container_registry = getattr(cluster_spec, 'container_registry', None)
 
   @property
   def num_nodes(self) -> int:
@@ -600,6 +601,9 @@ class BaseContainerCluster(resource.BaseResource):
           'min_size': self.min_nodes,
       })
 
+    if self.container_registry:
+        metadata['container_registry'] = self.container_registry
+
     return metadata
 
   def DeployContainer(self, name, container_spec):
@@ -676,6 +680,15 @@ def GetContainerClusterClass(
   return resource.GetResourceClass(
       BaseContainerCluster, CLOUD=cloud, CLUSTER_TYPE=cluster_type
   )
+
+def SetContainerRegistry(self):
+    """Sets the constructed container registry name."""
+    if self.container_registry:
+        self.container_registry_name = self.container_registry.name
+        logging.info('Container registry name: %s', self.container_registry_name)
+    else:
+        self.container_registry_name = None
+        logging.warning('No container registry constructed')
 
 
 class KubernetesPod:

--- a/perfkitbenchmarker/providers/azure/azure_kubernetes_service.py
+++ b/perfkitbenchmarker/providers/azure/azure_kubernetes_service.py
@@ -135,7 +135,7 @@ class AksCluster(container_service.KubernetesCluster):
 
   CLOUD = provider_info.AZURE
 
-  def __init__(self, spec, container_registry=None):
+  def __init__(self, spec):
     """Initializes the cluster."""
     super().__init__(spec)
     self.region = util.GetRegionFromZone(self.zone)
@@ -147,7 +147,6 @@ class AksCluster(container_service.KubernetesCluster):
     self.service_principal = service_principal.ServicePrincipal.GetInstance()
     self.cluster_version = FLAGS.container_cluster_version
     self._deleted = False
-    self.container_registry = container_registry
 
   def InitializeNodePoolForCloud(
       self,
@@ -537,7 +536,19 @@ class AksAutomaticCluster(AksCluster):
     )
 
   def _PostCreate(self):
-    pass
+    if self.container_registry:
+      attach_registry_cmd = [
+          azure.AZURE_PATH,
+          'aks',
+          'update',
+          '--name',
+          self.name,
+          '--resource-group',
+          self.resource_group.name,
+          '--attach-acr',
+          self.container_registry.name,
+      ]
+      vm_util.IssueCommand(attach_registry_cmd)
 
 
 def _AzureNodePoolName(pkb_nodepool_name: str) -> str:

--- a/perfkitbenchmarker/providers/azure/azure_kubernetes_service.py
+++ b/perfkitbenchmarker/providers/azure/azure_kubernetes_service.py
@@ -316,7 +316,7 @@ class AksCluster(container_service.KubernetesCluster):
     ]
     vm_util.IssueCommand(set_tags_cmd)
 
-    if hasattr(self, 'container_registry') and self.container_registry:
+    if self.container_registry:
       attach_registry_cmd = [
           azure.AZURE_PATH,
           'aks',

--- a/perfkitbenchmarker/providers/azure/azure_kubernetes_service.py
+++ b/perfkitbenchmarker/providers/azure/azure_kubernetes_service.py
@@ -135,7 +135,7 @@ class AksCluster(container_service.KubernetesCluster):
 
   CLOUD = provider_info.AZURE
 
-  def __init__(self, spec):
+  def __init__(self, spec, container_registry=None):
     """Initializes the cluster."""
     super().__init__(spec)
     self.region = util.GetRegionFromZone(self.zone)
@@ -147,6 +147,7 @@ class AksCluster(container_service.KubernetesCluster):
     self.service_principal = service_principal.ServicePrincipal.GetInstance()
     self.cluster_version = FLAGS.container_cluster_version
     self._deleted = False
+    self.container_registry = container_registry
 
   def InitializeNodePoolForCloud(
       self,
@@ -314,6 +315,20 @@ class AksCluster(container_service.KubernetesCluster):
         util.GetTagsJson(self.resource_group.timeout_minutes),
     ]
     vm_util.IssueCommand(set_tags_cmd)
+
+    if hasattr(self, 'container_registry') and self.container_registry:
+      attach_registry_cmd = [
+          azure.AZURE_PATH,
+          'aks',
+          'update',
+          '--name',
+          self.name,
+          '--resource-group',
+          self.resource_group.name,
+          '--attach-acr',
+          self.container_registry.name,
+      ]
+      vm_util.IssueCommand(attach_registry_cmd)
 
   def _IsReady(self):
     """Returns True if the cluster is ready."""

--- a/perfkitbenchmarker/providers/azure/azure_kubernetes_service.py
+++ b/perfkitbenchmarker/providers/azure/azure_kubernetes_service.py
@@ -449,7 +449,11 @@ class AksAutomaticCluster(AksCluster):
     )
 
   def _PostCreate(self):
-    """Run only the container registry attach."""
+    """Skip the superclass's _PostCreate() method.
+
+    Needed as the node_resource_group is pre-configured and fully managed in Automatic clusters
+    """
+    super(container_service.KubernetesCluster, self)._PostCreate()
     self._AttachContainerRegistry()
 
 


### PR DESCRIPTION
This PR addresses an issue where **Azure Kubernetes Service (AKS)** instances fail to pull container images from **Azure Container Registry (ACR)**, resulting in a `401 Unauthorized error`.