### PR TITLE
Add n4a (Google Axion/Neoverse N3) to GCP ARM architecture map

### DIFF
--- a/perfkitbenchmarker/providers/gcp/gce_virtual_machine.py
+++ b/perfkitbenchmarker/providers/gcp/gce_virtual_machine.py
@@ -107,6 +107,7 @@ _MACHINE_TYPE_PREFIX_TO_ARM_ARCH = {
     't2a': 'neoverse-n1',
     'c3a': 'ampere1',
     'c4a': 'neoverse-v2',
+    'n4a': 'neoverse-n3',
 }
 # When requesting a specific GPU type independently of the machine type, choose
 # the most common version. When using a machine type from the


### PR DESCRIPTION
## Summary
- The N4A machine family (Google Axion, Arm Neoverse N3) is missing from `_MACHINE_TYPE_PREFIX_TO_ARM_ARCH` in `gce_virtual_machine.py`
- Without this entry, PKB does not recognize N4A instances as ARM and defaults to the x86_64 image family (`ubuntu-2404-lts-amd64`), causing VM creation to fail with: `Requested boot disk architecture (X86_64) is not compatible with machine type architecture (ARM64).`
- This adds `'n4a': 'neoverse-n3'` to the map, matching the Neoverse N3 cores used by Google Axion in the N4A family

## Test plan
- Verified fix by running PerfKit coremark benchmarks against n4a-standard-32, n4a-highcpu-32, and n4a-highmem-32 in us-central1 — all completed successfully with the ARM64 image auto-selected