### PR TITLE
kubernetes_cluster: revert AddNodepool to no-op to fix provision_node…

### DIFF
--- a/perfkitbenchmarker/resources/container_service/kubernetes_cluster.py
+++ b/perfkitbenchmarker/resources/container_service/kubernetes_cluster.py
@@ -301,19 +301,16 @@ class KubernetesCluster(container_cluster.BaseContainerCluster):
     return 'http://' + ip.strip()
 
   def AddNodepool(self, batch_name: str, pool_id: str) -> None:
-    """Adds a node pool; delegates to CreateNodePool for standard clusters.
+    """Adds an additional nodepool with the given name to the cluster.
 
-    Karpenter-based subclasses override this to apply a manifest instead.
+    Providers that support dynamic nodepool creation should override this
+    method. The default implementation is a no-op.
 
     Args:
       batch_name: The batch identifier for the new node pool.
       pool_id: The pool identifier within the batch.
     """
-    nodepool_config = container_lib.BaseNodePoolConfig(
-        self.nodepools[container_cluster.DEFAULT_NODEPOOL].vm_spec,
-        name=f'{batch_name}-{pool_id}',
-    )
-    self.CreateNodePool(nodepool_config)
+    pass
 
   def CreateNodePool(
       self,


### PR DESCRIPTION
…_pools on GCP

PR #6746 changed AddNodepool to call CreateNodePool, breaking the provision_node_pools benchmark on GCP (reported by Zach Howell). GkeCluster has no AddNodepool override and CreateNodePool is not implemented for that use case.

Revert to pass (no-op) — AKS, EKS, and Karpenter variants already override AddNodepool with the correct provider-specific implementation.