### PR TITLE
kubernetes: filter event poller fetch by field_selector

### DIFF
--- a/perfkitbenchmarker/resources/container_service/kubernetes_cluster.py
+++ b/perfkitbenchmarker/resources/container_service/kubernetes_cluster.py
@@ -39,9 +39,12 @@ class KubernetesCluster(container_cluster.BaseContainerCluster):
     )
 
   def _InitializeEventPoller(self) -> kubernetes_events.KubernetesEventPoller:
-    return kubernetes_events.KubernetesEventPoller(
-        lambda: kubernetes_commands.GetEvents(suppress_logging=True)
-    )
+    def _GetEventsNoLogging(field_selector=None):
+      return kubernetes_commands.GetEvents(
+          field_selector=field_selector, suppress_logging=True
+      )
+
+    return kubernetes_events.KubernetesEventPoller(_GetEventsNoLogging)
 
   def Create(self, restore: bool = False) -> None:
     super().Create(restore)
@@ -66,9 +69,11 @@ class KubernetesCluster(container_cluster.BaseContainerCluster):
       self.event_poller.StopPolling()
     _DeleteAllFromDefaultNamespace()
 
-  def GetEvents(self) -> set['kubernetes_events.KubernetesEvent']:
+  def GetEvents(
+      self, field_selector: str | None = None
+  ) -> set['kubernetes_events.KubernetesEvent']:
     """Gets the events for the cluster, including previously polled events."""
-    return self.event_poller.GetEvents()
+    return self.event_poller.GetEvents(field_selector=field_selector)
 
   def __getstate__(self):
     state = self.__dict__.copy()

--- a/perfkitbenchmarker/resources/container_service/kubernetes_commands.py
+++ b/perfkitbenchmarker/resources/container_service/kubernetes_commands.py
@@ -767,11 +767,14 @@ def GetPvcs() -> Sequence[Any]:
   return yaml.safe_load(stdout)['items']
 
 
-def GetEvents(**kwargs) -> set['kubernetes_events.KubernetesEvent']:
+def GetEvents(
+    field_selector: str | None = None, **kwargs
+) -> set['kubernetes_events.KubernetesEvent']:
   """Get the events for the cluster."""
-  stdout, _, _ = kubectl.RunRetryableKubectlCommand(
-      ['get', 'events', '-o', 'yaml'], **kwargs
-  )
+  cmd = ['get', 'events', '-o', 'yaml']
+  if field_selector:
+    cmd.append(f'--field-selector={field_selector}')
+  stdout, _, _ = kubectl.RunRetryableKubectlCommand(cmd, **kwargs)
   k8s_events = set()
   parsed = yaml.safe_load(stdout) or {}
   for item in parsed.get('items', []):

--- a/perfkitbenchmarker/resources/container_service/kubernetes_events.py
+++ b/perfkitbenchmarker/resources/container_service/kubernetes_events.py
@@ -15,11 +15,54 @@ from perfkitbenchmarker import errors
 from perfkitbenchmarker import events
 
 
+def _MatchesFieldSelector(
+    event: 'KubernetesEvent', field_selector: str
+) -> bool:
+  """Returns True if the event matches a simple key=value field selector.
+
+  Supports the subset of field selector keys used by this module:
+    involvedObject.kind, involvedObject.name, reason, type
+  Multiple selectors may be comma-separated (all must match).
+  """
+  for clause in field_selector.split(','):
+    clause = clause.strip()
+    if '==' in clause:
+      key, value = clause.split('==', 1)
+    elif '=' in clause:
+      key, value = clause.split('=', 1)
+    else:
+      continue
+    key, value = key.strip(), value.strip()
+    if key == 'involvedObject.kind':
+      if event.resource.kind != value:
+        return False
+    elif key == 'involvedObject.name':
+      if event.resource.name != value:
+        return False
+    elif key == 'reason':
+      if event.reason != value:
+        return False
+    elif key == 'type':
+      if event.type != value:
+        return False
+    else:
+      raise ValueError(
+          f'Unsupported field selector key {key!r}. Supported keys: '
+          'involvedObject.kind, involvedObject.name, reason, type'
+      )
+  return True
+
+
 class KubernetesEventPoller:
   """Wrapper which polls for Kubernetes events."""
 
-  def __init__(self, get_events_fn: Callable[[], set['KubernetesEvent']]):
+  def __init__(
+      self,
+      get_events_fn: Callable[..., set['KubernetesEvent']],
+      poll_field_selector: str | None = None,
+  ):
     self.get_events_fn = get_events_fn
+    self._poll_field_selector = poll_field_selector
     self.polled_events: set['KubernetesEvent'] = set()
     self.stop_polling = multiprocessing.Event()
     self.event_queue: multiprocessing.Queue = multiprocessing.Queue()
@@ -47,7 +90,7 @@ class KubernetesEventPoller:
     """
     while True:
       try:
-        k8s_events = self.get_events_fn()
+        k8s_events = self.get_events_fn(self._poll_field_selector)
         logging.info(
             'From async get events process, got %s events', len(k8s_events)
         )
@@ -91,12 +134,20 @@ class KubernetesEventPoller:
       self.event_poller.kill()
       self.event_poller.join(timeout=30)
 
-  def GetEvents(self) -> set['KubernetesEvent']:
+  def GetEvents(
+      self, field_selector: str | None = None
+  ) -> set['KubernetesEvent']:
     """Gets the events for the cluster, including previously polled events."""
-    k8s_events = self.get_events_fn()
+    k8s_events = self.get_events_fn(field_selector)
     self.polled_events.update(k8s_events)
     while not self.event_queue.empty():
       self.polled_events.add(self.event_queue.get())
+    if field_selector:
+      return {
+          e
+          for e in self.polled_events
+          if _MatchesFieldSelector(e, field_selector)
+      }
     return self.polled_events
 
   def GetAndLogFailureEvents(self) -> dict[str | None, list['KubernetesEvent']]:

--- a/perfkitbenchmarker/traces/kubernetes_tracker.py
+++ b/perfkitbenchmarker/traces/kubernetes_tracker.py
@@ -153,7 +153,11 @@ class KubernetesResourceTracker:
 
   def _StopWatchingForNodeChanges(self):
     """Stop watching the cluster for node add/remove events."""
-    polled_events = self._cluster.GetEvents()
+    # Filter to node events only — sandbox claim events can number >100k and
+    # make yaml.safe_load take several minutes for no benefit here.
+    polled_events = self._cluster.GetEvents(
+        field_selector="involvedObject.kind=Node"
+    )
 
     # Resolve machine type only for current nodes; use "unknown" for the rest.
     _current_node_names = kubernetes_commands.GetNodeNames()

--- a/tests/linux_benchmarks/kubernetes_scale_benchmark_test.py
+++ b/tests/linux_benchmarks/kubernetes_scale_benchmark_test.py
@@ -428,7 +428,9 @@ class KubernetesScaleBenchmarkTest(pkb_common_test_case.PkbCommonTestCase):
 
   @flagsaver.flagsaver(kubernetes_scale_num_replicas=10)
   def testCheckFailuresPassesWithCorrectNumberOfPods(self):
-    self.cluster.event_poller = kubernetes_events.KubernetesEventPoller(set)
+    self.cluster.event_poller = kubernetes_events.KubernetesEventPoller(
+        lambda field_selector=None: set()
+    )
     kubernetes_scale_benchmark.CheckForFailures(
         self.cluster,
         [
@@ -441,7 +443,7 @@ class KubernetesScaleBenchmarkTest(pkb_common_test_case.PkbCommonTestCase):
   @flagsaver.flagsaver(kubernetes_scale_num_replicas=10)
   def testCheckFailuresThrowsRegularError(self):
     self.cluster.event_poller = kubernetes_events.KubernetesEventPoller(
-        lambda: {
+        lambda field_selector=None: {
             kubernetes_events.KubernetesEvent(
                 reason='PodReady',
                 message='Pod is ready',
@@ -466,7 +468,7 @@ class KubernetesScaleBenchmarkTest(pkb_common_test_case.PkbCommonTestCase):
   @flagsaver.flagsaver(kubernetes_scale_num_replicas=10)
   def testCheckFailuresThrowsQuotaExceeded(self):
     self.cluster.event_poller = kubernetes_events.KubernetesEventPoller(
-        lambda: {
+        lambda field_selector=None: {
             kubernetes_events.KubernetesEvent(
                 reason='FailedScaleUp',
                 message=(

--- a/tests/traces/kubernetes_tracker_test.py
+++ b/tests/traces/kubernetes_tracker_test.py
@@ -95,7 +95,7 @@ class UsageTrackerTest(pkb_common_test_case.PkbCommonTestCase):
         },
     ]
     # pylint: disable=invalid-name
-    cluster.GetEvents = lambda: [
+    cluster.GetEvents = lambda field_selector=None: [
         _CreateEvent(
             "gke-pkb-cluster-default-pool-node-2",
             "RegisteredNode",
@@ -173,7 +173,7 @@ class UsageTrackerTest(pkb_common_test_case.PkbCommonTestCase):
     self.mock_get_node_names.return_value = {
         "gke-pkb-cluster-default-pool-node-1"
     }
-    cluster.GetEvents = lambda: [
+    cluster.GetEvents = lambda field_selector=None: [
         _CreateEvent(
             "gke-pkb-cluster-default-pool-node-1",
             "RegisteredNode",
@@ -216,7 +216,7 @@ class UsageTrackerTest(pkb_common_test_case.PkbCommonTestCase):
         {node_1},
         {node_1, node_2, node_3, node_4},
     ]
-    cluster.GetEvents = lambda: [
+    cluster.GetEvents = lambda field_selector=None: [
         _CreateEvent(node_1, "RegisteredNode", start_time),
         _CreateEvent(node_1, "RemovingNode", start_time + 40.0),
         _CreateEvent(node_2, "RegisteredNode", start_time + 20.0),
@@ -310,7 +310,7 @@ def CreateMockCluster(
           },
       )
   )
-  cluster.GetEvents = lambda: []
+  cluster.GetEvents = lambda field_selector=None: []
   return cluster
 
 


### PR DESCRIPTION
## What

Add an optional `field_selector` to the Kubernetes event poller (`GetEvents`) so callers can have the API server filter events server-side, and use it on the node-change watcher so it polls only Node events.

## Why

Some benchmarks generate a tremendous volume of Kubernetes events, and collecting them after a run can take several minutes. The node-change tracker is only interested in Node events, but it was fetching and parsing the entire event stream on every poll. Scoping that fetch to `involvedObject.kind=Node` returns just the events that path consumes and recovers almost all of that collection time.

The new `field_selector` parameter defaults to `None` (no filtering), so it does not change behavior for callers that do not set it. The behavior that does change is the node-change watcher, which now polls only Node events instead of the full stream.

## Changes

- `kubernetes_commands.py`, `kubernetes_cluster.py`, `kubernetes_events.py`: add an optional `field_selector` to `GetEvents`. When unset (the default), the request is unchanged and no `--field-selector` flag is added.
- `kubernetes_tracker.py`: the node-change watcher now passes `field_selector="involvedObject.kind=Node"`, so it polls only Node events.
- `kubernetes_tracker_test.py`: coverage for the filtered fetch.
