### PR TITLE
elastic_kubernetes_service: remove AddNodepool no-op stub

### DIFF
--- a/perfkitbenchmarker/providers/aws/elastic_kubernetes_service.py
+++ b/perfkitbenchmarker/providers/aws/elastic_kubernetes_service.py
@@ -375,9 +375,6 @@ class BaseEksCluster(kubernetes_cluster.KubernetesCluster):
     nodegroups = json.loads(stdout)
     return [ng['Name'] for ng in nodegroups]
 
-  def AddNodepool(self, batch_name, pool_id):
-    pass
-
 
 class EksCluster(BaseEksCluster):
   """Class representing an Elastic Kubernetes Service cluster."""


### PR DESCRIPTION
**Summary**
Removes BaseEksCluster.AddNodepool pass stub so the base class
KubernetesCluster.AddNodepool delegates to CreateNodePool correctly.

**How tested**
- 4/4 provision_node_pools tests passing
- pyink + lint-diffs clean