### PR TITLE
[AWS/EKS] Tune VPC CNI warm pool for kubernetes_node_scale in EksKarpenterCluster

### DIFF
--- a/perfkitbenchmarker/providers/aws/elastic_kubernetes_service.py
+++ b/perfkitbenchmarker/providers/aws/elastic_kubernetes_service.py
@@ -1007,7 +1007,7 @@ class EksKarpenterCluster(BaseEksCluster):
   def _PostCreate(self):
     """Performs post-creation steps for the cluster."""
     super()._PostCreate()
-    if 'kubernetes_node_scale' in FLAGS.benchmarks:
+    if FLAGS.eks_tune_vpc_cni_for_scale:
       logging.info('Tuning aws-node (VPC CNI) for kubernetes_node_scale')
       kubectl.RunKubectlCommand([
           'set',

--- a/perfkitbenchmarker/providers/aws/elastic_kubernetes_service.py
+++ b/perfkitbenchmarker/providers/aws/elastic_kubernetes_service.py
@@ -1006,6 +1006,29 @@ class EksKarpenterCluster(BaseEksCluster):
   def _PostCreate(self):
     """Performs post-creation steps for the cluster."""
     super()._PostCreate()
+    if 'kubernetes_node_scale' in FLAGS.benchmarks:
+      logging.info('Tuning aws-node (VPC CNI) for kubernetes_node_scale')
+      kubectl.RunKubectlCommand([
+          'set',
+          'env',
+          'daemonset/aws-node',
+          '-n',
+          'kube-system',
+          'WARM_ENI_TARGET=0',
+          'WARM_IP_TARGET=1',
+          'MINIMUM_IP_TARGET=1',
+      ])
+      kubectl.RunRetryableKubectlCommand(
+          [
+              'rollout',
+              'status',
+              'daemonset/aws-node',
+              '-n',
+              'kube-system',
+              '--timeout=%ds' % vm_util.DEFAULT_TIMEOUT,
+          ],
+          timeout=vm_util.DEFAULT_TIMEOUT,
+      )
     # Karpenter controller resources: default 1/1Gi; scale up when node_scale target is set.
     num_nodes = getattr(FLAGS, 'kubernetes_scale_num_nodes', None)
     if num_nodes is not None and num_nodes > 1000:

--- a/perfkitbenchmarker/providers/aws/flags.py
+++ b/perfkitbenchmarker/providers/aws/flags.py
@@ -246,6 +246,14 @@ flags.DEFINE_list(
     'Comma-separated EC2 types for the Karpenter default NodePool (worker '
     'nodes only). Empty keeps instance-category/generation in the template.',
 )
+flags.DEFINE_boolean(
+    'eks_tune_vpc_cni_for_scale',
+    False,
+    'Tune aws-node DaemonSet warm-pool settings (WARM_ENI_TARGET=0, '
+    'WARM_IP_TARGET=1, MINIMUM_IP_TARGET=1) after cluster creation. '
+    'Required when scaling to thousands of nodes to prevent subnet IP '
+    'exhaustion. Enable when running kubernetes_node_scale at large scale.',
+)
 AWS_CAPACITY_BLOCK_RESERVATION_ID = flags.DEFINE_string(
     'aws_capacity_block_reservation_id',
     None,


### PR DESCRIPTION
NOTE: should be merged only after [PR#6512](https://github.com/GoogleCloudPlatform/PerfKitBenchmarker/pull/6512) is merged.
## What
In `EksKarpenterCluster._PostCreate`, when the benchmark is
`kubernetes_node_scale`, tune the VPC CNI warm-pool settings on the
`aws-node` DaemonSet in `kube-system` and wait for the rollout to
complete before the benchmark run starts.
Settings applied:
- WARM_ENI_TARGET=0
- WARM_IP_TARGET=1
- MINIMUM_IP_TARGET=1
## Why
By default, the AWS VPC CNI pre-allocates a warm pool of ENIs and
secondary IPs on each node as soon as it joins the cluster. The number
of IPs reserved scales with the instance type — larger instances have
more ENI slots and more IPs per ENI, so each node can reserve 10–30+
IPs before a single pod is scheduled.
At 5k-node scale this becomes a hard blocker: the cumulative IP
pre-allocation across all nodes exhausts the subnet address space
before all nodes can be scheduled, causing the benchmark to fail with
`InsufficientCapacityError` and `FailedScheduling` events.
Setting `WARM_ENI_TARGET=0`, `WARM_IP_TARGET=1`, `MINIMUM_IP_TARGET=1`
instructs the CNI to keep only 1 IP warm per node instead of a full
ENI's worth, which is sufficient for the `kubernetes_node_scale`
workload (one pod per node). This is not a performance optimization —
it is a prerequisite for the benchmark to complete successfully at
this scale.
See [`WARM_IP_TARGET` and `MINIMUM_IP_TARGET`](https://github.com/aws/amazon-vpc-cni-k8s/blob/master/docs/prefix-and-ip-target.md) for reference, and [this overview](https://medium.com/@GiteshWadhwa/optimizing-kubernetes-networking-understanding-warm-eni-target-warm-ip-target-and-14e74096b067) for a practical explanation.
## Scope
The tuning block is guarded by `'kubernetes_node_scale' in
FLAGS.benchmarks`, so it is a no-op for all other benchmarks. No
existing behaviour is changed outside that gate.
## Testing
Validated with two back-to-back 5k-node runs on EKS + Karpenter in
us-east-1. Both runs completed with status
SUCCEEDED.

## Usage 
python pkb.py \\
    --benchmarks=kubernetes_node_scale \\
    --eks_tune_vpc_cni_for_scale=True \\
  ....