### PR TITLE
agent_sandbox: benchmark for SandboxClaim provisioning latency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@
 /.idea
 /*git_ignore*
 .DS_Store
+
+# Local private key, never commit
+*.pem
+perfitbenchmarker-sync.*.private-key.pem

--- a/perfkitbenchmarker/configs/container_spec.py
+++ b/perfkitbenchmarker/configs/container_spec.py
@@ -243,6 +243,9 @@ class NodepoolSpec(spec.BaseSpec):
     self.vm_spec: virtual_machine_spec.BaseVmSpec
     self.machine_families: list[str] | None
     self.sandbox_config: SandboxSpec | None
+    self.max_pods_per_node: int | None
+    self.node_labels: dict[str, str] | None
+    self.node_taints: list[str] | None
 
   @classmethod
   def _GetOptionDecoderConstructions(cls):
@@ -273,6 +276,18 @@ class NodepoolSpec(spec.BaseSpec):
         ),
         'vm_spec': (spec.PerCloudConfigDecoder, {}),
         'sandbox_config': (_SandboxDecoder, {'default': None}),
+        'max_pods_per_node': (
+            option_decoders.IntDecoder,
+            {'default': None, 'none_ok': True, 'min': 1},
+        ),
+        'node_labels': (
+            option_decoders.TypeVerifier,
+            {'valid_types': (dict,), 'default': None, 'none_ok': True},
+        ),
+        'node_taints': (
+            option_decoders.TypeVerifier,
+            {'valid_types': (list,), 'default': None, 'none_ok': True},
+        ),
     })
     return result
 

--- a/perfkitbenchmarker/data/agent_sandbox/gvisor-installer/daemonset.yaml
+++ b/perfkitbenchmarker/data/agent_sandbox/gvisor-installer/daemonset.yaml
@@ -1,0 +1,71 @@
+# Privileged DaemonSet that runs an init container to install runsc and the
+# containerd-runsc shim onto the host, then sleeps as a pause container.
+#
+# The actual install logic comes from a ConfigMap named gvisor-installer-script
+# (created by install_gvisor() in linux_packages/agent_sandbox.py from
+# data/agent_sandbox/gvisor-installer/install.sh before this DaemonSet is
+# applied). The ConfigMap key is "install.sh", mounted at /scripts.
+#
+# Targets nodes labelled sandbox.gke.io/runtime=runsc (the label the
+# benchmark applies to the sandbox node pool).
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: gvisor-installer
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: gvisor-installer
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: gvisor-installer
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: gvisor-installer
+    spec:
+      hostPID: true
+      tolerations:
+        - key: sandbox.gke.io/runtime
+          operator: Equal
+          value: runsc
+          effect: NoSchedule
+      nodeSelector:
+        sandbox.gke.io/runtime: runsc
+      initContainers:
+        - name: install
+          image: docker.io/library/ubuntu:24.04
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+          env:
+            - name: GVISOR_VERSION
+              # Pinned for benchmarking. Update in lockstep across all envs.
+              # Verify available releases at https://gvisor.dev/docs/user_guide/install/
+              value: "20260511"
+          command: ["/bin/bash", "/scripts/install.sh"]
+          volumeMounts:
+            - name: host
+              mountPath: /host
+            - name: script
+              mountPath: /scripts
+              readOnly: true
+      containers:
+        # Pause container keeps the DaemonSet "Running" after install completes.
+        - name: pause
+          image: registry.k8s.io/pause:3.9
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 50m
+              memory: 64Mi
+      volumes:
+        - name: host
+          hostPath:
+            path: /
+        - name: script
+          configMap:
+            name: gvisor-installer-script
+            defaultMode: 0755

--- a/perfkitbenchmarker/data/agent_sandbox/gvisor-installer/install.sh
+++ b/perfkitbenchmarker/data/agent_sandbox/gvisor-installer/install.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+set -euxo pipefail
+
+: "${GVISOR_VERSION:?must be set}"
+HOST=/host
+ARCH=$(uname -m)
+URL="https://storage.googleapis.com/gvisor/releases/release/${GVISOR_VERSION}/${ARCH}"
+
+apt-get update -qq
+apt-get install -y -qq curl util-linux
+
+NEEDS_RESTART=0
+
+# On COS nodes /usr/local/bin is read-only; binaries live on the writable
+# stateful partition at /home/kubernetes/bin. On all other nodes (Ubuntu,
+# Amazon Linux) /usr/local/bin is writable and already on PATH.
+if [ -d "${HOST}/home/kubernetes" ]; then
+  INSTALL_DIR="${HOST}/home/kubernetes/bin"
+  NEEDS_PATH_DROPIN=1
+else
+  INSTALL_DIR="${HOST}/usr/local/bin"
+  NEEDS_PATH_DROPIN=0
+fi
+mkdir -p "${INSTALL_DIR}"
+
+for bin in runsc containerd-shim-runsc-v1; do
+  TARGET="${INSTALL_DIR}/${bin}"
+  if [ ! -x "${TARGET}" ]; then
+    curl -fsSL "${URL}/${bin}" -o "${TARGET}.new"
+    chmod +x "${TARGET}.new"
+    mv "${TARGET}.new" "${TARGET}"
+    NEEDS_RESTART=1
+  fi
+done
+
+# On COS, /home/kubernetes/bin is not on systemd's default PATH; drop in a
+# unit override for containerd so the shim is found. Not needed on non-COS
+# nodes where /usr/local/bin is already on PATH.
+if [ "${NEEDS_PATH_DROPIN}" -eq 1 ]; then
+  DROPIN_DIR="${HOST}/etc/systemd/system/containerd.service.d"
+  DROPIN="${DROPIN_DIR}/10-runsc-path.conf"
+  mkdir -p "${DROPIN_DIR}"
+  if [ ! -f "${DROPIN}" ]; then
+    cat > "${DROPIN}" <<'EOF'
+[Service]
+Environment="PATH=/home/kubernetes/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+EOF
+    NEEDS_RESTART=1
+  fi
+fi
+
+# Register the runsc runtime with containerd.
+CONFIG="${HOST}/etc/containerd/config.toml"
+if [ ! -f "${CONFIG}" ]; then
+  mkdir -p "$(dirname "${CONFIG}")"
+  nsenter -t 1 -m -u -i -n -p -- containerd config default > "${CONFIG}"
+fi
+if ! grep -q 'io.containerd.runsc.v1' "${CONFIG}"; then
+  # containerd v2+ uses config version 3 where the CRI runtime plugin moved
+  # from io.containerd.grpc.v1.cri to io.containerd.cri.v1.runtime.
+  # Appending to the wrong section is silently ignored, leaving runsc
+  # unconfigured even though the binary is installed.
+  if grep -q 'version = 3' "${CONFIG}"; then
+    CRI_PLUGIN='io.containerd.cri.v1.runtime'
+  else
+    CRI_PLUGIN='io.containerd.grpc.v1.cri'
+  fi
+  cat >>"${CONFIG}" <<TOML
+
+[plugins."${CRI_PLUGIN}".containerd.runtimes.runsc]
+runtime_type = "io.containerd.runsc.v1"
+TOML
+  NEEDS_RESTART=1
+fi
+
+if [ "${NEEDS_RESTART}" -eq 1 ]; then
+  nsenter -t 1 -m -u -i -n -p -- systemctl daemon-reload
+  nsenter -t 1 -m -u -i -n -p -- systemctl restart containerd
+fi
+
+echo "gVisor self-install complete on $(uname -n)."

--- a/perfkitbenchmarker/data/agent_sandbox/gvisor-installer/runtimeclass.yaml
+++ b/perfkitbenchmarker/data/agent_sandbox/gvisor-installer/runtimeclass.yaml
@@ -1,0 +1,15 @@
+# RuntimeClass that self-managed sandbox pods reference via
+# runtimeClassName: runsc. The handler "runsc" matches the runtime
+# registered in containerd's config by the installer DaemonSet:
+#   [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runsc]
+#     runtime_type = "io.containerd.runsc.v1"
+#
+# Named "runsc" (not "gvisor") because GKE Standard ships a pre-installed
+# "gvisor" RuntimeClass with handler "gvisor" and addonmanager mode
+# Reconcile, so we can't own that name. Platform-managed scenarios use
+# GKE's "gvisor" RC and don't need this manifest.
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: runsc
+handler: runsc

--- a/perfkitbenchmarker/data/agent_sandbox/sandbox-template.yaml.j2
+++ b/perfkitbenchmarker/data/agent_sandbox/sandbox-template.yaml.j2
@@ -1,0 +1,57 @@
+# Reusable blueprint for the sandboxes that SandboxClaim will provision.
+# The `runtimeClassName` is set per-run via the runtime_class template
+# variable (default: runsc for GKE self-managed gVisor).
+#
+# The security/placement fields below are REQUIRED by GKE's
+# `secure-sandbox-policy` ValidatingAdmissionPolicy on Agent-Sandbox-
+# enabled clusters (Sandbox CRs without them are rejected). The same
+# fields are harmless on clusters that don't run the policy.
+apiVersion: extensions.agents.x-k8s.io/v1beta1
+kind: SandboxTemplate
+metadata:
+  name: {{ template_name }}
+spec:
+  podTemplate:
+    metadata:
+      labels:
+        sandbox: python-sandbox-bench
+    spec:
+      runtimeClassName: {{ runtime_class }}
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+      nodeSelector:
+        sandbox.gke.io/runtime: {{ runtime_class }}
+      tolerations:
+        - key: sandbox.gke.io/runtime
+          operator: Equal
+          value: {{ runtime_class }}
+          effect: NoSchedule
+      containers:
+        - name: python-runtime
+          image: registry.k8s.io/agent-sandbox/python-runtime-sandbox:v0.4.6
+          ports:
+            - containerPort: 8888
+          readinessProbe:
+            httpGet:
+              path: "/"
+              port: 8888
+            initialDelaySeconds: 0
+            periodSeconds: 1
+          securityContext:
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            # These values are the defaults. All four are overridable at run time
+            # via benchmark flags.
+            requests:
+              cpu: "100m"
+              memory: "256Mi"
+              ephemeral-storage: "256Mi"
+            limits:
+              # CPU limit is decoupled from the request: a limit equal to the 100m request throttled
+              # warm-pod startup. Giving the pod burst headroom (500m limit) improves startup while
+              # keeping the 100m request so node packing density is unchanged.
+              cpu: "500m"
+              memory: "1Gi"
+      restartPolicy: "OnFailure"

--- a/perfkitbenchmarker/data/agent_sandbox/sandbox-warmpool.yaml.j2
+++ b/perfkitbenchmarker/data/agent_sandbox/sandbox-warmpool.yaml.j2
@@ -1,0 +1,11 @@
+# Pre-warmed pool of sandbox pods. Replenishment latency under contention is
+# one of the primary metrics for the benchmark -- keep replicas identical
+# across envs so claim throughput is the only variable.
+apiVersion: extensions.agents.x-k8s.io/v1beta1
+kind: SandboxWarmPool
+metadata:
+  name: {{ warmpool_name }}
+spec:
+  replicas: {{ replicas }}
+  sandboxTemplateRef:
+    name: {{ template_name }}

--- a/perfkitbenchmarker/linux_benchmarks/agent_sandbox_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/agent_sandbox_benchmark.py
@@ -1,0 +1,343 @@
+# Copyright 2026 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Measures agent-sandbox controller claim provisioning latency under load.
+
+Installs the agent-sandbox controller stack (Prepare) and submits SandboxClaim
+custom resources at a target QPS from the PKB host, measuring time to the claim
+reporting a Ready status condition (Run). Cluster and node pools are provisioned
+by PerfKitBenchmarker from BENCHMARK_CONFIG.
+"""
+
+from absl import flags
+
+from perfkitbenchmarker import configs
+from perfkitbenchmarker.linux_packages import agent_sandbox
+from perfkitbenchmarker.linux_packages import agent_sandbox_loadgen
+from perfkitbenchmarker.linux_packages import agent_sandbox_metrics
+
+BENCHMARK_NAME = 'agent_sandbox'
+
+BENCHMARK_CONFIG = """
+agent_sandbox:
+  description: >
+    Measure agent-sandbox controller claim provisioning latency under load.
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-4
+        zone: us-central1-a
+      AWS:
+        machine_type: m8i.xlarge
+        zone: us-east-1a
+    nodepools:
+      sandbox:
+        vm_count: 4
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-16
+            zone: us-central1-a
+          AWS:
+            machine_type: m8i.4xlarge
+            zone: us-east-1a
+        node_labels:
+          sandbox.gke.io/runtime: runsc
+        node_taints:
+          - sandbox.gke.io/runtime=runsc:NoSchedule
+"""
+
+# Load shape.
+_QPS = flags.DEFINE_float(
+    'agent_sandbox_qps',
+    10.0,
+    'Target SandboxClaim submission rate (claims per second).',
+)
+_DURATION = flags.DEFINE_float(
+    'agent_sandbox_duration',
+    60.0,
+    'Submission window in seconds. Combined with qps to derive total.',
+)
+_TOTAL = flags.DEFINE_integer(
+    'agent_sandbox_total',
+    None,
+    'Total claims to submit. If set, overrides duration derivation.',
+)
+_MAX_CONCURRENT = flags.DEFINE_integer(
+    'agent_sandbox_max_concurrent', 200, 'Maximum in-flight claims.'
+)
+_READY_TIMEOUT = flags.DEFINE_integer(
+    'agent_sandbox_ready_timeout', 180, 'Per-claim ready timeout in seconds.'
+)
+_WORKLOAD_DURATION = flags.DEFINE_integer(
+    'agent_sandbox_workload_duration',
+    0,
+    'Seconds to run a CPU busy-loop inside each sandbox after it becomes '
+    'Ready, before releasing it. 0 (default) releases immediately (pure '
+    'provisioning benchmark). >0 holds the sandbox, so peak_concurrency '
+    'reflects simultaneously-alive sandboxes and exec_duration_s / '
+    'total_lifecycle_s metrics are emitted.',
+)
+_CLAIM_TTL = flags.DEFINE_integer(
+    'agent_sandbox_claim_ttl_seconds',
+    120,
+    'Server-side TTL (ttlSecondsAfterFinished) set on each SandboxClaim so the'
+    ' controller auto-deletes orphaned claims if the driver is hard-killed.'
+    ' 0 disables the TTL.',
+)
+# Sandbox stack.
+_NAMESPACE = flags.DEFINE_string(
+    'agent_sandbox_namespace',
+    'default',
+    'Namespace in which SandboxClaims are created.',
+)
+_TEMPLATE = flags.DEFINE_string(
+    'agent_sandbox_template', 'python-runtime-template', 'SandboxTemplate name.'
+)
+_RUNTIME_CLASS = flags.DEFINE_string(
+    'agent_sandbox_runtime_class', 'runsc', 'RuntimeClass for sandbox pods.'
+)
+_WARMPOOL = flags.DEFINE_string(
+    'agent_sandbox_warmpool',
+    'python-sandbox-warmpool',
+    'SandboxWarmPool name. Empty disables the warm pool reference.',
+)
+_WARMPOOL_REPLICAS = flags.DEFINE_integer(
+    'agent_sandbox_warmpool_replicas',
+    0,
+    'SandboxWarmPool size to provision in Prepare.',
+)
+_CONTROLLER_REF = flags.DEFINE_string(
+    'agent_sandbox_controller_ref',
+    '32c4f231a116f76eb707fe34510b8143d61268ae',
+    'agent-sandbox release ref (tag or SHA) for CRD, RBAC, and controller '
+    'manifests.',
+)
+_CONTROLLER_IMAGE = flags.DEFINE_string(
+    'agent_sandbox_controller_image',
+    'us-central1-docker.pkg.dev/k8s-staging-images/agent-sandbox/'
+    'agent-sandbox-controller:v20260527-v0.4.6-31-gd43447b-main',
+    'Controller container image.',
+)
+
+# Cloud selection uses PKB's standard global --cloud flag (GCP provisions GKE,
+# AWS provisions EKS). Both run the identical controller install, load
+# generator, and metrics path. The flag is read in GetConfig to select the
+# per-cloud vm_spec block and is applied to the cluster spec automatically by
+# ContainerClusterSpec._ApplyFlags.
+
+# Node pool sizing.
+_GENERAL_POOL_MACHINE_TYPE = flags.DEFINE_string(
+    'agent_sandbox_general_pool_machine_type',
+    None,
+    'Machine type for the general (default) node pool. None uses the '
+    'per-cloud default from the benchmark config.',
+)
+_GENERAL_POOL_NODES = flags.DEFINE_integer(
+    'agent_sandbox_general_pool_nodes',
+    1,
+    'Node count for the general (default) node pool.',
+)
+_SANDBOX_POOL_MACHINE_TYPE = flags.DEFINE_string(
+    'agent_sandbox_sandbox_pool_machine_type',
+    None,
+    'Machine type for the sandbox node pool. None uses the per-cloud '
+    'default from the benchmark config.',
+)
+_SANDBOX_POOL_NODES = flags.DEFINE_integer(
+    'agent_sandbox_sandbox_pool_nodes',
+    4,
+    'Node count for the sandbox node pool.',
+)
+_SANDBOX_POOL_MAX_PODS = flags.DEFINE_integer(
+    'agent_sandbox_sandbox_pool_max_pods_per_node',
+    None,
+    'Max pods per node for the sandbox node pool. None uses the cluster'
+    ' default.',
+)
+
+# Controller tuning. None means use the controller binary defaults.
+_CTRL_CLAIM_WORKERS = flags.DEFINE_integer(
+    'agent_sandbox_controller_claim_workers',
+    None,
+    'Controller --sandbox-claim-concurrent-workers value.',
+)
+_CTRL_SANDBOX_WORKERS = flags.DEFINE_integer(
+    'agent_sandbox_controller_sandbox_workers',
+    None,
+    'Controller --sandbox-concurrent-workers value.',
+)
+_CTRL_WARMPOOL_WORKERS = flags.DEFINE_integer(
+    'agent_sandbox_controller_warmpool_workers',
+    None,
+    'Controller --sandbox-warm-pool-concurrent-workers value.',
+)
+_CTRL_WARMPOOL_MAX_BATCH_SIZE = flags.DEFINE_integer(
+    'agent_sandbox_controller_warmpool_max_batch_size',
+    None,
+    'Controller --sandbox-warm-pool-max-batch-size value.',
+)
+_CTRL_KUBE_API_BURST = flags.DEFINE_integer(
+    'agent_sandbox_controller_kube_api_burst',
+    None,
+    'Controller --kube-api-burst value.',
+)
+_CTRL_KUBE_API_QPS = flags.DEFINE_integer(
+    'agent_sandbox_controller_kube_api_qps',
+    None,
+    'Controller --kube-api-qps value.',
+)
+_CTRL_ENABLE_TRACING = flags.DEFINE_boolean(
+    'agent_sandbox_controller_enable_tracing',
+    False,
+    'Enable controller OpenTelemetry tracing.',
+)
+_CTRL_OTEL_ENDPOINT = flags.DEFINE_string(
+    'agent_sandbox_controller_otel_endpoint',
+    None,
+    'OTLP exporter endpoint when tracing is enabled.',
+)
+_CTRL_LEADER_ELECT = flags.DEFINE_boolean(
+    'agent_sandbox_controller_leader_elect',
+    False,
+    'Whether the controller runs with leader election enabled.',
+)
+
+FLAGS = flags.FLAGS
+
+
+def GetConfig(user_config):
+  """Loads the benchmark config and merges user overrides."""
+  config = configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
+  cluster = config['container_cluster']
+  cluster['cloud'] = FLAGS.cloud
+  cloud = cluster['cloud']
+
+  # Wire general (default) pool sizing. Machine type falls back to the
+  # per-cloud config default when the flag is unset.
+  cluster['vm_count'] = _GENERAL_POOL_NODES.value
+  if _GENERAL_POOL_MACHINE_TYPE.value is not None:
+    cluster['vm_spec'][cloud]['machine_type'] = _GENERAL_POOL_MACHINE_TYPE.value
+  # ContainerClusterSpec does not accept max_pods_per_node at the top level;
+  # the key is only valid on NodepoolSpec. General-pool max-pods is therefore
+  # not supported via this flag path and is silently ignored here.
+
+  # Wire sandbox pool sizing.
+  sandbox = cluster['nodepools']['sandbox']
+  sandbox['vm_count'] = _SANDBOX_POOL_NODES.value
+  if _SANDBOX_POOL_MACHINE_TYPE.value is not None:
+    sandbox['vm_spec'][cloud]['machine_type'] = _SANDBOX_POOL_MACHINE_TYPE.value
+  if _SANDBOX_POOL_MAX_PODS.value is not None:
+    sandbox['max_pods_per_node'] = _SANDBOX_POOL_MAX_PODS.value
+
+  return config
+
+
+def Prepare(benchmark_spec):
+  """Installs the agent-sandbox controller stack on the provisioned cluster."""
+  del benchmark_spec  # Cluster is provisioned by PKB; install via kubectl.
+  tuning: dict[str, object] = {
+      'enable_tracing': _CTRL_ENABLE_TRACING.value,
+      'leader_elect': _CTRL_LEADER_ELECT.value,
+  }
+  for key, flag in (
+      ('claim_workers', _CTRL_CLAIM_WORKERS),
+      ('sandbox_workers', _CTRL_SANDBOX_WORKERS),
+      ('warmpool_workers', _CTRL_WARMPOOL_WORKERS),
+      ('warmpool_max_batch_size', _CTRL_WARMPOOL_MAX_BATCH_SIZE),
+      ('kube_api_burst', _CTRL_KUBE_API_BURST),
+      ('kube_api_qps', _CTRL_KUBE_API_QPS),
+      ('otel_endpoint', _CTRL_OTEL_ENDPOINT),
+  ):
+    if flag.value is not None:
+      tuning[key] = flag.value
+  agent_sandbox.install_stack(
+      controller_ref=_CONTROLLER_REF.value,
+      controller_image=_CONTROLLER_IMAGE.value,
+      runtime_class=_RUNTIME_CLASS.value,
+      template_name=_TEMPLATE.value,
+      warmpool_name=_WARMPOOL.value,
+      warmpool_replicas=_WARMPOOL_REPLICAS.value,
+      controller_tuning=tuning,
+  )
+
+
+def Run(benchmark_spec):
+  """Submits claims at the target rate and returns latency samples."""
+  shape = agent_sandbox_loadgen.resolve_run_shape(
+      qps=_QPS.value,
+      duration=_DURATION.value if _TOTAL.value is None else None,
+      total=_TOTAL.value,
+  )
+  driver = agent_sandbox_loadgen.ClaimDriver(
+      namespace=_NAMESPACE.value,
+      template_name=_TEMPLATE.value,
+      warmpool_name=_WARMPOOL.value or None,
+      claim_ttl_seconds=_CLAIM_TTL.value,
+      max_concurrent=_MAX_CONCURRENT.value,
+  )
+  workload_duration = _WORKLOAD_DURATION.value
+  executor = None
+  if workload_duration > 0:
+    exec_pool_size = _MAX_CONCURRENT.value + 50
+    executor = agent_sandbox_loadgen.StreamExecExecutor(
+        core_v1_api=agent_sandbox_loadgen._make_core_v1_api(exec_pool_size),
+        custom_objects_api=agent_sandbox_loadgen._make_custom_objects_api(
+            exec_pool_size
+        ),
+        namespace=_NAMESPACE.value,
+        workload_duration=workload_duration,
+    )
+  generator = agent_sandbox_loadgen.LoadGenerator(
+      driver,
+      ready_timeout=_READY_TIMEOUT.value,
+      max_concurrent=_MAX_CONCURRENT.value,
+      workload_executor=executor,
+      workload_duration=workload_duration,
+  )
+  records = generator.run(shape)
+
+  metadata = {
+      'target_qps': shape.qps,
+      'duration': shape.duration,
+      'total_claims': shape.total,
+      'warmpool_replicas': _WARMPOOL_REPLICAS.value,
+      'template': _TEMPLATE.value,
+      'runtime_class': _RUNTIME_CLASS.value,
+  }
+  cluster = getattr(benchmark_spec, 'container_cluster', None)
+  if cluster is not None:
+    metadata.update(cluster.GetResourceMetadata())
+  return agent_sandbox_metrics.build_samples(
+      records, generator.peak_concurrency, metadata
+  )
+
+
+def Cleanup(benchmark_spec):
+  """Best-effort deletion of any SandboxClaims left in the namespace."""
+  del benchmark_spec
+  from perfkitbenchmarker.resources.container_service import kubectl
+
+  kubectl.RunKubectlCommand(
+      [
+          'delete',
+          'sandboxclaims',
+          '--all',
+          '-n',
+          _NAMESPACE.value,
+          '--ignore-not-found',
+      ],
+      raise_on_failure=False,
+  )

--- a/perfkitbenchmarker/linux_packages/agent_sandbox.py
+++ b/perfkitbenchmarker/linux_packages/agent_sandbox.py
@@ -1,0 +1,353 @@
+# Copyright 2026 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Installs the agent-sandbox controller stack (gVisor, CRDs, RBAC, controller).
+
+This is the only domain logic in the benchmark that touches Kubernetes resources
+directly. It uses PKB's ApplyManifest/WaitForResource/WaitForRollout APIs
+rather than raw kubectl calls.
+"""
+
+import os
+import tempfile
+import yaml
+
+from absl import logging
+
+from perfkitbenchmarker import data
+from perfkitbenchmarker import vm_util
+from perfkitbenchmarker.resources.container_service import kubectl
+from perfkitbenchmarker.resources.container_service import kubernetes_commands
+
+_GVISOR_DAEMONSET = 'agent_sandbox/gvisor-installer/daemonset.yaml'
+_GVISOR_RUNTIMECLASS = 'agent_sandbox/gvisor-installer/runtimeclass.yaml'
+_GVISOR_INSTALLER_SCRIPT = 'agent_sandbox/gvisor-installer/install.sh'
+_GVISOR_CONFIGMAP_NAME = 'gvisor-installer-script'
+_TEMPLATE_MANIFEST = 'agent_sandbox/sandbox-template.yaml.j2'
+_WARMPOOL_MANIFEST = 'agent_sandbox/sandbox-warmpool.yaml.j2'
+
+# Public agent-sandbox release assets, parameterized by release ref.
+# The exact public base URL is confirmed during live-cluster validation.
+# URL pattern for upstream raw asset access.
+# The path segment 'k8s/' is incorporated into each filename constant below via subpaths.
+_RELEASE_BASE = (
+    'https://raw.githubusercontent.com/kubernetes-sigs/agent-sandbox'
+)
+
+# CRD filenames live under k8s/crds/ in the upstream repo.
+_CRD_FILES = (
+    'crds/agents.x-k8s.io_sandboxes.yaml',
+    'crds/extensions.agents.x-k8s.io_sandboxclaims.yaml',
+    'crds/extensions.agents.x-k8s.io_sandboxtemplates.yaml',
+    'crds/extensions.agents.x-k8s.io_sandboxwarmpools.yaml',
+)
+
+# RBAC files live at the root of k8s/ in the upstream repo.
+_RBAC_FILES = (
+    'rbac.generated.yaml',
+    'extensions-rbac.generated.yaml',
+    # extensions.yaml is the ClusterRoleBinding that grants the controller SA
+    # the extensions ClusterRole. Without it the controller cannot watch
+    # sandboxclaims/sandboxwarmpools/sandboxtemplates and the warm pool hangs.
+    'extensions.yaml',
+)
+
+# controller.yaml bundles Namespace, ServiceAccount, ClusterRoleBinding, Service,
+# and a base Deployment with a placeholder image. We apply everything except the
+# Deployment; extensions.controller.yaml is the actual controller Deployment and
+# is applied once, fully configured, below.
+_CORE_FILE = 'controller.yaml'
+_CONTROLLER_FILE = 'extensions.controller.yaml'
+
+
+def _crd_name(filename):
+  """Derives a CRD resource name from its manifest filename.
+
+  Example: 'crds/agents.x-k8s.io_sandboxes.yaml' -> 'sandboxes.agents.x-k8s.io'.
+  """
+  base = filename.split('/')[-1].removesuffix('.yaml')
+  group, plural = base.rsplit('_', 1)
+  return f'{plural}.{group}'
+
+
+def _url(ref, filename):
+  return f'{_RELEASE_BASE}/{ref}/k8s/{filename}'
+
+
+def _apply_url(url):
+  """Applies a manifest from a URL. Isolated for test mocking."""
+  kubectl.RunKubectlCommand(['apply', '-f', url])
+
+
+def _wait_warmpool_ready(warmpool_name, replicas, timeout=600):
+  """Polls the SandboxWarmPool until readyReplicas matches the target."""
+  kubernetes_commands.WaitForResource(
+      f'sandboxwarmpool/{warmpool_name}',
+      f'jsonpath={{.status.readyReplicas}}={replicas}',
+      condition_type='',
+      timeout=timeout,
+  )
+
+
+def install_gvisor():
+  """Installs gVisor onto cluster nodes via the installer DaemonSet.
+
+  Creates the gvisor-installer-script ConfigMap (from install.sh) in
+  kube-system before applying the DaemonSet. The DaemonSet mounts that
+  ConfigMap at /scripts; the init container runs /scripts/install.sh.
+  The ConfigMap must exist before the DaemonSet pods schedule.
+  """
+  _create_installer_configmap()
+  # Plain .yaml files: ApplyManifest with NO kwargs.
+  kubernetes_commands.ApplyManifest(data.ResourcePath(_GVISOR_DAEMONSET))
+  kubernetes_commands.ApplyManifest(data.ResourcePath(_GVISOR_RUNTIMECLASS))
+  kubernetes_commands.WaitForRollout(
+      'daemonset/gvisor-installer', namespace='kube-system'
+  )
+
+
+def _create_installer_configmap():
+  """Creates or updates the gvisor-installer-script ConfigMap in kube-system.
+
+  Uses --dry-run=client -o yaml to render the ConfigMap manifest (idempotent
+  on re-runs), writes it to a temp file, then applies it. A plain
+  'kubectl create configmap' would fail if the resource already exists.
+  """
+  script_path = data.ResourcePath(_GVISOR_INSTALLER_SCRIPT)
+  # Render the ConfigMap manifest without hitting the cluster.
+  # Use --from-file=install.sh=<path> so the ConfigMap has exactly one key
+  # named install.sh, instead of pulling the whole directory (which would
+  # also include daemonset.yaml and runtimeclass.yaml as keys).
+  yaml_out, _, _ = kubectl.RunKubectlCommand([
+      'create',
+      'configmap',
+      _GVISOR_CONFIGMAP_NAME,
+      f'--from-file=install.sh={script_path}',
+      '--namespace',
+      'kube-system',
+      '--dry-run=client',
+      '-o',
+      'yaml',
+  ])
+  # Write the rendered manifest to a temp file and apply it.
+  tmpfile = tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False)
+  with tmpfile as tmp:
+    tmp.write(yaml_out)
+    tmp_path = tmp.name
+  try:
+    kubectl.RunKubectlCommand(['apply', '-f', tmp_path])
+  finally:
+    os.unlink(tmp_path)
+
+
+def _apply_yaml(yaml_str):
+  """Writes yaml_str to a temp file and applies it with kubectl apply."""
+  tmpfile = tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False)
+  with tmpfile as tmp:
+    tmp.write(yaml_str)
+    tmp_path = tmp.name
+  try:
+    kubectl.RunKubectlCommand(['apply', '-f', tmp_path])
+  finally:
+    os.unlink(tmp_path)
+
+
+def _configure_controller_manifest(manifest_yaml, controller_image, tuning):
+  """Injects image and all tuning into a controller Deployment manifest dict.
+
+  Returns the modified manifest as a YAML string ready to pipe to kubectl apply.
+  """
+  manifest = yaml.safe_load(manifest_yaml)
+  container = manifest['spec']['template']['spec']['containers'][0]
+
+  # Image.
+  if controller_image:
+    container['image'] = controller_image
+
+  # Resources (Burstable QoS; base manifest ships with nothing -> BestEffort).
+  container['resources'] = {
+      'requests': {
+          'cpu': tuning.get('cpu_request', _DEFAULT_CPU_REQUEST),
+          'memory': tuning.get('memory_request', _DEFAULT_MEMORY_REQUEST),
+      },
+      'limits': {
+          'cpu': tuning.get('cpu_limit', _DEFAULT_CPU_LIMIT),
+          'memory': tuning.get('memory_limit', _DEFAULT_MEMORY_LIMIT),
+      },
+  }
+
+  # Leader election: base manifest sets --leader-elect=true at args[0]; replace
+  # it so exactly one effective flag exists.
+  args = container.setdefault('args', [])
+  le_flag = (
+      '--leader-elect=true'
+      if tuning.get('leader_elect')
+      else '--leader-elect=false'
+  )
+  if args and args[0].startswith('--leader-elect'):
+    args[0] = le_flag
+  else:
+    args.insert(0, le_flag)
+
+  # Controller tuning args (appended; order doesn't matter).
+  for key, arg_fmt in _TUNING_ARG_MAP:
+    value = tuning.get(key)
+    if value is not None:
+      args.append(arg_fmt.format(value))
+  if tuning.get('enable_tracing'):
+    args.append('--enable-tracing=true')
+
+  # OTEL env vars (kubectl set env handles absent env array; we do it inline).
+  if tuning.get('enable_tracing') and tuning.get('otel_endpoint'):
+    env = container.setdefault('env', [])
+    env.append({
+        'name': 'OTEL_EXPORTER_OTLP_ENDPOINT',
+        'value': tuning['otel_endpoint'],
+    })
+    env.append({'name': 'OTEL_EXPORTER_OTLP_INSECURE', 'value': 'true'})
+
+  return yaml.dump(manifest, default_flow_style=False)
+
+
+def install_controller(
+    controller_ref, controller_image, controller_tuning=None
+):
+  """Installs CRDs, RBAC, and the controller Deployment from upstream.
+
+  Args:
+    controller_ref: Git ref (tag or SHA) for upstream raw asset URLs.
+    controller_image: Optional controller container image override. Ref-based
+      manifests ship a ko:// placeholder image that is not pullable; callers
+      must supply a real image when installing from a ref rather than a tagged
+      release (which bundles a resolved image in the manifest).
+    controller_tuning: Optional dict. Supported keys:
+      claim_workers, sandbox_workers, kube_api_burst, kube_api_qps,
+      enable_tracing, otel_endpoint (applied after manifests and image patch);
+      leader_elect (bool, default False), cpu_request, cpu_limit,
+      memory_request, memory_limit (strings, default values) which control
+      the unconditional leader-election and resources patch.
+  """
+  tuning = controller_tuning or {}
+  for filename in _CRD_FILES:
+    _apply_url(_url(controller_ref, filename))
+  for filename in _CRD_FILES:
+    kubernetes_commands.WaitForResource(
+        f'crd/{_crd_name(filename)}', 'established'
+    )
+  for filename in _RBAC_FILES:
+    _apply_url(_url(controller_ref, filename))
+  # Apply everything in controller.yaml except the Deployment. The base
+  # Deployment in that file has a placeholder image; skipping it here means
+  # the controller Deployment is created exactly once, fully configured, below.
+  raw_core, _, _ = vm_util.IssueCommand(
+      ['curl', '-fsSL', _url(controller_ref, _CORE_FILE)]
+  )
+  non_deployment = [
+      doc
+      for doc in yaml.safe_load_all(raw_core)
+      if doc and doc.get('kind') != 'Deployment'
+  ]
+  if non_deployment:
+    _apply_yaml(yaml.dump_all(non_deployment))
+  # Download extensions.controller.yaml, inject all configuration in memory,
+  # and apply in one shot -- one rollout, correct config from the first apply.
+  controller_url = _url(controller_ref, _CONTROLLER_FILE)
+  raw_manifest, _, _ = vm_util.IssueCommand(['curl', '-fsSL', controller_url])
+  configured = _configure_controller_manifest(
+      raw_manifest, controller_image, tuning
+  )
+  logging.info('Applying controller deployment (image=%s)', controller_image)
+  _apply_yaml(configured)
+  kubernetes_commands.WaitForRollout(
+      'deployment/agent-sandbox-controller', namespace='agent-sandbox-system'
+  )
+
+
+# Mapping from tuning dict keys to the controller CLI flag strings.
+# The args array is assumed to exist in the manifest (confirmed at live
+# validation); JSON-patch add to /args/- appends to it.
+_TUNING_ARG_MAP = (
+    ('claim_workers', '--sandbox-claim-concurrent-workers={}'),
+    ('sandbox_workers', '--sandbox-concurrent-workers={}'),
+    ('warmpool_workers', '--sandbox-warm-pool-concurrent-workers={}'),
+    ('warmpool_max_batch_size', '--sandbox-warm-pool-max-batch-size={}'),
+    ('kube_api_burst', '--kube-api-burst={}'),
+    ('kube_api_qps', '--kube-api-qps={}'),
+)
+
+_DEFAULT_CPU_REQUEST = '500m'
+_DEFAULT_CPU_LIMIT = '2'
+_DEFAULT_MEMORY_REQUEST = '256Mi'
+_DEFAULT_MEMORY_LIMIT = '1Gi'
+
+
+def apply_template(template_name, runtime_class):
+  """Applies a SandboxTemplate from a jinja2 data file."""
+  # .j2 file: kwargs become jinja2 template variables.
+  kubernetes_commands.ApplyManifest(
+      data.ResourcePath(_TEMPLATE_MANIFEST),
+      template_name=template_name,
+      runtime_class=runtime_class,
+  )
+
+
+def install_warmpool(warmpool_name, template_name, replicas):
+  """Applies a SandboxWarmPool and waits for it to reach the target size.
+
+  If replicas is 0, skips both the manifest apply and the readiness wait.
+  Waiting for readyReplicas=0 is ill-defined (the controller may never update
+  status on an empty pool), and applying a zero-replica warmpool is unnecessary
+  for cold-start benchmarks.
+  """
+  if replicas == 0:
+    logging.info('Warm pool replicas=0; skipping warm pool install.')
+    return
+  kubernetes_commands.ApplyManifest(
+      data.ResourcePath(_WARMPOOL_MANIFEST),
+      warmpool_name=warmpool_name,
+      template_name=template_name,
+      replicas=replicas,
+  )
+  _wait_warmpool_ready(warmpool_name, replicas)
+
+
+def install_stack(
+    controller_ref,
+    controller_image,
+    runtime_class,
+    template_name,
+    warmpool_name,
+    warmpool_replicas,
+    controller_tuning=None,
+):
+  """Installs gVisor, the controller, the template, and the warm pool in order.
+
+  Args:
+    controller_ref: agent-sandbox release ref for CRD, RBAC, controller assets.
+    controller_image: Controller container image reference.
+    runtime_class: RuntimeClass name set on the SandboxTemplate (e.g. runsc).
+    template_name: SandboxTemplate name.
+    warmpool_name: SandboxWarmPool name.
+    warmpool_replicas: Target warm pool size.
+    controller_tuning: Optional dict of controller tuning parameters. See
+      install_controller for supported keys.
+  """
+  logging.info('Installing agent-sandbox stack (ref=%s).', controller_ref)
+  install_gvisor()
+  install_controller(
+      controller_ref, controller_image, controller_tuning=controller_tuning
+  )
+  apply_template(template_name, runtime_class)
+  install_warmpool(warmpool_name, template_name, warmpool_replicas)

--- a/perfkitbenchmarker/linux_packages/agent_sandbox_loadgen.py
+++ b/perfkitbenchmarker/linux_packages/agent_sandbox_loadgen.py
@@ -1,0 +1,736 @@
+# Copyright 2026 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Host-side load generator for the agent_sandbox benchmark.
+
+Creates SandboxClaim custom resources at a target QPS and measures the time
+from claim creation to the claim reporting a Ready status condition.
+
+Design: a single shared Watch stream (stream_claim_events) records readiness
+from status events rather than per-claim polling, so we never flood the
+apiserver with individual status GETs under concurrency.
+"""
+
+import dataclasses
+import logging
+import threading
+import time
+from concurrent import futures
+from typing import Any, Optional, cast
+
+
+# Default connection pool size for kubernetes ApiClient instances. Callers that
+# know their concurrency level should pass an explicit value instead.
+_CONNECTION_POOL_MAXSIZE = 64
+
+# 429 retry parameters for create().
+_CREATE_MAX_RETRIES = 5
+_CREATE_RETRY_AFTER_DEFAULT = 1.0  # seconds
+_CREATE_RETRY_AFTER_CAP = 5.0  # seconds
+
+
+@dataclasses.dataclass(frozen=True)
+class RunShape:
+  """A fully resolved load shape: rate, window, and total claim count."""
+
+  qps: float
+  duration: float
+  total: int
+
+
+def resolve_run_shape(qps=None, duration=None, total=None):
+  """Resolves any two of qps, duration, total into a complete RunShape.
+
+  Args:
+    qps: Target claims per second.
+    duration: Submission window in seconds.
+    total: Total number of claims to submit.
+
+  Returns:
+    A RunShape with all three fields populated.
+
+  Raises:
+    ValueError: If fewer than two values are provided.
+  """
+  if qps is not None and duration is not None and total is not None:
+    # All three provided; respect them as-is.
+    pass
+  elif qps is not None and duration is not None:
+    total = int(round(qps * duration))
+  elif qps is not None and total is not None:
+    duration = total / qps
+  elif duration is not None and total is not None:
+    qps = total / duration
+  else:
+    raise ValueError('Provide at least two of qps, duration, total.')
+  return RunShape(qps=float(qps), duration=float(duration), total=int(total))
+
+
+CLAIM_API_GROUP = 'extensions.agents.x-k8s.io'
+CLAIM_API_VERSION = 'v1beta1'
+CLAIM_PLURAL = 'sandboxclaims'
+CLAIM_KIND = 'SandboxClaim'
+
+
+def _load_kube_config():
+  """Loads kubeconfig for the current PKB run. Isolated for test mocking."""
+  from kubernetes import config  # pylint: disable=import-error,no-name-in-module
+
+  config.load_kube_config()
+
+
+def _register_bearer_token_auth(cfg):
+  """Registers the exec-plugin bearer token under the key the client expects.
+
+  kubernetes-client>=36 auth_settings() looks for the token under the
+  'BearerToken' api_key, but load_kube_config() stores exec-plugin tokens
+  under 'authorization'. Without this remap the Authorization header is never
+  added to requests and every call goes out unauthenticated.
+  """
+  token = cfg.api_key.get('authorization', '')
+  if token and 'BearerToken' not in cfg.api_key:
+    if token.startswith('Bearer '):
+      token = token[len('Bearer ') :]
+    cfg.api_key['BearerToken'] = token
+    cfg.api_key_prefix['BearerToken'] = 'Bearer'
+
+
+def _new_api_client(connection_pool_maxsize=_CONNECTION_POOL_MAXSIZE):
+  """Builds a Kubernetes ApiClient with a sized connection pool and working
+  bearer-token auth.
+
+  Every API client in this module needs the same two things, so they are
+  applied once here rather than in each constructor:
+    - connection_pool_maxsize, so concurrent requests don't serialize behind
+      a small urllib3 pool.
+    - the exec-plugin bearer-token remap (see _register_bearer_token_auth).
+  """
+  from kubernetes import client  # pylint: disable=import-error,no-name-in-module
+
+  cfg = client.Configuration.get_default_copy()
+  cfg.connection_pool_maxsize = connection_pool_maxsize
+  _register_bearer_token_auth(cfg)
+  return client.ApiClient(cfg)
+
+
+def _make_custom_objects_api(connection_pool_maxsize=_CONNECTION_POOL_MAXSIZE):
+  """Builds a CustomObjectsApi client with a sized connection pool."""
+  from kubernetes import client  # pylint: disable=import-error,no-name-in-module
+
+  return client.CustomObjectsApi(_new_api_client(connection_pool_maxsize))
+
+
+def _make_core_v1_api(connection_pool_maxsize=_CONNECTION_POOL_MAXSIZE):
+  """Builds a CoreV1Api client with a sized connection pool (for pod exec)."""
+  from kubernetes import client  # pylint: disable=import-error,no-name-in-module
+
+  return client.CoreV1Api(_new_api_client(connection_pool_maxsize))
+
+
+@dataclasses.dataclass
+class ClaimRecord:
+  """Timing record for one SandboxClaim."""
+
+  name: str
+  requested_at: float
+  ready_at: Optional[float] = None
+  error: Optional[str] = None
+  warm_served: Optional[bool] = None
+  exec_started_at: Optional[float] = None
+  exec_completed_at: Optional[float] = None
+  released_at: Optional[float] = None
+
+  @property
+  def startup_time_s(self):
+    if self.ready_at is None:
+      return None
+    return self.ready_at - self.requested_at
+
+  @property
+  def exec_duration_s(self):
+    if self.exec_started_at is None or self.exec_completed_at is None:
+      return None
+    return self.exec_completed_at - self.exec_started_at
+
+  @property
+  def total_lifecycle_s(self):
+    if self.released_at is None:
+      return None
+    return self.released_at - self.requested_at
+
+
+def _busy_loop_code(workload_duration):
+  """Python source for a CPU busy-loop that runs ~workload_duration seconds."""
+  return (
+      'import time\n'
+      'start = time.monotonic()\n'
+      'count = 0\n'
+      f'while time.monotonic() - start < {workload_duration}:\n'
+      '    _ = (count * 2) + (count ** 2)\n'
+      '    count += 1\n'
+      'print(f"iterations={count}")\n'
+  )
+
+
+class WorkloadExecutor:
+  """Runs a workload inside a Ready sandbox and blocks until it completes."""
+
+  def prepare(self, _claim_name, _status):
+    """Called eagerly in the watch consumer when the claim becomes Ready.
+
+    Returns any pre-fetched data that execute() needs. The return value is
+    passed through as the `prepared` argument to execute(). Default: None."""
+    return None
+
+  def execute(self, _claim_name, _status, _prepared):
+    raise NotImplementedError
+
+
+class NoopExecutor(WorkloadExecutor):
+  """No workload: used when workload_duration == 0 (immediate release)."""
+
+  def execute(self, _claim_name, _status, _prepared):
+    return
+
+
+class StreamExecExecutor(WorkloadExecutor):
+  """Execs the workload into the sandbox pod via the Kubernetes API server
+  (connect_get_namespaced_pod_exec). Works from any host with kubeconfig."""
+
+  def __init__(
+      self,
+      core_v1_api,
+      custom_objects_api,
+      namespace,
+      workload_duration,
+      sandbox_group='agents.x-k8s.io',
+      sandbox_version='v1beta1',
+      sandbox_plural='sandboxes',
+  ):
+    self._core = core_v1_api
+    self._co = custom_objects_api
+    self._namespace = namespace
+    self._workload_duration = workload_duration
+    self._sandbox_group = sandbox_group
+    self._sandbox_version = sandbox_version
+    self._sandbox_plural = sandbox_plural
+
+  def _resolve_pod_name(self, status):
+    """Ready claim -> sandbox pod name. status.sandbox.name is the Sandbox CR
+    name; the actual pod is that name UNLESS a warm-pool pod was adopted, in
+    which case the pod name is in the Sandbox's agents.x-k8s.io/pod-name
+    annotation (per the controller's resolvePodName)."""
+    sandbox = status.get('sandbox') or {}
+    sandbox_name = sandbox.get('name')
+    if not sandbox_name:
+      return None
+    sb = self._co.get_namespaced_custom_object(
+        self._sandbox_group,
+        self._sandbox_version,
+        self._namespace,
+        self._sandbox_plural,
+        sandbox_name,
+    )
+    annotations = (sb.get('metadata') or {}).get('annotations') or {}
+    return annotations.get('agents.x-k8s.io/pod-name') or sandbox_name
+
+  def prepare(self, claim_name, status):
+    """Resolves the pod name while the Sandbox CR is guaranteed to exist."""
+    return self._resolve_pod_name(status)
+
+  def execute(self, claim_name, _status, prepared):
+    from kubernetes.stream import stream  # pylint: disable=import-error,no-name-in-module
+
+    pod_name = prepared
+    if not pod_name:
+      raise RuntimeError(f'no sandbox pod bound for claim {claim_name}')
+    ws = stream(
+        self._core.connect_get_namespaced_pod_exec,
+        pod_name,
+        self._namespace,
+        command=['python3', '-c', _busy_loop_code(self._workload_duration)],
+        stderr=True,
+        stdin=False,
+        stdout=True,
+        tty=False,
+        _request_timeout=self._workload_duration + 60,
+        _preload_content=False,
+    )
+    try:
+      ws.run_forever(timeout=self._workload_duration + 60)
+    finally:
+      ws.close()
+
+
+class ClaimDriver:
+  """Creates, watches, and deletes SandboxClaim custom resources."""
+
+  def __init__(
+      self,
+      namespace,
+      template_name,
+      warmpool_name=None,
+      group=CLAIM_API_GROUP,
+      version=CLAIM_API_VERSION,
+      plural=CLAIM_PLURAL,
+      claim_ttl_seconds=None,
+      max_concurrent=64,
+  ):
+    _load_kube_config()
+    pool_size = max_concurrent + 50
+    self._api = _make_custom_objects_api(pool_size)
+    self._delete_api = _make_custom_objects_api(pool_size)
+    self._namespace = namespace
+    self._template_name = template_name
+    self._warmpool_name = warmpool_name
+    self._group = group
+    self._version = version
+    self._plural = plural
+    self._claim_ttl_seconds = claim_ttl_seconds or 0
+
+  def _body(self, name):
+    lifecycle: dict[str, Any] = {'shutdownPolicy': 'Delete'}
+    if self._claim_ttl_seconds:
+      lifecycle['ttlSecondsAfterFinished'] = self._claim_ttl_seconds
+    spec = {
+        'sandboxTemplateRef': {'name': self._template_name},
+        'lifecycle': lifecycle,
+    }
+    if self._warmpool_name:
+      spec['warmpool'] = self._warmpool_name
+    return {
+        'apiVersion': f'{self._group}/{self._version}',
+        'kind': CLAIM_KIND,
+        'metadata': {'name': name},
+        'spec': spec,
+    }
+
+  def create(self, name, sleeper=time.sleep):
+    """Creates a SandboxClaim, retrying on 429 up to _CREATE_MAX_RETRIES."""
+    from kubernetes.client.rest import ApiException  # pylint: disable=import-error,no-name-in-module
+
+    attempt = 0
+    while True:
+      try:
+        self._api.create_namespaced_custom_object(
+            self._group,
+            self._version,
+            self._namespace,
+            self._plural,
+            body=self._body(name),
+        )
+        return
+      except ApiException as exc:
+        if exc.status == 429 and attempt < _CREATE_MAX_RETRIES:
+          attempt += 1
+          retry_after = _CREATE_RETRY_AFTER_DEFAULT
+          try:
+            if exc.headers and exc.headers.get('Retry-After'):
+              retry_after = float(exc.headers['Retry-After'])
+          except (TypeError, ValueError):
+            pass
+          retry_after = min(retry_after, _CREATE_RETRY_AFTER_CAP)
+          logging.warning(
+              'Claim %s create got 429; retry %d/%d after %.1fs',
+              name,
+              attempt,
+              _CREATE_MAX_RETRIES,
+              retry_after,
+          )
+          sleeper(retry_after)
+        else:
+          raise
+
+  def is_ready(self, status):
+    for condition in status.get('conditions', []):
+      if condition.get('type') == 'Ready' and condition.get('status') == 'True':
+        return True
+    return False
+
+  def served_warm(self, status):
+    """Warm-served iff the bound sandbox name carries the warm pool prefix.
+
+    Cold-provisioned sandboxes are named after the claim; warm-served ones
+    are named after the warm pool. Returns None if no sandbox is bound yet.
+    """
+    sandbox = status.get('sandbox') or {}
+    name = sandbox.get('name')
+    if not name:
+      return None
+    return bool(self._warmpool_name) and name.startswith(self._warmpool_name)
+
+  def stream_claim_events(self, stop_event, timeout_seconds=60):
+    """Generates {'name': str, 'status': dict} dicts from a Watch stream.
+
+    Re-establishes the watch if it times out, until stop_event is set.
+    Resumes from the last seen resourceVersion so no events are missed across
+    reconnects (BOOKMARK events advance the cursor without being yielded).
+    Isolated as a method so tests can substitute a fake generator.
+
+    Args:
+      stop_event: threading.Event; when set the generator stops after the
+        current watch iteration completes.
+      timeout_seconds: Per-watch-call timeout forwarded to the Watch stream.
+
+    Yields:
+      {'name': str, 'status': dict} for every SandboxClaim event.
+    """
+    from kubernetes import watch as kwatch  # pylint: disable=import-error,no-name-in-module
+    from kubernetes.client.rest import ApiException  # pylint: disable=import-error,no-name-in-module
+
+    resource_version = None
+    while not stop_event.is_set():
+      w = kwatch.Watch()
+      try:
+        stream_kwargs = dict(
+            timeout_seconds=timeout_seconds,
+            allow_watch_bookmarks=True,
+        )
+        if resource_version is not None:
+          stream_kwargs['resource_version'] = resource_version
+        for _raw_event in w.stream(
+            self._api.list_namespaced_custom_object,
+            self._group,
+            self._version,
+            self._namespace,
+            self._plural,
+            **stream_kwargs,
+        ):
+          event: dict[str, Any] = cast(dict[str, Any], _raw_event)
+          if stop_event.is_set():
+            w.stop()
+            return
+          obj = event['object']
+          rv = (obj.get('metadata') or {}).get('resourceVersion')
+          if rv:
+            resource_version = rv
+          if event.get('type') == 'BOOKMARK':
+            continue
+          if event.get('type') == 'ERROR':
+            code = (
+                obj.get('code')
+                if isinstance(obj, dict)
+                else getattr(obj, 'code', None)
+            )
+            logging.warning('Watch stream ERROR event (code=%s): %s', code, obj)
+            resource_version = None
+            w.stop()
+            break
+          name = obj['metadata']['name']
+          status = obj.get('status', {}) or {}
+          yield {'name': name, 'status': status}
+      except ApiException as exc:
+        if stop_event.is_set():
+          return
+        if exc.status == 410:
+          logging.warning(
+              'Watch resourceVersion too old (410 Gone); re-listing: %s', exc
+          )
+          resource_version = None
+        else:
+          logging.warning('Watch stream API error (will reconnect): %s', exc)
+          time.sleep(1)
+      except Exception as exc:  # noqa: BLE001  watch reconnect on any error
+        if stop_event.is_set():
+          return
+        logging.warning('Watch stream error (will reconnect): %s', exc)
+        time.sleep(1)
+
+  def delete(self, name):
+    self._delete_api.delete_namespaced_custom_object(
+        self._group, self._version, self._namespace, self._plural, name
+    )
+
+  @property
+  def custom_objects_api(self):
+    return self._api
+
+
+class LoadGenerator:
+  """Submits claims at a target QPS; records readiness via a Watch stream.
+
+  Architecture:
+    - A background thread consumes stream_claim_events() and records ready_at
+      timestamps in shared maps (no per-claim API polling).
+    - A bounded ThreadPoolExecutor submits creates only (one API call per task,
+      no blocking wait inside the task).
+    - After all creates are submitted, the run() method drains locally by
+      polling the in-memory maps until all claims are accounted for or the
+      ready_timeout elapses.
+    - Cleanup deletes all created claims best-effort after the run.
+  """
+
+  def __init__(
+      self,
+      driver,
+      ready_timeout,
+      max_concurrent,
+      workload_executor=None,
+      workload_duration=0,
+  ):
+    self._driver = driver
+    self._ready_timeout = ready_timeout
+    self._max_concurrent = max_concurrent
+    self._workload_duration = workload_duration
+    self._executor = workload_executor or NoopExecutor()
+    self._lock = threading.Lock()
+    self._in_flight = 0
+    self._peak = 0
+    self._clock = time.monotonic
+    self._hold_pool = None
+
+  @property
+  def peak_concurrency(self):
+    return self._peak
+
+  def _watch_consumer(
+      self,
+      stop_event,
+      ready_at_map,
+      warm_map,
+      created_set,
+      released,
+      exec_started_map,
+      exec_completed_map,
+      released_at_map,
+  ):
+    """Background thread: consume watch events and record readiness."""
+    for event in self._driver.stream_claim_events(stop_event):
+      name = event['name']
+      status = event['status']
+      if not self._driver.is_ready(status):
+        continue
+      with self._lock:
+        if name not in created_set:
+          continue
+        if name in ready_at_map:
+          continue  # already recorded
+        ready_at_map[name] = self._clock()
+        warm_map[name] = self._driver.served_warm(status)
+      try:
+        prepared = self._executor.prepare(name, status)
+      except Exception as exc:  # noqa: BLE001
+        logging.warning(
+            'Failed to prepare workload for claim %s: %s', name, exc
+        )
+        prepared = None
+      hold_pool = self._hold_pool
+      if hold_pool is not None:
+        hold_pool.submit(
+            self._hold_task,
+            name,
+            prepared,
+            exec_started_map,
+            exec_completed_map,
+            released_at_map,
+            released,
+        )
+
+  def _hold_task(
+      self,
+      name,
+      prepared,
+      exec_started_map,
+      exec_completed_map,
+      released_at_map,
+      released,
+  ):
+    """Worker thread: run workload then delete the claim."""
+    exec_started = self._clock()
+    try:
+      self._executor.execute(name, None, prepared)
+    except Exception as exc:  # noqa: BLE001  workload failure must not abort the run
+      logging.warning('Workload exec failed for claim %s: %s', name, exc)
+      exec_started = None  # leave exec timings unset so a bad exec does not skew exec_duration
+    finally:
+      exec_completed = self._clock() if exec_started is not None else None
+      try:
+        self._driver.delete(name)
+      except Exception as exc:  # noqa: BLE001  best-effort release
+        logging.warning('Failed to release claim %s: %s', name, exc)
+      with self._lock:
+        exec_started_map[name] = exec_started
+        exec_completed_map[name] = exec_completed
+        released_at_map[name] = self._clock()
+        released.add(name)
+        self._in_flight -= 1
+
+  def run(self, shape, clock=time.monotonic, sleeper=time.sleep):
+    """Run the load shape, returning a list of ClaimRecord in submission order.
+
+    Args:
+      shape: RunShape describing qps, duration, and total claims.
+      clock: Callable returning a float timestamp (injectable for tests).
+      sleeper: Callable(seconds) for pacing sleeps (injectable for tests).
+
+    Returns:
+      List of ClaimRecord, one per submitted claim index, in order.
+    """
+    self._clock = clock
+
+    requested_at_map = {}
+    ready_at_map = {}
+    warm_map = {}
+    errors_map = {}
+    created_set = set()
+    released = set()
+    exec_started_map = {}
+    exec_completed_map = {}
+    released_at_map = {}
+    submitted_names = []
+
+    stop_event = threading.Event()
+
+    # Initialize hold_pool before starting watch_thread so that a Ready event
+    # from a pre-existing claim cannot race against self._hold_pool being None.
+    hold_pool = futures.ThreadPoolExecutor(
+        max_workers=self._max_concurrent, thread_name_prefix='claim-hold'
+    )
+    self._hold_pool = hold_pool
+
+    watch_thread = threading.Thread(
+        target=self._watch_consumer,
+        args=(
+            stop_event,
+            ready_at_map,
+            warm_map,
+            created_set,
+            released,
+            exec_started_map,
+            exec_completed_map,
+            released_at_map,
+        ),
+        daemon=True,
+        name='claim-watch-consumer',
+    )
+    watch_thread.start()
+
+    def _create_task(name):
+      # Record requested_at BEFORE create() so the watch consumer always finds
+      # the entry even if a Ready event arrives before create() returns.
+      with self._lock:
+        requested_at_map[name] = clock()
+      try:
+        self._driver.create(name)
+        with self._lock:
+          created_set.add(name)
+          self._in_flight += 1
+          self._peak = max(self._peak, self._in_flight)
+      except Exception as exc:  # noqa: BLE001  record and continue
+        logging.warning(
+            'Claim %s create failed: %s: %s', name, type(exc).__name__, exc
+        )
+        with self._lock:
+          errors_map[name] = type(exc).__name__
+
+    start = clock()
+    last_create_time = start
+    create_futs = []
+
+    try:
+      with futures.ThreadPoolExecutor(max_workers=self._max_concurrent) as pool:
+        for idx in range(shape.total):
+          name = f'claim-{idx}'
+          submitted_names.append(name)
+          deadline = start + (idx / shape.qps)
+          now = clock()
+          if now < deadline:
+            sleeper(deadline - now)
+          last_create_time = clock()
+          create_futs.append(pool.submit(_create_task, name))
+        # Wait for all create tasks to complete before starting drain.
+        for fut in create_futs:
+          fut.result()
+
+      # Drain: wait for accounts of all successfully created claims, or until
+      # the deadline elapses since the last create. When workload is enabled,
+      # "accounted" means released_at is set (hold finished) or errored. When
+      # workload is disabled, "accounted" means ready_at set or errored.
+      drain_window = self._ready_timeout + self._workload_duration
+      drain_deadline = last_create_time + drain_window
+      while True:
+        now = clock()
+        with self._lock:
+          accounted = len(released_at_map) + sum(
+              1 for n in created_set if n in errors_map
+          )
+          outstanding = len(created_set) - accounted
+        if outstanding <= 0:
+          break
+        if now >= drain_deadline:
+          # Mark remaining created-but-never-Ready claims as Timeout.
+          # Claims that already reached Ready (name in ready_at_map) must
+          # never be Timeout'd: their startup_time is already captured and
+          # their hold will finish in the finally block below.
+          with self._lock:
+            for name in list(created_set):
+              if (
+                  name not in released
+                  and name not in errors_map
+                  and name not in ready_at_map
+              ):
+                errors_map[name] = 'Timeout'
+          break
+        sleeper(0.1)
+
+    finally:
+      # Always stop the watch thread and delete any created-but-not-released
+      # claims. Runs on normal completion AND on KeyboardInterrupt/exception
+      # so Ctrl-C or crashes do not leak SandboxClaims (and their pods).
+      stop_event.set()
+      # Join the watch thread first so any in-progress _watch_consumer
+      # iteration finishes submitting hold tasks before we shut down the pool.
+      watch_thread.join(timeout=2.0)
+      if watch_thread.is_alive():
+        logging.warning(
+            'Watch consumer thread did not exit within 2s; '
+            'proceeding with hold pool shutdown.'
+        )
+      # Drain all in-flight hold tasks before nulling the pool reference so
+      # that a still-running watch consumer can still submit tasks.
+      hold_pool.shutdown(wait=True)
+      self._hold_pool = None
+
+      with self._lock:
+        stragglers = [n for n in created_set if n not in released]
+      for name in stragglers:
+        try:
+          self._driver.delete(name)
+        except Exception as exc:  # noqa: BLE001  best-effort cleanup
+          logging.warning('Failed to delete claim %s: %s', name, exc)
+
+    # Build ordered result list.
+    records = []
+    for name in submitted_names:
+      released_at = released_at_map.get(name)
+      error = errors_map.get(name)
+      # A claim that completed its hold (released_at set) is a success.
+      # If a stale 'Timeout' error was recorded before the hold finished,
+      # drop it so released_at is authoritative. Other error types (e.g.
+      # create failures, exec errors) are kept regardless.
+      if released_at is not None and error == 'Timeout':
+        error = None
+      rec = ClaimRecord(
+          name=name,
+          requested_at=requested_at_map.get(name, 0.0),
+          ready_at=ready_at_map.get(name),
+          error=error,
+          warm_served=warm_map.get(name),
+          exec_started_at=exec_started_map.get(name),
+          exec_completed_at=exec_completed_map.get(name),
+          released_at=released_at,
+      )
+      records.append(rec)
+    return records

--- a/perfkitbenchmarker/linux_packages/agent_sandbox_metrics.py
+++ b/perfkitbenchmarker/linux_packages/agent_sandbox_metrics.py
@@ -1,0 +1,183 @@
+# Copyright 2026 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Aggregates load-generator records into PerfKitBenchmarker samples."""
+
+import collections
+import math
+
+from perfkitbenchmarker import sample
+
+_PERCENTILES = (50, 90, 95, 99)
+
+
+def _peak_from_records(records):
+  """Computes peak concurrent alive sandboxes from ClaimRecord timing fields.
+
+  Uses released_at as the close event when present (hold path), else ready_at.
+  Claims with no ready_at are skipped (never became ready).
+  """
+  events = []
+  for r in records:
+    if r.ready_at is None:
+      continue
+    close = (
+        r.released_at
+        if getattr(r, 'released_at', None) is not None
+        else r.ready_at
+    )
+    events.append((r.requested_at, 1))
+    events.append((close, -1))
+  if not events:
+    return 0
+  events.sort(key=lambda e: (e[0], e[1]))
+  peak = 0
+  current = 0
+  for _, delta in events:
+    current += delta
+    if current > peak:
+      peak = current
+  return peak
+
+
+def percentile(values, pct):
+  """Linear-interpolated percentile. Returns 0.0 for an empty input."""
+  if not values:
+    return 0.0
+  ordered = sorted(values)
+  rank = (len(ordered) - 1) * (pct / 100.0)
+  low = math.floor(rank)
+  high = math.ceil(rank)
+  if low == high:
+    return float(ordered[int(rank)])
+  return float(ordered[low] + (ordered[high] - ordered[low]) * (rank - low))
+
+
+def build_samples(records, peak_concurrency, metadata):
+  """Builds the sample list for one benchmark Run.
+
+  Args:
+    records: List of ClaimRecord, one per submitted claim.
+    peak_concurrency: Maximum in-flight claim count observed.
+    metadata: Dict attached to every emitted sample.
+
+  Returns:
+    A list of sample.Sample.
+  """
+  successes = [r for r in records if r.error is None and r.ready_at is not None]
+  startup_times = [r.startup_time_s for r in successes]
+  errors = collections.Counter(r.error for r in records if r.error is not None)
+
+  samples = []
+  for pct in _PERCENTILES:
+    samples.append(
+        sample.Sample(
+            f'startup_time_p{pct}',
+            percentile(startup_times, pct),
+            'seconds',
+            metadata,
+        )
+    )
+  samples.append(
+      sample.Sample(
+          'startup_time_max',
+          max(startup_times) if startup_times else 0.0,
+          'seconds',
+          metadata,
+      )
+  )
+
+  exec_durations = sorted(
+      r.exec_duration_s
+      for r in successes
+      if getattr(r, 'exec_duration_s', None) is not None
+  )
+  if exec_durations:
+    for pct in _PERCENTILES:
+      samples.append(
+          sample.Sample(
+              f'exec_duration_s_p{pct}',
+              percentile(exec_durations, pct),
+              'seconds',
+              metadata,
+          )
+      )
+    samples.append(
+        sample.Sample(
+            'exec_duration_s_max', exec_durations[-1], 'seconds', metadata
+        )
+    )
+
+  lifecycles = sorted(
+      r.total_lifecycle_s
+      for r in successes
+      if getattr(r, 'total_lifecycle_s', None) is not None
+  )
+  if lifecycles:
+    for pct in _PERCENTILES:
+      samples.append(
+          sample.Sample(
+              f'total_lifecycle_s_p{pct}',
+              percentile(lifecycles, pct),
+              'seconds',
+              metadata,
+          )
+      )
+    samples.append(
+        sample.Sample(
+            'total_lifecycle_s_max', lifecycles[-1], 'seconds', metadata
+        )
+    )
+
+  request_times = [r.requested_at for r in records]
+  ready_times = [r.ready_at for r in successes]
+  # Submit QPS over the request window; 0.0 fallback when all requests
+  # share a timestamp.
+  submit_span = (max(request_times) - min(request_times)) if records else 0.0
+  submit_qps = (len(records) / submit_span) if submit_span > 0 else 0.0
+  # Completion QPS over the full experiment wall clock: first request to
+  # last ready.
+  completion_span = (
+      (max(ready_times) - min(request_times)) if ready_times else 0.0
+  )
+  completion_qps = (
+      (len(successes) / completion_span) if completion_span > 0 else 0.0
+  )
+
+  warm = [r for r in successes if r.warm_served]
+  warm_fraction = (len(warm) / len(successes)) if successes else 0.0
+
+  samples.append(sample.Sample('submit_qps', submit_qps, 'count/sec', metadata))
+  samples.append(
+      sample.Sample('completion_qps', completion_qps, 'count/sec', metadata)
+  )
+  samples.append(
+      sample.Sample('peak_concurrency', peak_concurrency, 'count', metadata)
+  )
+  samples.append(
+      sample.Sample('warm_served_fraction', warm_fraction, 'fraction', metadata)
+  )
+  samples.append(
+      sample.Sample('success_count', len(successes), 'count', metadata)
+  )
+  samples.append(
+      sample.Sample('error_count', sum(errors.values()), 'count', metadata)
+  )
+  for error_type, count in errors.items():
+    error_metadata = dict(metadata, error_type=error_type)
+    samples.append(
+        sample.Sample(
+            f'error_count_{error_type}', count, 'count', error_metadata
+        )
+    )
+  return samples

--- a/perfkitbenchmarker/providers/aws/aws_virtual_machine.py
+++ b/perfkitbenchmarker/providers/aws/aws_virtual_machine.py
@@ -441,8 +441,10 @@ class AwsKeyFileManager:
     with cls._lock:
       if _GetKeyfileSetKey(region) in cls.imported_keyfile_set:
         return
-      cat_cmd = ['cat', vm_util.GetPublicKeyPath()]
-      keyfile, _ = vm_util.IssueRetryableCommand(cat_cmd)
+      # `aws ec2 import-key-pair --public-key-material` rejects a raw
+      # OpenSSH-formatted key with "Invalid base64" when the value comes
+      # in as a CLI string. The `fileb://` URI tells the CLI to read the
+      # file as bytes and send them through, which AWS accepts.
       formatted_tags = util.FormatTagSpecifications(
           'key-pair', util.MakeDefaultTags()
       )
@@ -451,7 +453,7 @@ class AwsKeyFileManager:
           '--region=%s' % region,
           'import-key-pair',
           '--key-name=%s' % cls.GetKeyNameForRun(),
-          '--public-key-material=%s' % keyfile,
+          '--public-key-material=fileb://%s' % vm_util.GetPublicKeyPath(),
           '--tag-specifications=%s' % formatted_tags,
       ]
       _, stderr, retcode = vm_util.IssueCommand(
@@ -793,7 +795,8 @@ class AwsVirtualMachine(virtual_machine.BaseVirtualMachine):
     describe_cmd = util.AWS_PREFIX + [
         'ec2',
         'describe-instances',
-        '--region=%s' % self.region,]
+        '--region=%s' % self.region,
+    ]
     if self.client_token:
       describe_cmd.append(
           f'--filter=Name=client-token,Values={self.client_token}'
@@ -1063,10 +1066,7 @@ class AwsVirtualMachine(virtual_machine.BaseVirtualMachine):
             'SubnetId': self.network.subnet.id,
         })
         # Only allowed for single NIC instances.
-        if (
-            self.assign_external_ip
-            and self.network_eni_count == 1
-        ):
+        if self.assign_external_ip and self.network_eni_count == 1:
           eni_params['AssociatePublicIpAddress'] = True
         if aws_flags.AWS_NIC_QUEUE_COUNTS.value:
           eni_params['EnaQueueCount'] = aws_flags.AWS_NIC_QUEUE_COUNTS.value[
@@ -1326,7 +1326,8 @@ class AwsVirtualMachine(virtual_machine.BaseVirtualMachine):
           '--region=%s' % self.region,
           'ec2',
           'cancel-spot-instance-requests',
-          '--spot-instance-request-ids=%s' % self.spot_instance_request_id,  # pytype: disable=attribute-error
+          '--spot-instance-request-ids=%s'
+          % self.spot_instance_request_id,  # pytype: disable=attribute-error
       ]
       vm_util.IssueCommand(cancel_cmd, raise_on_failure=False)
 
@@ -1558,7 +1559,9 @@ class AwsVirtualMachine(virtual_machine.BaseVirtualMachine):
     """Adds metadata to the VM."""
     util.AddTags(self.id, self.region, **kwargs)
     if self.use_spot_instance:
-      util.AddDefaultTags(self.spot_instance_request_id, self.region)  # pytype: disable=attribute-error
+      util.AddDefaultTags(
+          self.spot_instance_request_id, self.region
+      )  # pytype: disable=attribute-error
 
   def InstallCli(self):
     """Installs the AWS cli and credentials on this AWS vm."""

--- a/perfkitbenchmarker/providers/aws/elastic_kubernetes_service.py
+++ b/perfkitbenchmarker/providers/aws/elastic_kubernetes_service.py
@@ -78,6 +78,18 @@ def RecursivelyUpdateDictionary(
   return original
 
 
+def _ParseTaint(taint: str) -> dict[str, str]:
+  """Converts a 'key=value:Effect' taint string into eksctl's taint object.
+
+  GKE and the shared node_taints config express taints as 'key=value:Effect'
+  strings (the gcloud --node-taints format). eksctl wants {key, value, effect}
+  objects, so translate here and keep node_taints cloud-agnostic in config.
+  """
+  key_value, _, effect = taint.partition(':')
+  key, _, value = key_value.partition('=')
+  return {'key': key, 'value': value, 'effect': effect}
+
+
 class BaseEksCluster(kubernetes_cluster.KubernetesCluster):
   """Shared base class for Elastic Kubernetes Service cluster auto mode & not."""
 
@@ -182,6 +194,12 @@ class BaseEksCluster(kubernetes_cluster.KubernetesCluster):
             'pkb_nodepool': nodepool.name,
         },
     }
+    if nodepool.node_labels:
+      group_json['labels'].update(nodepool.node_labels)
+    if nodepool.node_taints:
+      group_json['taints'] = [
+          _ParseTaint(taint) for taint in nodepool.node_taints
+      ]
     if nodepool.min_nodes != nodepool.max_nodes:
       group_json['minSize'] = nodepool.min_nodes
       group_json['maxSize'] = nodepool.max_nodes
@@ -613,9 +631,7 @@ class EksAutoCluster(BaseEksCluster):
     if self.use_spot:
       selectors['karpenter.sh/capacity-type'] = 'spot'
     if self.gpu_type:
-      selectors['eks.amazonaws.com/instance-gpu-name'] = (
-          self.gpu_type
-      )
+      selectors['eks.amazonaws.com/instance-gpu-name'] = self.gpu_type
     return selectors
 
 

--- a/perfkitbenchmarker/providers/gcp/flags.py
+++ b/perfkitbenchmarker/providers/gcp/flags.py
@@ -67,9 +67,7 @@ GCE_CONFIDENTIAL_COMPUTE = flags.DEFINE_boolean(
     'Whether or not we create a Confidential VM Instance',
 )
 GCE_CONFIDENTIAL_COMPUTE_TYPE = flags.DEFINE_string(
-    'gce_confidential_compute_type',
-    'sev',
-    'Type of Confidential VM Instance'
+    'gce_confidential_compute_type', 'sev', 'Type of Confidential VM Instance'
 )
 GCE_NETWORK_NAMES = flags.DEFINE_list(
     'gce_network_name',
@@ -560,6 +558,97 @@ GKE_ENABLE_SHIELDED_NODES = flags.DEFINE_boolean(
     'gke_enable_shielded_nodes',
     False,
     'Whether to enable shielded nodes.',
+)
+GKE_ENABLE_PRIVATE_NODES = flags.DEFINE_boolean(
+    'gke_enable_private_nodes',
+    False,
+    'Whether to create the cluster with private nodes (nodes have only internal'
+    ' IPs).',
+)
+GKE_ENABLE_DNS_ACCESS = flags.DEFINE_boolean(
+    'gke_enable_dns_access',
+    False,
+    'Whether to enable DNS-based control plane access (replaces the'
+    ' public/private IP endpoint model).',
+)
+GKE_ENABLE_IP_ACCESS = flags.DEFINE_boolean(
+    'gke_enable_ip_access',
+    True,
+    'Whether to enable IP-based control plane access. Disabling requires DNS'
+    ' access and is mutually exclusive with public clusters (nodes with public'
+    ' IPs).',
+)
+GKE_MASTER_IPV4_CIDR = flags.DEFINE_string(
+    'gke_master_ipv4_cidr',
+    None,
+    'CIDR range to use for the hosted master network. Required when private'
+    ' nodes are enabled without DNS access.',
+)
+GKE_ENABLE_DATAPLANE_V2 = flags.DEFINE_boolean(
+    'gke_enable_dataplane_v2',
+    False,
+    'Whether to enable GKE Dataplane V2 (eBPF-based datapath, Cilium under the'
+    ' hood). Requires cluster recreation; cannot be toggled on an existing'
+    ' cluster.',
+)
+GKE_ENABLE_MANAGED_PROMETHEUS = flags.DEFINE_boolean(
+    'gke_enable_managed_prometheus',
+    False,
+    'Whether to enable Google Cloud Managed Service for Prometheus on the'
+    ' cluster.',
+)
+GKE_ENABLE_COST_ALLOCATION = flags.DEFINE_boolean(
+    'gke_enable_cost_allocation',
+    False,
+    'Whether to enable GKE cost allocation tracking.',
+)
+GKE_MONITORING_COMPONENTS = flags.DEFINE_string(
+    'gke_monitoring_components',
+    'SYSTEM,API_SERVER,SCHEDULER,CONTROLLER_MANAGER',
+    'Comma-separated list of GKE monitoring components to enable '
+    '(e.g. SYSTEM,API_SERVER,SCHEDULER,CONTROLLER_MANAGER,POD,DEPLOYMENT,'
+    'STATEFULSET,DAEMONSET,HPA,STORAGE,CADVISOR,KUBELET).',
+)
+GKE_ENABLE_AGENT_SANDBOX = flags.DEFINE_boolean(
+    'gke_enable_agent_sandbox',
+    False,
+    'Whether to enable the GKE Agent Sandbox controller on the cluster. '
+    'Installs the managed agent-sandbox controller and CRDs, enabling '
+    'SandboxClaim/Sandbox/SandboxWarmPool reconciliation by GKE. This is '
+    'separate from the gvisor sandbox runtime (--sandbox=type=gvisor on a '
+    'node pool). Requires GKE 1.35.2-gke.1269000 or later. See '
+    'https://docs.cloud.google.com/kubernetes-engine/docs/how-to/agent-sandbox.',
+)
+
+
+def _ValidateGkePrivateNodeFlags(flags_dict):
+  if (
+      not flags_dict['gke_enable_ip_access']
+      and not flags_dict['gke_enable_dns_access']
+  ):
+    raise flags.ValidationError(
+        '--no-gke_enable_ip_access requires --gke_enable_dns_access.'
+    )
+  if (
+      flags_dict['gke_enable_private_nodes']
+      and not flags_dict['gke_enable_dns_access']
+      and not flags_dict['gke_master_ipv4_cidr']
+  ):
+    raise flags.ValidationError(
+        '--gke_enable_private_nodes without --gke_enable_dns_access requires'
+        ' --gke_master_ipv4_cidr.'
+    )
+  return True
+
+
+flags.register_multi_flags_validator(
+    [
+        'gke_enable_ip_access',
+        'gke_enable_dns_access',
+        'gke_enable_private_nodes',
+        'gke_master_ipv4_cidr',
+    ],
+    _ValidateGkePrivateNodeFlags,
 )
 GKE_ADDONS = flags.DEFINE_string(
     'gke_addons',

--- a/perfkitbenchmarker/providers/gcp/gce_network.py
+++ b/perfkitbenchmarker/providers/gcp/gce_network.py
@@ -914,6 +914,7 @@ class GceNetwork(network.BaseNetwork):
   def __init__(self, network_spec: GceNetworkSpec):
     super().__init__(network_spec)
     self.project: str | None = network_spec.project
+    self._zone: str = network_spec.zone
     self.vpn_gateway: Dict[str, GceVpnGateway] = {}
 
     #  Figuring out the type of network here.
@@ -1231,6 +1232,60 @@ class GceNetwork(network.BaseNetwork):
         for group_spec in benchmark_spec.config.vm_groups.values()
     )
 
+  def _CreateCloudNat(self):
+    """Provision a Cloud Router + NAT so private resources can egress.
+
+    Called during network provisioning so NAT has time to fully propagate
+    before any cluster lifecycle code starts. Shared across all resources
+    in the network.
+    """
+    region = util.GetRegionFromZone(self._zone)
+    router_name = f'{self.primary_subnet_name}-router'
+    nat_name = f'{self.primary_subnet_name}-nat'
+
+    router_cmd = util.GcloudCommand(
+        self, 'compute', 'routers', 'create', router_name
+    )
+    router_cmd.flags['network'] = self.primary_subnet_name
+    router_cmd.flags['region'] = region
+    router_cmd.flags.pop('zone', None)
+    _, stderr, retcode = router_cmd.Issue(raise_on_failure=False)
+    if retcode and 'already exists' not in stderr:
+      logging.warning('Cloud Router create failed: %s', stderr)
+
+    nat_cmd = util.GcloudCommand(
+        self, 'compute', 'routers', 'nats', 'create', nat_name
+    )
+    nat_cmd.flags['router'] = router_name
+    nat_cmd.flags['region'] = region
+    nat_cmd.flags.pop('zone', None)
+    nat_cmd.args.append('--auto-allocate-nat-external-ips')
+    nat_cmd.args.append('--nat-all-subnet-ip-ranges')
+    _, stderr, retcode = nat_cmd.Issue(raise_on_failure=False)
+    if retcode and 'already exists' not in stderr:
+      logging.warning('Cloud NAT create failed: %s', stderr)
+
+  def _DeleteCloudNat(self):
+    """Best-effort teardown of the NAT and router this network created."""
+    region = util.GetRegionFromZone(self._zone)
+    router_name = f'{self.primary_subnet_name}-router'
+    nat_name = f'{self.primary_subnet_name}-nat'
+
+    nat_cmd = util.GcloudCommand(
+        self, 'compute', 'routers', 'nats', 'delete', nat_name
+    )
+    nat_cmd.flags['router'] = router_name
+    nat_cmd.flags['region'] = region
+    nat_cmd.flags.pop('zone', None)
+    nat_cmd.Issue(raise_on_failure=False)
+
+    router_cmd = util.GcloudCommand(
+        self, 'compute', 'routers', 'delete', router_name
+    )
+    router_cmd.flags['region'] = region
+    router_cmd.flags.pop('zone', None)
+    router_cmd.Issue(raise_on_failure=False)
+
   def Create(self):
     """Creates the actual network."""
     if not self.is_existing_network:
@@ -1244,6 +1299,8 @@ class GceNetwork(network.BaseNetwork):
             lambda rule: self.external_nets_rules[rule].Create(),
             list(self.external_nets_rules.keys()),
         )
+      if gcp_flags.GKE_ENABLE_PRIVATE_NODES.value:
+        self._CreateCloudNat()
       if getattr(self, 'vpn_gateway', False):
         background_tasks.RunThreaded(
             lambda gateway: self.vpn_gateway[gateway].Create(),
@@ -1257,6 +1314,12 @@ class GceNetwork(network.BaseNetwork):
     if self.placement_group:
       self.placement_group.Delete()
     if not self.is_existing_network:
+      # Always attempt NAT+router cleanup: both gcloud calls use
+      # raise_on_failure=False so this is a no-op when none was created.
+      # Checking the live flag here is wrong because teardown runs from a
+      # restored pickle and the flag may default to False even when a NAT
+      # was created at provision time.
+      self._DeleteCloudNat()
       if getattr(self, 'vpn_gateway', False):
         background_tasks.RunThreaded(
             lambda gateway: self.vpn_gateway[gateway].Delete(),

--- a/perfkitbenchmarker/providers/gcp/google_kubernetes_engine.py
+++ b/perfkitbenchmarker/providers/gcp/google_kubernetes_engine.py
@@ -168,10 +168,37 @@ class BaseGkeCluster(kubernetes_cluster.KubernetesCluster):
         )
       cmd.flags['release-channel'] = self.release_channel
 
+    if gcp_flags.GKE_ENABLE_PRIVATE_NODES.value:
+      cmd.args.append('--enable-private-nodes')
+      # GKE requires VPC-native (alias IPs) when private nodes are enabled.
+      # Without this gcloud rejects the create with:
+      #   Cannot specify --enable-private-nodes without --enable-ip-alias.
+      cmd.args.append('--enable-ip-alias')
+    else:
+      cmd.args.append('--no-enable-private-nodes')
+    if gcp_flags.GKE_ENABLE_DNS_ACCESS.value:
+      cmd.args.append('--enable-dns-access')
+    else:
+      cmd.args.append('--no-enable-dns-access')
+    if gcp_flags.GKE_ENABLE_IP_ACCESS.value:
+      cmd.args.append('--enable-ip-access')
+    else:
+      cmd.args.append('--no-enable-ip-access')
+    if gcp_flags.GKE_ENABLE_DATAPLANE_V2.value:
+      cmd.args.append('--enable-dataplane-v2')
+    if gcp_flags.GKE_ENABLE_AGENT_SANDBOX.value:
+      cmd.args.append('--enable-agent-sandbox')
+    if gcp_flags.GKE_MASTER_IPV4_CIDR.value:
+      cmd.flags['master-ipv4-cidr'] = gcp_flags.GKE_MASTER_IPV4_CIDR.value
+
     if FLAGS.gke_enable_alpha:
       cmd.args.append('--enable-kubernetes-alpha')
       cmd.args.append('--no-enable-autorepair')
-    cmd.flags['monitoring'] = 'SYSTEM,API_SERVER,SCHEDULER,CONTROLLER_MANAGER'
+    cmd.flags['monitoring'] = gcp_flags.GKE_MONITORING_COMPONENTS.value
+    if gcp_flags.GKE_ENABLE_MANAGED_PROMETHEUS.value:
+      cmd.args.append('--enable-managed-prometheus')
+    if gcp_flags.GKE_ENABLE_COST_ALLOCATION.value:
+      cmd.args.append('--enable-cost-allocation')
 
     user = util.GetDefaultUser()
     if FLAGS.gcp_service_account:
@@ -579,10 +606,19 @@ class GkeCluster(BaseGkeCluster):
     if nodepool_config.sandbox_config is not None:
       cmd.flags['sandbox'] = nodepool_config.sandbox_config.ToSandboxFlag()
 
+    if nodepool_config.max_pods_per_node is not None:
+      cmd.flags['max-pods-per-node'] = nodepool_config.max_pods_per_node
+
     if self.image_type:
       cmd.flags['image-type'] = self.image_type
 
-    cmd.flags['node-labels'] = f'pkb_nodepool={nodepool_config.name}'
+    labels = {}
+    if nodepool_config.node_labels:
+      labels.update(nodepool_config.node_labels)
+    labels['pkb_nodepool'] = nodepool_config.name
+    cmd.flags['node-labels'] = ','.join(f'{k}={v}' for k, v in labels.items())
+    if nodepool_config.node_taints:
+      cmd.flags['node-taints'] = ','.join(nodepool_config.node_taints)
     if nodepool_config.min_nodes != nodepool_config.max_nodes:
       cmd.args.append('--enable-autoscaling')
       cmd.flags['min-nodes'] = nodepool_config.min_nodes

--- a/perfkitbenchmarker/resources/container_service/container.py
+++ b/perfkitbenchmarker/resources/container_service/container.py
@@ -187,6 +187,9 @@ class BaseNodePoolConfig:
     # Defined by GceVirtualMachineConfig. Used by google_kubernetes_engine
     # pylint: disable=g-missing-from-attributes
     self.sandbox_config: container_spec_lib.SandboxSpec | None = None
+    self.node_labels: dict[str, str] | None = None
+    self.node_taints: list[str] | None = None
+    self.max_pods_per_node: int | None = None
     self.max_local_disks: int | None
     self.ssd_interface: str | None
     self.threads_per_core: int

--- a/perfkitbenchmarker/resources/container_service/container_cluster.py
+++ b/perfkitbenchmarker/resources/container_service/container_cluster.py
@@ -116,6 +116,9 @@ class BaseContainerCluster(resource.BaseResource):
         nodepool_spec.machine_families,
     )
     nodepool_config.sandbox_config = nodepool_spec.sandbox_config
+    nodepool_config.node_labels = nodepool_spec.node_labels
+    nodepool_config.node_taints = nodepool_spec.node_taints
+    nodepool_config.max_pods_per_node = nodepool_spec.max_pods_per_node
     nodepool_config.zone = zone
     nodepool_config.num_nodes = nodepool_spec.vm_count
     if nodepool_spec.min_vm_count is None:

--- a/perfkitbenchmarker/resources/container_service/kubernetes_cluster.py
+++ b/perfkitbenchmarker/resources/container_service/kubernetes_cluster.py
@@ -41,8 +41,10 @@ class KubernetesCluster(container_cluster.BaseContainerCluster):
     if not self.cluster_spec.poll_for_events:
       return
 
-    def _GetEventsNoLogging():
-      return kubernetes_commands.GetEvents(suppress_logging=True)
+    def _GetEventsNoLogging(field_selector=None):
+      return kubernetes_commands.GetEvents(
+          field_selector=field_selector, suppress_logging=True
+      )
 
     self.event_poller = kubernetes_events.KubernetesEventPoller(
         _GetEventsNoLogging
@@ -71,11 +73,13 @@ class KubernetesCluster(container_cluster.BaseContainerCluster):
       self.event_poller.StopPolling()
     _DeleteAllFromDefaultNamespace()
 
-  def GetEvents(self) -> set['kubernetes_events.KubernetesEvent']:
+  def GetEvents(
+      self, field_selector: str | None = None
+  ) -> set['kubernetes_events.KubernetesEvent']:
     """Gets the events for the cluster, including previously polled events."""
     if self.event_poller:
-      return self.event_poller.GetEvents()
-    return kubernetes_commands.GetEvents()
+      return self.event_poller.GetEvents(field_selector=field_selector)
+    return kubernetes_commands.GetEvents(field_selector=field_selector)
 
   def __getstate__(self):
     state = self.__dict__.copy()

--- a/perfkitbenchmarker/resources/container_service/kubernetes_commands.py
+++ b/perfkitbenchmarker/resources/container_service/kubernetes_commands.py
@@ -767,11 +767,14 @@ def GetPvcs() -> Sequence[Any]:
   return yaml.safe_load(stdout)['items']
 
 
-def GetEvents(**kwargs) -> set['kubernetes_events.KubernetesEvent']:
+def GetEvents(
+    field_selector: str | None = None, **kwargs
+) -> set['kubernetes_events.KubernetesEvent']:
   """Get the events for the cluster."""
-  stdout, _, _ = kubectl.RunRetryableKubectlCommand(
-      ['get', 'events', '-o', 'yaml'], **kwargs
-  )
+  cmd = ['get', 'events', '-o', 'yaml']
+  if field_selector:
+    cmd.append(f'--field-selector={field_selector}')
+  stdout, _, _ = kubectl.RunRetryableKubectlCommand(cmd, **kwargs)
   k8s_events = set()
   for item in yaml.safe_load(stdout)['items']:
     k8s_event = kubernetes_events.KubernetesEvent.FromDict(item)

--- a/perfkitbenchmarker/resources/container_service/kubernetes_events.py
+++ b/perfkitbenchmarker/resources/container_service/kubernetes_events.py
@@ -15,11 +15,54 @@ from perfkitbenchmarker import errors
 from perfkitbenchmarker import events
 
 
+def _MatchesFieldSelector(
+    event: 'KubernetesEvent', field_selector: str
+) -> bool:
+  """Returns True if the event matches a simple key=value field selector.
+
+  Supports the subset of field selector keys used by this module:
+    involvedObject.kind, involvedObject.name, reason, type
+  Multiple selectors may be comma-separated (all must match).
+  """
+  for clause in field_selector.split(','):
+    clause = clause.strip()
+    if '==' in clause:
+      key, value = clause.split('==', 1)
+    elif '=' in clause:
+      key, value = clause.split('=', 1)
+    else:
+      continue
+    key, value = key.strip(), value.strip()
+    if key == 'involvedObject.kind':
+      if event.resource.kind != value:
+        return False
+    elif key == 'involvedObject.name':
+      if event.resource.name != value:
+        return False
+    elif key == 'reason':
+      if event.reason != value:
+        return False
+    elif key == 'type':
+      if event.type != value:
+        return False
+    else:
+      raise ValueError(
+          f'Unsupported field selector key {key!r}. Supported keys: '
+          'involvedObject.kind, involvedObject.name, reason, type'
+      )
+  return True
+
+
 class KubernetesEventPoller:
   """Wrapper which polls for Kubernetes events."""
 
-  def __init__(self, get_events_fn: Callable[[], set['KubernetesEvent']]):
+  def __init__(
+      self,
+      get_events_fn: Callable[..., set['KubernetesEvent']],
+      poll_field_selector: str | None = None,
+  ):
     self.get_events_fn = get_events_fn
+    self._poll_field_selector = poll_field_selector
     self.polled_events: set['KubernetesEvent'] = set()
     self.stop_polling = multiprocessing.Event()
     self.event_queue: multiprocessing.Queue = multiprocessing.Queue()
@@ -47,7 +90,7 @@ class KubernetesEventPoller:
     """
     while True:
       try:
-        k8s_events = self.get_events_fn()
+        k8s_events = self.get_events_fn(self._poll_field_selector)
         logging.info(
             'From async get events process, got %s events', len(k8s_events)
         )
@@ -91,12 +134,20 @@ class KubernetesEventPoller:
       self.event_poller.kill()
       self.event_poller.join(timeout=30)
 
-  def GetEvents(self) -> set['KubernetesEvent']:
+  def GetEvents(
+      self, field_selector: str | None = None
+  ) -> set['KubernetesEvent']:
     """Gets the events for the cluster, including previously polled events."""
-    k8s_events = self.get_events_fn()
+    k8s_events = self.get_events_fn(field_selector)
     self.polled_events.update(k8s_events)
     while not self.event_queue.empty():
       self.polled_events.add(self.event_queue.get())
+    if field_selector:
+      return {
+          e
+          for e in self.polled_events
+          if _MatchesFieldSelector(e, field_selector)
+      }
     return self.polled_events
 
   def GetAndLogFailureEvents(self) -> dict[str | None, list['KubernetesEvent']]:

--- a/perfkitbenchmarker/traces/kubernetes_tracker.py
+++ b/perfkitbenchmarker/traces/kubernetes_tracker.py
@@ -153,7 +153,11 @@ class KubernetesResourceTracker:
 
   def _StopWatchingForNodeChanges(self):
     """Stop watching the cluster for node add/remove events."""
-    polled_events = self._cluster.GetEvents()
+    # Filter to node events only — sandbox claim events can number >100k and
+    # make yaml.safe_load take several minutes for no benefit here.
+    polled_events = self._cluster.GetEvents(
+        field_selector="involvedObject.kind=Node"
+    )
 
     # Resolve machine type only for current nodes; use "unknown" for the rest.
     _current_node_names = kubernetes_commands.GetNodeNames()

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ google-cloud-core
 google-cloud-monitoring>=2.0.0
 immutabledict
 jinja2>=2.10.2
+kubernetes>=31.0.0
 numpy>=1.16.5
 packaging
 pandas>=1.1.5

--- a/tests/linux_benchmarks/agent_sandbox_benchmark_test.py
+++ b/tests/linux_benchmarks/agent_sandbox_benchmark_test.py
@@ -1,0 +1,185 @@
+# Copyright 2026 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for perfkitbenchmarker.linux_benchmarks.agent_sandbox_benchmark."""
+
+import unittest
+from unittest import mock
+
+from absl import flags
+from absl.testing import flagsaver
+from absl.testing import parameterized
+
+from perfkitbenchmarker.configs import benchmark_config_spec
+from perfkitbenchmarker.linux_benchmarks import agent_sandbox_benchmark
+from tests import pkb_common_test_case
+
+FLAGS = flags.FLAGS
+
+
+class GetConfigTest(pkb_common_test_case.PkbCommonTestCase):
+
+  def testBenchmarkNameConstant(self):
+    self.assertEqual(agent_sandbox_benchmark.BENCHMARK_NAME, 'agent_sandbox')
+
+  @parameterized.named_parameters(
+      ('Gcp', 'GCP', 'c4-standard-4', 'c4-standard-16'),
+      ('Aws', 'AWS', 'm8i.xlarge', 'm8i.4xlarge'),
+  )
+  def testGetConfigSelectsCloudAndDefaultMachineTypes(
+      self, cloud, general_machine_type, sandbox_machine_type
+  ):
+    """Cloud selection drives the vm_spec block and per-cloud default types."""
+    with flagsaver.flagsaver(cloud=cloud):
+      config = agent_sandbox_benchmark.GetConfig({})
+    cluster = config['container_cluster']
+    self.assertEqual(cluster['cloud'], cloud)
+    self.assertEqual(cluster['type'], 'Kubernetes')
+    self.assertIn('sandbox', cluster['nodepools'])
+    self.assertEqual(
+        cluster['vm_spec'][cloud]['machine_type'], general_machine_type
+    )
+    self.assertEqual(
+        cluster['nodepools']['sandbox']['vm_spec'][cloud]['machine_type'],
+        sandbox_machine_type,
+    )
+
+  @parameterized.named_parameters(
+      ('Gcp', 'GCP', 'n2-standard-16', 'n2-standard-32'),
+      ('Aws', 'AWS', 'm8i.2xlarge', 'm8i.8xlarge'),
+  )
+  def testGetConfigAppliesPoolFlags(
+      self, cloud, general_machine_type, sandbox_machine_type
+  ):
+    """Sizing and machine-type flags override the selected cloud's vm_spec."""
+    with flagsaver.flagsaver(
+        cloud=cloud,
+        agent_sandbox_general_pool_machine_type=general_machine_type,
+        agent_sandbox_general_pool_nodes=2,
+        agent_sandbox_sandbox_pool_machine_type=sandbox_machine_type,
+        agent_sandbox_sandbox_pool_nodes=5,
+        agent_sandbox_sandbox_pool_max_pods_per_node=64,
+    ):
+      config = agent_sandbox_benchmark.GetConfig({})
+    cluster = config['container_cluster']
+    self.assertEqual(cluster['vm_count'], 2)
+    self.assertEqual(
+        cluster['vm_spec'][cloud]['machine_type'], general_machine_type
+    )
+    sandbox = cluster['nodepools']['sandbox']
+    self.assertEqual(sandbox['vm_count'], 5)
+    self.assertEqual(
+        sandbox['vm_spec'][cloud]['machine_type'], sandbox_machine_type
+    )
+    self.assertEqual(sandbox['max_pods_per_node'], 64)
+
+
+class ConfigDecodeTest(pkb_common_test_case.PkbCommonTestCase):
+  """Exercises full spec decode so unrecognized nodepool keys raise at test time.
+
+  The GetConfigTest class only inspects the raw dict returned by
+  configs.LoadConfig. That dict is never validated against the NodepoolSpec
+  decoder, so keys like node_labels/node_taints silently survive. This class
+  runs the same BenchmarkConfigSpec decode that PKB executes at startup, so any
+  unrecognized key raises errors.Config.UnrecognizedOption and the test fails.
+  """
+
+  def testBenchmarkConfigDecodesWithoutError(self):
+    config = agent_sandbox_benchmark.GetConfig({})
+    # This is exactly the call PKB makes during benchmark setup. It must not
+    # raise errors.Config.UnrecognizedOption.
+    benchmark_config_spec.BenchmarkConfigSpec(
+        agent_sandbox_benchmark.BENCHMARK_NAME,
+        flag_values=FLAGS,
+        **config,
+    )
+
+  def testSandboxNodepoolSpecHasSandboxConfigAndMaxPods(self):
+    """Confirm decoded spec carries sandbox_config and max_pods_per_node."""
+    config = agent_sandbox_benchmark.GetConfig({})
+    spec = benchmark_config_spec.BenchmarkConfigSpec(
+        agent_sandbox_benchmark.BENCHMARK_NAME,
+        flag_values=FLAGS,
+        **config,
+    )
+    sandbox_nodepool = spec.container_cluster.nodepools['sandbox']  # pylint: disable=no-member
+    # sandbox_config defaults to None when not set in config; that is fine.
+    self.assertIsNone(sandbox_nodepool.sandbox_config)
+    # max_pods_per_node defaults to None when not overridden by flag.
+    self.assertIsNone(sandbox_nodepool.max_pods_per_node)
+
+  def testSandboxNodepoolSpecCarriesNodeLabelsAndTaints(self):
+    """Confirm decoded spec carries the restored gVisor node_labels/node_taints."""
+    config = agent_sandbox_benchmark.GetConfig({})
+    spec = benchmark_config_spec.BenchmarkConfigSpec(
+        agent_sandbox_benchmark.BENCHMARK_NAME,
+        flag_values=FLAGS,
+        **config,
+    )
+    sandbox_nodepool = spec.container_cluster.nodepools['sandbox']  # pylint: disable=no-member
+    self.assertEqual(
+        sandbox_nodepool.node_labels,
+        {'sandbox.gke.io/runtime': 'runsc'},
+    )
+    self.assertEqual(
+        sandbox_nodepool.node_taints,
+        ['sandbox.gke.io/runtime=runsc:NoSchedule'],
+    )
+
+
+class PrepareRunTest(pkb_common_test_case.PkbCommonTestCase):
+
+  @flagsaver.flagsaver(
+      agent_sandbox_controller_ref='v0.4.6', agent_sandbox_warmpool_replicas=5
+  )
+  def testPrepareInstallsStackWithFlags(self):
+    with mock.patch.object(
+        agent_sandbox_benchmark.agent_sandbox, 'install_stack'
+    ) as install:
+      agent_sandbox_benchmark.Prepare(mock.Mock())
+    install.assert_called_once()
+    self.assertEqual(install.call_args.kwargs['controller_ref'], 'v0.4.6')
+    self.assertEqual(install.call_args.kwargs['warmpool_replicas'], 5)
+
+  @flagsaver.flagsaver(agent_sandbox_qps=5.0, agent_sandbox_duration=2.0)
+  def testRunDrivesLoadAndReturnsSamples(self):
+    fake_records = [
+        _loadgen_record('claim-0', 0.0, 1.0),
+    ]
+    with mock.patch.object(
+        agent_sandbox_benchmark.agent_sandbox_loadgen, 'ClaimDriver'
+    ), mock.patch.object(
+        agent_sandbox_benchmark.agent_sandbox_loadgen, 'LoadGenerator'
+    ) as gen_cls:
+      gen = gen_cls.return_value
+      gen.run.return_value = fake_records
+      gen.peak_concurrency = 1
+      spec = mock.Mock()
+      spec.container_cluster.GetResourceMetadata.return_value = {'k8s': 'x'}
+      samples = agent_sandbox_benchmark.Run(spec)
+
+    metrics = {s.metric for s in samples}
+    self.assertIn('startup_time_p50', metrics)
+    self.assertIn('success_count', metrics)
+
+
+def _loadgen_record(name, requested_at, ready_at):
+  from perfkitbenchmarker.linux_packages import agent_sandbox_loadgen
+
+  rec = agent_sandbox_loadgen.ClaimRecord(name=name, requested_at=requested_at)
+  rec.ready_at = ready_at
+  return rec
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tests/linux_packages/agent_sandbox_loadgen_test.py
+++ b/tests/linux_packages/agent_sandbox_loadgen_test.py
@@ -1,0 +1,831 @@
+# Copyright 2026 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for perfkitbenchmarker.linux_packages.agent_sandbox_loadgen."""
+
+import threading
+import unittest
+from unittest import mock
+
+from perfkitbenchmarker.linux_packages import agent_sandbox_loadgen
+from tests import pkb_common_test_case
+
+
+class RunShapeTest(pkb_common_test_case.PkbCommonTestCase):
+
+  def testDerivesTotalFromQpsAndDuration(self):
+    shape = agent_sandbox_loadgen.resolve_run_shape(qps=10, duration=30)
+    self.assertEqual(shape.total, 300)
+    self.assertEqual(shape.qps, 10.0)
+    self.assertEqual(shape.duration, 30.0)
+
+  def testDerivesDurationFromQpsAndTotal(self):
+    shape = agent_sandbox_loadgen.resolve_run_shape(qps=10, total=300)
+    self.assertEqual(shape.duration, 30.0)
+
+  def testDerivesQpsFromDurationAndTotal(self):
+    shape = agent_sandbox_loadgen.resolve_run_shape(duration=30, total=300)
+    self.assertEqual(shape.qps, 10.0)
+
+  def testRespectsAllThreeWhenProvided(self):
+    shape = agent_sandbox_loadgen.resolve_run_shape(
+        qps=10, duration=30, total=999
+    )
+    self.assertEqual(shape.total, 999)
+    self.assertEqual(shape.qps, 10.0)
+    self.assertEqual(shape.duration, 30.0)
+
+  def testRaisesWhenFewerThanTwoProvided(self):
+    with self.assertRaises(ValueError):
+      agent_sandbox_loadgen.resolve_run_shape(qps=10)
+
+
+class ClaimRecordTest(pkb_common_test_case.PkbCommonTestCase):
+
+  def testStartupTimeNoneUntilReady(self):
+    rec = agent_sandbox_loadgen.ClaimRecord(name='c0', requested_at=1.0)
+    self.assertIsNone(rec.startup_time_s)
+    rec.ready_at = 3.5
+    self.assertAlmostEqual(rec.startup_time_s, 2.5)
+
+
+class ClaimDriverTest(pkb_common_test_case.PkbCommonTestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.enter_context(
+        mock.patch.object(agent_sandbox_loadgen, '_load_kube_config')
+    )
+    self.mock_api = mock.Mock()
+    self.enter_context(
+        mock.patch.object(
+            agent_sandbox_loadgen,
+            '_make_custom_objects_api',
+            return_value=self.mock_api,
+        )
+    )
+    self.driver = agent_sandbox_loadgen.ClaimDriver(
+        namespace='default',
+        template_name='python-runtime',
+        warmpool_name='default',
+    )
+
+  def testCreateSendsExpectedBody(self):
+    self.driver.create('claim-7')
+    sent = self.mock_api.create_namespaced_custom_object.call_args
+    body = sent.kwargs.get('body') or sent.args[4]
+    self.assertEqual(body['apiVersion'], 'extensions.agents.x-k8s.io/v1beta1')
+    self.assertEqual(body['kind'], 'SandboxClaim')
+    self.assertEqual(body['metadata']['name'], 'claim-7')
+    self.assertEqual(
+        body['spec']['sandboxTemplateRef']['name'], 'python-runtime'
+    )
+    self.assertEqual(body['spec']['warmpool'], 'default')
+    self.assertEqual(body['spec']['lifecycle']['shutdownPolicy'], 'Delete')
+
+  def testIsReadyTrueOnReadyCondition(self):
+    status = {'conditions': [{'type': 'Ready', 'status': 'True'}]}
+    self.assertTrue(self.driver.is_ready(status))
+
+  def testIsReadyFalseWithoutReadyCondition(self):
+    status = {'conditions': [{'type': 'Ready', 'status': 'False'}]}
+    self.assertFalse(self.driver.is_ready(status))
+    self.assertFalse(self.driver.is_ready({}))
+
+  def testServedWarmTrueWhenSandboxNameStartsWithWarmpool(self):
+    driver = agent_sandbox_loadgen.ClaimDriver(
+        namespace='default',
+        template_name='python-runtime',
+        warmpool_name='python-sandbox-warmpool',
+    )
+    result = driver.served_warm(
+        {'sandbox': {'name': 'python-sandbox-warmpool-abc'}}
+    )
+    self.assertTrue(result)
+
+  def testServedWarmFalseWhenSandboxNameIsColdClaim(self):
+    driver = agent_sandbox_loadgen.ClaimDriver(
+        namespace='default',
+        template_name='python-runtime',
+        warmpool_name='python-sandbox-warmpool',
+    )
+    result = driver.served_warm({'sandbox': {'name': 'claim-5'}})
+    self.assertFalse(result)
+
+  def testServedWarmNoneWhenNoSandboxBound(self):
+    driver = agent_sandbox_loadgen.ClaimDriver(
+        namespace='default',
+        template_name='python-runtime',
+        warmpool_name='python-sandbox-warmpool',
+    )
+    result = driver.served_warm({})
+    self.assertIsNone(result)
+
+  def testBodyIncludesTtlWhenSet(self):
+    """claim_ttl_seconds>0 adds ttlSecondsAfterFinished to lifecycle."""
+    driver = agent_sandbox_loadgen.ClaimDriver(
+        namespace='default',
+        template_name='python-runtime',
+        claim_ttl_seconds=120,
+    )
+    body = driver._body('claim-ttl')
+    lifecycle = body['spec']['lifecycle']
+    self.assertEqual(lifecycle['shutdownPolicy'], 'Delete')
+    self.assertEqual(lifecycle['ttlSecondsAfterFinished'], 120)
+
+  def testBodyOmitsTtlWhenZero(self):
+    """claim_ttl_seconds=0: shutdownPolicy present, no ttlSecondsAfterFinished."""
+    driver = agent_sandbox_loadgen.ClaimDriver(
+        namespace='default', template_name='python-runtime', claim_ttl_seconds=0
+    )
+    body = driver._body('claim-no-ttl')
+    lifecycle = body['spec']['lifecycle']
+    self.assertEqual(lifecycle['shutdownPolicy'], 'Delete')
+    self.assertNotIn('ttlSecondsAfterFinished', lifecycle)
+
+  def testBodyOmitsTtlWhenNone(self):
+    """claim_ttl_seconds=None (default) omits ttlSecondsAfterFinished."""
+    driver = agent_sandbox_loadgen.ClaimDriver(
+        namespace='default', template_name='python-runtime'
+    )
+    body = driver._body('claim-default')
+    lifecycle = body['spec']['lifecycle']
+    self.assertEqual(lifecycle['shutdownPolicy'], 'Delete')
+    self.assertNotIn('ttlSecondsAfterFinished', lifecycle)
+
+  def testCreateRetries429ThenSucceeds(self):
+    """A single 429 is retried and the second call succeeds."""
+    from kubernetes.client.rest import ApiException  # pylint: disable=import-error,no-name-in-module
+
+    exc_429 = ApiException(status=429)
+    exc_429.headers = {'Retry-After': '0'}
+    self.mock_api.create_namespaced_custom_object.side_effect = [exc_429, None]
+    sleeper = mock.Mock()
+    self.driver.create('claim-retry', sleeper=sleeper)
+    self.assertEqual(
+        self.mock_api.create_namespaced_custom_object.call_count, 2
+    )
+    sleeper.assert_called_once_with(0.0)
+
+  def testCreateRaisesAfterMaxRetries(self):
+    """Exhausted 429 retries re-raise the exception."""
+    from kubernetes.client.rest import ApiException  # pylint: disable=import-error,no-name-in-module
+
+    exc_429 = ApiException(status=429)
+    exc_429.headers = {}
+    self.mock_api.create_namespaced_custom_object.side_effect = exc_429
+    sleeper = mock.Mock()
+    with self.assertRaises(ApiException):
+      self.driver.create('claim-fail', sleeper=sleeper)
+    self.assertEqual(
+        self.mock_api.create_namespaced_custom_object.call_count,
+        agent_sandbox_loadgen._CREATE_MAX_RETRIES + 1,
+    )
+
+  def _make_watch_event(self, event_type, name, rv, status=None):
+    """Helper: build a fake kubernetes watch event dict."""
+    obj = {'metadata': {'name': name, 'resourceVersion': rv}}
+    if status is not None:
+      obj['status'] = status
+    return {'type': event_type, 'object': obj}
+
+  def testStreamBookmarkFilteredAndResourceVersionPropagated(self):
+    """BOOKMARK events are not yielded; normal events are; rv starts None."""
+    stop = threading.Event()
+    events = [
+        self._make_watch_event('ADDED', 'claim-A', '10', status={}),
+        self._make_watch_event('BOOKMARK', '', '99'),
+        self._make_watch_event('ADDED', 'claim-B', '100', status={}),
+    ]
+    captured_rv = []
+
+    class FakeWatch:
+
+      def stream(self, _func, *_args, **kwargs):
+        captured_rv.append(kwargs.get('resource_version'))
+        yield from events
+        stop.set()
+
+      def stop(self):
+        pass
+
+    import kubernetes.watch as kw  # pylint: disable=import-error,no-name-in-module
+
+    with mock.patch.object(kw, 'Watch', FakeWatch):
+      results = list(self.driver.stream_claim_events(stop))
+
+    self.assertEqual([r['name'] for r in results], ['claim-A', 'claim-B'])
+    self.assertIsNone(captured_rv[0])
+
+  def testStream410ResetsResourceVersion(self):
+    """A 410 ApiException resets resource_version so the next call re-lists."""
+    from kubernetes.client.rest import ApiException  # pylint: disable=import-error,no-name-in-module
+
+    stop = threading.Event()
+    calls = [0]
+    captured_rv = []
+
+    class FakeWatch:
+
+      def stream(inner_self, _func, *_args, **kwargs):  # pylint: disable=no-self-argument
+        captured_rv.append(kwargs.get('resource_version'))
+        calls[0] += 1
+        if calls[0] == 1:
+          yield self._make_watch_event('ADDED', 'claim-X', '77', {})
+          raise ApiException(status=410)
+        else:
+          stop.set()
+          return
+          yield  # make this a generator
+
+      def stop(self):
+        pass
+
+    import kubernetes.watch as kw  # pylint: disable=import-error,no-name-in-module
+
+    with mock.patch.object(kw, 'Watch', FakeWatch):
+      results = list(self.driver.stream_claim_events(stop))
+
+    self.assertEqual([r['name'] for r in results], ['claim-X'])
+    self.assertIsNone(captured_rv[0])
+    self.assertIsNone(captured_rv[1])
+
+  def testStreamPassesResourceVersionOnReconnect(self):
+    """After a normal timeout, the next stream call gets the last seen rv."""
+    stop = threading.Event()
+    calls = [0]
+    captured_rv = []
+
+    class FakeWatch:
+
+      def stream(inner_self, _func, *_args, **kwargs):  # pylint: disable=no-self-argument
+        captured_rv.append(kwargs.get('resource_version'))
+        calls[0] += 1
+        if calls[0] == 1:
+          yield self._make_watch_event('ADDED', 'claim-0', '55', {})
+        else:
+          stop.set()
+          return
+          yield  # make this a generator
+
+      def stop(self):
+        pass
+
+    import kubernetes.watch as kw  # pylint: disable=import-error,no-name-in-module
+
+    with mock.patch.object(kw, 'Watch', FakeWatch):
+      results = list(self.driver.stream_claim_events(stop))
+
+    self.assertEqual([r['name'] for r in results], ['claim-0'])
+    self.assertIsNone(captured_rv[0])
+    self.assertEqual(captured_rv[1], '55')
+
+
+# ---------------------------------------------------------------------------
+# Fake driver for LoadGenerator tests
+# ---------------------------------------------------------------------------
+
+
+class _FakeDriver:
+  """In-memory driver whose stream_claim_events returns ready events for
+  every claim that has been created.
+
+  Designed for deterministic tests: stream_claim_events() yields events for
+  all claims registered via create() at the time it is called, then blocks
+  (via a threading.Event) until stop_event is set.
+
+  To keep tests that don't care about the timing synchronous, we use a
+  real thread for the watch consumer (matching production) but the fake
+  stream terminates as soon as stop_event is set.
+  """
+
+  def __init__(self, error_on=None, warm_on=(), never_ready=()):
+    self.created = []
+    self.deleted = []
+    self._error_on = error_on
+    self._warm_on = set(warm_on)
+    self._never_ready = set(never_ready)
+    # Lock guarding created list so stream_claim_events can read it safely.
+    self._lock = threading.Lock()
+    # Event signaled when new claims are created so the stream wakes up.
+    self._created_event = threading.Event()
+
+  def create(self, name):
+    if name == self._error_on:
+      raise RuntimeError('boom')
+    with self._lock:
+      self.created.append(name)
+    self._created_event.set()
+
+  def is_ready(self, status):
+    return status.get('_ready', False)
+
+  def served_warm(self, status):
+    return status.get('_warm', None)
+
+  def stream_claim_events(self, stop_event, timeout_seconds=60):
+    """Yield ready events for created (non-never_ready) claims, then stop."""
+    yielded = set()
+    while not stop_event.is_set():
+      with self._lock:
+        names = list(self.created)
+      for name in names:
+        if name not in yielded and name not in self._never_ready:
+          yielded.add(name)
+          warm = name in self._warm_on
+          yield {
+              'name': name,
+              'status': {'_ready': True, '_warm': warm},
+          }
+      # Wait briefly for new creates or stop, then loop.
+      self._created_event.wait(timeout=0.05)
+      self._created_event.clear()
+
+  def delete(self, name):
+    self.deleted.append(name)
+
+
+def _make_counter_clock(step=0.001):
+  """Returns a thread-safe monotonically increasing clock function."""
+  state = [0.0]
+  lock = threading.Lock()
+
+  def clock():
+    with lock:
+      v = state[0]
+      state[0] += step
+      return v
+
+  return clock
+
+
+class LoadGeneratorTest(pkb_common_test_case.PkbCommonTestCase):
+
+  def testRunCreatesAllAndRecordsReadyViaWatch(self):
+    """All claims created, all become ready from watch events, all deleted."""
+    driver = _FakeDriver(warm_on={'claim-0'})
+    gen = agent_sandbox_loadgen.LoadGenerator(
+        driver, ready_timeout=9999, max_concurrent=4
+    )
+    shape = agent_sandbox_loadgen.RunShape(qps=1000.0, duration=0.003, total=3)
+
+    records = gen.run(
+        shape, clock=_make_counter_clock(), sleeper=lambda _: None
+    )
+
+    self.assertEqual(len(records), 3)
+    self.assertEqual(sorted(driver.created), ['claim-0', 'claim-1', 'claim-2'])
+    self.assertEqual(sorted(driver.deleted), ['claim-0', 'claim-1', 'claim-2'])
+    self.assertTrue(
+        all(r.ready_at is not None for r in records),
+        [r for r in records if r.ready_at is None],
+    )
+    self.assertTrue(all(r.error is None for r in records))
+    warm = {r.name: r.warm_served for r in records}
+    self.assertTrue(warm['claim-0'])
+    self.assertFalse(warm['claim-1'])
+
+  def testCreateErrorRecordedNoReady(self):
+    """A create failure records the error; cleanup still runs for others."""
+    driver = _FakeDriver(error_on='claim-1')
+    gen = agent_sandbox_loadgen.LoadGenerator(
+        driver, ready_timeout=9999, max_concurrent=4
+    )
+    shape = agent_sandbox_loadgen.RunShape(qps=1000.0, duration=0.002, total=2)
+
+    records = gen.run(
+        shape, clock=_make_counter_clock(), sleeper=lambda _: None
+    )
+
+    errored = {r.name: r.error for r in records}
+    self.assertEqual(errored['claim-1'], 'RuntimeError')
+    self.assertIsNone(records[1].ready_at)
+    # claim-1 failed create so it is NOT in created_set; no delete attempted.
+    self.assertNotIn('claim-1', driver.deleted)
+    # claim-0 succeeded.
+    self.assertIn('claim-0', driver.deleted)
+
+  def testClaimNeverReadyTimesOut(self):
+    """Claims the watch never reports ready get error='Timeout' at deadline."""
+    driver = _FakeDriver(never_ready={'claim-0', 'claim-1'})
+    gen = agent_sandbox_loadgen.LoadGenerator(
+        driver, ready_timeout=0.5, max_concurrent=2
+    )
+    shape = agent_sandbox_loadgen.RunShape(qps=1000.0, duration=0.002, total=2)
+
+    # Use a monotonically advancing fake clock that runs fast enough to
+    # quickly advance past the drain deadline. Each call increments by 0.3s so
+    # we hit the ready_timeout (0.5s) within a few sleeper calls.
+    clock_state = [0.0]
+
+    def fast_clock():
+      v = clock_state[0]
+      clock_state[0] += 0.3
+      return v
+
+    # Sleeper that also advances the clock so the drain loop terminates.
+    def fast_sleeper(_):
+      clock_state[0] += 0.3
+
+    records = gen.run(shape, clock=fast_clock, sleeper=fast_sleeper)
+
+    for rec in records:
+      self.assertEqual(
+          rec.error,
+          'Timeout',
+          f'{rec.name} expected Timeout, got error={rec.error!r}',
+      )
+      self.assertIsNone(rec.ready_at)
+
+  def testReadyClaimsDeletedImmediatelyByWatchConsumer(self):
+    """Each ready claim is deleted inline by the watch consumer (release-on-ready)."""
+    driver = _FakeDriver()
+    gen = agent_sandbox_loadgen.LoadGenerator(
+        driver, ready_timeout=9999, max_concurrent=4
+    )
+    shape = agent_sandbox_loadgen.RunShape(qps=1000.0, duration=0.003, total=3)
+
+    records = gen.run(
+        shape, clock=_make_counter_clock(), sleeper=lambda _: None
+    )
+
+    # All claims ready, all must have been deleted.
+    self.assertEqual(sorted(driver.deleted), ['claim-0', 'claim-1', 'claim-2'])
+    # All records have ready_at set.
+    self.assertTrue(all(r.ready_at is not None for r in records))
+
+  def testNeverReadyClaimsDeletedByStraggerCleanup(self):
+    """Claims the watch never reports ready are deleted by end-of-run cleanup."""
+    driver = _FakeDriver(never_ready={'claim-0', 'claim-1'})
+    gen = agent_sandbox_loadgen.LoadGenerator(
+        driver, ready_timeout=0.5, max_concurrent=2
+    )
+    shape = agent_sandbox_loadgen.RunShape(qps=1000.0, duration=0.002, total=2)
+
+    clock_state = [0.0]
+
+    def fast_clock():
+      v = clock_state[0]
+      clock_state[0] += 0.3
+      return v
+
+    def fast_sleeper(_):
+      clock_state[0] += 0.3
+
+    gen.run(shape, clock=fast_clock, sleeper=fast_sleeper)
+
+    # Never-ready claims are cleaned up by the straggler sweep, not the consumer.
+    self.assertIn('claim-0', driver.deleted)
+    self.assertIn('claim-1', driver.deleted)
+
+  def testCleanupRunsOnInterruption(self):
+    """KeyboardInterrupt during drain causes all created claims to be deleted.
+
+    The interrupt fires from the drain-loop sleeper (outside the executor),
+    so it propagates cleanly through the try/finally and re-raises after
+    cleanup.
+    """
+    # Use never_ready so all claims stay in-flight through the drain loop,
+    # giving the sleeper a chance to fire.
+    driver = _FakeDriver(never_ready={'claim-0', 'claim-1', 'claim-2'})
+    gen = agent_sandbox_loadgen.LoadGenerator(
+        driver, ready_timeout=10, max_concurrent=4
+    )
+    shape = agent_sandbox_loadgen.RunShape(qps=1000.0, duration=0.003, total=3)
+
+    # Clock: advance just enough that submit completes, then hold still so
+    # drain_deadline is far in the future (keeps outstanding > 0).
+    clock_vals = [float(i) * 0.001 for i in range(20)] + [0.01] * 10000
+    clock_iter = iter(clock_vals)
+
+    drain_calls = [0]
+
+    def interrupting_sleeper(seconds):
+      drain_calls[0] += 1
+      # The first sleeper call is for pacing (may not occur at high QPS);
+      # raise on the first drain-loop call (0.1s sleep).
+      if seconds == 0.1:
+        raise KeyboardInterrupt
+
+    with self.assertRaises(KeyboardInterrupt):
+      gen.run(
+          shape, clock=lambda: next(clock_iter), sleeper=interrupting_sleeper
+      )
+
+    # All claims that were created must have been deleted by the finally block.
+    self.assertTrue(
+        len(driver.created) > 0,
+        'Expected at least one claim to be created before interrupt',
+    )
+    for name in driver.created:
+      self.assertIn(
+          name,
+          driver.deleted,
+          f'{name} created but not deleted after KeyboardInterrupt',
+      )
+
+  def testPeakConcurrencyTracked(self):
+    """peak_concurrency reflects the high-water mark of in-flight creates."""
+    driver = _FakeDriver()
+    gen = agent_sandbox_loadgen.LoadGenerator(
+        driver, ready_timeout=9999, max_concurrent=4
+    )
+    shape = agent_sandbox_loadgen.RunShape(qps=1000.0, duration=0.004, total=4)
+    gen.run(shape, clock=_make_counter_clock(), sleeper=lambda _: None)
+    self.assertGreater(gen.peak_concurrency, 0)
+
+
+class ClaimRecordWorkloadFieldsTest(pkb_common_test_case.PkbCommonTestCase):
+
+  def testExecDurationNoneWhenTimingsAbsent(self):
+    rec = agent_sandbox_loadgen.ClaimRecord(name='c0', requested_at=1.0)
+    self.assertIsNone(rec.exec_duration_s)
+
+  def testExecDurationComputedWhenBothSet(self):
+    rec = agent_sandbox_loadgen.ClaimRecord(name='c0', requested_at=1.0)
+    rec.exec_started_at = 5.0
+    rec.exec_completed_at = 8.0
+    self.assertAlmostEqual(rec.exec_duration_s, 3.0)
+
+  def testTotalLifecycleNoneWhenReleasedAbsent(self):
+    rec = agent_sandbox_loadgen.ClaimRecord(name='c0', requested_at=1.0)
+    self.assertIsNone(rec.total_lifecycle_s)
+
+  def testTotalLifecycleComputedWhenSet(self):
+    rec = agent_sandbox_loadgen.ClaimRecord(name='c0', requested_at=2.0)
+    rec.released_at = 12.0
+    self.assertAlmostEqual(rec.total_lifecycle_s, 10.0)
+
+
+class _FakeExecutor(agent_sandbox_loadgen.WorkloadExecutor):
+  """Records execute() calls; does not block."""
+
+  def __init__(self):
+    self.calls = []  # list of (claim_name, status)
+
+  def execute(self, claim_name, _status, _prepared):
+    self.calls.append((claim_name, _status))
+
+
+class WorkloadEnabledTest(pkb_common_test_case.PkbCommonTestCase):
+
+  def _counter_clock(self):
+    """Returns a thread-safe monotonically increasing clock function."""
+    return _make_counter_clock()
+
+  def testWorkloadExecutorCalledOncePerReadyClaim(self):
+    """With a workload executor, execute() is called once per ready claim."""
+    import time as _time
+
+    driver = _FakeDriver()
+    executor = _FakeExecutor()
+    gen = agent_sandbox_loadgen.LoadGenerator(
+        driver,
+        ready_timeout=5,
+        max_concurrent=4,
+        workload_executor=executor,
+        workload_duration=1,
+    )
+    shape = agent_sandbox_loadgen.RunShape(qps=1000.0, duration=0.003, total=3)
+
+    # Use time.sleep(0) as sleeper: releases the GIL so the watch/hold threads
+    # make progress, while the counter clock keeps drain timing deterministic.
+    records = gen.run(
+        shape, clock=self._counter_clock(), sleeper=lambda _: _time.sleep(0)
+    )
+
+    # executor.execute should be called for each of the 3 ready claims
+    executed_names = sorted(name for name, _ in executor.calls)
+    self.assertEqual(executed_names, ['claim-0', 'claim-1', 'claim-2'])
+
+  def testWorkloadRecordsHaveExecAndLifecycleTimings(self):
+    """Records carry exec_started_at, exec_completed_at, released_at."""
+    import time as _time
+
+    driver = _FakeDriver()
+    executor = _FakeExecutor()
+    gen = agent_sandbox_loadgen.LoadGenerator(
+        driver,
+        ready_timeout=5,
+        max_concurrent=4,
+        workload_executor=executor,
+        workload_duration=1,
+    )
+    shape = agent_sandbox_loadgen.RunShape(qps=1000.0, duration=0.003, total=3)
+
+    records = gen.run(
+        shape, clock=self._counter_clock(), sleeper=lambda _: _time.sleep(0)
+    )
+
+    for rec in records:
+      if rec.error is not None:
+        continue
+      self.assertIsNotNone(
+          rec.exec_started_at, f'{rec.name} missing exec_started_at'
+      )
+      self.assertIsNotNone(
+          rec.exec_completed_at, f'{rec.name} missing exec_completed_at'
+      )
+      self.assertIsNotNone(rec.released_at, f'{rec.name} missing released_at')
+
+  def testWorkloadDeleteCalledAfterExecute(self):
+    """driver.delete is called for each claim after execute() completes."""
+    import time as _time
+
+    driver = _FakeDriver()
+    executor = _FakeExecutor()
+    gen = agent_sandbox_loadgen.LoadGenerator(
+        driver,
+        ready_timeout=5,
+        max_concurrent=4,
+        workload_executor=executor,
+        workload_duration=1,
+    )
+    shape = agent_sandbox_loadgen.RunShape(qps=1000.0, duration=0.003, total=3)
+
+    records = gen.run(
+        shape, clock=self._counter_clock(), sleeper=lambda _: _time.sleep(0)
+    )
+
+    self.assertEqual(sorted(driver.deleted), ['claim-0', 'claim-1', 'claim-2'])
+
+  def testNoWorkloadExecutorNeverCalled(self):
+    """When workload_duration=0 (NoopExecutor), executor is never triggered."""
+    driver = _FakeDriver()
+    executor = _FakeExecutor()
+    # Wrap NoopExecutor check: passing a NoopExecutor means workload disabled.
+    noop = agent_sandbox_loadgen.NoopExecutor()
+    gen = agent_sandbox_loadgen.LoadGenerator(
+        driver,
+        ready_timeout=9999,
+        max_concurrent=4,
+        workload_executor=noop,
+        workload_duration=0,
+    )
+    shape = agent_sandbox_loadgen.RunShape(qps=1000.0, duration=0.003, total=3)
+
+    records = gen.run(
+        shape, clock=_make_counter_clock(), sleeper=lambda _: None
+    )
+
+    # FakeExecutor was not passed in; verify claims still deleted at ready.
+    self.assertEqual(sorted(driver.deleted), ['claim-0', 'claim-1', 'claim-2'])
+    # NoopExecutor.execute() is never called, so the _FakeExecutor has no calls.
+    self.assertEqual(executor.calls, [])
+
+  def testNoWorkloadPathDeletesAllClaims(self):
+    """Default (no executor) path: all claims are deleted after becoming ready."""
+    driver = _FakeDriver()
+    gen = agent_sandbox_loadgen.LoadGenerator(
+        driver, ready_timeout=9999, max_concurrent=4
+    )
+    shape = agent_sandbox_loadgen.RunShape(qps=1000.0, duration=0.003, total=3)
+    records = gen.run(
+        shape, clock=_make_counter_clock(), sleeper=lambda _: None
+    )
+
+    self.assertEqual(sorted(driver.deleted), ['claim-0', 'claim-1', 'claim-2'])
+    self.assertEqual(len(records), 3)
+
+
+class SaturatedHoldPoolTimeoutRegressionTest(
+    pkb_common_test_case.PkbCommonTestCase
+):
+  """Regression: ready claims must never get error='Timeout' when the hold pool
+  is saturated and some holds are still queued when the drain deadline fires.
+
+  Setup: max_concurrent=2, total=5 claims.  The fake executor blocks each
+  hold until a shared release_event is set, so after 2 holds are in-flight
+  the remaining 3 are queued.  A fast fake clock causes the drain deadline to
+  fire while those holds are still queued.  A background thread sets the
+  release event after a short real-time delay so all holds finish during
+  hold_pool.shutdown(wait=True) regardless of the drain-loop code path.
+
+  Without fix #1 (the `and name not in ready_at_map` guard), the Timeout
+  sweep stamps all 5 names (none yet in `released` at deadline time), and the
+  regression assertions below would fail.
+  """
+
+  def testReadyClaimsNotTimedOutWhenHoldPoolSaturated(self):
+    import time as _time
+
+    release_event = threading.Event()
+
+    class BlockingExecutor(agent_sandbox_loadgen.WorkloadExecutor):
+
+      def execute(self, claim_name, _status, _prepared):
+        release_event.wait()
+
+    total = 5
+    max_concurrent = 2
+    driver = _FakeDriver()
+    executor = BlockingExecutor()
+    # Use a thread-safe clock with step=1.0 so the drain deadline fires
+    # quickly (ready_timeout + workload_duration = 0.05 + 1 = 1.05 fake-s,
+    # reached in 2 clock calls), while the watch consumer and create loop
+    # use the same clock without a race.
+    clock = _make_counter_clock(step=1.0)
+    gen = agent_sandbox_loadgen.LoadGenerator(
+        driver,
+        ready_timeout=0.05,
+        max_concurrent=max_concurrent,
+        workload_executor=executor,
+        workload_duration=1,
+    )
+    shape = agent_sandbox_loadgen.RunShape(
+        qps=1000.0, duration=float(total) / 1000.0, total=total
+    )
+
+    # Drain-loop sleeper yields the GIL so worker threads make progress.
+    def fast_sleeper(_seconds):
+      _time.sleep(0)
+
+    # Background thread: wait a short real time, then unblock the executor.
+    def _unblock():
+      _time.sleep(0.5)
+      release_event.set()
+
+    unblock_thread = threading.Thread(target=_unblock, daemon=True)
+    unblock_thread.start()
+
+    records = gen.run(shape, clock=clock, sleeper=fast_sleeper)
+
+    unblock_thread.join(timeout=5.0)
+
+    # Every claim that reached Ready must not have error='Timeout'.
+    # This is the core regression check: the Timeout sweep must not
+    # stamp claims that already recorded ready_at.
+    for rec in records:
+      if rec.ready_at is not None:
+        self.assertIsNone(
+            rec.error,
+            f'{rec.name} reached Ready but got error={rec.error!r}; '
+            'Timeout sweep incorrectly stamped a ready claim',
+        )
+        self.assertIsNotNone(
+            rec.released_at, f'{rec.name} reached Ready but released_at is None'
+        )
+
+    # At least one claim must have become ready (the fake driver reports
+    # every created claim as ready immediately).
+    ready_count = sum(1 for r in records if r.ready_at is not None)
+    self.assertGreater(ready_count, 0, 'Expected at least one ready claim')
+
+
+class StreamExecExecutorResolveTest(pkb_common_test_case.PkbCommonTestCase):
+
+  def _make_executor(self, co_api):
+    return agent_sandbox_loadgen.StreamExecExecutor(
+        core_v1_api=None,
+        custom_objects_api=co_api,
+        namespace='default',
+        workload_duration=5,
+    )
+
+  def testResolvesPodNameFromAnnotation(self):
+    """When the Sandbox CR has agents.x-k8s.io/pod-name annotation, that name
+    is returned."""
+    co = mock.Mock()
+    co.get_namespaced_custom_object.return_value = {
+        'metadata': {
+            'annotations': {'agents.x-k8s.io/pod-name': 'warmpool-pod-xyz'},
+        }
+    }
+    executor = self._make_executor(co)
+    result = executor._resolve_pod_name(
+        {'sandbox': {'name': 'python-sandbox-warmpool-abc'}}
+    )
+    self.assertEqual(result, 'warmpool-pod-xyz')
+
+  def testFallsBackToSandboxNameWhenNoAnnotation(self):
+    """Without the annotation, the sandbox CR name is used as the pod name."""
+    co = mock.Mock()
+    co.get_namespaced_custom_object.return_value = {
+        'metadata': {'annotations': {}}
+    }
+    executor = self._make_executor(co)
+    result = executor._resolve_pod_name({'sandbox': {'name': 'claim-5'}})
+    self.assertEqual(result, 'claim-5')
+
+  def testReturnsNoneWhenNoSandboxBound(self):
+    """Empty status.sandbox means the claim has no sandbox; returns None."""
+    co = mock.Mock()
+    executor = self._make_executor(co)
+    result = executor._resolve_pod_name({})
+    self.assertIsNone(result)
+    co.get_namespaced_custom_object.assert_not_called()
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tests/linux_packages/agent_sandbox_metrics_test.py
+++ b/tests/linux_packages/agent_sandbox_metrics_test.py
@@ -1,0 +1,187 @@
+# Copyright 2026 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for agent_sandbox_metrics."""
+
+import unittest
+
+from perfkitbenchmarker.linux_packages import agent_sandbox_loadgen
+from perfkitbenchmarker.linux_packages import agent_sandbox_metrics
+from tests import pkb_common_test_case
+
+
+def _record(
+    name,
+    requested_at,
+    ready_at=None,
+    error=None,
+    warm_served=None,
+    exec_started_at=None,
+    exec_completed_at=None,
+    released_at=None,
+):
+  rec = agent_sandbox_loadgen.ClaimRecord(name=name, requested_at=requested_at)
+  rec.ready_at = ready_at
+  rec.error = error
+  rec.warm_served = warm_served
+  rec.exec_started_at = exec_started_at
+  rec.exec_completed_at = exec_completed_at
+  rec.released_at = released_at
+  return rec
+
+
+class PercentileTest(pkb_common_test_case.PkbCommonTestCase):
+
+  def testPercentileInterpolates(self):
+    self.assertAlmostEqual(
+        agent_sandbox_metrics.percentile([1, 2, 3, 4], 50), 2.5
+    )
+
+  def testPercentileEmptyIsZero(self):
+    self.assertEqual(agent_sandbox_metrics.percentile([], 99), 0.0)
+
+
+class BuildSamplesTest(pkb_common_test_case.PkbCommonTestCase):
+
+  def testBuildSamplesEmitsLatencyAndCounts(self):
+    records = [
+        _record('claim-0', 0.0, ready_at=2.0, warm_served=True),
+        _record('claim-1', 1.0, ready_at=5.0, warm_served=False),
+        _record('claim-2', 2.0, error='TimeoutError'),
+    ]
+    samples = agent_sandbox_metrics.build_samples(
+        records, peak_concurrency=2, metadata={'target_qps': 10}
+    )
+    by_metric = {s.metric: s for s in samples}
+
+    self.assertIn('startup_time_p50', by_metric)
+    self.assertEqual(by_metric['startup_time_p50'].unit, 'seconds')
+    self.assertEqual(by_metric['success_count'].value, 2)
+    self.assertEqual(by_metric['error_count'].value, 1)
+    self.assertEqual(by_metric['peak_concurrency'].value, 2)
+    self.assertAlmostEqual(by_metric['warm_served_fraction'].value, 0.5)
+    self.assertEqual(by_metric['startup_time_p50'].metadata['target_qps'], 10)
+    self.assertAlmostEqual(by_metric['startup_time_p50'].value, 3.0)
+    self.assertAlmostEqual(by_metric['startup_time_max'].value, 4.0)
+    self.assertAlmostEqual(by_metric['submit_qps'].value, 1.5)
+    self.assertAlmostEqual(by_metric['completion_qps'].value, 0.4)
+    self.assertIn('error_count_TimeoutError', by_metric)
+    self.assertEqual(by_metric['error_count_TimeoutError'].value, 1)
+
+
+class PeakFromRecordsTest(pkb_common_test_case.PkbCommonTestCase):
+
+  def testPeakUsesReadyAtWhenNoReleasedAt(self):
+    """Without released_at, peak interval closes at ready_at (point event)."""
+    records = [
+        _record('c0', 0.0, ready_at=1.0),
+        _record('c1', 0.5, ready_at=1.5),
+    ]
+    # Both intervals close immediately at ready_at: no overlap after closing.
+    peak = agent_sandbox_metrics._peak_from_records(records)
+    self.assertGreaterEqual(peak, 1)
+
+  def testPeakUsesReleasedAtWhenPresent(self):
+    """With released_at, sandboxes stay alive until release.
+
+    Two claims: c0 ready at t=1, released at t=10; c1 ready at t=2, released
+    at t=11. Both alive from t=2..t=10, so peak should be 2.
+    """
+    records = [
+        _record('c0', 0.0, ready_at=1.0, released_at=10.0),
+        _record('c1', 0.5, ready_at=2.0, released_at=11.0),
+    ]
+    peak = agent_sandbox_metrics._peak_from_records(records)
+    self.assertEqual(peak, 2)
+
+  def testPeakSkipsRecordsWithNoReadyAt(self):
+    """Claims that never became ready (error/timeout) are excluded."""
+    records = [
+        _record('c0', 0.0, ready_at=1.0, released_at=5.0),
+        _record('c1', 0.0, error='Timeout'),
+    ]
+    peak = agent_sandbox_metrics._peak_from_records(records)
+    self.assertEqual(peak, 1)
+
+  def testPeakEmptyRecordsIsZero(self):
+    self.assertEqual(agent_sandbox_metrics._peak_from_records([]), 0)
+
+
+class BuildSamplesWorkloadMetricsTest(pkb_common_test_case.PkbCommonTestCase):
+
+  def testExecDurationSamplesEmittedWhenPresent(self):
+    """exec_duration_s_p50 .. _max emitted when records have exec timings."""
+    records = [
+        _record(
+            'c0',
+            0.0,
+            ready_at=1.0,
+            exec_started_at=1.0,
+            exec_completed_at=6.0,
+            released_at=6.1,
+        ),
+        _record(
+            'c1',
+            0.5,
+            ready_at=1.5,
+            exec_started_at=1.5,
+            exec_completed_at=7.5,
+            released_at=7.6,
+        ),
+    ]
+    samples = agent_sandbox_metrics.build_samples(
+        records, peak_concurrency=2, metadata={}
+    )
+    by_metric = {s.metric: s for s in samples}
+    self.assertIn('exec_duration_s_p50', by_metric)
+    self.assertIn('exec_duration_s_p90', by_metric)
+    self.assertIn('exec_duration_s_p95', by_metric)
+    self.assertIn('exec_duration_s_p99', by_metric)
+    self.assertIn('exec_duration_s_max', by_metric)
+    self.assertEqual(by_metric['exec_duration_s_p50'].unit, 'seconds')
+    # c0: 5.0s, c1: 6.0s -> p50 interpolated = 5.5
+    self.assertAlmostEqual(by_metric['exec_duration_s_p50'].value, 5.5)
+    self.assertAlmostEqual(by_metric['exec_duration_s_max'].value, 6.0)
+
+  def testTotalLifecycleSamplesEmittedWhenPresent(self):
+    """total_lifecycle_s_p50 .. _max emitted when records have released_at."""
+    records = [
+        _record('c0', 0.0, ready_at=1.0, released_at=10.0),
+        _record('c1', 1.0, ready_at=2.0, released_at=14.0),
+    ]
+    samples = agent_sandbox_metrics.build_samples(
+        records, peak_concurrency=2, metadata={}
+    )
+    by_metric = {s.metric: s for s in samples}
+    self.assertIn('total_lifecycle_s_p50', by_metric)
+    self.assertIn('total_lifecycle_s_max', by_metric)
+    # c0: 10.0s, c1: 13.0s -> p50 = 11.5
+    self.assertAlmostEqual(by_metric['total_lifecycle_s_p50'].value, 11.5)
+    self.assertAlmostEqual(by_metric['total_lifecycle_s_max'].value, 13.0)
+
+  def testWorkloadMetricsAbsentWhenNoTimings(self):
+    """When records have no exec/lifecycle timings, those metrics are absent."""
+    records = [
+        _record('c0', 0.0, ready_at=1.0),
+        _record('c1', 1.0, ready_at=2.0),
+    ]
+    samples = agent_sandbox_metrics.build_samples(
+        records, peak_concurrency=2, metadata={}
+    )
+    by_metric = {s.metric: s for s in samples}
+    self.assertNotIn('exec_duration_s_p50', by_metric)
+    self.assertNotIn('total_lifecycle_s_p50', by_metric)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tests/linux_packages/agent_sandbox_test.py
+++ b/tests/linux_packages/agent_sandbox_test.py
@@ -1,0 +1,460 @@
+# Copyright 2026 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Tests for perfkitbenchmarker.linux_packages.agent_sandbox."""
+
+import os
+import unittest
+from unittest import mock
+
+import yaml
+
+from perfkitbenchmarker import data
+from perfkitbenchmarker.linux_packages import agent_sandbox
+from tests import pkb_common_test_case
+
+# Minimal controller.yaml (core file): one non-Deployment doc so the
+# non-Deployment apply path runs.
+_FAKE_CORE_YAML = yaml.dump({
+    'apiVersion': 'v1',
+    'kind': 'ServiceAccount',
+    'metadata': {
+        'name': 'agent-sandbox-controller',
+        'namespace': 'agent-sandbox-system',
+    },
+})
+
+# Minimal extensions.controller.yaml: a Deployment with the structure that
+# _configure_controller_manifest expects.
+_FAKE_CONTROLLER_YAML = yaml.dump({
+    'apiVersion': 'apps/v1',
+    'kind': 'Deployment',
+    'metadata': {
+        'name': 'agent-sandbox-controller',
+        'namespace': 'agent-sandbox-system',
+    },
+    'spec': {
+        'selector': {'matchLabels': {'app': 'agent-sandbox-controller'}},
+        'template': {
+            'metadata': {'labels': {'app': 'agent-sandbox-controller'}},
+            'spec': {
+                'containers': [{
+                    'name': 'controller',
+                    'image': 'ko://controller',
+                    'args': ['--leader-elect=true'],
+                }],
+            },
+        },
+    },
+})
+
+
+def _fake_issue_command(cmd, **kwargs):
+  """Returns canned YAML for the two curl calls in install_controller."""
+  url = cmd[-1]
+  if url.endswith(agent_sandbox._CONTROLLER_FILE):
+    return (_FAKE_CONTROLLER_YAML, '', 0)
+  return (_FAKE_CORE_YAML, '', 0)
+
+
+class InstallStackTest(pkb_common_test_case.PkbCommonTestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.apply_manifest = self.enter_context(
+        mock.patch.object(agent_sandbox.kubernetes_commands, 'ApplyManifest')
+    )
+    self.wait_resource = self.enter_context(
+        mock.patch.object(agent_sandbox.kubernetes_commands, 'WaitForResource')
+    )
+    self.wait_rollout = self.enter_context(
+        mock.patch.object(agent_sandbox.kubernetes_commands, 'WaitForRollout')
+    )
+    self.apply_url = self.enter_context(
+        mock.patch.object(agent_sandbox, '_apply_url')
+    )
+    self.apply_yaml = self.enter_context(
+        mock.patch.object(agent_sandbox, '_apply_yaml')
+    )
+    self.wait_warmpool = self.enter_context(
+        mock.patch.object(agent_sandbox, '_wait_warmpool_ready')
+    )
+    self.create_configmap = self.enter_context(
+        mock.patch.object(agent_sandbox, '_create_installer_configmap')
+    )
+    self.run_kubectl = self.enter_context(
+        mock.patch.object(
+            agent_sandbox.kubectl, 'RunKubectlCommand', return_value=('', '', 0)
+        )
+    )
+    self.enter_context(
+        mock.patch.object(
+            agent_sandbox.vm_util,
+            'IssueCommand',
+            side_effect=_fake_issue_command,
+        )
+    )
+    self.enter_context(
+        mock.patch.object(
+            agent_sandbox.data, 'ResourcePath', side_effect=lambda p: p
+        )
+    )
+
+  def testInstallStackOrdersCrdsBeforeController(self):
+    # Track the global call order across _apply_url and _apply_yaml.
+    call_log = []
+    self.apply_url.side_effect = lambda url: call_log.append(('url', url))
+    self.apply_yaml.side_effect = lambda s: call_log.append(('yaml', s))
+
+    agent_sandbox.install_stack(
+        controller_ref='v0.4.6',
+        controller_image='example.com/controller:v0.4.6',
+        runtime_class='runsc',
+        template_name='python-runtime',
+        warmpool_name='default',
+        warmpool_replicas=10,
+    )
+
+    # Find last CRD _apply_url index and first controller _apply_yaml index.
+    crd_index = max(
+        i
+        for i, (kind, val) in enumerate(call_log)
+        if kind == 'url' and 'sandboxclaims' in val
+    )
+    # The controller Deployment yaml contains 'agent-sandbox-controller'.
+    controller_index = next(
+        i
+        for i, (kind, val) in enumerate(call_log)
+        if kind == 'yaml'
+        and 'agent-sandbox-controller' in val
+        and 'Deployment' in val
+    )
+    self.assertLess(crd_index, controller_index)
+
+  def testInstallStackScalesWarmpoolToRequestedReplicas(self):
+    agent_sandbox.install_stack(
+        controller_ref='v0.4.6',
+        controller_image='example.com/controller:v0.4.6',
+        runtime_class='runsc',
+        template_name='python-runtime',
+        warmpool_name='default',
+        warmpool_replicas=10,
+    )
+
+    warmpool_calls = [
+        c
+        for c in self.apply_manifest.call_args_list
+        if 'sandbox-warmpool' in c.args[0]
+    ]
+    self.assertTrue(warmpool_calls)
+    self.assertEqual(warmpool_calls[0].kwargs['replicas'], 10)
+    self.wait_warmpool.assert_called_once_with('default', 10)
+
+  def testInstallStackSkipsWarmpoolAtZeroReplicas(self):
+    """install_stack with warmpool_replicas=0 must not apply or wait."""
+    agent_sandbox.install_stack(
+        controller_ref='v0.4.6',
+        controller_image=None,
+        runtime_class='runsc',
+        template_name='python-runtime',
+        warmpool_name='default',
+        warmpool_replicas=0,
+    )
+
+    warmpool_calls = [
+        c
+        for c in self.apply_manifest.call_args_list
+        if 'sandbox-warmpool' in c.args[0]
+    ]
+    self.assertFalse(warmpool_calls, 'warmpool manifest should not be applied')
+    self.wait_warmpool.assert_not_called()
+
+  def testInstallControllerPatchesImageWhenProvided(self):
+    """Injects the controller image into the Deployment manifest in memory."""
+    agent_sandbox.install_controller(
+        controller_ref='abc123',
+        controller_image='example.com/controller:abc123',
+    )
+
+    # The controller Deployment is applied via _apply_yaml; verify the image
+    # was injected into the YAML that was passed.
+    controller_yamls = [
+        yaml.safe_load(c.args[0])
+        for c in self.apply_yaml.call_args_list
+        if c.args[0] and yaml.safe_load(c.args[0]).get('kind') == 'Deployment'
+    ]
+    self.assertTrue(controller_yamls, 'expected a Deployment to be applied')
+    container = controller_yamls[0]['spec']['template']['spec']['containers'][0]
+    self.assertEqual(container['image'], 'example.com/controller:abc123')
+
+  def testInstallControllerDoesNotPatchImageWhenImageIsNone(self):
+    """Does not replace the image in the manifest when controller_image is None."""
+    agent_sandbox.install_controller(
+        controller_ref='v0.4.6', controller_image=None
+    )
+
+    controller_yamls = [
+        yaml.safe_load(c.args[0])
+        for c in self.apply_yaml.call_args_list
+        if c.args[0] and yaml.safe_load(c.args[0]).get('kind') == 'Deployment'
+    ]
+    self.assertTrue(controller_yamls, 'expected a Deployment to be applied')
+    container = controller_yamls[0]['spec']['template']['spec']['containers'][0]
+    # When controller_image is None, the image field is left as-is from the
+    # fake manifest (the placeholder value).
+    self.assertEqual(
+        container['image'],
+        'ko://controller',
+        'image should not be overwritten when controller_image is None',
+    )
+
+  def testControllerTuningPatchesArgs(self):
+    """install_controller with tuning injects the args into the Deployment YAML."""
+    agent_sandbox.install_controller(
+        controller_ref='v0.4.6',
+        controller_image=None,
+        controller_tuning={
+            'claim_workers': 100,
+            'sandbox_workers': 70,
+            'kube_api_burst': 600,
+        },
+    )
+
+    controller_yamls = [
+        yaml.safe_load(c.args[0])
+        for c in self.apply_yaml.call_args_list
+        if c.args[0] and yaml.safe_load(c.args[0]).get('kind') == 'Deployment'
+    ]
+    self.assertTrue(controller_yamls, 'expected a Deployment to be applied')
+    container = controller_yamls[0]['spec']['template']['spec']['containers'][0]
+    args = container.get('args', [])
+    self.assertIn('--sandbox-claim-concurrent-workers=100', args)
+    self.assertIn('--sandbox-concurrent-workers=70', args)
+    self.assertIn('--kube-api-burst=600', args)
+
+  def testControllerTuningSetsOtelEnvWhenTracing(self):
+    """enable_tracing=True injects --enable-tracing=true and OTEL env in YAML."""
+    endpoint = 'http://otel-collector.observability:4317'
+    agent_sandbox.install_controller(
+        controller_ref='v0.4.6',
+        controller_image=None,
+        controller_tuning={
+            'enable_tracing': True,
+            'otel_endpoint': endpoint,
+        },
+    )
+
+    controller_yamls = [
+        yaml.safe_load(c.args[0])
+        for c in self.apply_yaml.call_args_list
+        if c.args[0] and yaml.safe_load(c.args[0]).get('kind') == 'Deployment'
+    ]
+    self.assertTrue(controller_yamls, 'expected a Deployment to be applied')
+    container = controller_yamls[0]['spec']['template']['spec']['containers'][0]
+
+    # --enable-tracing=true must be in the args list.
+    args = container.get('args', [])
+    self.assertIn('--enable-tracing=true', args)
+
+    # OTEL env vars must be injected into the container env.
+    env = {e['name']: e['value'] for e in container.get('env', [])}
+    self.assertEqual(env.get('OTEL_EXPORTER_OTLP_ENDPOINT'), endpoint)
+    self.assertEqual(env.get('OTEL_EXPORTER_OTLP_INSECURE'), 'true')
+
+  def testNoControllerTuningNoExtraKubectl(self):
+    """install_controller with no tuning applies a clean Deployment with no extras."""
+    agent_sandbox.install_controller(
+        controller_ref='v0.4.6', controller_image=None, controller_tuning=None
+    )
+
+    controller_yamls = [
+        yaml.safe_load(c.args[0])
+        for c in self.apply_yaml.call_args_list
+        if c.args[0] and yaml.safe_load(c.args[0]).get('kind') == 'Deployment'
+    ]
+    self.assertTrue(controller_yamls, 'expected a Deployment to be applied')
+    container = controller_yamls[0]['spec']['template']['spec']['containers'][0]
+
+    # No OTEL env vars when tracing is not enabled.
+    env = {e['name']: e['value'] for e in container.get('env', [])}
+    self.assertNotIn(
+        'OTEL_EXPORTER_OTLP_ENDPOINT',
+        env,
+        'no OTEL env expected with no tuning',
+    )
+    # No extra tuning args beyond leader-elect and resources (which are always set).
+    args = container.get('args', [])
+    extra_tuning_args = [
+        a
+        for a in args
+        if a.startswith('--sandbox-')
+        or a.startswith('--kube-api-')
+        or a.startswith('--enable-tracing')
+    ]
+    self.assertFalse(
+        extra_tuning_args, 'no extra tuning args expected with no tuning'
+    )
+
+  def testInstallControllerDisablesLeaderElectionByDefault(self):
+    """install_controller sets --leader-elect=false in the manifest by default."""
+    agent_sandbox.install_controller(
+        controller_ref='v0.4.6', controller_image=None, controller_tuning=None
+    )
+
+    controller_yamls = [
+        yaml.safe_load(c.args[0])
+        for c in self.apply_yaml.call_args_list
+        if c.args[0] and yaml.safe_load(c.args[0]).get('kind') == 'Deployment'
+    ]
+    self.assertTrue(controller_yamls, 'expected a Deployment to be applied')
+    container = controller_yamls[0]['spec']['template']['spec']['containers'][0]
+    args = container.get('args', [])
+    le_args = [a for a in args if a.startswith('--leader-elect')]
+    self.assertLen(
+        le_args,
+        1,
+        'expected exactly one --leader-elect flag to avoid duplicates',
+    )
+    self.assertEqual(le_args[0], '--leader-elect=false')
+
+  def testInstallControllerEnablesLeaderElectionWhenRequested(self):
+    """install_controller sets --leader-elect=true when leader_elect=True."""
+    agent_sandbox.install_controller(
+        controller_ref='v0.4.6',
+        controller_image=None,
+        controller_tuning={'leader_elect': True},
+    )
+
+    controller_yamls = [
+        yaml.safe_load(c.args[0])
+        for c in self.apply_yaml.call_args_list
+        if c.args[0] and yaml.safe_load(c.args[0]).get('kind') == 'Deployment'
+    ]
+    self.assertTrue(controller_yamls, 'expected a Deployment to be applied')
+    container = controller_yamls[0]['spec']['template']['spec']['containers'][0]
+    args = container.get('args', [])
+    le_args = [a for a in args if a.startswith('--leader-elect')]
+    self.assertLen(
+        le_args,
+        1,
+        'expected exactly one --leader-elect flag to avoid duplicates',
+    )
+    self.assertEqual(le_args[0], '--leader-elect=true')
+
+  def testInstallControllerSetsResourceRequests(self):
+    """install_controller injects default resource requests/limits into the YAML."""
+    agent_sandbox.install_controller(
+        controller_ref='v0.4.6', controller_image=None, controller_tuning=None
+    )
+
+    controller_yamls = [
+        yaml.safe_load(c.args[0])
+        for c in self.apply_yaml.call_args_list
+        if c.args[0] and yaml.safe_load(c.args[0]).get('kind') == 'Deployment'
+    ]
+    self.assertTrue(controller_yamls, 'expected a Deployment to be applied')
+    container = controller_yamls[0]['spec']['template']['spec']['containers'][0]
+    resources = container.get('resources', {})
+    self.assertEqual(resources['requests']['cpu'], '500m')
+    self.assertEqual(resources['requests']['memory'], '256Mi')
+    self.assertEqual(resources['limits']['cpu'], '2')
+    self.assertEqual(resources['limits']['memory'], '1Gi')
+
+  def testInstallControllerUsesOverriddenResourceValues(self):
+    """Resource values in controller_tuning override the defaults in the YAML."""
+    agent_sandbox.install_controller(
+        controller_ref='v0.4.6',
+        controller_image=None,
+        controller_tuning={
+            'cpu_request': '1',
+            'cpu_limit': '4',
+            'memory_request': '512Mi',
+            'memory_limit': '2Gi',
+        },
+    )
+
+    controller_yamls = [
+        yaml.safe_load(c.args[0])
+        for c in self.apply_yaml.call_args_list
+        if c.args[0] and yaml.safe_load(c.args[0]).get('kind') == 'Deployment'
+    ]
+    self.assertTrue(controller_yamls, 'expected a Deployment to be applied')
+    container = controller_yamls[0]['spec']['template']['spec']['containers'][0]
+    resources = container.get('resources', {})
+    self.assertEqual(resources['requests']['cpu'], '1')
+    self.assertEqual(resources['requests']['memory'], '512Mi')
+    self.assertEqual(resources['limits']['cpu'], '4')
+    self.assertEqual(resources['limits']['memory'], '2Gi')
+
+
+class DaemonSetManifestTest(pkb_common_test_case.PkbCommonTestCase):
+  """Verifies daemonset.yaml scheduling matches the BENCHMARK_CONFIG labels."""
+
+  def _load_daemonset(self):
+    path = data.ResourcePath('agent_sandbox/gvisor-installer/daemonset.yaml')
+    with open(path) as f:
+      return yaml.safe_load(f)
+
+  def testNodeSelectorMatchesBenchmarkLabel(self):
+    """DaemonSet nodeSelector must match the sandbox nodepool label key."""
+    ds = self._load_daemonset()
+    node_selector = ds['spec']['template']['spec']['nodeSelector']
+    self.assertIn(
+        'sandbox.gke.io/runtime',
+        node_selector,
+        'DaemonSet nodeSelector must use sandbox.gke.io/runtime (the key '
+        'set on the sandbox nodepool in BENCHMARK_CONFIG)',
+    )
+
+  def testTolerationMatchesBenchmarkTaint(self):
+    """DaemonSet must tolerate the NoSchedule taint on the sandbox nodepool."""
+    ds = self._load_daemonset()
+    tolerations = ds['spec']['template']['spec']['tolerations']
+    taint_keys = [t.get('key') for t in tolerations]
+    self.assertIn(
+        'sandbox.gke.io/runtime',
+        taint_keys,
+        'DaemonSet must tolerate sandbox.gke.io/runtime=runsc:NoSchedule',
+    )
+    runsc_tol = next(
+        t for t in tolerations if t.get('key') == 'sandbox.gke.io/runtime'
+    )
+    self.assertEqual(runsc_tol.get('value'), 'runsc')
+    self.assertEqual(runsc_tol.get('effect'), 'NoSchedule')
+
+
+class DataFilesTest(pkb_common_test_case.PkbCommonTestCase):
+
+  def testTemplateAndWarmpoolResolve(self):
+    for resource in (
+        'agent_sandbox/sandbox-template.yaml.j2',
+        'agent_sandbox/sandbox-warmpool.yaml.j2',
+        'agent_sandbox/gvisor-installer/daemonset.yaml',
+        'agent_sandbox/gvisor-installer/runtimeclass.yaml',
+        'agent_sandbox/gvisor-installer/install.sh',
+    ):
+      self.assertTrue(data.ResourcePath(resource))
+
+  def testInstallScriptIsPresent(self):
+    path = data.ResourcePath('agent_sandbox/gvisor-installer/install.sh')
+    self.assertTrue(os.path.isfile(path))
+    with open(path) as f:
+      content = f.read()
+    self.assertIn('GVISOR_VERSION', content)
+    self.assertIn('containerd-shim-runsc-v1', content)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tests/providers/aws/elastic_kubernetes_service_test.py
+++ b/tests/providers/aws/elastic_kubernetes_service_test.py
@@ -235,6 +235,48 @@ class ElasticKubernetesServiceTest(BaseEksTest):
     self.assertEqual(node_groups[1]['maxSize'], 10)
     self.assertEqual(node_groups[1]['desiredCapacity'], 3)
 
+  def testRenderNodeGroupJsonWithLabelsAndTaints(self):
+    spec2 = EKS_SPEC_DICT.copy()
+    spec2['nodepools'] = {
+        'sandbox': {
+            'vm_count': 1,
+            'vm_spec': {
+                'AWS': {
+                    'machine_type': 'm5.large',
+                    'zone': 'us-west-1a',
+                }
+            },
+        }
+    }
+    cluster = elastic_kubernetes_service.EksCluster(
+        container_spec.ContainerClusterSpec('NAME', **spec2)
+    )
+    nodepool = cluster.nodepools['sandbox']
+    nodepool.node_labels = {'sandbox.gke.io/runtime': 'runsc'}
+    nodepool.node_taints = ['sandbox.gke.io/runtime=runsc:NoSchedule']
+
+    group_json = cluster._RenderNodeGroupJson(nodepool)
+
+    self.assertEqual(group_json['labels']['pkb_nodepool'], 'sandbox')
+    self.assertEqual(group_json['labels']['sandbox.gke.io/runtime'], 'runsc')
+    self.assertEqual(
+        group_json['taints'],
+        [{
+            'key': 'sandbox.gke.io/runtime',
+            'value': 'runsc',
+            'effect': 'NoSchedule',
+        }],
+    )
+
+  def testRenderNodeGroupJsonWithoutLabelsOrTaints(self):
+    cluster = elastic_kubernetes_service.EksCluster(EKS_SPEC)
+    nodepool = cluster.default_nodepool
+
+    group_json = cluster._RenderNodeGroupJson(nodepool)
+
+    self.assertEqual(group_json['labels'], {'pkb_nodepool': 'default'})
+    self.assertNotIn('taints', group_json)
+
   def testGetNodePoolNames(self):
     # Mock the output of the aws cli command
     cluster = elastic_kubernetes_service.EksCluster(EKS_SPEC)

--- a/tests/providers/gcp/google_kubernetes_engine_test.py
+++ b/tests/providers/gcp/google_kubernetes_engine_test.py
@@ -887,9 +887,7 @@ class GoogleKubernetesEngineAutopilotTestCase(PatchedObjectsTestCase):
     spec = self.create_kubernetes_engine_spec()
     with self.patch_critical_objects():
       cluster = google_kubernetes_engine.GkeAutopilotCluster(spec)
-    self.MockIssueCommand(
-        {'get node': [('ek-standard-16', '', 0)]}
-    )
+    self.MockIssueCommand({'get node': [('ek-standard-16', '', 0)]})
     self.assertEqual(
         cluster.GetMachineTypeFromNodeName(
             'gke-pkb-cluster-default-pool-node-1'
@@ -947,6 +945,89 @@ class GoogleKubernetesEngineNodepoolAutoscalingTestCase(PatchedObjectsTestCase):
       self.assertIn('--enable-autoscaling', nodepool_cmd)
       self.assertIn('--min-nodes 2', nodepool_cmd)
       self.assertIn('--max-nodes 10', nodepool_cmd)
+
+
+class GoogleKubernetesEngineNodeLabelsAndTaintsTestCase(PatchedObjectsTestCase):
+
+  def testNodepoolWithLabelsAndTaintsIncludesBothInGcloudCmd(self):
+    kubernetes_engine_spec = container_spec.ContainerClusterSpec(
+        'NAME',
+        **{
+            'cloud': 'GCP',
+            'vm_spec': {
+                'GCP': {
+                    'machine_type': 'fake-machine-type',
+                    'zone': 'us-central1-a',
+                },
+            },
+            'vm_count': 1,
+            'nodepools': {
+                'sandbox': {
+                    'vm_spec': {
+                        'GCP': {
+                            'machine_type': 'n2-standard-8',
+                        },
+                    },
+                    'vm_count': 3,
+                    'node_labels': {'sandbox.gke.io/runtime': 'runsc'},
+                    'node_taints': ['sandbox.gke.io/runtime=runsc:NoSchedule'],
+                },
+            },
+            'poll_for_events': False,
+        },
+    )
+    with self.patch_critical_objects() as issue_command:
+      cluster = google_kubernetes_engine.GkeCluster(kubernetes_engine_spec)
+      cluster._Create()
+
+      nodepool_cmd = issue_command.GetCommandWithSubstring(
+          'node-pools create sandbox'
+      )
+      # pkb_nodepool label must always be present.
+      self.assertIn('pkb_nodepool=sandbox', nodepool_cmd)
+      # Custom label must also be present in the same --node-labels value.
+      self.assertIn('sandbox.gke.io/runtime=runsc', nodepool_cmd)
+      # Both appear under a single --node-labels flag.
+      self.assertIn('--node-labels', nodepool_cmd)
+      # Taint must be present.
+      self.assertIn(
+          '--node-taints sandbox.gke.io/runtime=runsc:NoSchedule', nodepool_cmd
+      )
+
+  def testNodepoolWithoutLabelsOrTaintsOnlyEmitsPkbNodepoolLabel(self):
+    kubernetes_engine_spec = container_spec.ContainerClusterSpec(
+        'NAME',
+        **{
+            'cloud': 'GCP',
+            'vm_spec': {
+                'GCP': {
+                    'machine_type': 'fake-machine-type',
+                    'zone': 'us-central1-a',
+                },
+            },
+            'vm_count': 1,
+            'nodepools': {
+                'default-pool': {
+                    'vm_spec': {
+                        'GCP': {
+                            'machine_type': 'n2-standard-4',
+                        },
+                    },
+                    'vm_count': 2,
+                },
+            },
+            'poll_for_events': False,
+        },
+    )
+    with self.patch_critical_objects() as issue_command:
+      cluster = google_kubernetes_engine.GkeCluster(kubernetes_engine_spec)
+      cluster._Create()
+
+      nodepool_cmd = issue_command.GetCommandWithSubstring(
+          'node-pools create default-pool'
+      )
+      self.assertIn('--node-labels pkb_nodepool=default-pool', nodepool_cmd)
+      self.assertNotIn('--node-taints', nodepool_cmd)
 
 
 if __name__ == '__main__':

--- a/tests/traces/kubernetes_tracker_test.py
+++ b/tests/traces/kubernetes_tracker_test.py
@@ -95,7 +95,7 @@ class UsageTrackerTest(pkb_common_test_case.PkbCommonTestCase):
         },
     ]
     # pylint: disable=invalid-name
-    cluster.GetEvents = lambda: [
+    cluster.GetEvents = lambda field_selector=None: [
         _CreateEvent(
             "gke-pkb-cluster-default-pool-node-2",
             "RegisteredNode",
@@ -173,7 +173,7 @@ class UsageTrackerTest(pkb_common_test_case.PkbCommonTestCase):
     self.mock_get_node_names.return_value = {
         "gke-pkb-cluster-default-pool-node-1"
     }
-    cluster.GetEvents = lambda: [
+    cluster.GetEvents = lambda field_selector=None: [
         _CreateEvent(
             "gke-pkb-cluster-default-pool-node-1",
             "RegisteredNode",
@@ -216,7 +216,7 @@ class UsageTrackerTest(pkb_common_test_case.PkbCommonTestCase):
         {node_1},
         {node_1, node_2, node_3, node_4},
     ]
-    cluster.GetEvents = lambda: [
+    cluster.GetEvents = lambda field_selector=None: [
         _CreateEvent(node_1, "RegisteredNode", start_time),
         _CreateEvent(node_1, "RemovingNode", start_time + 40.0),
         _CreateEvent(node_2, "RegisteredNode", start_time + 20.0),
@@ -310,7 +310,7 @@ def CreateMockCluster(
           },
       )
   )
-  cluster.GetEvents = lambda: []
+  cluster.GetEvents = lambda field_selector=None: []
   return cluster
 
 


### PR DESCRIPTION
### Summary

Adds an `agent_sandbox` benchmark that measures Kubernetes agent-sandbox controller `SandboxClaim` provisioning latency under concurrent load, on both GKE and EKS.

The benchmark submits `SandboxClaim` custom resources at a configurable QPS and tracks time-to-Ready for each claim through a single Kubernetes Watch stream (no per-claim polling). It can optionally hold each sandbox with an in-cluster workload via the API server streaming exec (`connect_get_namespaced_pod_exec`). The cluster, node pools, and gVisor runtime are provisioned by PerfKitBenchmarker from the benchmark config.

### What's in this PR

- **`agent_sandbox` benchmark.** Load generator (`ClaimDriver` with 429-retry and separate connection pools, QPS-paced `LoadGenerator`, watch-based readiness, bounded concurrency), metrics (startup_time percentiles, submit/completion QPS, peak concurrency, warm_served_fraction, error counts), and the controller stack install: gVisor DaemonSet + RuntimeClass, CRDs/RBAC, the controller Deployment (applied once to avoid a double rollout), SandboxTemplate, and SandboxWarmPool. One cloud-aware config runs the same benchmark on GKE or EKS.
- **GKE cluster options.** Private nodes, DNS-based control plane endpoint, Dataplane V2, cost allocation, GKE managed Prometheus, configurable monitoring components, and per-nodepool `max_pods_per_node`, `node_labels`, and `node_taints`.
- **EKS nodepool labels/taints.** The eksctl node group spec now carries `node_labels` and `node_taints`, mirroring GKE.
- **Faster event tracking.** The kubernetes event poller takes a `field_selector` so it fetches only node events (`involvedObject.kind=Node`). On runs with >100k events the unfiltered fetch plus `yaml.safe_load` took minutes; this brings it under a second.
- **AWS fix.** `ec2 import-key-pair` reads the key material with `fileb://` so binary content isn't corrupted.

### Test plan

- [x] Unit tests: `agent_sandbox_benchmark_test.py`, `agent_sandbox_loadgen_test.py`, `agent_sandbox_metrics_test.py`, `agent_sandbox_test.py`, `kubernetes_tracker_test.py`, `google_kubernetes_engine_test.py`, `elastic_kubernetes_service_test.py`
- [x] Successful benchmarks run on GKE and EKS
