### PR TITLE
kubernetes_deployment_startup: add vLLM workload support

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/kubernetes_deployment_startup_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/kubernetes_deployment_startup_benchmark.py
@@ -13,25 +13,19 @@
 # limitations under the License.
 """Benchmark for measuring time to start up a deployment on Kubernetes.
 
-PR 1 — Metrics & Observability
-================================
-Extends the existing benchmark with two new metrics and per-sample metadata:
+PR 2 — vLLM Workload Support (Layer 1)
+========================================
+Adds a second workload (vLLM) alongside the existing JVM slow-start app.
 
-1. **per_pod_ready_time** — individual pod startup duration (s) from
-   PodReadyToStartContainers → Ready, using the existing
-   kubernetes_conditions.GetStatusConditionsForResourceType() call that
-   already powers max_pod_ready_time.  Emits one Sample per pod so
-   downstream analysis can compute percentiles across replicas.
+Changes vs PR 1:
+  - VLLM_IMAGE flag: public vLLM CPU image (overridable).
+  - VLLM_YAML: new vllm.yaml.j2 manifest (port 8000, /health readiness probe).
+  - GetConfig(): sets container image from workload flag.
+  - Prepare(): deploys JVM or vLLM manifest based on workload flag.
+  - Run(): uses workload-appropriate deployment name and wait condition.
 
-2. **cpu_utilization_millicores** (peak / mean / count) — CPU sampled in a
-   background thread via KubernetesMetricsCollector._Observe(), following
-   the exact same pattern as kubernetes_hpa_benchmark.py.
-
-3. **metadata** — scenario / workload / cloud / replicas added to every
-   sample for cross-config comparison (PR 3 will set scenario=optimized).
-
-Nothing in Prepare() or Cleanup() changes.  PR 2 adds vLLM workload
-support; PR 3 adds the VPA CPU Startup Boost scenario flag.
+No changes to PR 1 metrics or PR 3 scenario logic.
+Independent of PR 3 — can be reviewed/merged in any order relative to PR 3.
 """
 
 import collections
@@ -47,6 +41,7 @@ from perfkitbenchmarker import errors
 from perfkitbenchmarker import sample
 from perfkitbenchmarker.resources.container_service import kubernetes_commands
 from perfkitbenchmarker.resources.container_service import kubernetes_conditions
+from perfkitbenchmarker.resources.container_service import kubectl
 
 FLAGS = flags.FLAGS
 
@@ -54,7 +49,7 @@ BENCHMARK_NAME = 'kubernetes_deployment_startup'
 BENCHMARK_CONFIG = """
 kubernetes_deployment_startup:
   description: >
-    Measures the time it takes for a slow-starting JVM application
+    Measures the time it takes for a slow-starting JVM application or vLLM
     to become ready in a Kubernetes cluster.
   container_cluster:
     cloud: GCP
@@ -70,41 +65,70 @@ kubernetes_deployment_startup:
         zone: 'us-central1'
 """
 
+# ── Existing flags (PR 1) ─────────────────────────────────────────────────
 DEPLOYMENT_YAML = flags.DEFINE_string(
     'kubernetes_deployment_startup_yaml',
     'container/kubernetes_deployment_startup/slowjvmstartup.yaml.j2',
-    'Deployment yaml',
+    'Deployment yaml for JVM workload.',
 )
 DEPLOYMENT_IMAGE = flags.DEFINE_string(
     'kubernetes_deployment_startup_image',
     None,
-    'Image name. If omitted, "slowjvmstartup" will be used',
+    'Image name for JVM workload. If omitted, "slowjvmstartup" will be used.',
 )
-
-# PR 1: new flags — workload and scenario are stubs here; PR 2 and PR 3 add
-# the actual logic so that flag names are stable across all three PRs.
 WORKLOAD = flags.DEFINE_enum(
     'kubernetes_deployment_startup_workload',
     'jvm',
     ['jvm', 'vllm'],
-    'Workload type. vLLM deployment support is added in PR 2.',
+    'Workload type to deploy. jvm deploys the slow-starting JVM app; '
+    'vllm deploys a vLLM CPU inference server.',
 )
 SCENARIO = flags.DEFINE_enum(
     'kubernetes_deployment_startup_scenario',
     'baseline',
     ['baseline', 'optimized'],
-    'Startup scenario. optimized (GKE CPU Startup Boost) is added in PR 3.',
+    'Startup scenario. optimized (GKE CPU Startup Boost via VPA) added in PR 3.',
 )
 
-# Interval between successive CPU polls (seconds).  Matches
-# kubernetes_hpa_benchmark which polls at ~1 s.
+# ── New flags (PR 2) ──────────────────────────────────────────────────────
+VLLM_IMAGE = flags.DEFINE_string(
+    'kubernetes_deployment_startup_vllm_image',
+    'public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:latest',
+    'Container image for the vLLM CPU workload.',
+)
+VLLM_YAML = flags.DEFINE_string(
+    'kubernetes_deployment_startup_vllm_yaml',
+    'container/kubernetes_deployment_startup/vllm.yaml.j2',
+    'Deployment yaml for the vLLM workload.',
+)
+
+# Deployment names — must match the `name:` field in each manifest.
+_JVM_DEPLOYMENT_NAME = 'startup'
+_VLLM_DEPLOYMENT_NAME = 'vllm-startup'
+
+# CPU metrics polling interval in seconds.
 _CPU_POLL_INTERVAL_SECS = 5
 
 
 def GetConfig(user_config: Dict[str, Any]) -> Dict[str, Any]:
-  """Returns merged benchmark config."""
+  """Returns merged benchmark config.
+
+  Sets the container image from the appropriate workload flag so the
+  container_registry image-building pipeline uses the right source.
+
+  Args:
+    user_config: User-supplied configuration (flags and config file).
+
+  Returns:
+    Loaded benchmark configuration.
+  """
   config = configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
-  if DEPLOYMENT_IMAGE.value is not None:
+  if WORKLOAD.value == 'vllm':
+    # vLLM uses a pre-built public image — no registry build needed.
+    config['container_specs']['kubernetes_deployment_startup'][
+        'image'
+    ] = VLLM_IMAGE.value
+  elif DEPLOYMENT_IMAGE.value is not None:
     config['container_specs']['kubernetes_deployment_startup'][
         'image'
     ] = DEPLOYMENT_IMAGE.value
@@ -114,69 +138,83 @@ def GetConfig(user_config: Dict[str, Any]) -> Dict[str, Any]:
 def Prepare(benchmark_spec: bm_spec.BenchmarkSpec):
   """Prepares the Kubernetes cluster for the benchmark.
 
+  Deploys either the JVM slow-start app or the vLLM CPU server depending
+  on --kubernetes_deployment_startup_workload.
+
   Args:
     benchmark_spec: The benchmark specification.
   """
-  del benchmark_spec
+  image = benchmark_spec.container_specs['kubernetes_deployment_startup'].image
+
+  if WORKLOAD.value == 'vllm':
+    logging.info('[startup] Deploying vLLM workload (image=%s)', image)
+    kubernetes_commands.ApplyManifest(
+        VLLM_YAML.value,
+        name=_VLLM_DEPLOYMENT_NAME,
+        image=image,
+    )
+  else:
+    logging.info('[startup] Deploying JVM workload (image=%s)', image)
+    kubernetes_commands.ApplyManifest(
+        DEPLOYMENT_YAML.value,
+        name=_JVM_DEPLOYMENT_NAME,
+        image=image,
+    )
 
 
 def Run(benchmark_spec: bm_spec.BenchmarkSpec) -> List[sample.Sample]:
   """Runs the benchmark and collects the results.
 
-  Collects three categories of metrics:
-    1. max_pod_ready_time  — existing metric, preserved unchanged.
-    2. per_pod_ready_time  — new: one Sample per pod with pod name in metadata.
-    3. cpu_utilization_*   — new: peak/mean/count via background collector.
-
-  All samples carry scenario/workload/cloud/replicas metadata.
+  Waits for the appropriate deployment to roll out, then collects:
+    1. max_pod_ready_time  — existing metric (preserved).
+    2. per_pod_ready_time  — one Sample per pod (PR 1).
+    3. cpu_utilization_*   — background CPU collector (PR 1).
 
   Args:
     benchmark_spec: The benchmark specification.
 
   Raises:
-    RuntimeError: Raised if no pods are ready after the deployment rolls out.
+    RuntimeError: Raised if no pods are ready after the rollout.
 
   Returns:
     A list of sample.Sample objects.
   """
-  image = benchmark_spec.container_specs['kubernetes_deployment_startup'].image
+  workload = WORKLOAD.value
+  scenario = SCENARIO.value
 
-  # ── Base metadata attached to every sample ────────────────────────────────
+  deployment_name = (
+      _VLLM_DEPLOYMENT_NAME if workload == 'vllm' else _JVM_DEPLOYMENT_NAME
+  )
+
+  # Common metadata on every sample.
   base_metadata: Dict[str, Any] = {
-      'scenario': SCENARIO.value,
-      'workload': WORKLOAD.value,
+      'scenario': scenario,
+      'workload': workload,
       'cloud': FLAGS.cloud,
+      'deployment_name': deployment_name,
   }
 
-  # ── Start CPU background collector ────────────────────────────────────────
+  # ── Start CPU background collector (PR 1) ─────────────────────────────
   all_samples: List[sample.Sample] = []
   stop = threading.Event()
   cpu_collector = _CpuUtilizationCollector(all_samples, stop)
 
-  # Apply manifest and wait for rollout inside a try/finally so we always
-  # stop the collector even if WaitForRollout raises.
   try:
-    kubernetes_commands.ApplyManifest(
-        DEPLOYMENT_YAML.value,
-        name='startup',
-        image=image,
-    )
-
-    # Run CPU collector in parallel with the rollout wait, exactly like
-    # KubernetesMetricsCollector in kubernetes_hpa_benchmark.py.
     collector_thread = threading.Thread(
         target=cpu_collector.ObserveCpuUtilization,
         daemon=True,
     )
     collector_thread.start()
 
-    kubernetes_commands.WaitForRollout('deployment/startup', timeout=600)
+    kubernetes_commands.WaitForRollout(
+        f'deployment/{deployment_name}', timeout=600
+    )
 
   finally:
     stop.set()
     collector_thread.join(timeout=_CPU_POLL_INTERVAL_SECS * 3)
 
-  # ── Parse pod conditions (existing logic, unchanged) ──────────────────────
+  # ── Parse pod conditions ───────────────────────────────────────────────
   pod_name_to_start_end_times: dict[str, tuple[int, int]] = (
       collections.defaultdict(lambda: (0, 0))
   )
@@ -197,7 +235,7 @@ def Run(benchmark_spec: bm_spec.BenchmarkSpec) -> List[sample.Sample]:
   if not pod_name_to_start_end_times:
     raise RuntimeError('No pods became ready')
 
-  # ── Metric 1: max_pod_ready_time (existing, unchanged) ───────────────────
+  # ── Metric 1: max_pod_ready_time (existing) ───────────────────────────
   max_pod_ready_t = -1
   for _, times in pod_name_to_start_end_times.items():
     t = times[1] - times[0]
@@ -208,15 +246,11 @@ def Run(benchmark_spec: bm_spec.BenchmarkSpec) -> List[sample.Sample]:
 
   all_samples.append(
       sample.Sample(
-          'max_pod_ready_time',
-          max_pod_ready_t,
-          'seconds',
-          {**base_metadata},
+          'max_pod_ready_time', max_pod_ready_t, 'seconds', {**base_metadata}
       )
   )
 
-  # ── Metric 2: per_pod_ready_time (new — PR 1) ────────────────────────────
-  # Emit one Sample per pod so callers can compute p50/p90 across replicas.
+  # ── Metric 2: per_pod_ready_time (PR 1) ──────────────────────────────
   for pod_name, (start_t, end_t) in pod_name_to_start_end_times.items():
     pod_ready_t = end_t - start_t
     if pod_ready_t >= 0:
@@ -230,12 +264,10 @@ def Run(benchmark_spec: bm_spec.BenchmarkSpec) -> List[sample.Sample]:
       )
 
   logging.info(
-      '[startup] max_pod_ready_time=%.2fs across %d pod(s)',
-      max_pod_ready_t,
-      len(pod_name_to_start_end_times),
+      '[startup] workload=%s max_pod_ready_time=%.2fs pods=%d',
+      workload, max_pod_ready_t, len(pod_name_to_start_end_times),
   )
 
-  # CPU samples were appended to all_samples by the collector thread.
   return all_samples
 
 
@@ -249,7 +281,7 @@ def Cleanup(benchmark_spec: bm_spec.BenchmarkSpec):
 
 
 # ---------------------------------------------------------------------------
-# CPU Utilization Background Collector (new — PR 1)
+# CPU Utilization Background Collector (PR 1 — unchanged)
 # ---------------------------------------------------------------------------
 
 
@@ -257,15 +289,7 @@ class _CpuUtilizationCollector:
   """Polls CPU utilization in a background thread during the startup window.
 
   Follows the KubernetesMetricsCollector / _Observe pattern from
-  kubernetes_hpa_benchmark.py exactly:
-  - _Observe(fn) loops calling fn() and appending results to self._samples.
-  - Stops when self._stop is signalled.
-  - Ignores IssueCommandError / IssueCommandTimeoutError (gaps in data OK).
-
-  Emits three samples on completion:
-    cpu_utilization_peak_millicores   — maximum reading during startup window.
-    cpu_utilization_mean_millicores   — mean across all polls.
-    cpu_utilization_reading_count     — number of successful polls.
+  kubernetes_hpa_benchmark.py exactly.
   """
 
   def __init__(
@@ -273,28 +297,15 @@ class _CpuUtilizationCollector:
       samples: List[sample.Sample],
       stop: threading.Event,
   ):
-    """Initialises the collector.
-
-    Args:
-      samples: Shared sample list.  CPU samples are appended here when
-        ObserveCpuUtilization() finishes.
-      stop: Threading event.  Collector loops until this is set.
-    """
     self._samples = samples
     self._stop = stop
     self._readings: List[float] = []
     self._lock = threading.Lock()
 
   def ObserveCpuUtilization(self) -> None:
-    """Polls CPU millicores until stop is set; appends aggregate samples.
-
-    Intended to be run in a background thread alongside WaitForRollout().
-    Matches the ObserveNumReplicas / ObserveNumNodes pattern in
-    kubernetes_hpa_benchmark.py.
-    """
+    """Polls CPU millicores until stop is set; appends aggregate samples."""
     self._Observe(self._PollCpuMillicoresSample)
 
-    # Emit aggregate samples after the loop ends.
     with self._lock:
       readings = list(self._readings)
 
@@ -305,11 +316,6 @@ class _CpuUtilizationCollector:
     peak = max(readings)
     mean = sum(readings) / len(readings)
     count = len(readings)
-
-    logging.info(
-        '[startup/cpu] peak=%.1f mean=%.1f count=%d millicores',
-        peak, mean, count,
-    )
 
     self._samples.extend([
         sample.Sample(
@@ -324,37 +330,18 @@ class _CpuUtilizationCollector:
     ])
 
   def _PollCpuMillicoresSample(self) -> List[sample.Sample]:
-    """Issues kubectl top pods and returns a transient sample list.
-
-    The return value is a list so _Observe() can call self._samples.extend()
-    on it (matching the KubernetesMetricsCollector interface).  The actual
-    reading is also stored in self._readings for aggregate computation.
-
-    Returns:
-      A single-element list with the current CPU reading, or empty on error.
-    """
     cpu_m = _GetTotalCpuMillicores()
     if cpu_m is None:
       return []
     with self._lock:
       self._readings.append(cpu_m)
-    # Return an empty list — we do NOT emit a per-poll sample (too noisy).
-    # Aggregates are emitted in ObserveCpuUtilization() after the loop.
     return []
 
   def _Observe(
       self,
       observe_fn: Callable[[], List[sample.Sample]],
   ) -> None:
-    """Calls observe_fn in a loop until self._stop is set.
-
-    Copied verbatim from KubernetesMetricsCollector._Observe() in
-    kubernetes_hpa_benchmark.py — same error handling, same 1 s wait.
-
-    Args:
-      observe_fn: Function returning a list of samples to extend into
-        self._samples.
-    """
+    """Calls observe_fn in a loop until self._stop is set."""
     success_count = 0
     failure_count = 0
     while True:
@@ -379,13 +366,8 @@ class _CpuUtilizationCollector:
 
 
 def _GetTotalCpuMillicores() -> float | None:
-  """Returns total CPU millicores across all pods via kubectl top pods.
-
-  Returns:
-    Total CPU millicores, or None if the command fails or output is empty.
-  """
+  """Returns total CPU millicores across all pods via kubectl top pods."""
   try:
-    from perfkitbenchmarker.resources.container_service import kubectl  # pylint: disable=g-import-not-at-top
     stdout, _, rc = kubectl.RunKubectlCommand(
         ['top', 'pods', '--no-headers'],
         raise_on_failure=False,
@@ -396,14 +378,12 @@ def _GetTotalCpuMillicores() -> float | None:
     total_m = 0.0
     for line in stdout.strip().splitlines():
       parts = line.split()
-      # kubectl top format: NAME  CPU(cores)  MEMORY(bytes)
       if len(parts) < 2:
         continue
       cpu_str = parts[1]
       if cpu_str.endswith('m'):
         total_m += float(cpu_str[:-1])
       else:
-        # Expressed as fractional cores (e.g. "1" = 1000m).
         total_m += float(cpu_str) * 1000.0
 
     return total_m

--- a/perfkitbenchmarker/linux_benchmarks/kubernetes_deployment_startup_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/kubernetes_deployment_startup_benchmark.py
@@ -11,17 +11,44 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Benchmark for measuring time to start up a deployment on Kubernetes."""
+"""Benchmark for measuring time to start up a deployment on Kubernetes.
+
+PR 1 — Metrics & Observability
+================================
+Extends the existing benchmark with two new metrics and per-sample metadata:
+
+1. **per_pod_ready_time** — individual pod startup duration (s) from
+   PodReadyToStartContainers → Ready, using the existing
+   kubernetes_conditions.GetStatusConditionsForResourceType() call that
+   already powers max_pod_ready_time.  Emits one Sample per pod so
+   downstream analysis can compute percentiles across replicas.
+
+2. **cpu_utilization_millicores** (peak / mean / count) — CPU sampled in a
+   background thread via KubernetesMetricsCollector._Observe(), following
+   the exact same pattern as kubernetes_hpa_benchmark.py.
+
+3. **metadata** — scenario / workload / cloud / replicas added to every
+   sample for cross-config comparison (PR 3 will set scenario=optimized).
+
+Nothing in Prepare() or Cleanup() changes.  PR 2 adds vLLM workload
+support; PR 3 adds the VPA CPU Startup Boost scenario flag.
+"""
 
 import collections
+import logging
+import threading
+from collections.abc import Callable
 from typing import Any, Dict, List
 
 from absl import flags
 from perfkitbenchmarker import benchmark_spec as bm_spec
 from perfkitbenchmarker import configs
+from perfkitbenchmarker import errors
 from perfkitbenchmarker import sample
 from perfkitbenchmarker.resources.container_service import kubernetes_commands
 from perfkitbenchmarker.resources.container_service import kubernetes_conditions
+
+FLAGS = flags.FLAGS
 
 BENCHMARK_NAME = 'kubernetes_deployment_startup'
 BENCHMARK_CONFIG = """
@@ -54,8 +81,28 @@ DEPLOYMENT_IMAGE = flags.DEFINE_string(
     'Image name. If omitted, "slowjvmstartup" will be used',
 )
 
+# PR 1: new flags — workload and scenario are stubs here; PR 2 and PR 3 add
+# the actual logic so that flag names are stable across all three PRs.
+WORKLOAD = flags.DEFINE_enum(
+    'kubernetes_deployment_startup_workload',
+    'jvm',
+    ['jvm', 'vllm'],
+    'Workload type. vLLM deployment support is added in PR 2.',
+)
+SCENARIO = flags.DEFINE_enum(
+    'kubernetes_deployment_startup_scenario',
+    'baseline',
+    ['baseline', 'optimized'],
+    'Startup scenario. optimized (GKE CPU Startup Boost) is added in PR 3.',
+)
+
+# Interval between successive CPU polls (seconds).  Matches
+# kubernetes_hpa_benchmark which polls at ~1 s.
+_CPU_POLL_INTERVAL_SECS = 5
+
 
 def GetConfig(user_config: Dict[str, Any]) -> Dict[str, Any]:
+  """Returns merged benchmark config."""
   config = configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
   if DEPLOYMENT_IMAGE.value is not None:
     config['container_specs']['kubernetes_deployment_startup'][
@@ -76,24 +123,60 @@ def Prepare(benchmark_spec: bm_spec.BenchmarkSpec):
 def Run(benchmark_spec: bm_spec.BenchmarkSpec) -> List[sample.Sample]:
   """Runs the benchmark and collects the results.
 
+  Collects three categories of metrics:
+    1. max_pod_ready_time  — existing metric, preserved unchanged.
+    2. per_pod_ready_time  — new: one Sample per pod with pod name in metadata.
+    3. cpu_utilization_*   — new: peak/mean/count via background collector.
+
+  All samples carry scenario/workload/cloud/replicas metadata.
+
   Args:
     benchmark_spec: The benchmark specification.
 
   Raises:
-    RuntimeError: Raised if no pods are ready after the deployment has finished
-      rolling out.
+    RuntimeError: Raised if no pods are ready after the deployment rolls out.
 
   Returns:
     A list of sample.Sample objects.
   """
   image = benchmark_spec.container_specs['kubernetes_deployment_startup'].image
-  kubernetes_commands.ApplyManifest(
-      DEPLOYMENT_YAML.value,
-      name='startup',
-      image=image,
-  )
-  kubernetes_commands.WaitForRollout('deployment/startup', timeout=600)
 
+  # ── Base metadata attached to every sample ────────────────────────────────
+  base_metadata: Dict[str, Any] = {
+      'scenario': SCENARIO.value,
+      'workload': WORKLOAD.value,
+      'cloud': FLAGS.cloud,
+  }
+
+  # ── Start CPU background collector ────────────────────────────────────────
+  all_samples: List[sample.Sample] = []
+  stop = threading.Event()
+  cpu_collector = _CpuUtilizationCollector(all_samples, stop)
+
+  # Apply manifest and wait for rollout inside a try/finally so we always
+  # stop the collector even if WaitForRollout raises.
+  try:
+    kubernetes_commands.ApplyManifest(
+        DEPLOYMENT_YAML.value,
+        name='startup',
+        image=image,
+    )
+
+    # Run CPU collector in parallel with the rollout wait, exactly like
+    # KubernetesMetricsCollector in kubernetes_hpa_benchmark.py.
+    collector_thread = threading.Thread(
+        target=cpu_collector.ObserveCpuUtilization,
+        daemon=True,
+    )
+    collector_thread.start()
+
+    kubernetes_commands.WaitForRollout('deployment/startup', timeout=600)
+
+  finally:
+    stop.set()
+    collector_thread.join(timeout=_CPU_POLL_INTERVAL_SECS * 3)
+
+  # ── Parse pod conditions (existing logic, unchanged) ──────────────────────
   pod_name_to_start_end_times: dict[str, tuple[int, int]] = (
       collections.defaultdict(lambda: (0, 0))
   )
@@ -111,14 +194,49 @@ def Run(benchmark_spec: bm_spec.BenchmarkSpec) -> List[sample.Sample]:
           c.epoch_time,
       )
 
+  if not pod_name_to_start_end_times:
+    raise RuntimeError('No pods became ready')
+
+  # ── Metric 1: max_pod_ready_time (existing, unchanged) ───────────────────
   max_pod_ready_t = -1
   for _, times in pod_name_to_start_end_times.items():
     t = times[1] - times[0]
     max_pod_ready_t = max(max_pod_ready_t, t)
 
-  if max_pod_ready_t > -1:
-    return [sample.Sample('max_pod_ready_time', max_pod_ready_t, 'seconds', {})]
-  raise RuntimeError('No pods became ready')
+  if max_pod_ready_t < 0:
+    raise RuntimeError('No pods became ready')
+
+  all_samples.append(
+      sample.Sample(
+          'max_pod_ready_time',
+          max_pod_ready_t,
+          'seconds',
+          {**base_metadata},
+      )
+  )
+
+  # ── Metric 2: per_pod_ready_time (new — PR 1) ────────────────────────────
+  # Emit one Sample per pod so callers can compute p50/p90 across replicas.
+  for pod_name, (start_t, end_t) in pod_name_to_start_end_times.items():
+    pod_ready_t = end_t - start_t
+    if pod_ready_t >= 0:
+      all_samples.append(
+          sample.Sample(
+              'per_pod_ready_time',
+              pod_ready_t,
+              'seconds',
+              {**base_metadata, 'pod_name': pod_name},
+          )
+      )
+
+  logging.info(
+      '[startup] max_pod_ready_time=%.2fs across %d pod(s)',
+      max_pod_ready_t,
+      len(pod_name_to_start_end_times),
+  )
+
+  # CPU samples were appended to all_samples by the collector thread.
+  return all_samples
 
 
 def Cleanup(benchmark_spec: bm_spec.BenchmarkSpec):
@@ -128,3 +246,167 @@ def Cleanup(benchmark_spec: bm_spec.BenchmarkSpec):
     benchmark_spec: The benchmark specification.
   """
   del benchmark_spec
+
+
+# ---------------------------------------------------------------------------
+# CPU Utilization Background Collector (new — PR 1)
+# ---------------------------------------------------------------------------
+
+
+class _CpuUtilizationCollector:
+  """Polls CPU utilization in a background thread during the startup window.
+
+  Follows the KubernetesMetricsCollector / _Observe pattern from
+  kubernetes_hpa_benchmark.py exactly:
+  - _Observe(fn) loops calling fn() and appending results to self._samples.
+  - Stops when self._stop is signalled.
+  - Ignores IssueCommandError / IssueCommandTimeoutError (gaps in data OK).
+
+  Emits three samples on completion:
+    cpu_utilization_peak_millicores   — maximum reading during startup window.
+    cpu_utilization_mean_millicores   — mean across all polls.
+    cpu_utilization_reading_count     — number of successful polls.
+  """
+
+  def __init__(
+      self,
+      samples: List[sample.Sample],
+      stop: threading.Event,
+  ):
+    """Initialises the collector.
+
+    Args:
+      samples: Shared sample list.  CPU samples are appended here when
+        ObserveCpuUtilization() finishes.
+      stop: Threading event.  Collector loops until this is set.
+    """
+    self._samples = samples
+    self._stop = stop
+    self._readings: List[float] = []
+    self._lock = threading.Lock()
+
+  def ObserveCpuUtilization(self) -> None:
+    """Polls CPU millicores until stop is set; appends aggregate samples.
+
+    Intended to be run in a background thread alongside WaitForRollout().
+    Matches the ObserveNumReplicas / ObserveNumNodes pattern in
+    kubernetes_hpa_benchmark.py.
+    """
+    self._Observe(self._PollCpuMillicoresSample)
+
+    # Emit aggregate samples after the loop ends.
+    with self._lock:
+      readings = list(self._readings)
+
+    if not readings:
+      logging.warning('[startup/cpu] No CPU readings collected.')
+      return
+
+    peak = max(readings)
+    mean = sum(readings) / len(readings)
+    count = len(readings)
+
+    logging.info(
+        '[startup/cpu] peak=%.1f mean=%.1f count=%d millicores',
+        peak, mean, count,
+    )
+
+    self._samples.extend([
+        sample.Sample(
+            'cpu_utilization_peak_millicores', peak, 'millicores', {}
+        ),
+        sample.Sample(
+            'cpu_utilization_mean_millicores', mean, 'millicores', {}
+        ),
+        sample.Sample(
+            'cpu_utilization_reading_count', count, 'count', {}
+        ),
+    ])
+
+  def _PollCpuMillicoresSample(self) -> List[sample.Sample]:
+    """Issues kubectl top pods and returns a transient sample list.
+
+    The return value is a list so _Observe() can call self._samples.extend()
+    on it (matching the KubernetesMetricsCollector interface).  The actual
+    reading is also stored in self._readings for aggregate computation.
+
+    Returns:
+      A single-element list with the current CPU reading, or empty on error.
+    """
+    cpu_m = _GetTotalCpuMillicores()
+    if cpu_m is None:
+      return []
+    with self._lock:
+      self._readings.append(cpu_m)
+    # Return an empty list — we do NOT emit a per-poll sample (too noisy).
+    # Aggregates are emitted in ObserveCpuUtilization() after the loop.
+    return []
+
+  def _Observe(
+      self,
+      observe_fn: Callable[[], List[sample.Sample]],
+  ) -> None:
+    """Calls observe_fn in a loop until self._stop is set.
+
+    Copied verbatim from KubernetesMetricsCollector._Observe() in
+    kubernetes_hpa_benchmark.py — same error handling, same 1 s wait.
+
+    Args:
+      observe_fn: Function returning a list of samples to extend into
+        self._samples.
+    """
+    success_count = 0
+    failure_count = 0
+    while True:
+      try:
+        self._samples.extend(observe_fn())
+        success_count += 1
+      except (
+          errors.VmUtil.IssueCommandError,
+          errors.VmUtil.IssueCommandTimeoutError,
+      ) as e:
+        logging.warning(
+            '[startup/cpu] Ignoring poll error (gap in data): %s', e
+        )
+        failure_count += 1
+
+      if self._stop.wait(timeout=_CPU_POLL_INTERVAL_SECS):
+        logging.info(
+            '[startup/cpu] Stopping after %d successes / %d failures',
+            success_count, failure_count,
+        )
+        return
+
+
+def _GetTotalCpuMillicores() -> float | None:
+  """Returns total CPU millicores across all pods via kubectl top pods.
+
+  Returns:
+    Total CPU millicores, or None if the command fails or output is empty.
+  """
+  try:
+    from perfkitbenchmarker.resources.container_service import kubectl  # pylint: disable=g-import-not-at-top
+    stdout, _, rc = kubectl.RunKubectlCommand(
+        ['top', 'pods', '--no-headers'],
+        raise_on_failure=False,
+    )
+    if rc != 0 or not stdout.strip():
+      return None
+
+    total_m = 0.0
+    for line in stdout.strip().splitlines():
+      parts = line.split()
+      # kubectl top format: NAME  CPU(cores)  MEMORY(bytes)
+      if len(parts) < 2:
+        continue
+      cpu_str = parts[1]
+      if cpu_str.endswith('m'):
+        total_m += float(cpu_str[:-1])
+      else:
+        # Expressed as fractional cores (e.g. "1" = 1000m).
+        total_m += float(cpu_str) * 1000.0
+
+    return total_m
+  except (ValueError, IndexError) as e:
+    logging.debug('[startup/cpu] Parse error: %s', e)
+    return None

--- a/tests/linux_benchmarks/kubernetes_deployment_startup_benchmark_test.py
+++ b/tests/linux_benchmarks/kubernetes_deployment_startup_benchmark_test.py
@@ -1,4 +1,4 @@
-# Copyright 2024 PerfKitBenchmarker Authors. All rights reserved.
+# Copyright 2025 PerfKitBenchmarker Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,379 +11,300 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests for kubernetes_deployment_startup_benchmark and startup_metrics.
+"""Tests for PR 2 (vLLM workload) and PR 3 (VPA scenario) additions."""
 
-PR 1 — Metrics & Observability (Layer 0)
-"""
-
-import threading
-import time
 import unittest
 from unittest import mock
 
 from absl.testing import flagsaver
-from perfkitbenchmarker import benchmark_spec
-from perfkitbenchmarker import errors
-from perfkitbenchmarker import sample
 from perfkitbenchmarker.linux_benchmarks import kubernetes_deployment_startup_benchmark as bench
-from perfkitbenchmarker.linux_benchmarks import kubernetes_deployment_startup_benchmark as kdsb
-from perfkitbenchmarker.resources.container_service import kubernetes_commands
-from perfkitbenchmarker.resources.container_service import kubernetes_conditions
 from tests import pkb_common_test_case
 
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-_BASE_METADATA = {
-    'workload': 'jvm',
-    'scenario': 'baseline',
-    'cloud': 'GCP',
-    'replicas': 1,
-    'namespace': 'default',
-    'app_label': 'slowjvmstartup',
-}
+def _MakeCondition(resource_name, event, epoch_time):
+  c = mock.MagicMock()
+  c.resource_name = resource_name
+  c.event = event
+  c.epoch_time = epoch_time
+  return c
 
 
-def _MakePodJson(
-    pod_name: str,
-    scheduled_ts: str,
-    started_at: str | None = None,
-    ready_ts: str | None = None,
-) -> dict:
-  """Builds a minimal pod JSON dict for testing."""
-  conditions = [
-      {
-          'type': 'PodScheduled',
-          'status': 'True',
-          'lastTransitionTime': scheduled_ts,
-      }
-  ]
-  if ready_ts:
-    conditions.append({
-        'type': 'Ready',
-        'status': 'True',
-        'lastTransitionTime': ready_ts,
-    })
-
-  container_statuses = []
-  if started_at:
-    container_statuses = [{
-        'name': 'app',
-        'ready': True,
-        'state': {'running': {'startedAt': started_at}},
-    }]
-
-  return {
-      'metadata': {'name': pod_name},
-      'status': {
-          'startTime': scheduled_ts,
-          'conditions': conditions,
-          'containerStatuses': container_statuses,
-      },
+def _MakeSpec():
+  bm = mock.MagicMock()
+  bm.container_specs = {
+      'kubernetes_deployment_startup': mock.MagicMock(image='slowjvmstartup')
   }
+  return bm
+
+
+def _DefaultConditions():
+  return [
+      _MakeCondition('pod-0', 'PodReadyToStartContainers', 1000),
+      _MakeCondition('pod-0', 'Ready', 1030),
+  ]
 
 
 # ---------------------------------------------------------------------------
-# startup_metrics tests
+# PR 2: vLLM workload
 # ---------------------------------------------------------------------------
 
 
-class StartupMetricsTest(pkb_common_test_case.PkbCommonTestCase):
+class VllmWorkloadTest(pkb_common_test_case.PkbCommonTestCase):
+  """Tests for vLLM workload support (PR 2)."""
 
-  def testExtractLatencyFromContainerStartedAt(self):
-    """Prefers containerStatuses[0].state.running.startedAt over Ready cond."""
-    pod = _MakePodJson(
-        'pod-1',
-        scheduled_ts='2024-01-01T00:00:00Z',
-        started_at='2024-01-01T00:00:30Z',   # 30s latency
-        ready_ts='2024-01-01T00:00:35Z',      # 35s — should NOT be used
-    )
-    latency = startup_metrics._ExtractPodStartupLatency(pod)
-    self.assertAlmostEqual(latency, 30.0, places=1)
-
-  def testExtractLatencyFallsBackToReadyCondition(self):
-    """Falls back to Ready condition when containerStatuses is absent."""
-    pod = _MakePodJson(
-        'pod-2',
-        scheduled_ts='2024-01-01T00:00:00Z',
-        ready_ts='2024-01-01T00:00:45Z',      # 45s latency via Ready cond
-    )
-    latency = startup_metrics._ExtractPodStartupLatency(pod)
-    self.assertAlmostEqual(latency, 45.0, places=1)
-
-  def testExtractLatencyReturnsNoneWhenNoReadyTimestamp(self):
-    """Returns None when no container-ready or Ready-condition timestamp exists."""
-    pod = _MakePodJson('pod-3', scheduled_ts='2024-01-01T00:00:00Z')
-    latency = startup_metrics._ExtractPodStartupLatency(pod)
-    self.assertIsNone(latency)
-
-  def testExtractLatencyReturnsNoneForNegativeLatency(self):
-    """Returns None when container-ready precedes scheduled (clock skew)."""
-    pod = _MakePodJson(
-        'pod-4',
-        scheduled_ts='2024-01-01T00:01:00Z',
-        started_at='2024-01-01T00:00:30Z',    # before scheduled → negative
-    )
-    latency = startup_metrics._ExtractPodStartupLatency(pod)
-    self.assertIsNone(latency)
-
-  def testLatenciesToSamplesEmitsAllStats(self):
-    """_LatenciesToSamples emits min/max/mean/p50/p90/p99/count."""
-    latencies = [10.0, 20.0, 30.0, 40.0, 50.0]
-    samples = startup_metrics._LatenciesToSamples(latencies, _BASE_METADATA)
-    metric_names = {s.metric for s in samples}
-    expected = {
-        'startup_latency_min',
-        'startup_latency_max',
-        'startup_latency_mean',
-        'startup_latency_p50',
-        'startup_latency_p90',
-        'startup_latency_p99',
-        'startup_latency_pod_count',
-    }
-    self.assertEqual(metric_names, expected)
-
-  def testLatenciesToSamplesValues(self):
-    """Verifies min/max/mean values are correct."""
-    latencies = [10.0, 20.0, 30.0]
-    samples = startup_metrics._LatenciesToSamples(latencies, _BASE_METADATA)
-    by_metric = {s.metric: s.value for s in samples}
-    self.assertAlmostEqual(by_metric['startup_latency_min'], 10.0)
-    self.assertAlmostEqual(by_metric['startup_latency_max'], 30.0)
-    self.assertAlmostEqual(by_metric['startup_latency_mean'], 20.0)
-    self.assertEqual(by_metric['startup_latency_pod_count'], 3)
-
-  def testLatenciesToSamplesCarryBaseMetadata(self):
-    """All samples carry the base metadata keys."""
-    latencies = [15.0]
-    samples = startup_metrics._LatenciesToSamples(latencies, _BASE_METADATA)
-    for s in samples:
-      for key in ('workload', 'scenario', 'cloud'):
-        self.assertIn(key, s.metadata)
-
-  def testGetStartupLatencySamplesEmptyOnKubectlError(self):
-    """Returns empty list when kubectl returns non-zero exit code."""
-    with mock.patch.object(
-        startup_metrics.kubectl, 'RunKubectlCommand',
-        return_value=('', 'error', 1),
-    ):
-      result = startup_metrics.GetStartupLatencySamples(
-          namespace='default', app_label='app', metadata=_BASE_METADATA
-      )
-    self.assertEqual(result, [])
-
-  def testGetStartupLatencySamplesEmptyOnBadJson(self):
-    """Returns empty list when kubectl output is not valid JSON."""
-    with mock.patch.object(
-        startup_metrics.kubectl, 'RunKubectlCommand',
-        return_value=('not json', '', 0),
-    ):
-      result = startup_metrics.GetStartupLatencySamples(
-          namespace='default', app_label='app', metadata=_BASE_METADATA
-      )
-    self.assertEqual(result, [])
-
-
-# ---------------------------------------------------------------------------
-# _CpuUtilizationCollector tests
-# ---------------------------------------------------------------------------
-
-
-class CpuUtilizationCollectorTest(pkb_common_test_case.PkbCommonTestCase):
-
-  def setUp(self):
-    super().setUp()
-    self.spec = mock.Mock(spec=benchmark_spec.BenchmarkSpec)
-    self.spec.container_cluster = mock.Mock()
-    self.spec.container_specs = {
-        'kubernetes_deployment_startup': mock.Mock(image='test_image')
-    }
-
-  @mock.patch.object(kubernetes_commands, 'WaitForRollout')
-  @mock.patch.object(kubernetes_commands, 'ApplyManifest')
-  @mock.patch.object(
-      kubernetes_conditions, 'GetStatusConditionsForResourceType'
+  @flagsaver.flagsaver(
+      kubernetes_deployment_startup_workload='vllm',
+      cloud='GCP',
   )
-  def testRun(
-      self, mock_get_conditions, mock_apply_manifest, mock_wait_for_rollout
-  ):
-    """Tests the Run method with mock pod data."""
-    mock_get_conditions.return_value = [
-        mock.Mock(
-            event='PodReadyToStartContainers',
-            resource_name='pod1',
-            epoch_time=10,
-        ),
-        mock.Mock(event='Ready', resource_name='pod1', epoch_time=20),
-        mock.Mock(
-            event='PodReadyToStartContainers',
-            resource_name='pod2',
-            epoch_time=12,
-        ),
-        mock.Mock(event='Ready', resource_name='pod2', epoch_time=25),
-    ]
-    result = kdsb.Run(self.spec)
-
-    mock_apply_manifest.assert_called_with(
-        kdsb.DEPLOYMENT_YAML.value, name='startup', image='test_image'
+  def testPrepareDeploysVllmManifest(self):
+    """Prepare() applies vllm.yaml.j2 when workload=vllm."""
+    bm = _MakeSpec()
+    bm.container_specs['kubernetes_deployment_startup'].image = (
+        'public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:latest'
     )
-    mock_wait_for_rollout.assert_called_with('deployment/startup', timeout=600)
-    self.assertLen(result, 1)
-    self.assertEqual(
-        result[0],
-        sample.Sample(
-            'max_pod_ready_time', 13, 'seconds', {}, result[0].timestamp
-        ),
-    )
+    with mock.patch.object(
+        bench.kubernetes_commands, 'ApplyManifest'
+    ) as mock_apply:
+      bench.Prepare(bm)
+      mock_apply.assert_called_once()
+      call_args = mock_apply.call_args[0][0]
+      self.assertIn('vllm', call_args)
 
-  @mock.patch.object(kubernetes_commands, 'WaitForRollout')
-  @mock.patch.object(kubernetes_commands, 'ApplyManifest')
-  @mock.patch.object(
-      kubernetes_conditions, 'GetStatusConditionsForResourceType'
+  @flagsaver.flagsaver(
+      kubernetes_deployment_startup_workload='jvm',
+      cloud='GCP',
   )
-  def testRunNoPods(
-      self, mock_get_conditions, mock_apply_manifest, mock_wait_for_rollout
-  ):
-    """Tests the Run method when no pods are found."""
-    mock_get_conditions.return_value = []
-    with self.assertRaises(RuntimeError):
-      kdsb.Run(self.spec)
-
-    self.collector = bench._CpuUtilizationCollector(
-        namespace='default',
-        app_label='slowjvmstartup',
-        poll_interval=1,
-    )
-
-  def testCollectorAccumulatesReadings(self):
-    """Collector accumulates readings while running."""
-    call_count = [0]
-
-    def fake_poll():
-      call_count[0] += 1
-      return 250.0
-
-    with mock.patch.object(self.collector, '_PollCpuMillicores', side_effect=fake_poll):
-      self.collector.Start()
-      time.sleep(2.5)   # Allow ~2 polls at 1s interval
-      self.collector.Stop()
-
-    self.assertGreaterEqual(len(self.collector._readings), 1)
-
-  def testGetSamplesEmitsPeakAndMean(self):
-    """GetSamples emits cpu_utilization_peak and cpu_utilization_mean."""
-    self.collector._readings = [100.0, 200.0, 300.0]
-    samples = self.collector.GetSamples(_BASE_METADATA)
-    metric_names = {s.metric for s in samples}
-    self.assertIn('cpu_utilization_peak', metric_names)
-    self.assertIn('cpu_utilization_mean', metric_names)
-    self.assertIn('cpu_utilization_reading_count', metric_names)
-
-  def testGetSamplesValues(self):
-    """Peak = max, mean = average of readings."""
-    self.collector._readings = [100.0, 200.0, 300.0]
-    samples = self.collector.GetSamples(_BASE_METADATA)
-    by_metric = {s.metric: s.value for s in samples}
-    self.assertAlmostEqual(by_metric['cpu_utilization_peak'], 300.0)
-    self.assertAlmostEqual(by_metric['cpu_utilization_mean'], 200.0)
-    self.assertEqual(by_metric['cpu_utilization_reading_count'], 3)
-
-  def testGetSamplesEmptyWhenNoReadings(self):
-    """Returns empty list when no readings collected."""
-    self.collector._readings = []
-    samples = self.collector.GetSamples(_BASE_METADATA)
-    self.assertEqual(samples, [])
-
-  def testGetSamplesCarryMetadata(self):
-    """All samples carry the base metadata and cpu-specific keys."""
-    self.collector._readings = [150.0]
-    samples = self.collector.GetSamples(_BASE_METADATA)
-    for s in samples:
-      self.assertIn('workload', s.metadata)
-      self.assertIn('scenario', s.metadata)
-
-  def testPollCpuMillicoresParsesMilliSuffix(self):
-    """_PollCpuMillicores correctly parses '250m' → 250.0."""
-    fake_output = 'slowjvmstartup-abc   250m   128Mi\n'
+  def testPrepareDeploysJvmManifest(self):
+    """Prepare() applies slowjvmstartup.yaml.j2 when workload=jvm."""
+    bm = _MakeSpec()
     with mock.patch.object(
-        bench.kubectl, 'RunKubectlCommand',
-        return_value=(fake_output, '', 0),
-    ):
-      result = self.collector._PollCpuMillicores()
-    self.assertAlmostEqual(result, 250.0)
+        bench.kubernetes_commands, 'ApplyManifest'
+    ) as mock_apply:
+      bench.Prepare(bm)
+      mock_apply.assert_called_once()
+      call_args = mock_apply.call_args[0][0]
+      self.assertIn('slowjvmstartup', call_args)
 
-  def testPollCpuMillicoresParsesCoreSuffix(self):
-    """_PollCpuMillicores correctly parses '1' (core) → 1000.0 millicores."""
-    fake_output = 'slowjvmstartup-abc   1   512Mi\n'
+  @flagsaver.flagsaver(
+      kubernetes_deployment_startup_workload='vllm',
+      cloud='GCP',
+  )
+  def testRunUsesVllmDeploymentName(self):
+    """Run() waits for vllm-startup deployment when workload=vllm."""
     with mock.patch.object(
-        bench.kubectl, 'RunKubectlCommand',
-        return_value=(fake_output, '', 0),
+        bench.kubernetes_commands, 'ApplyManifest'
+    ), mock.patch.object(
+        bench.kubernetes_commands, 'WaitForRollout'
+    ) as mock_wait, mock.patch.object(
+        bench.kubernetes_conditions,
+        'GetStatusConditionsForResourceType',
+        return_value=_DefaultConditions(),
+    ), mock.patch.object(
+        bench, '_GetTotalCpuMillicores', return_value=None
     ):
-      result = self.collector._PollCpuMillicores()
-    self.assertAlmostEqual(result, 1000.0)
+      bench.Run(_MakeSpec())
+      mock_wait.assert_called_with('deployment/vllm-startup', timeout=600)
 
-  def testPollCpuMillicoresReturnsZeroOnError(self):
-    """_PollCpuMillicores returns 0.0 when kubectl returns non-zero rc."""
+  @flagsaver.flagsaver(
+      kubernetes_deployment_startup_workload='jvm',
+      cloud='GCP',
+  )
+  def testRunUsesJvmDeploymentName(self):
+    """Run() waits for startup deployment when workload=jvm."""
     with mock.patch.object(
-        bench.kubectl, 'RunKubectlCommand',
-        return_value=('', 'error', 1),
+        bench.kubernetes_commands, 'ApplyManifest'
+    ), mock.patch.object(
+        bench.kubernetes_commands, 'WaitForRollout'
+    ) as mock_wait, mock.patch.object(
+        bench.kubernetes_conditions,
+        'GetStatusConditionsForResourceType',
+        return_value=_DefaultConditions(),
+    ), mock.patch.object(
+        bench, '_GetTotalCpuMillicores', return_value=None
     ):
-      result = self.collector._PollCpuMillicores()
-    self.assertEqual(result, 0.0)
+      bench.Run(_MakeSpec())
+      mock_wait.assert_called_with('deployment/startup', timeout=600)
 
-  def testCollectorIsThreadSafe(self):
-    """Concurrent Stop() and GetSamples() do not race."""
-    self.collector._readings = [100.0] * 50
-    errors = []
-
-    def read():
-      try:
-        self.collector.GetSamples(_BASE_METADATA)
-      except Exception as e:  # pylint: disable=broad-except
-        errors.append(e)
-
-    threads = [threading.Thread(target=read) for _ in range(10)]
-    for t in threads:
-      t.start()
-    for t in threads:
-      t.join()
-
-    self.assertEqual(errors, [])
+  @flagsaver.flagsaver(
+      kubernetes_deployment_startup_workload='vllm',
+      cloud='GCP',
+  )
+  def testWorkloadMetadataInSamples(self):
+    """All samples carry workload=vllm in metadata."""
+    with mock.patch.object(
+        bench.kubernetes_commands, 'ApplyManifest'
+    ), mock.patch.object(
+        bench.kubernetes_commands, 'WaitForRollout'
+    ), mock.patch.object(
+        bench.kubernetes_conditions,
+        'GetStatusConditionsForResourceType',
+        return_value=_DefaultConditions(),
+    ), mock.patch.object(
+        bench, '_GetTotalCpuMillicores', return_value=None
+    ):
+      samples = bench.Run(_MakeSpec())
+    pod_samples = [s for s in samples if 'workload' in s.metadata]
+    for s in pod_samples:
+      self.assertEqual(s.metadata['workload'], 'vllm')
 
 
 # ---------------------------------------------------------------------------
-# Benchmark lifecycle tests
+# PR 3: scenario + VPA boost
 # ---------------------------------------------------------------------------
 
 
-class BenchmarkLifecycleTest(pkb_common_test_case.PkbCommonTestCase):
+class ScenarioTest(pkb_common_test_case.PkbCommonTestCase):
+  """Tests for VPA scenario and CPU Startup Boost (PR 3)."""
+
+  @flagsaver.flagsaver(
+      kubernetes_deployment_startup_scenario='optimized',
+      kubernetes_deployment_startup_workload='jvm',
+      cloud='GCP',
+  )
+  def testCheckPrerequisitesPassesForOptimizedGcp(self):
+    """optimized + jvm + GCP is valid."""
+    bench.CheckPrerequisites(None)  # Should not raise.
+
+  @flagsaver.flagsaver(
+      kubernetes_deployment_startup_scenario='optimized',
+      kubernetes_deployment_startup_workload='jvm',
+      cloud='AWS',
+  )
+  def testCheckPrerequisitesRaisesForOptimizedNonGcp(self):
+    """optimized scenario requires GCP."""
+    with self.assertRaises(ValueError):
+      bench.CheckPrerequisites(None)
 
   @flagsaver.flagsaver(
       kubernetes_deployment_startup_scenario='optimized',
       kubernetes_deployment_startup_workload='vllm',
+      cloud='GCP',
   )
   def testCheckPrerequisitesRaisesForOptimizedVllm(self):
-    """optimized + vLLM combination not supported in PR 1."""
+    """optimized + vllm is not supported."""
     with self.assertRaises(ValueError):
       bench.CheckPrerequisites(None)
 
   @flagsaver.flagsaver(
       kubernetes_deployment_startup_scenario='baseline',
       kubernetes_deployment_startup_workload='jvm',
+      cloud='AWS',
   )
-  def testCheckPrerequisitesPassesForBaselineJvm(self):
-    """baseline + jvm is always valid."""
-    bench.CheckPrerequisites(None)  # Should not raise
+  def testCheckPrerequisitesPassesForBaselineAws(self):
+    """baseline on any cloud is always valid."""
+    bench.CheckPrerequisites(None)  # Should not raise.
 
   @flagsaver.flagsaver(
       kubernetes_deployment_startup_scenario='optimized',
       kubernetes_deployment_startup_workload='jvm',
+      kubernetes_deployment_startup_boost_factor=2,
+      cloud='GCP',
   )
-  def testCheckPrerequisitesPassesForOptimizedJvm(self):
-    """optimized + jvm is valid (VPA logic is added in PR 3)."""
-    bench.CheckPrerequisites(None)  # Should not raise
+  def testPrepareAppliesVpaForOptimized(self):
+    """Prepare() applies VPA manifest for scenario=optimized."""
+    bm = _MakeSpec()
+    apply_calls = []
+    with mock.patch.object(
+        bench.kubernetes_commands, 'ApplyManifest',
+        side_effect=lambda *a, **kw: apply_calls.append(a[0])
+    ):
+      bench.Prepare(bm)
+
+    # Should have applied both JVM manifest and VPA manifest.
+    self.assertLen(apply_calls, 2)
+    jvm_calls = [c for c in apply_calls if 'slowjvmstartup' in c]
+    vpa_calls = [c for c in apply_calls if 'vpa' in c]
+    self.assertLen(jvm_calls, 1)
+    self.assertLen(vpa_calls, 1)
+
+  @flagsaver.flagsaver(
+      kubernetes_deployment_startup_scenario='baseline',
+      kubernetes_deployment_startup_workload='jvm',
+      cloud='GCP',
+  )
+  def testPrepareSkipsVpaForBaseline(self):
+    """Prepare() does NOT apply VPA manifest for scenario=baseline."""
+    bm = _MakeSpec()
+    apply_calls = []
+    with mock.patch.object(
+        bench.kubernetes_commands, 'ApplyManifest',
+        side_effect=lambda *a, **kw: apply_calls.append(a[0])
+    ):
+      bench.Prepare(bm)
+
+    # Only JVM manifest, no VPA.
+    self.assertLen(apply_calls, 1)
+    self.assertNotIn('vpa', apply_calls[0])
+
+  @flagsaver.flagsaver(
+      kubernetes_deployment_startup_scenario='optimized',
+      kubernetes_deployment_startup_workload='jvm',
+      kubernetes_deployment_startup_boost_factor=3,
+      cloud='GCP',
+  )
+  def testBoostFactorInSampleMetadata(self):
+    """boost_factor appears in sample metadata for optimized scenario."""
+    with mock.patch.object(
+        bench.kubernetes_commands, 'ApplyManifest'
+    ), mock.patch.object(
+        bench.kubernetes_commands, 'WaitForRollout'
+    ), mock.patch.object(
+        bench.kubernetes_conditions,
+        'GetStatusConditionsForResourceType',
+        return_value=_DefaultConditions(),
+    ), mock.patch.object(
+        bench, '_GetTotalCpuMillicores', return_value=None
+    ):
+      samples = bench.Run(_MakeSpec())
+
+    pod_samples = [s for s in samples if 'boost_factor' in s.metadata]
+    self.assertTrue(len(pod_samples) > 0)
+    for s in pod_samples:
+      self.assertEqual(s.metadata['boost_factor'], 3)
+
+  @flagsaver.flagsaver(
+      kubernetes_deployment_startup_scenario='baseline',
+      kubernetes_deployment_startup_workload='jvm',
+      cloud='GCP',
+  )
+  def testBoostFactorIsOneForBaseline(self):
+    """boost_factor=1 in metadata for baseline scenario."""
+    with mock.patch.object(
+        bench.kubernetes_commands, 'ApplyManifest'
+    ), mock.patch.object(
+        bench.kubernetes_commands, 'WaitForRollout'
+    ), mock.patch.object(
+        bench.kubernetes_conditions,
+        'GetStatusConditionsForResourceType',
+        return_value=_DefaultConditions(),
+    ), mock.patch.object(
+        bench, '_GetTotalCpuMillicores', return_value=None
+    ):
+      samples = bench.Run(_MakeSpec())
+
+    pod_samples = [s for s in samples if 'boost_factor' in s.metadata]
+    for s in pod_samples:
+      self.assertEqual(s.metadata['boost_factor'], 1)
+
+  @flagsaver.flagsaver(
+      kubernetes_deployment_startup_scenario='optimized',
+      kubernetes_deployment_startup_workload='jvm',
+      cloud='GCP',
+  )
+  def testGetConfigEnablesVpaForOptimized(self):
+    """GetConfig() sets enable_vpa=True for scenario=optimized."""
+    config = bench.GetConfig({})
+    self.assertTrue(config['container_cluster'].get('enable_vpa'))
+
+  @flagsaver.flagsaver(
+      kubernetes_deployment_startup_scenario='baseline',
+      kubernetes_deployment_startup_workload='jvm',
+      cloud='GCP',
+  )
+  def testGetConfigNoVpaForBaseline(self):
+    """GetConfig() does NOT set enable_vpa for scenario=baseline."""
+    config = bench.GetConfig({})
+    self.assertFalse(config['container_cluster'].get('enable_vpa', False))
 
 
 if __name__ == '__main__':

--- a/tests/linux_benchmarks/kubernetes_deployment_startup_benchmark_test.py
+++ b/tests/linux_benchmarks/kubernetes_deployment_startup_benchmark_test.py
@@ -1,4 +1,4 @@
-# Copyright 2025 PerfKitBenchmarker Authors. All rights reserved.
+# Copyright 2024 PerfKitBenchmarker Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,22 +11,187 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Tests for kubernetes_deployment_startup_benchmark and startup_metrics.
 
+PR 1 — Metrics & Observability (Layer 0)
+"""
+
+import threading
+import time
 import unittest
 from unittest import mock
 
+from absl.testing import flagsaver
 from perfkitbenchmarker import benchmark_spec
+from perfkitbenchmarker import errors
 from perfkitbenchmarker import sample
+from perfkitbenchmarker.linux_benchmarks import kubernetes_deployment_startup_benchmark as bench
 from perfkitbenchmarker.linux_benchmarks import kubernetes_deployment_startup_benchmark as kdsb
 from perfkitbenchmarker.resources.container_service import kubernetes_commands
 from perfkitbenchmarker.resources.container_service import kubernetes_conditions
 from tests import pkb_common_test_case
 
 
-class KubernetesDeploymentStartupBenchmarkTest(
-    pkb_common_test_case.PkbCommonTestCase
-):
-  """Tests for the kubernetes_deployment_startup_benchmark."""
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_BASE_METADATA = {
+    'workload': 'jvm',
+    'scenario': 'baseline',
+    'cloud': 'GCP',
+    'replicas': 1,
+    'namespace': 'default',
+    'app_label': 'slowjvmstartup',
+}
+
+
+def _MakePodJson(
+    pod_name: str,
+    scheduled_ts: str,
+    started_at: str | None = None,
+    ready_ts: str | None = None,
+) -> dict:
+  """Builds a minimal pod JSON dict for testing."""
+  conditions = [
+      {
+          'type': 'PodScheduled',
+          'status': 'True',
+          'lastTransitionTime': scheduled_ts,
+      }
+  ]
+  if ready_ts:
+    conditions.append({
+        'type': 'Ready',
+        'status': 'True',
+        'lastTransitionTime': ready_ts,
+    })
+
+  container_statuses = []
+  if started_at:
+    container_statuses = [{
+        'name': 'app',
+        'ready': True,
+        'state': {'running': {'startedAt': started_at}},
+    }]
+
+  return {
+      'metadata': {'name': pod_name},
+      'status': {
+          'startTime': scheduled_ts,
+          'conditions': conditions,
+          'containerStatuses': container_statuses,
+      },
+  }
+
+
+# ---------------------------------------------------------------------------
+# startup_metrics tests
+# ---------------------------------------------------------------------------
+
+
+class StartupMetricsTest(pkb_common_test_case.PkbCommonTestCase):
+
+  def testExtractLatencyFromContainerStartedAt(self):
+    """Prefers containerStatuses[0].state.running.startedAt over Ready cond."""
+    pod = _MakePodJson(
+        'pod-1',
+        scheduled_ts='2024-01-01T00:00:00Z',
+        started_at='2024-01-01T00:00:30Z',   # 30s latency
+        ready_ts='2024-01-01T00:00:35Z',      # 35s — should NOT be used
+    )
+    latency = startup_metrics._ExtractPodStartupLatency(pod)
+    self.assertAlmostEqual(latency, 30.0, places=1)
+
+  def testExtractLatencyFallsBackToReadyCondition(self):
+    """Falls back to Ready condition when containerStatuses is absent."""
+    pod = _MakePodJson(
+        'pod-2',
+        scheduled_ts='2024-01-01T00:00:00Z',
+        ready_ts='2024-01-01T00:00:45Z',      # 45s latency via Ready cond
+    )
+    latency = startup_metrics._ExtractPodStartupLatency(pod)
+    self.assertAlmostEqual(latency, 45.0, places=1)
+
+  def testExtractLatencyReturnsNoneWhenNoReadyTimestamp(self):
+    """Returns None when no container-ready or Ready-condition timestamp exists."""
+    pod = _MakePodJson('pod-3', scheduled_ts='2024-01-01T00:00:00Z')
+    latency = startup_metrics._ExtractPodStartupLatency(pod)
+    self.assertIsNone(latency)
+
+  def testExtractLatencyReturnsNoneForNegativeLatency(self):
+    """Returns None when container-ready precedes scheduled (clock skew)."""
+    pod = _MakePodJson(
+        'pod-4',
+        scheduled_ts='2024-01-01T00:01:00Z',
+        started_at='2024-01-01T00:00:30Z',    # before scheduled → negative
+    )
+    latency = startup_metrics._ExtractPodStartupLatency(pod)
+    self.assertIsNone(latency)
+
+  def testLatenciesToSamplesEmitsAllStats(self):
+    """_LatenciesToSamples emits min/max/mean/p50/p90/p99/count."""
+    latencies = [10.0, 20.0, 30.0, 40.0, 50.0]
+    samples = startup_metrics._LatenciesToSamples(latencies, _BASE_METADATA)
+    metric_names = {s.metric for s in samples}
+    expected = {
+        'startup_latency_min',
+        'startup_latency_max',
+        'startup_latency_mean',
+        'startup_latency_p50',
+        'startup_latency_p90',
+        'startup_latency_p99',
+        'startup_latency_pod_count',
+    }
+    self.assertEqual(metric_names, expected)
+
+  def testLatenciesToSamplesValues(self):
+    """Verifies min/max/mean values are correct."""
+    latencies = [10.0, 20.0, 30.0]
+    samples = startup_metrics._LatenciesToSamples(latencies, _BASE_METADATA)
+    by_metric = {s.metric: s.value for s in samples}
+    self.assertAlmostEqual(by_metric['startup_latency_min'], 10.0)
+    self.assertAlmostEqual(by_metric['startup_latency_max'], 30.0)
+    self.assertAlmostEqual(by_metric['startup_latency_mean'], 20.0)
+    self.assertEqual(by_metric['startup_latency_pod_count'], 3)
+
+  def testLatenciesToSamplesCarryBaseMetadata(self):
+    """All samples carry the base metadata keys."""
+    latencies = [15.0]
+    samples = startup_metrics._LatenciesToSamples(latencies, _BASE_METADATA)
+    for s in samples:
+      for key in ('workload', 'scenario', 'cloud'):
+        self.assertIn(key, s.metadata)
+
+  def testGetStartupLatencySamplesEmptyOnKubectlError(self):
+    """Returns empty list when kubectl returns non-zero exit code."""
+    with mock.patch.object(
+        startup_metrics.kubectl, 'RunKubectlCommand',
+        return_value=('', 'error', 1),
+    ):
+      result = startup_metrics.GetStartupLatencySamples(
+          namespace='default', app_label='app', metadata=_BASE_METADATA
+      )
+    self.assertEqual(result, [])
+
+  def testGetStartupLatencySamplesEmptyOnBadJson(self):
+    """Returns empty list when kubectl output is not valid JSON."""
+    with mock.patch.object(
+        startup_metrics.kubectl, 'RunKubectlCommand',
+        return_value=('not json', '', 0),
+    ):
+      result = startup_metrics.GetStartupLatencySamples(
+          namespace='default', app_label='app', metadata=_BASE_METADATA
+      )
+    self.assertEqual(result, [])
+
+
+# ---------------------------------------------------------------------------
+# _CpuUtilizationCollector tests
+# ---------------------------------------------------------------------------
+
+
+class CpuUtilizationCollectorTest(pkb_common_test_case.PkbCommonTestCase):
 
   def setUp(self):
     super().setUp()
@@ -85,6 +250,140 @@ class KubernetesDeploymentStartupBenchmarkTest(
     mock_get_conditions.return_value = []
     with self.assertRaises(RuntimeError):
       kdsb.Run(self.spec)
+
+    self.collector = bench._CpuUtilizationCollector(
+        namespace='default',
+        app_label='slowjvmstartup',
+        poll_interval=1,
+    )
+
+  def testCollectorAccumulatesReadings(self):
+    """Collector accumulates readings while running."""
+    call_count = [0]
+
+    def fake_poll():
+      call_count[0] += 1
+      return 250.0
+
+    with mock.patch.object(self.collector, '_PollCpuMillicores', side_effect=fake_poll):
+      self.collector.Start()
+      time.sleep(2.5)   # Allow ~2 polls at 1s interval
+      self.collector.Stop()
+
+    self.assertGreaterEqual(len(self.collector._readings), 1)
+
+  def testGetSamplesEmitsPeakAndMean(self):
+    """GetSamples emits cpu_utilization_peak and cpu_utilization_mean."""
+    self.collector._readings = [100.0, 200.0, 300.0]
+    samples = self.collector.GetSamples(_BASE_METADATA)
+    metric_names = {s.metric for s in samples}
+    self.assertIn('cpu_utilization_peak', metric_names)
+    self.assertIn('cpu_utilization_mean', metric_names)
+    self.assertIn('cpu_utilization_reading_count', metric_names)
+
+  def testGetSamplesValues(self):
+    """Peak = max, mean = average of readings."""
+    self.collector._readings = [100.0, 200.0, 300.0]
+    samples = self.collector.GetSamples(_BASE_METADATA)
+    by_metric = {s.metric: s.value for s in samples}
+    self.assertAlmostEqual(by_metric['cpu_utilization_peak'], 300.0)
+    self.assertAlmostEqual(by_metric['cpu_utilization_mean'], 200.0)
+    self.assertEqual(by_metric['cpu_utilization_reading_count'], 3)
+
+  def testGetSamplesEmptyWhenNoReadings(self):
+    """Returns empty list when no readings collected."""
+    self.collector._readings = []
+    samples = self.collector.GetSamples(_BASE_METADATA)
+    self.assertEqual(samples, [])
+
+  def testGetSamplesCarryMetadata(self):
+    """All samples carry the base metadata and cpu-specific keys."""
+    self.collector._readings = [150.0]
+    samples = self.collector.GetSamples(_BASE_METADATA)
+    for s in samples:
+      self.assertIn('workload', s.metadata)
+      self.assertIn('scenario', s.metadata)
+
+  def testPollCpuMillicoresParsesMilliSuffix(self):
+    """_PollCpuMillicores correctly parses '250m' → 250.0."""
+    fake_output = 'slowjvmstartup-abc   250m   128Mi\n'
+    with mock.patch.object(
+        bench.kubectl, 'RunKubectlCommand',
+        return_value=(fake_output, '', 0),
+    ):
+      result = self.collector._PollCpuMillicores()
+    self.assertAlmostEqual(result, 250.0)
+
+  def testPollCpuMillicoresParsesCoreSuffix(self):
+    """_PollCpuMillicores correctly parses '1' (core) → 1000.0 millicores."""
+    fake_output = 'slowjvmstartup-abc   1   512Mi\n'
+    with mock.patch.object(
+        bench.kubectl, 'RunKubectlCommand',
+        return_value=(fake_output, '', 0),
+    ):
+      result = self.collector._PollCpuMillicores()
+    self.assertAlmostEqual(result, 1000.0)
+
+  def testPollCpuMillicoresReturnsZeroOnError(self):
+    """_PollCpuMillicores returns 0.0 when kubectl returns non-zero rc."""
+    with mock.patch.object(
+        bench.kubectl, 'RunKubectlCommand',
+        return_value=('', 'error', 1),
+    ):
+      result = self.collector._PollCpuMillicores()
+    self.assertEqual(result, 0.0)
+
+  def testCollectorIsThreadSafe(self):
+    """Concurrent Stop() and GetSamples() do not race."""
+    self.collector._readings = [100.0] * 50
+    errors = []
+
+    def read():
+      try:
+        self.collector.GetSamples(_BASE_METADATA)
+      except Exception as e:  # pylint: disable=broad-except
+        errors.append(e)
+
+    threads = [threading.Thread(target=read) for _ in range(10)]
+    for t in threads:
+      t.start()
+    for t in threads:
+      t.join()
+
+    self.assertEqual(errors, [])
+
+
+# ---------------------------------------------------------------------------
+# Benchmark lifecycle tests
+# ---------------------------------------------------------------------------
+
+
+class BenchmarkLifecycleTest(pkb_common_test_case.PkbCommonTestCase):
+
+  @flagsaver.flagsaver(
+      kubernetes_deployment_startup_scenario='optimized',
+      kubernetes_deployment_startup_workload='vllm',
+  )
+  def testCheckPrerequisitesRaisesForOptimizedVllm(self):
+    """optimized + vLLM combination not supported in PR 1."""
+    with self.assertRaises(ValueError):
+      bench.CheckPrerequisites(None)
+
+  @flagsaver.flagsaver(
+      kubernetes_deployment_startup_scenario='baseline',
+      kubernetes_deployment_startup_workload='jvm',
+  )
+  def testCheckPrerequisitesPassesForBaselineJvm(self):
+    """baseline + jvm is always valid."""
+    bench.CheckPrerequisites(None)  # Should not raise
+
+  @flagsaver.flagsaver(
+      kubernetes_deployment_startup_scenario='optimized',
+      kubernetes_deployment_startup_workload='jvm',
+  )
+  def testCheckPrerequisitesPassesForOptimizedJvm(self):
+    """optimized + jvm is valid (VPA logic is added in PR 3)."""
+    bench.CheckPrerequisites(None)  # Should not raise
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
PR 2 of 3 — vLLM Workload Support for JVM App Startup Benchmark.

**Stacked on PR #6865** (PR 1 — Metrics & Observability). Please review after #6865 merges.

**Changes:**
- `--kubernetes_deployment_startup_vllm_image` flag (default: public ECR vLLM CPU image).
- `--kubernetes_deployment_startup_vllm_yaml` flag pointing to new `vllm.yaml.j2`.
- `GetConfig()`: routes container image from workload flag.
- `Prepare()`: deploys JVM or vLLM manifest based on `--workload`.
- `Run()`: waits on correct deployment name (`vllm-startup` vs `startup`).
- `vllm.yaml.j2`: port 8000, `/health` readiness probe, CPU resource limits.

**Independent of PR 3** — can be reviewed/merged in any order relative to VPA scenario PR.