### PR TITLE
Fix cleanup for apt package snapshots on Debian-based static VMs

### DIFF
--- a/CHANGES.next.md
+++ b/CHANGES.next.md
@@ -613,3 +613,4 @@
 -   Add fio max IOPS microbenchmark
 -   Add support for MongoDB PSS (Primary-Secondary-Secondary) setup.
 -   Add flags to allow modifying multiple settings in "mongod.conf".
+-   Fix cleanup for apt package snapshots on Debian-based static VMs


### PR DESCRIPTION
SUT: GCP VM c3d-standard-4 (static)
OS: Debian 12
Benchmark: coremark

Running `coremark` (or any benchmark) on a statically provisioned Debian-based VM results in a `RuntimeError: Set changed size during iteration`, which halts the remainder of the PackageCleanup phase.

The root cause is that the `BaseDebianMixin` uses the `discard()` method on package entries in the set `self._installed_packages`. However, the `BaseRhelMixin` and others do not call this method, it seems safe to remove this line and fix the bug to bring the `BaseDebianMixin` in line with the others.

Fixing this bug allowed the rest of the PackageCleanup to take place, which revealed another issue. PKB attempts to restore system packages based on the dpkg snapshot captured prior to the Run phase. This failed due to some obscure `pkgResolver` errors, so this PR changes the logic for package snapshots and restoration on Debian-based systems (using `dpkg-query`).