### PR TITLE
AKS nodepool provisioning

### DIFF
--- a/perfkitbenchmarker/data/provision_node_pools/nodepool_azure.yaml.j2
+++ b/perfkitbenchmarker/data/provision_node_pools/nodepool_azure.yaml.j2
@@ -8,7 +8,7 @@ spec:
 apiVersion: karpenter.sh/v1
 kind: NodePool
 metadata:
-  name: batch-processing
+  name: {{ batch }}-nodepool
 spec:
   disruption:
     budgets:

--- a/perfkitbenchmarker/data/provision_node_pools/nodepool_azure.yaml.j2
+++ b/perfkitbenchmarker/data/provision_node_pools/nodepool_azure.yaml.j2
@@ -1,0 +1,21 @@
+# nodepool-azure.yaml.j2
+# Configures the Azure Node Auto Provisioner (Karpenter) to provision nodes
+# for pods that request a 'group' label matching the 'pool-{{ batch }}-{{ id }}' pattern.
+apiVersion: karpenter.sh/v1beta1
+kind: NodePool
+metadata:
+  name: {{ name | default('default') }}
+spec:
+  template:
+    metadata:
+      labels:
+        pkb_nodepool: {{ name | default('default') }}
+    spec:
+      # Define the rules for provisioning.
+      requirements:
+        - key: "group"
+          operator: In
+          values:
+          {% for i in range(1, job_count + 1) %}
+          - pool-{{ batch }}-{{ "%03d" | format(i) }}
+          {% endfor %}

--- a/perfkitbenchmarker/data/provision_node_pools/nodepool_azure.yaml.j2
+++ b/perfkitbenchmarker/data/provision_node_pools/nodepool_azure.yaml.j2
@@ -24,20 +24,16 @@ spec:
       requirements:
         - key: kubernetes.io/arch
           operator: In
-          values:
-          - amd64
+          values: ["amd64"]
         - key: kubernetes.io/os
           operator: In
-          values:
-          - linux
+          values: ["linux"]
         - key: karpenter.sh/capacity-type
           operator: In
-          values:
-          - on-demand
+          values: ["spot", "on-demand"]
         - key: karpenter.azure.com/sku-family
           operator: In
-          values:
-          - D
+          values: ["D", "E", "F"]
         - key: "group"
           operator: In
           values:

--- a/perfkitbenchmarker/data/provision_node_pools/nodepool_azure.yaml.j2
+++ b/perfkitbenchmarker/data/provision_node_pools/nodepool_azure.yaml.j2
@@ -1,18 +1,43 @@
-# nodepool-azure.yaml.j2
-# Configures the Azure Node Auto Provisioner (Karpenter) to provision nodes
-# for pods that request a 'group' label matching the 'pool-{{ batch }}-{{ id }}' pattern.
-apiVersion: karpenter.sh/v1beta1
+apiVersion: karpenter.azure.com/v1beta1
+kind: AKSNodeClass
+metadata:
+  name: aks-managed-class
+spec:
+  imageFamily: "Ubuntu2204"
+---
+apiVersion: karpenter.sh/v1
 kind: NodePool
 metadata:
-  name: {{ name | default('default') }}
+  name: batch-processing
 spec:
+  disruption:
+    budgets:
+    - nodes: 30%
+    consolidateAfter: 0s
+    consolidationPolicy: WhenEmptyOrUnderutilized
   template:
-    metadata:
-      labels:
-        pkb_nodepool: {{ name | default('default') }}
     spec:
-      # Define the rules for provisioning.
+      nodeClassRef:
+        group: karpenter.azure.com
+        kind: AKSNodeClass
+        name: aks-managed-class
       requirements:
+        - key: kubernetes.io/arch
+          operator: In
+          values:
+          - amd64
+        - key: kubernetes.io/os
+          operator: In
+          values:
+          - linux
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values:
+          - on-demand
+        - key: karpenter.azure.com/sku-family
+          operator: In
+          values:
+          - D
         - key: "group"
           operator: In
           values:

--- a/perfkitbenchmarker/linux_benchmarks/provisioning_benchmarks/provision_node_pools_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/provisioning_benchmarks/provision_node_pools_benchmark.py
@@ -84,7 +84,6 @@ TEST_BATCH_NAME = "test-batch"
 JOB_MANIFEST_TEMPLATE = "provision_node_pools/job_manifest.yaml.j2"
 AKS_NODEPOOL_MANIFEST_TEMPLATE = "provision_node_pools/nodepool_azure.yaml.j2"
 
-
 def GetConfig(user_config):
   return configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
 
@@ -107,9 +106,9 @@ def _CreateJobsAndWait(
   if cluster.CLOUD == 'Azure':
     cluster.ApplyManifest(
         AKS_NODEPOOL_MANIFEST_TEMPLATE,
-        name='default',
         batch=batch_name,
         job_count=jobs,
+        cloud=cluster.CLOUD,
     )
 
   apply_start = time.monotonic()

--- a/perfkitbenchmarker/linux_benchmarks/provisioning_benchmarks/provision_node_pools_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/provisioning_benchmarks/provision_node_pools_benchmark.py
@@ -82,6 +82,7 @@ provision_node_pools:
 INIT_BATCH_NAME = "init-batch"
 TEST_BATCH_NAME = "test-batch"
 JOB_MANIFEST_TEMPLATE = "provision_node_pools/job_manifest.yaml.j2"
+AKS_NODEPOOL_MANIFEST_TEMPLATE = "provision_node_pools/nodepool_azure.yaml.j2"
 
 
 def GetConfig(user_config):
@@ -102,6 +103,15 @@ def _CreateJobsAndWait(
       batch_name,
       jobs,
   )
+
+  if cluster.CLOUD == 'Azure':
+    cluster.ApplyManifest(
+        AKS_NODEPOOL_MANIFEST_TEMPLATE,
+        name='default',
+        batch=batch_name,
+        job_count=jobs,
+    )
+
   apply_start = time.monotonic()
   for i in range(jobs):
     cluster.ApplyManifest(

--- a/perfkitbenchmarker/linux_benchmarks/provisioning_benchmarks/provision_node_pools_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/provisioning_benchmarks/provision_node_pools_benchmark.py
@@ -84,6 +84,7 @@ TEST_BATCH_NAME = "test-batch"
 JOB_MANIFEST_TEMPLATE = "provision_node_pools/job_manifest.yaml.j2"
 AKS_NODEPOOL_MANIFEST_TEMPLATE = "provision_node_pools/nodepool_azure.yaml.j2"
 
+
 def GetConfig(user_config):
   return configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
 
@@ -103,7 +104,7 @@ def _CreateJobsAndWait(
       jobs,
   )
 
-  if cluster.CLOUD == 'Azure':
+  if cluster.CLOUD == "Azure":
     cluster.ApplyManifest(
         AKS_NODEPOOL_MANIFEST_TEMPLATE,
         batch=batch_name,
@@ -206,7 +207,7 @@ def _AssertNodePools(
 ) -> None:
   """Asserts expected number of node pools in the cluster."""
   # Skip node pool count check for Azure AKS when using auto-provisioning, as nodes are added without associated node pools
-  if cluster.CLOUD == 'Azure':
+  if cluster.CLOUD == "Azure":
     logging.info("Skipping node pool check for Azure AKS")
     return
   node_pools = len(cluster.GetNodePoolNames())

--- a/perfkitbenchmarker/linux_benchmarks/provisioning_benchmarks/provision_node_pools_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/provisioning_benchmarks/provision_node_pools_benchmark.py
@@ -205,6 +205,10 @@ def _AssertNodePools(
     added_node_pools: int,
 ) -> None:
   """Asserts expected number of node pools in the cluster."""
+  # Skip node pool count check for Azure AKS when using auto-provisioning, as nodes are added without associated node pools
+  if cluster.CLOUD == 'Azure':
+    logging.info("Skipping node pool check for Azure AKS")
+    return
   node_pools = len(cluster.GetNodePoolNames())
   if node_pools < added_node_pools:
     raise ValueError(

--- a/perfkitbenchmarker/providers/azure/azure_kubernetes_service.py
+++ b/perfkitbenchmarker/providers/azure/azure_kubernetes_service.py
@@ -169,19 +169,19 @@ class AksCluster(container_service.KubernetesCluster):
         container_service.DEFAULT_NODEPOOL,
         '--nodepool-labels',
         f'pkb_nodepool={container_service.DEFAULT_NODEPOOL}',
-    ] 
+    ]
     if FLAGS.benchmarks and 'provision_node_pools' in FLAGS.benchmarks:
-        # For provision_node_pools benchmark, add auto provisioning mode
-        cmd.append('--node-provisioning-mode=auto')
-        cmd += self._GetNodeFlags(self.default_nodepool)
+      # For provision_node_pools benchmark, add auto provisioning mode
+      cmd.append('--node-provisioning-mode=auto')
+      cmd += self._GetNodeFlags(self.default_nodepool)
     else:
-        cmd += self._GetNodeFlags(self.default_nodepool)
-        if self._IsAutoscalerEnabled():
-          cmd += [
-              '--enable-cluster-autoscaler',
-              f'--min-count={self.min_nodes}',
-              f'--max-count={self.max_nodes}',
-          ]
+      cmd += self._GetNodeFlags(self.default_nodepool)
+      if self._IsAutoscalerEnabled():
+        cmd += [
+            '--enable-cluster-autoscaler',
+            f'--min-count={self.min_nodes}',
+            f'--max-count={self.max_nodes}',
+        ]
 
     # TODO(pclay): expose quota and capacity errors
     # Creating an AKS cluster with a fresh service principal usually fails due

--- a/perfkitbenchmarker/providers/azure/azure_kubernetes_service.py
+++ b/perfkitbenchmarker/providers/azure/azure_kubernetes_service.py
@@ -169,13 +169,19 @@ class AksCluster(container_service.KubernetesCluster):
         container_service.DEFAULT_NODEPOOL,
         '--nodepool-labels',
         f'pkb_nodepool={container_service.DEFAULT_NODEPOOL}',
-    ] + self._GetNodeFlags(self.default_nodepool)
-    if self._IsAutoscalerEnabled():
-      cmd += [
-          '--enable-cluster-autoscaler',
-          f'--min-count={self.min_nodes}',
-          f'--max-count={self.max_nodes}',
-      ]
+    ] 
+    if FLAGS.benchmarks and 'provision_node_pools' in FLAGS.benchmarks:
+        # For provision_node_pools benchmark, add auto provisioning mode
+        cmd.append('--node-provisioning-mode=auto')
+        cmd += self._GetNodeFlags(self.default_nodepool)
+    else:
+        cmd += self._GetNodeFlags(self.default_nodepool)
+        if self._IsAutoscalerEnabled():
+          cmd += [
+              '--enable-cluster-autoscaler',
+              f'--min-count={self.min_nodes}',
+              f'--max-count={self.max_nodes}',
+          ]
 
     # TODO(pclay): expose quota and capacity errors
     # Creating an AKS cluster with a fresh service principal usually fails due


### PR DESCRIPTION
This PR adds support for `nodepool provisioning` in AKS with the auto-provisioning feature.

**Key Changes:**
1. Manifests for `AKSNodeClass` and `NodePool`:
    - Added manifests to handle tolerations and nodeSelector for job scheduling.
2. Modifications to the _Create Method in AksCluster:
    - Updated the `_Create` method to create an AKS cluster with the `--node-provisioning-mode=auto` feature.
3. Updates to the `Provisioning Node Pool Benchmark`:
    - Applied additional Azure-specific manifests.
    - Skipped the node pool count check, as AKS auto-provisioning does not manage node pools in the traditional sense.

**Additional Notes**
- This implementation uses the nodepools.karpenter.sh Kubernetes CRD to manage node provisioning policies and workload-specific configurations, as AKS auto-provisioning operates at the Kubernetes level, not the cloud-based node pool level.
- For more details, refer to the Microsoft documentation:
   [Node auto-provisioning overview](https://learn.microsoft.com/en-us/azure/aks/node-autoprovision?tabs=azure-cli)
   [Node auto-provisioning with node pools](https://learn.microsoft.com/en-us/azure/aks/node-autoprovision-node-pools)