### PR TITLE
publisher: support promoting metadata keys to top-level BigQuery columns

### DIFF
--- a/perfkitbenchmarker/publisher.py
+++ b/perfkitbenchmarker/publisher.py
@@ -157,6 +157,16 @@ _PROMOTE_METADATA_TO_TOP_LEVEL = flags.DEFINE_list(
     'value to disable promotion.',
 )
 
+_BQ_SCHEMA_UPDATE_OPTIONS = flags.DEFINE_list(
+    'bq_schema_update_options',
+    [],
+    'Schema update options passed through to "bq load" via '
+    '--schema_update_option, e.g. ALLOW_FIELD_ADDITION. Needed to add newly '
+    'promoted (--promote_metadata_to_top_level) keys as columns on a '
+    'pre-existing table; without it, bq load only adds columns when creating '
+    'the table. Empty by default, which preserves the prior load behavior.',
+)
+
 _THROW_ON_METADATA_CONFLICT = flags.DEFINE_boolean(
     'throw_on_metadata_conflict',
     True,
@@ -754,6 +764,10 @@ class BigQueryPublisher(SamplePublisher):
           'load',
           '--autodetect',
           '--source_format=NEWLINE_DELIMITED_JSON',
+      ])
+      for option in _BQ_SCHEMA_UPDATE_OPTIONS.value or ():
+        load_cmd.append('--schema_update_option=' + option)
+      load_cmd.extend([
           self.bigquery_table,
           tf.name,
       ])

--- a/perfkitbenchmarker/publisher.py
+++ b/perfkitbenchmarker/publisher.py
@@ -147,6 +147,16 @@ flags.DEFINE_multi_string(
     'by separating each pair by commas.',
 )
 
+_PROMOTE_METADATA_TO_TOP_LEVEL = flags.DEFINE_list(
+    'promote_metadata_to_top_level',
+    [],
+    'Comma-separated list of metadata keys to promote to top-level sample '
+    'fields before publishing. Useful with --collapse_labels=true (the '
+    'BigQuery default) so these keys remain queryable as typed columns '
+    'instead of being pipe-joined into the labels string. Pass an empty '
+    'value to disable promotion.',
+)
+
 _THROW_ON_METADATA_CONFLICT = flags.DEFINE_boolean(
     'throw_on_metadata_conflict',
     True,
@@ -717,7 +727,7 @@ class BigQueryPublisher(SamplePublisher):
         prefix='perfkit-bq-pub', dir=vm_util.GetTempDir(), suffix='.json'
     ) as tf:
       json_publisher = NewlineDelimitedJSONPublisher(
-          tf.name, collapse_labels=True
+          tf.name, collapse_labels=FLAGS.collapse_labels
       )
       json_publisher.PublishSamples(samples)
       tf.close()
@@ -1220,6 +1230,18 @@ class SampleCollector:
       sample['owner'] = FLAGS.owner
       sample['run_uri'] = benchmark_spec.uuid
       sample['sample_uri'] = str(uuid.uuid4())
+
+      # Promote select metadata keys to top-level columns. With
+      # collapse_labels=True (BigQuery's default path), the rest of
+      # metadata gets pipe-joined into a string; promoting before the
+      # collapse keeps these queryable as typed columns. Configure via
+      # --promote_metadata_to_top_level; keep the list short, only for
+      # keys that are useful as join/filter keys.
+      metadata = sample.get('metadata') or {}
+      for key in _PROMOTE_METADATA_TO_TOP_LEVEL.value or ():
+        if key in metadata:
+          sample[key] = metadata.pop(key)
+
       self.samples.append(sample)
 
   def PublishSamples(self):


### PR DESCRIPTION
**What this does**

Adds `--promote_metadata_to_top_level`, a comma-separated list of metadata keys to lift out of the nested `metadata` blob into top-level sample fields before publishing. This keeps high-value keys queryable as their own typed BigQuery columns instead of being buried in metadata (or pipe-joined into the collapsed `labels` string).

Defaults to empty, so it is opt-in and changes nothing unless you set it.

**Behavior change to note**

`BigQueryPublisher` previously hardcoded `collapse_labels=True` and ignored the `--collapse_labels` flag. It now honors the flag. The default is still `True`, so default output is unchanged, but if you were already passing `--collapse_labels=false`, your BigQuery `labels` will now actually be expanded instead of being silently collapsed.

**BigQuery schema note**

The BQ publisher loads with `bq load --autodetect` (no explicit schema). Promoted keys become top-level columns automatically when the table is created on a fresh load, or when the column already exists. Adding a newly promoted key to a pre-existing, long-lived results table would otherwise fail the load, since `bq load` only adds columns to an existing table when given `--schema_update_option=ALLOW_FIELD_ADDITION`.

To support that case, this PR also adds `--bq_schema_update_options`, a list passed through to `bq load` (e.g. `ALLOW_FIELD_ADDITION`). It defaults to empty, preserving the prior load behavior.

**Example**

```
./pkb.py --benchmarks=... \
  --bigquery_table=my_dataset.results \
  --promote_metadata_to_top_level=vm_instance_type,zone,git_commit \
  --bq_schema_update_options=ALLOW_FIELD_ADDITION
```

Then query directly:

```sql
SELECT vm_instance_type, AVG(value)
FROM my_dataset.results
WHERE zone = 'us-central1-a'
GROUP BY vm_instance_type
```

instead of parsing those values out of the `labels` string. Keep the promotion list short: only keys you actually filter or join on.
