### PR TITLE
feat: Add llm_eval benchmark

### DIFF
--- a/perfkitbenchmarker/data/llm_eval/logger.py
+++ b/perfkitbenchmarker/data/llm_eval/logger.py
@@ -1,0 +1,38 @@
+"""Configures and provides a logger for the application."""
+
+import logging
+import sys
+
+
+def get_logger(name: str) -> logging.Logger:
+  """Configures and returns a logger instance.
+
+  Args:
+    name: The name of the logger.
+
+  Returns:
+    A configured logger instance.
+  """
+  logger = logging.getLogger(name)
+
+  handler = logging.StreamHandler(sys.stdout)
+  formatter = logging.Formatter(
+      '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+      ' (%(filename)s:%(lineno)d)'
+  )
+  handler.setFormatter(formatter)
+
+  logger.addHandler(handler)
+  return logger
+
+
+def set_logging_level(debug: bool) -> None:
+  """Sets the logging level for the root logger.
+
+  Args:
+    debug: If True, sets the logging level to DEBUG, otherwise INFO.
+  """
+  if debug:
+    logging.getLogger().setLevel(logging.DEBUG)
+  else:
+    logging.getLogger().setLevel(logging.INFO)

--- a/perfkitbenchmarker/data/llm_eval/main.py
+++ b/perfkitbenchmarker/data/llm_eval/main.py
@@ -1,0 +1,217 @@
+"""Main script for running LLM benchmarks.
+
+This script provides a command-line interface for benchmarking large language
+models from various providers. It supports model discovery, benchmarking
+specific models, and various output formats.
+"""
+
+import enum
+import json
+from typing import Any, Dict, List, Tuple
+
+from absl import app
+from absl import flags
+import dotenv
+from logger import get_logger
+from logger import set_logging_level
+from prompts import OPEN_ENDED_PROMPTS
+from prompts import SUMMARIZATION_PROMPTS
+from providers.anthropic_provider import AnthropicProvider
+from providers.base_provider import BaseProvider
+from providers.google_provider import GoogleProvider
+from providers.openai_provider import OpenAIProvider
+
+dotenv.load_dotenv()
+
+FLAGS = flags.FLAGS
+logger = get_logger(__name__)
+
+
+class Provider(enum.Enum):
+  GOOGLE = 'google'
+  OPENAI = 'openai'
+  ANTHROPIC = 'anthropic'
+
+
+flags.DEFINE_enum(
+    'provider',
+    None,
+    [p.value for p in Provider],
+    'The provider to benchmark.',
+)
+flags.mark_flag_as_required('provider')
+flags.DEFINE_integer(
+    'max_models',
+    -1,
+    (
+        'The maximum number of models to test in a single invocation. This '
+        'flag has no effect if the --models flag is specified.'
+    ),
+)
+flags.DEFINE_list(
+    'specific_models',
+    None,
+    'An optional list of models to benchmark, overriding the discovery.',
+)
+flags.DEFINE_boolean(
+    'discover_models_only',
+    False,
+    'Discover models and exit without benchmarking. Can be used with'
+    ' --include_preview.',
+)
+flags.DEFINE_boolean(
+    'include_preview',
+    False,
+    'Include preview models from the benchmark. This flag has no effect when'
+    ' --models is used.',
+)
+flags.DEFINE_boolean('debug', False, 'Enable debug logging.')
+
+
+PROVIDER_MAPPING = {
+    Provider.GOOGLE.value: GoogleProvider,
+    Provider.OPENAI.value: OpenAIProvider,
+    Provider.ANTHROPIC.value: AnthropicProvider,
+}
+
+
+def _get_models_to_test(provider: BaseProvider) -> Tuple[List[str], List[str]]:
+  """Gets the list of models to test based on the command-line flags.
+
+  Args:
+    provider: The provider to get models from.
+
+  Returns:
+    A tuple containing the list of models to test and the list of skipped
+    models.
+  """
+  if FLAGS.specific_models:
+    if FLAGS.include_preview:
+      raise ValueError('Cannot use --specific_models with --include_preview.')
+    if FLAGS.max_models != 20:
+      raise ValueError('Cannot use --specific_models with --max_models.')
+    models_to_test = FLAGS.specific_models
+    skipped_models = []
+  else:
+    all_models = provider.get_models(include_preview=FLAGS.include_preview)
+    models_to_test = all_models[: FLAGS.max_models]
+    skipped_models = all_models[FLAGS.max_models :]
+
+  logger.debug(f'Models to be benchmarked: {models_to_test}')
+
+  return models_to_test, skipped_models
+
+
+def _get_provider() -> BaseProvider:
+  """Gets the provider instance based on the command-line flags.
+
+  Returns:
+    An instance of the selected provider.
+  """
+  logger.debug(f'Starting benchmark for provider: {FLAGS.provider}')
+
+  provider_class = PROVIDER_MAPPING.get(FLAGS.provider)
+  if not provider_class:
+    raise ValueError(f'Invalid provider: {FLAGS.provider}')
+  return provider_class()
+
+
+def _handle_discover_only(models_to_test: List[str]) -> bool:
+  """Handles the discover_models_only flag.
+
+  Args:
+    models_to_test: The list of models to test.
+
+  Returns:
+    True if the script should exit after discovering models, False otherwise.
+  """
+  if not FLAGS.discover_models_only:
+    return False
+
+  if FLAGS.specific_models:
+    raise ValueError(
+        'Cannot use --specific_models with --discover_models_only.'
+    )
+
+  logger.debug('Discovering models...')
+  print(json.dumps({'models': models_to_test}, indent=2))
+  return True
+
+
+def _run_benchmarks(
+    provider: BaseProvider, models_to_test: List[str]
+) -> Dict[str, Any]:
+  """Runs the benchmarks for the given models.
+
+  Args:
+    provider: The provider to use for benchmarking.
+    models_to_test: The list of models to test.
+
+  Returns:
+    A dictionary of benchmark results.
+  """
+  results = {}
+  for model_name in models_to_test:
+    logger.debug(f'Benchmarking model: {model_name}')
+    results[model_name] = {}
+    for prompt_id, prompt_data in SUMMARIZATION_PROMPTS.items():
+      try:
+        results[model_name][prompt_id] = provider.benchmark_model(
+            model_name,
+            prompt_data['text'],
+            prompt_id,
+            prompt_data['max_tokens'],
+        )
+      except Exception as e:  # pylint: disable=broad-exception-caught
+        # Catching broad exception to ensure one failed prompt doesn't stop
+        # the entire benchmark run.
+        logger.debug(f"  Error benchmarking prompt '{prompt_id}': {e}")
+        results[model_name][prompt_id] = {'error': str(e)}
+    for prompt_id, prompt_data in OPEN_ENDED_PROMPTS.items():
+      try:
+        results[model_name][prompt_id] = provider.benchmark_model(
+            model_name,
+            prompt_data['text'],
+            prompt_id,
+            prompt_data['max_tokens'],
+        )
+      except Exception as e:  # pylint: disable=broad-exception-caught
+        # Catching broad exception to ensure one failed prompt doesn't stop
+        # the entire benchmark run.
+        logger.debug(f"  Error benchmarking prompt '{prompt_id}': {e}")
+        results[model_name][prompt_id] = {'error': str(e)}
+    logger.debug(f'Finished benchmarking model: {model_name}')
+  return results
+
+
+def main(argv: List[str]) -> None:
+  """Main function for the benchmark script.
+
+  Args:
+    argv: The command-line arguments.
+  """
+  del argv  # Unused
+  set_logging_level(FLAGS.debug)
+  provider = _get_provider()
+  models_to_test, skipped_models = _get_models_to_test(provider)
+
+  if _handle_discover_only(models_to_test):
+    return
+
+  results = _run_benchmarks(provider, models_to_test)
+
+  logger.debug('Benchmark complete. Finalizing output.')
+
+  num_skipped_models = len(skipped_models)
+  output = {
+      'results': results,
+      'models_skipped': num_skipped_models,
+      'skipped_models': skipped_models,
+      'prompts_tested': {**SUMMARIZATION_PROMPTS, **OPEN_ENDED_PROMPTS},
+  }
+
+  print(json.dumps(output, indent=2))
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/perfkitbenchmarker/data/llm_eval/prompts.py
+++ b/perfkitbenchmarker/data/llm_eval/prompts.py
@@ -1,0 +1,25 @@
+"""Loads and categorizes prompts from the prompts.txt file.
+
+This module reads the prompts.txt file, splits it into individual prompts,
+and categorizes them into summarization and open-ended prompts based on
+the presence of the word "summarize".
+"""
+
+SUMMARIZATION_PROMPTS = {}
+OPEN_ENDED_PROMPTS = {}
+
+with open('prompts.txt', 'r', encoding='utf-8') as f:
+  prompts = f.read().split('---')
+  for i, prompt in enumerate(prompts):
+    if 'summarize' in prompt.lower():
+      # Set to 4096, the maximum supported by some models
+      # (e.g., gpt-4-turbo).
+      SUMMARIZATION_PROMPTS[f'prompt_{i+1}'] = {
+          'text': prompt.strip(),
+          'max_tokens': 4096,
+      }
+    else:
+      OPEN_ENDED_PROMPTS[f'prompt_{i+1}'] = {
+          'text': prompt.strip(),
+          'max_tokens': None,
+      }

--- a/perfkitbenchmarker/data/llm_eval/prompts.txt
+++ b/perfkitbenchmarker/data/llm_eval/prompts.txt
@@ -1,0 +1,37 @@
+Please summarize the following text:
+Letter 1
+
+_To Mrs. Saville, England._
+
+
+St. Petersburgh, Dec. 11th, 17—. You will rejoice to hear that no disaster has accompanied the
+commencement of an enterprise which you have regarded with such evil
+forebodings. I arrived here yesterday, and my first task is to assure
+my dear sister of my welfare and increasing confidence in the success
+of my undertaking. I am already far north of London, and as I walk in the streets of
+Petersburgh, I feel a cold northern breeze play upon my cheeks, which
+braces my nerves and fills me with delight. Do you understand this
+feeling? This breeze, which has travelled from the regions towards
+which I am advancing, gives me a foretaste of those icy climes. Inspirited by this wind of promise, my daydreams become more fervent
+and vivid. I try in vain to be persuaded that the pole is the seat of
+frost and desolation; it ever presents itself to my imagination as the
+region of beauty and delight.
+---
+Please summarize the following text:
+CHAPTER 1. Loomings. Call me Ishmael. Some years ago—never mind how long precisely—having
+little or no money in my purse, and nothing particular to interest me
+on shore, I thought I would sail about a little and see the watery part
+of the world. It is a way I have of driving off the spleen and
+regulating the circulation. Whenever I find myself growing grim about
+the mouth; whenever it is a damp, drizzly November in my soul; whenever
+I find myself involuntarily pausing before coffin warehouses, and
+bringing up the rear of every funeral I meet; and especially whenever
+my hypos get such an upper hand of me, that it requires a strong moral
+principle to prevent me from deliberately stepping into the street, and
+methodically knocking people’s hats off—then, I account it high time to
+get to sea as soon as I can. This is my substitute for pistol and ball. With a philosophical flourish Cato throws himself upon his sword; I
+quietly take to the ship.
+---
+Explain the concept of gravity in simple terms.
+---
+Write a 'Hello, World!' program in Python.

--- a/perfkitbenchmarker/data/llm_eval/providers/anthropic_provider.py
+++ b/perfkitbenchmarker/data/llm_eval/providers/anthropic_provider.py
@@ -1,0 +1,83 @@
+"""Provider for benchmarking Anthropic models."""
+
+import os
+import time
+from typing import Any, Dict, List
+
+from anthropic import Anthropic
+
+from . import base_provider
+
+MAX_OUTPUT_TOKENS = 1024
+
+
+class AnthropicProvider(base_provider.BaseProvider):
+  """Provider for benchmarking Anthropic models."""
+
+  def get_models(self, include_preview: bool = False) -> List[str]:
+    """Fetches the latest generation of text-based models from Anthropic.
+
+    Args:
+      include_preview: Whether to include preview models in the list.
+
+    Returns:
+      A list of model names.
+    """
+    client = Anthropic(api_key=os.environ['ANTHROPIC_API_KEY'])
+    return [
+        model.id
+        for model in client.models.list()
+        if 'claude' in model.id
+        and 'instant' not in model.id
+        and '2024' not in model.id
+    ]
+
+  def benchmark_model(
+      self, model_name: str, prompt: str, prompt_id: str, max_output_tokens: int
+  ) -> Dict[str, Any]:
+    super().benchmark_model(model_name, prompt, prompt_id, max_output_tokens)
+    client = Anthropic(api_key=os.environ['ANTHROPIC_API_KEY'])
+    results = {}
+
+    # Non-streaming
+    start_time = time.time()
+    response = client.messages.create(
+        model=model_name,
+        max_tokens=MAX_OUTPUT_TOKENS,
+        messages=[{'role': 'user', 'content': prompt}],
+        temperature=base_provider.TEMPERATURE,
+    )
+    end_time = time.time()
+    results['non_streaming_full_response_time_in_seconds'] = round(
+        end_time - start_time, 2
+    )
+    results['input_request_tokens'] = response.usage.input_tokens
+    results['non_streaming_full_response_output_tokens'] = (
+        response.usage.output_tokens
+    )
+
+    # Streaming
+    start_time = time.time()
+    first_token_time = None
+    output_text = ''
+    with client.messages.stream(
+        model=model_name,
+        max_tokens=MAX_OUTPUT_TOKENS,
+        messages=[{'role': 'user', 'content': prompt}],
+        temperature=base_provider.TEMPERATURE,
+    ) as stream:
+      for text in stream.text_stream:
+        if first_token_time is None:
+          first_token_time = time.time()
+        output_text += text
+    end_time = time.time()
+
+    results['streaming_time_to_first_token_in_seconds'] = round(
+        first_token_time - start_time, 2
+    )
+    results['streaming_full_response_time_in_seconds'] = round(
+        end_time - start_time, 2
+    )
+    results['streaming_full_response_output_tokens'] = len(output_text)
+
+    return results

--- a/perfkitbenchmarker/data/llm_eval/providers/base_provider.py
+++ b/perfkitbenchmarker/data/llm_eval/providers/base_provider.py
@@ -1,0 +1,44 @@
+"""Abstract base class for LLM providers."""
+
+import abc
+from typing import Any, Dict, List
+
+from logger import get_logger
+
+
+logger = get_logger(__name__)
+
+TEMPERATURE = 0.0
+
+
+class BaseProvider(abc.ABC):
+  """Abstract base class for LLM providers."""
+
+  @abc.abstractmethod
+  def get_models(self, include_preview: bool = False) -> List[str]:
+    """Fetches the latest generation of text-based models from the provider.
+
+    Args:
+      include_preview: Whether to include preview models in the list.
+
+    Returns:
+      A list of model names.
+    """
+    pass
+
+  @abc.abstractmethod
+  def benchmark_model(
+      self, model_name: str, prompt: str, prompt_id: str, max_output_tokens: int
+  ) -> Dict[str, Any]:
+    """Benchmarks a single model.
+
+    Args:
+      model_name: The name of the model to benchmark.
+      prompt: The prompt to send to the model.
+      prompt_id: The ID of the prompt.
+      max_output_tokens: The maximum number of tokens to generate.
+
+    Returns:
+      A dictionary of benchmark results.
+    """
+    logger.debug(f"Benchmarking model: {model_name} with prompt: '{prompt_id}'")

--- a/perfkitbenchmarker/data/llm_eval/providers/google_provider.py
+++ b/perfkitbenchmarker/data/llm_eval/providers/google_provider.py
@@ -1,0 +1,268 @@
+"""Provider for benchmarking Google models."""
+
+import datetime
+import itertools
+import os
+import re
+import time
+from typing import Any, Dict, List
+
+from google import genai
+from google.api_core import exceptions
+from google.genai import types
+from logger import get_logger
+
+from . import base_provider
+
+MAX_OUTPUT_TOKENS = 1024
+logger = get_logger(__name__)
+
+SAFETY_SETTINGS = [
+    {
+        'category': types.HarmCategory.HARM_CATEGORY_HARASSMENT,
+        'threshold': types.HarmBlockThreshold.BLOCK_NONE,
+    },
+    {
+        'category': types.HarmCategory.HARM_CATEGORY_HATE_SPEECH,
+        'threshold': types.HarmBlockThreshold.BLOCK_NONE,
+    },
+    {
+        'category': types.HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT,
+        'threshold': types.HarmBlockThreshold.BLOCK_NONE,
+    },
+    {
+        'category': types.HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
+        'threshold': types.HarmBlockThreshold.BLOCK_NONE,
+    },
+]
+
+
+class GoogleProvider(base_provider.BaseProvider):
+  """Provider for benchmarking Google models."""
+
+  def get_models(self, include_preview: bool = False) -> List[str]:
+    """Fetches the latest generation of text-based models from Google.
+
+    Args:
+      include_preview: Whether to include preview models in the list.
+
+    Returns:
+      A list of model names.
+    """
+    client = genai.Client(api_key=os.environ['GOOGLE_API_KEY'])
+    models = []
+    for m in client.models.list():
+      if (
+          'generateContent' in m.supported_actions
+          and '2.5' in m.name
+          and 'tts' not in m.name
+          and 'image' not in m.name
+      ):
+        models.append(m.name)
+
+    if not include_preview:
+      return [m for m in models if 'preview' not in m]
+
+    def get_base_model(model_name):
+      return model_name.split('-preview-')[0]
+
+    models.sort(key=get_base_model)
+    grouped_models = {
+        k: list(v) for k, v in itertools.groupby(models, key=get_base_model)
+    }
+
+    final_models = []
+    for _, model_list in grouped_models.items():
+      timed_models = [m for m in model_list if 'preview' in m]
+      other_models = [m for m in model_list if 'preview' not in m]
+
+      def extract_date(model_name: str) -> datetime.datetime:
+        """Extracts the date from a model name.
+
+        Args:
+          model_name: The name of the model.
+
+        Returns:
+          The date from the model name, or the minimum datetime if no date is
+          found.
+        """
+        match = re.search(r'(\d{2}-\d{2})$', model_name)
+        if match:
+          return datetime.datetime.strptime(match.group(1), '%m-%d')
+        return datetime.datetime.min
+
+      timed_models.sort(key=extract_date, reverse=True)
+      final_models.extend(other_models)
+      final_models.extend(timed_models[:2])
+
+    return final_models
+
+  def _benchmark_non_streaming(
+      self,
+      client: genai.Client,
+      model_name: str,
+      prompt: str,
+      safety_settings: List[Dict[str, Any]],
+      max_output_tokens: int,
+  ) -> Dict[str, Any]:
+    """Benchmarks a single model in non-streaming mode.
+
+    Args:
+      client: The Google GenAI client.
+      model_name: The name of the model to benchmark.
+      prompt: The prompt to send to the model.
+      safety_settings: The safety settings to use for the request.
+      max_output_tokens: The maximum number of tokens to generate.
+
+    Returns:
+      A dictionary of benchmark results.
+    """
+    logger.debug('Starting non-streaming benchmark...')
+    start_time = time.time()
+    try:
+      config = types.GenerateContentConfig(
+          temperature=base_provider.TEMPERATURE
+      )
+      if max_output_tokens:
+        config.max_output_tokens = max_output_tokens
+      config.safety_settings = safety_settings
+      response = client.models.generate_content(
+          model=model_name,
+          contents=prompt,
+          config=config,
+      )
+      end_time = time.time()
+      logger.debug(f'Response: {response}')
+      if not response.text:
+        logger.debug('Non-streaming benchmark failed.')
+        if response.candidates:
+          return {
+              'error': (
+                  'No response text found. Finish reason:'
+                  f' {response.candidates[0].finish_reason}, Safety Ratings:'
+                  f' {response.candidates[0].safety_ratings}'
+              )
+          }
+        else:
+          block_reason = (
+              response.prompt_feedback.block_reason
+              if response.prompt_feedback
+              else 'Unknown'
+          )
+          return {
+              'error': (
+                  'No response text found. Finish reason:'
+                  f' {block_reason}'
+              )
+          }
+    except exceptions.GoogleAPIError as e:
+      logger.debug('Non-streaming benchmark failed.')
+      return {'error': str(e)}
+    logger.debug('Finished non-streaming benchmark.')
+
+    return {
+        'non_streaming_full_response_time_in_seconds': round(
+            end_time - start_time, 2
+        ),
+        'non_streaming_full_response_output_tokens': (
+            client.models.count_tokens(
+                model=model_name, contents=response.text
+            ).total_tokens
+        ),
+    }
+
+  def _benchmark_streaming(
+      self,
+      client: genai.Client,
+      model_name: str,
+      prompt: str,
+      safety_settings: List[Dict[str, Any]],
+      max_output_tokens: int,
+  ) -> Dict[str, Any]:
+    """Benchmarks a single model in streaming mode.
+
+    Args:
+      client: The Google GenAI client.
+      model_name: The name of the model to benchmark.
+      prompt: The prompt to send to the model.
+      safety_settings: The safety settings to use for the request.
+      max_output_tokens: The maximum number of tokens to generate.
+
+    Returns:
+      A dictionary of benchmark results.
+    """
+    logger.debug('Starting streaming benchmark...')
+    start_time = time.time()
+    first_token_time = None
+    config = types.GenerateContentConfig(temperature=base_provider.TEMPERATURE)
+    if max_output_tokens:
+      config.max_output_tokens = max_output_tokens
+    config.safety_settings = safety_settings
+    stream = client.models.generate_content_stream(
+        model=model_name,
+        contents=prompt,
+        config=config,
+    )
+    output_text = ''
+    for chunk in stream:
+      if first_token_time is None:
+        first_token_time = time.time()
+      if chunk.text:
+        output_text += chunk.text
+    end_time = time.time()
+    logger.debug('Finished streaming benchmark.')
+
+    return {
+        'streaming_time_to_first_token_in_seconds': round(
+            first_token_time - start_time, 2
+        ),
+        'streaming_full_response_time_in_seconds': round(
+            end_time - start_time, 2
+        ),
+        'streaming_full_response_output_tokens': (
+            client.models.count_tokens(
+                model=model_name, contents=output_text
+            ).total_tokens
+        ),
+    }
+
+  def benchmark_model(
+      self,
+      model_name: str,
+      prompt: str,
+      prompt_id: str,
+      max_output_tokens: int,
+  ) -> Dict[str, Any]:
+    """Benchmarks a single Google model.
+
+    Args:
+      model_name: The name of the model to benchmark.
+      prompt: The prompt to send to the model.
+      prompt_id: The ID of the prompt.
+      max_output_tokens: The maximum number of tokens to generate.
+
+    Returns:
+      A dictionary of benchmark results.
+    """
+    super().benchmark_model(model_name, prompt, prompt_id, max_output_tokens)
+    client = genai.Client(api_key=os.environ['GOOGLE_API_KEY'])
+    results = {
+        'input_request_tokens': (
+            client.models.count_tokens(
+                model=model_name, contents=prompt
+            ).total_tokens
+        ),
+    }
+
+    non_streaming_results = self._benchmark_non_streaming(
+        client, model_name, prompt, SAFETY_SETTINGS, max_output_tokens
+    )
+    results.update(non_streaming_results)
+
+    streaming_results = self._benchmark_streaming(
+        client, model_name, prompt, SAFETY_SETTINGS, max_output_tokens
+    )
+    results.update(streaming_results)
+
+    logger.debug(f"  Finished benchmarking prompt: '{prompt_id}'")
+    return results

--- a/perfkitbenchmarker/data/llm_eval/providers/openai_provider.py
+++ b/perfkitbenchmarker/data/llm_eval/providers/openai_provider.py
@@ -1,0 +1,217 @@
+"""Provider for benchmarking OpenAI models."""
+
+import datetime
+import itertools
+import os
+import re
+import time
+from typing import Any, Dict, List
+
+from logger import get_logger
+import openai
+from openai import OpenAI
+
+from . import base_provider
+
+MAX_OUTPUT_TOKENS = 1024
+logger = get_logger(__name__)
+
+
+class OpenAIProvider(base_provider.BaseProvider):
+  """Provider for benchmarking OpenAI models."""
+
+  def get_models(self, include_preview: bool = False) -> List[str]:
+    """Fetches the latest generation of text-based models from OpenAI.
+
+    Args:
+      include_preview: Whether to include preview models in the list.
+
+    Returns:
+      A list of model names.
+    """
+    client = OpenAI(api_key=os.environ['OPENAI_API_KEY'])
+    models = [
+        model.id
+        for model in client.models.list()
+        if 'gpt' in model.id
+        and 'audio' not in model.id
+        and 'realtime' not in model.id
+        and 'instruct' not in model.id
+        and 'tts' not in model.id
+        and 'transcribe' not in model.id
+        and 'image' not in model.id
+    ]
+
+    def get_base_model(model_name: str) -> str:
+      """Gets the base model name from a full model name.
+
+      Args:
+        model_name: The full name of the model.
+
+      Returns:
+        The base name of the model.
+      """
+      base = model_name.split('-preview')[0]
+      base = base.split('-latest')[0]
+
+      # Remove date suffixes like -2024-04-09
+      base = re.sub(r'-\d{4}-\d{2}-\d{2}$', '', base)
+
+      # Remove version suffixes like -0125 or -1106
+      base = re.sub(r'-\d{4}$', '', base)
+
+      # Remove size suffixes like -16k
+      base = re.sub(r'-\d+k$', '', base)
+
+      if 'chatgpt-' in base:
+        base = base.replace('chatgpt-', 'gpt-')
+
+      return base
+
+    models.sort(key=get_base_model)
+    grouped_models = {
+        k: list(v) for k, v in itertools.groupby(models, key=get_base_model)
+    }
+
+    final_models = []
+    for _, model_list in grouped_models.items():
+      preview_models = [m for m in model_list if 'preview' in m]
+      ga_models = [m for m in model_list if 'preview' not in m]
+
+      if ga_models:
+        # Sort by length to find the base model (e.g., 'gpt-4' vs 'gpt-4-0613')
+        ga_models.sort(key=len)
+        final_models.append(ga_models[0])
+
+      if include_preview and preview_models:
+
+        def extract_date(model_name):
+          match = re.search(r'(\d{4}-\d{2}-\d{2})', model_name)
+          if match:
+            return datetime.datetime.strptime(match.group(1), '%Y-%m-%d')
+
+          match = re.search(r'-(\d{4})-preview', model_name)
+          if match:
+            try:
+              # Handle MMDD format
+              return datetime.datetime.strptime(match.group(1), '%m%d').replace(
+                  year=datetime.datetime.now().year
+              )
+            except ValueError:
+              pass
+          return datetime.datetime.min
+
+        preview_models.sort(key=extract_date, reverse=True)
+        final_models.extend(preview_models[:2])
+
+    if not include_preview:
+      return sorted(list(set([m for m in final_models if 'preview' not in m])))
+
+    return sorted(list(set(final_models)))
+
+  def benchmark_model(
+      self,
+      model_name: str,
+      prompt: str,
+      prompt_id: str,
+      max_output_tokens: int,
+  ) -> Dict[str, Any]:
+    """Benchmarks a single OpenAI model.
+
+    Args:
+      model_name: The name of the model to benchmark.
+      prompt: The prompt to send to the model.
+      prompt_id: The ID of the prompt.
+      max_output_tokens: The maximum number of tokens to generate.
+
+    Returns:
+      A dictionary of benchmark results.
+    """
+    super().benchmark_model(model_name, prompt, prompt_id, max_output_tokens)
+    client = OpenAI(api_key=os.environ['OPENAI_API_KEY'])
+    results = {}
+
+    tokens_to_use = (
+        max_output_tokens
+        if max_output_tokens is not None
+        else MAX_OUTPUT_TOKENS
+    )
+
+    # Non-streaming
+    logger.debug('Starting non-streaming benchmark...')
+    start_time = time.time()
+    params = {
+        'model': model_name,
+        'messages': [{'role': 'user', 'content': prompt}],
+        'temperature': base_provider.TEMPERATURE,
+    }
+
+    if 'nano' in model_name or 'gpt-5' in model_name:
+      params['max_completion_tokens'] = tokens_to_use
+    else:
+      params['max_tokens'] = tokens_to_use
+
+    logger.debug(f'Non-streaming request params: {params}')
+    try:
+      response = client.chat.completions.create(**params)
+      end_time = time.time()
+      logger.debug(f'Non-streaming response: {response}')
+      results['non_streaming_full_response_time_in_seconds'] = round(
+          end_time - start_time, 2
+      )
+      results['input_request_tokens'] = response.usage.prompt_tokens
+      results['non_streaming_full_response_output_tokens'] = (
+          response.usage.completion_tokens
+      )
+    except openai.OpenAIError as e:
+      logger.debug(f'Non-streaming benchmark failed: {e}')
+      results['error'] = str(e)
+      return results
+
+    # Streaming
+    logger.debug('Starting streaming benchmark...')
+    start_time = time.time()
+    first_token_time = None
+
+    logger.debug(f'Streaming request params: {params}')
+    try:
+      stream = client.chat.completions.create(**params, stream=True)
+      output_text = ''
+      for chunk in stream:
+        if first_token_time is None:
+          first_token_time = time.time()
+        if chunk.choices[0].delta.content:
+          output_text += chunk.choices[0].delta.content
+      end_time = time.time()
+      logger.debug('Finished streaming benchmark.')
+
+      results['streaming_time_to_first_token_in_seconds'] = round(
+          first_token_time - start_time, 2
+      )
+      results['streaming_full_response_time_in_seconds'] = round(
+          end_time - start_time, 2
+      )
+
+      # Re-encode to count tokens for streaming
+      re_encode_params = {
+          'model': model_name,
+          'messages': [{'role': 'user', 'content': output_text}],
+      }
+
+      if 'nano' in model_name or 'gpt-5' in model_name:
+        re_encode_params['max_completion_tokens'] = tokens_to_use
+      else:
+        re_encode_params['max_tokens'] = tokens_to_use
+
+      logger.debug(f'Re-encoding request params: {re_encode_params}')
+      response = client.chat.completions.create(**re_encode_params)
+      logger.debug(f'Re-encoding response: {response}')
+      results['streaming_full_response_output_tokens'] = (
+          response.usage.prompt_tokens
+      )
+    except openai.OpenAIError as e:
+      logger.debug(f'Streaming benchmark failed: {e}')
+      results['streaming_error'] = str(e)
+
+    logger.debug(f"  Finished benchmarking prompt: '{prompt_id}'")
+    return results

--- a/perfkitbenchmarker/data/llm_eval/requirements.txt
+++ b/perfkitbenchmarker/data/llm_eval/requirements.txt
@@ -1,0 +1,7 @@
+requests
+google-genai
+openai
+anthropic
+python-dotenv
+absl-py
+google-api-core

--- a/perfkitbenchmarker/linux_benchmarks/llm_eval_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/llm_eval_benchmark.py
@@ -1,0 +1,217 @@
+# Copyright 2024 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Runs the llm_eval benchmark.
+
+This benchmark tool evaluates the performance of large language models (LLMs)
+from various providers, including Google, OpenAI, and Anthropic.
+
+Features:
+- Benchmark LLMs from Google, OpenAI, and Anthropic.
+- Discover the latest models from each provider.
+- Benchmark multiple prompts in a single run.
+- Output results in JSON format.
+- Filter out non-text models.
+- Discover-only mode to list models without benchmarking.
+- Optionally include preview models in the benchmark.
+- Consistent temperature setting of 0.0 for deterministic results.
+
+The benchmark can be customized using flags to select the provider,
+filter models, and control execution.
+"""
+
+import json
+import logging
+from typing import Any, Dict, List
+from absl import flags
+from perfkitbenchmarker import benchmark_spec
+from perfkitbenchmarker import configs
+from perfkitbenchmarker import data
+from perfkitbenchmarker import errors
+from perfkitbenchmarker import sample
+from perfkitbenchmarker import vm_util
+from perfkitbenchmarker.configs import benchmark_config_spec as pkb_benchmark_config_spec
+
+BENCHMARK_NAME = 'llm_eval'
+BENCHMARK_CONFIG = """
+llm_eval:
+  description: Runs llm_eval benchmark.
+  vm_groups:
+    clients:
+      vm_spec: *default_dual_core
+      vm_count: 1
+"""
+
+BENCHMARK_DATA = {
+    '.env': '6102705161035710e3866e44451531aad83174f71999c7b2a94313747375d0a0'
+}
+_PROVIDER = flags.DEFINE_enum(
+    'llm_eval_provider',
+    'google',
+    ['google', 'openai', 'anthropic'],
+    'The provider to benchmark.',
+)
+_MAX_MODELS = flags.DEFINE_integer(
+    'llm_eval_max_models',
+    20,
+    'The maximum number of models to test in a single invocation.',
+)
+_SPECIFIC_MODELS = flags.DEFINE_list(
+    'llm_eval_specific_models',
+    None,
+    'An optional list of models to benchmark, overriding the discovery.',
+)
+_DISCOVER_MODELS_ONLY = flags.DEFINE_boolean(
+    'llm_eval_discover_models_only',
+    False,
+    'Discover models and exit without benchmarking.',
+)
+_INCLUDE_PREVIEW = flags.DEFINE_boolean(
+    'llm_eval_include_preview',
+    False,
+    'Include preview models from the benchmark.',
+)
+
+FLAGS = flags.FLAGS
+
+
+def GetConfig(user_config: Dict[str, Any]) -> Dict[str, Any]:
+  """Loads and returns the benchmark config.
+
+  Args:
+    user_config: A dictionary of the user's command line flags.
+
+  Returns:
+    The benchmark configuration.
+  """
+  return configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
+
+
+def CheckPrerequisites(
+    benchmark_config: pkb_benchmark_config_spec.BenchmarkConfigSpec,
+) -> None:
+  """Verifies that the required resources are present.
+
+  Args:
+    benchmark_config: The benchmark configuration.
+
+  Raises:
+    errors.Config.InvalidValue: On invalid flag settings.
+  """
+  del benchmark_config
+  if _SPECIFIC_MODELS.value:
+    if _INCLUDE_PREVIEW.value:
+      raise errors.Config.InvalidValue(
+          'Cannot use --llm_eval_specific_models with'
+          ' --llm_eval_include_preview.'
+      )
+    if _MAX_MODELS.present:
+      raise errors.Config.InvalidValue(
+          'Cannot use --llm_eval_specific_models with --llm_eval_max_models.'
+      )
+  if _DISCOVER_MODELS_ONLY.value:
+    if _SPECIFIC_MODELS.value:
+      raise errors.Config.InvalidValue(
+          'Cannot use --llm_eval_specific_models with'
+          ' --llm_eval_discover_models_only.'
+      )
+
+
+def Prepare(spec: benchmark_spec.BenchmarkSpec) -> None:
+  """Installs and sets up llm_eval on the target vm.
+
+  Args:
+    spec: The benchmark specification.
+  """
+  logging.info('Executing llm_eval Prepare function.')
+  vm = spec.vm_groups['clients'][0]
+  vm.Install('pip')
+  vm.PushFile(data.ResourcePath('llm_eval'), vm_util.VM_TMP_DIR)
+  vm.RemoteCommand(
+      f'pip install -r {vm_util.VM_TMP_DIR}/llm_eval/requirements.txt'
+  )
+  vm.InstallPreprovisionedBenchmarkData(
+      BENCHMARK_NAME, ['.env'], f'{vm_util.VM_TMP_DIR}/llm_eval'
+  )
+
+
+def Run(spec: benchmark_spec.BenchmarkSpec) -> List[sample.Sample]:
+  """Runs llm_eval on the target vm.
+
+  Args:
+    spec: The benchmark specification.
+
+  Returns:
+    A list of sample.Sample objects.
+  """
+  vm = spec.vm_groups['clients'][0]
+  logging.info('Executing llm_eval Run function.')
+  cmd_parts = [
+      'python3',
+      'main.py',
+      f'--provider={_PROVIDER.value}',
+  ]
+  if _DISCOVER_MODELS_ONLY.value:
+    cmd_parts.append('--discover_models_only')
+    if _INCLUDE_PREVIEW.value:
+      cmd_parts.append('--include_preview')
+  else:
+    if _SPECIFIC_MODELS.value:
+      cmd_parts.append(f"--specific_models={','.join(_SPECIFIC_MODELS.value)}")
+    else:
+      cmd_parts.append(f'--max_models={_MAX_MODELS.value}')
+      if _INCLUDE_PREVIEW.value:
+        cmd_parts.append('--include_preview')
+
+  run_command = ' '.join(cmd_parts)
+  full_cmd = f'cd {vm_util.VM_TMP_DIR}/llm_eval && {run_command}'
+  stdout, _ = vm.RemoteCommand(full_cmd)
+
+  if _DISCOVER_MODELS_ONLY.value:
+    metadata = {'discovered_models': json.loads(stdout)}
+    return [sample.Sample('discovered_models', 0, '', metadata)]
+  else:
+    results = json.loads(stdout)
+    samples = []
+    prompts_tested = results.get('prompts_tested', {})
+    for model, model_results in results['results'].items():
+      for prompt, prompt_results in model_results.items():
+        metadata = {
+            'model': model,
+            'prompt': prompt,
+            'provider': _PROVIDER.value,
+            'prompt_text': prompts_tested.get(prompt, {}).get('text'),
+        }
+        if 'error' in prompt_results:
+          metadata['error_message'] = prompt_results['error']
+          samples.append(sample.Sample('error_count', 1, 'count', metadata))
+        else:
+          for metric, value in prompt_results.items():
+            unit = ''
+            if 'tokens' in metric:
+              unit = 'tokens'
+            elif 'seconds' in metric:
+              unit = 'seconds'
+            samples.append(sample.Sample(metric, value, unit, metadata))
+
+    return samples
+
+
+def Cleanup(spec: benchmark_spec.BenchmarkSpec) -> None:
+  """Cleans up llm_eval on the target vm.
+
+  Args:
+    spec: The benchmark specification.
+  """
+  del spec  # Unused


### PR DESCRIPTION
This pull request introduces a new benchmark, llm_eval, designed to evaluate the performance of various Large Language Model (LLM) providers. The benchmark measures key metrics such as time-to-first-token, full
  response time, and token counts for both streaming and non-streaming responses.

  Key Features

   * New Benchmark: llm_eval
   * Supported Providers: Google, OpenAI, Anthropic
   * Metrics:
       * Time to first token (streaming)
       * Full response time (streaming and non-streaming)
       * Input and output token counts

  Prerequisites

  This benchmark requires API keys for the respective LLM providers. These keys should be placed in a .env file and uploaded to a GCS bucket. The benchmark will download and use this file for authentication.

  Example .env file structure:

   1 GOOGLE_API_KEY=your_google_api_key
   2 OPENAI_API_KEY=your_openai_api_key
   3 ANTHROPIC_API_KEY=your_anthropic_api_key

  How to Run the Benchmark

  To run the benchmark, use the following pkb.py commands, replacing <your_gcs_bucket> with the name of the GCS bucket containing your .env file.

  Google:

   1 .venv/bin/python pkb.py --benchmarks=llm_eval --llm_eval_provider=google --gcp_preprovisioned_data_bucket=<your_gcs_bucket>

  OpenAI:

   1 .venv/bin/python pkb.py --benchmarks=llm_eval --llm_eval_provider=openai --gcp_preprovisioned_data_bucket=<your_gcs_bucket>

  Anthropic:

   1 .venv/bin/python pkb.py --benchmarks=llm_eval --llm_eval_provider=anthropic --gcp_preprovisioned_data_bucket=<your_gcs_bucket>