### PR TITLE
Fix GPU for AKS Automatic

### DIFF
--- a/perfkitbenchmarker/data/container/kubernetes_ai_inference/azure-gpu-nodepool.yaml.j2
+++ b/perfkitbenchmarker/data/container/kubernetes_ai_inference/azure-gpu-nodepool.yaml.j2
@@ -4,6 +4,8 @@ metadata:
   name: gpu-nodeclass
 spec:
   imageFamily: Ubuntu2204
+  tags:
+    EnableManagedGPUExperience: 'true'
 ---
 apiVersion: karpenter.sh/v1
 kind: NodePool
@@ -37,45 +39,3 @@ spec:
       taints:
         - key: 'nvidia.com/gpu'
           effect: NoSchedule
----
-# According to the official Microsoft documentation, the NVIDIA device plugin
-# must be deployed as a DaemonSet to enable GPU support in the Kubernetes cluster.
-# Reference: https://learn.microsoft.com/en-us/azure/aks/use-nvidia-gpu?tabs=add-ubuntu-gpu-node-pool#nvidia-device-plugin-installation
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: nvidia-device-plugin-daemonset
-  namespace: kube-system
-spec:
-  selector:
-    matchLabels:
-      name: nvidia-device-plugin-ds
-  updateStrategy:
-    type: RollingUpdate
-  template:
-    metadata:
-      labels:
-        name: nvidia-device-plugin-ds
-    spec:
-      tolerations:
-      - key: 'nvidia.com/gpu'
-        operator: Exists
-        effect: NoSchedule
-      priorityClassName: 'system-node-critical'
-      containers:
-      - image: nvcr.io/nvidia/k8s-device-plugin:v0.18.0
-        name: nvidia-device-plugin-ctr
-        env:
-          - name: FAIL_ON_INIT_ERROR
-            value: 'false'
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop: ['ALL']
-        volumeMounts:
-        - name: device-plugin
-          mountPath: /var/lib/kubelet/device-plugins
-      volumes:
-      - name: device-plugin
-        hostPath:
-          path: /var/lib/kubelet/device-plugins


### PR DESCRIPTION
### Fix for the GPU capacity issue in AKS Automatic

**The Problem**

Applying the DaemonSet to install the GPU device plugin manually fails with the following error:
```
STDERR: Error from server (Forbidden): error when creating "/var/folders/_7/qlc76gs57gjg9dw3cjqy4zp00000gn/T/tmp5egszs8u.yaml":
daemonsets.apps "nvidia-device-plugin-daemonset" is forbidden: ValidatingAdmissionPolicy
'aks-managed-protect-system-namespaces' with binding 
'aks-managed-protect-system-namespaces-binding' denied request: 
Modification of resources in managed system namespaces is not allowed
```
As a result, although the GPU node is successfully added to the cluster, the GPU capacity is not available because we are blocked from deploying the custom device plugin.

**How This Solution was Found**

Through collaboration with Azure Support, I received a workaround to unblock GPU usage on AKS Automatic / Node Auto-Provisioning (NAP) clusters (specifically targeting the Automatic cluster) while Microsoft continues to develop official managed GPU API field support natively with NAP.

**The Solution & What It Does**

Instead of manually deploying custom DaemonSets (which conflicts with the security policies on AKS Automatic), this PR leverages the EnableManagedGPUExperience VMSS tag (preview) directly within the NAP configuration.

When applied, this tag delegates the responsibility of setting up the GPU stack entirely to Azure. When an NVIDIA GPU VM size is selected by NAP (via NodePool and AKSNodeClass configuration), the tag automatically controls and triggers:

- The installation of the official NVIDIA GPU driver.
- The deployment of the GPU device plugin.

This approach is much simpler, aligns with AKS Automatic security standards (preventing system namespace violation errors), and is officially supported and managed by the cloud provider.