### PR TITLE
eks: support nodepool labels and taints

### DIFF
--- a/perfkitbenchmarker/configs/container_spec.py
+++ b/perfkitbenchmarker/configs/container_spec.py
@@ -243,6 +243,8 @@ class NodepoolSpec(spec.BaseSpec):
     self.vm_spec: virtual_machine_spec.BaseVmSpec
     self.machine_families: list[str] | None
     self.sandbox_config: SandboxSpec | None
+    self.node_labels: dict[str, str] | None
+    self.node_taints: list[str] | None
 
   @classmethod
   def _GetOptionDecoderConstructions(cls):
@@ -273,6 +275,14 @@ class NodepoolSpec(spec.BaseSpec):
         ),
         'vm_spec': (spec.PerCloudConfigDecoder, {}),
         'sandbox_config': (_SandboxDecoder, {'default': None}),
+        'node_labels': (
+            option_decoders.TypeVerifier,
+            {'valid_types': (dict,), 'default': None, 'none_ok': True},
+        ),
+        'node_taints': (
+            option_decoders.TypeVerifier,
+            {'valid_types': (list,), 'default': None, 'none_ok': True},
+        ),
     })
     return result
 

--- a/perfkitbenchmarker/providers/aws/aws_virtual_machine.py
+++ b/perfkitbenchmarker/providers/aws/aws_virtual_machine.py
@@ -441,8 +441,10 @@ class AwsKeyFileManager:
     with cls._lock:
       if _GetKeyfileSetKey(region) in cls.imported_keyfile_set:
         return
-      cat_cmd = ['cat', vm_util.GetPublicKeyPath()]
-      keyfile, _ = vm_util.IssueRetryableCommand(cat_cmd)
+      # `aws ec2 import-key-pair --public-key-material` rejects a raw
+      # OpenSSH-formatted key with "Invalid base64" when the value comes
+      # in as a CLI string. The `fileb://` URI tells the CLI to read the
+      # file as bytes and send them through, which AWS accepts.
       formatted_tags = util.FormatTagSpecifications(
           'key-pair', util.MakeDefaultTags()
       )
@@ -451,7 +453,7 @@ class AwsKeyFileManager:
           '--region=%s' % region,
           'import-key-pair',
           '--key-name=%s' % cls.GetKeyNameForRun(),
-          '--public-key-material=%s' % keyfile,
+          '--public-key-material=fileb://%s' % vm_util.GetPublicKeyPath(),
           '--tag-specifications=%s' % formatted_tags,
       ]
       _, stderr, retcode = vm_util.IssueCommand(

--- a/perfkitbenchmarker/providers/aws/elastic_kubernetes_service.py
+++ b/perfkitbenchmarker/providers/aws/elastic_kubernetes_service.py
@@ -101,6 +101,22 @@ def ApplyInferenceS3PvAndPvc() -> None:
   logging.info('Successfully applied S3 PVC.')
 
 
+def _ParseTaint(taint_str: str) -> dict[str, str]:
+  """Parses a taint string into eksctl's dict format.
+
+  Args:
+    taint_str: Taint in 'key=value:Effect' or 'key:Effect' format.
+
+  Returns:
+    Dict with 'key', 'value' (optional), and 'effect' keys for eksctl.
+  """
+  key_value, effect = taint_str.rsplit(':', 1)
+  if '=' in key_value:
+    key, value = key_value.split('=', 1)
+    return {'key': key, 'value': value, 'effect': effect}
+  return {'key': key_value, 'effect': effect}
+
+
 class BaseEksCluster(kubernetes_cluster.KubernetesCluster):
   """Shared base class for Elastic Kubernetes Service cluster auto mode & not."""
 
@@ -195,16 +211,19 @@ class BaseEksCluster(kubernetes_cluster.KubernetesCluster):
       self, nodepool: container.BaseNodePoolConfig
   ) -> dict[str, Any]:
     """Constructs the node group json dictionary."""
+    labels = {'pkb_nodepool': nodepool.name}
+    if nodepool.node_labels:
+      labels.update(nodepool.node_labels)
     group_json = {
         'name': nodepool.name,
         'instanceType': nodepool.machine_type,
         'desiredCapacity': nodepool.num_nodes,
         'amiFamily': 'AmazonLinux2023',
         'tags': util.MakeDefaultTags(),
-        'labels': {
-            'pkb_nodepool': nodepool.name,
-        },
+        'labels': labels,
     }
+    if nodepool.node_taints:
+      group_json['taints'] = [_ParseTaint(t) for t in nodepool.node_taints]
     if nodepool.min_nodes != nodepool.max_nodes:
       group_json['minSize'] = nodepool.min_nodes
       group_json['maxSize'] = nodepool.max_nodes

--- a/perfkitbenchmarker/resources/container_service/container.py
+++ b/perfkitbenchmarker/resources/container_service/container.py
@@ -184,6 +184,8 @@ class BaseNodePoolConfig:
     self.disk_size: int = vm_spec.boot_disk_size
     self.gpu_type: str | None = vm_spec.gpu_type
     self.gpu_count: int | None = vm_spec.gpu_count
+    self.node_labels: dict[str, str] | None = None
+    self.node_taints: list[str] | None = None
     # Defined by GceVirtualMachineConfig. Used by google_kubernetes_engine
     # pylint: disable=g-missing-from-attributes
     self.sandbox_config: container_spec_lib.SandboxSpec | None = None

--- a/perfkitbenchmarker/resources/container_service/container_cluster.py
+++ b/perfkitbenchmarker/resources/container_service/container_cluster.py
@@ -116,6 +116,8 @@ class BaseContainerCluster(resource.BaseResource):
         nodepool_spec.machine_families,
     )
     nodepool_config.sandbox_config = nodepool_spec.sandbox_config
+    nodepool_config.node_labels = nodepool_spec.node_labels
+    nodepool_config.node_taints = nodepool_spec.node_taints
     nodepool_config.zone = zone
     nodepool_config.num_nodes = nodepool_spec.vm_count
     if nodepool_spec.min_vm_count is None:

--- a/tests/providers/aws/aws_cluster_test.py
+++ b/tests/providers/aws/aws_cluster_test.py
@@ -58,7 +58,6 @@ class AwsClusterTest(pkb_common_test_case.PkbCommonTestCase):
 
   def testCreateDependencies(self):
     self.mock_issue.side_effect = [
-        ('fake_key', None, None),  # Mock 'cat key' from __init__
         ('', None, None),  # Mock import key from ImportKeyfile
         # Mock vpc creation
         ('''Creating CloudFormation stack...

--- a/tests/providers/aws/elastic_kubernetes_service_test.py
+++ b/tests/providers/aws/elastic_kubernetes_service_test.py
@@ -237,6 +237,47 @@ class ElasticKubernetesServiceTest(BaseEksTest):
     self.assertEqual(node_groups[1]['maxSize'], 10)
     self.assertEqual(node_groups[1]['desiredCapacity'], 3)
 
+  def testEksClusterNodepoolLabels(self):
+    cluster = elastic_kubernetes_service.EksCluster(EKS_SPEC)
+    nodepool = cluster.default_nodepool
+    nodepool.node_labels = {'env': 'prod', 'team': 'ml'}
+    actual = cluster._RenderNodeGroupJson(nodepool)
+    self.assertEqual(
+        actual['labels'],
+        {'pkb_nodepool': nodepool.name, 'env': 'prod', 'team': 'ml'},
+    )
+
+  def testEksClusterNodepoolTaints(self):
+    cluster = elastic_kubernetes_service.EksCluster(EKS_SPEC)
+    nodepool = cluster.default_nodepool
+    nodepool.node_taints = [
+        'sandbox.gke.io/runtime=runsc:NoSchedule',
+        'dedicated:NoExecute',
+    ]
+    actual = cluster._RenderNodeGroupJson(nodepool)
+    self.assertEqual(
+        actual['taints'],
+        [
+            {
+                'key': 'sandbox.gke.io/runtime',
+                'value': 'runsc',
+                'effect': 'NoSchedule',
+            },
+            {'key': 'dedicated', 'effect': 'NoExecute'},
+        ],
+    )
+
+
+  def testParseTaint(self):
+    self.assertEqual(
+        elastic_kubernetes_service._ParseTaint('key=value:NoSchedule'),
+        {'key': 'key', 'value': 'value', 'effect': 'NoSchedule'},
+    )
+    self.assertEqual(
+        elastic_kubernetes_service._ParseTaint('dedicated:NoExecute'),
+        {'key': 'dedicated', 'effect': 'NoExecute'},
+    )
+
   def testGetNodePoolNames(self):
     # Mock the output of the aws cli command
     cluster = elastic_kubernetes_service.EksCluster(EKS_SPEC)


### PR DESCRIPTION
Add support for `node_labels` and `node_taints` on EKS node groups.

## What this adds

- `_ParseTaint()`: parses taint strings in `key=value:Effect` or `key:Effect` format into the dict structure eksctl expects in its node group JSON.
- `BaseEksCluster._RenderNodeGroupJson()`: merges `nodepool.node_labels` into the labels dict and appends parsed taints when `nodepool.node_taints` is set.

These were written to simplify managing EKS clusters end-to-end with PKB for the `agent_sandbox` benchmark, but are neither required by nor exclusively useful for that benchmark -- any PKB benchmark that provisions EKS nodepools with label or taint requirements can use them.

Also includes a fix for AWS key import to use the `fileb://` URI scheme (`--public-key-material=fileb://<path>`), which avoids the AWS CLI's base64 interpretation of raw key material passed as a string argument.

## Tests

Added `testEksClusterNodepoolLabels`, `testEksClusterNodepoolTaints`, and `testParseTaint` to `ElasticKubernetesServiceTest`. All 27 tests in the EKS test file pass.

Thanks to @shubham-gaur-x for the inspiration and testing