### PR TITLE
Fix call to ConvertManifestToYamlDicts method

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/kubernetes_scale_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/kubernetes_scale_benchmark.py
@@ -236,7 +236,7 @@ def ScaleUpPods(
   if is_eks_karpenter_aws_gpu:
     manifest_kwargs['GpuTaintKey'] = 'nvidia.com/gpu'
 
-  yaml_docs = cluster.ConvertManifestToYamlDicts(
+  yaml_docs = kubernetes_commands.ConvertManifestToYamlDicts(
       MANIFEST_TEMPLATE,
       **manifest_kwargs,
   )


### PR DESCRIPTION
Fix call to the `ConvertManifestToYamlDicts` method.
The `ConvertManifestToYamlDicts` method is no longer on the cluster instance after switching to kubernetes_commands.