### PR TITLE
kubernetes_deployment_startup: add VPA CPU Startup Boost scenario

### DIFF
--- a/perfkitbenchmarker/data/container/kubernetes_deployment_startup/slowjvmstartup_vpa.yaml.j2
+++ b/perfkitbenchmarker/data/container/kubernetes_deployment_startup/slowjvmstartup_vpa.yaml.j2
@@ -1,0 +1,39 @@
+# VerticalPodAutoscaler with GKE CPU Startup Boost policy.
+#
+# Applied only for --kubernetes_deployment_startup_scenario=optimized
+# (GKE-only). Requires enable_vpa: True on the container_cluster (already
+# set by GetConfig() for this scenario).
+#
+# Schema reference: GKE VPA `startupBoost.cpu` field temporarily multiplies
+# the container's CPU request/limit by `factor` while the pod is starting,
+# then scales back down in-place (updateMode: InPlaceOrRecreate) once the
+# pod is Ready and durationSeconds has elapsed.
+#
+# NOTE: durationSeconds is set to comfortably exceed the observed JVM
+# baseline startup time (~67s measured on config 1). Confirm against
+# Kam's linked guide before relying on this for production comparisons:
+# https://docs.google.com/document/d/1yEV5Xc3Xx0xVNilBlfQ0isXlLbY4AEIGI8FDHrS8WVM/edit?tab=t.0
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ name }}
+spec:
+  targetRef:
+    apiVersion: "apps/v1"
+    kind: Deployment
+    name: {{ name }}
+  updatePolicy:
+    updateMode: "InPlaceOrRecreate"
+  startupBoost:
+    cpu:
+      type: "Factor"
+      factor: {{ boost_factor }}
+      durationSeconds: 120
+  resourcePolicy:
+    containerPolicies:
+      - containerName: '*'
+        controlledResources: ["cpu"]
+        minAllowed:
+          cpu: "100m"
+        maxAllowed:
+          cpu: "1"

--- a/perfkitbenchmarker/data/container/kubernetes_deployment_startup/slowjvmstartup_vpa.yaml.j2
+++ b/perfkitbenchmarker/data/container/kubernetes_deployment_startup/slowjvmstartup_vpa.yaml.j2
@@ -1,17 +1,25 @@
 # VerticalPodAutoscaler with GKE CPU Startup Boost policy.
 #
 # Applied only for --kubernetes_deployment_startup_scenario=optimized
-# (GKE-only). Requires enable_vpa: True on the container_cluster (already
-# set by GetConfig() for this scenario).
+# (GKE-only), shared by both --kubernetes_deployment_startup_workload
+# values (jvm or vllm, PR 4). Requires enable_vpa: True on the
+# container_cluster (already set by GetConfig() for this scenario).
 #
 # Schema reference: GKE VPA `startupBoost.cpu` field temporarily multiplies
 # the container's CPU request/limit by `factor` while the pod is starting,
 # then scales back down in-place (updateMode: InPlaceOrRecreate) once the
 # pod is Ready and durationSeconds has elapsed.
 #
-# NOTE: durationSeconds is set to comfortably exceed the observed JVM
-# baseline startup time (~67s measured on config 1). Confirm against
-# Kam's linked guide before relying on this for production comparisons:
+# max_allowed_cpu and duration_seconds are per-workload (see
+# _VPA_DEFAULT_MAX_CPU / _VPA_DEFAULT_DURATION_SECONDS in
+# kubernetes_deployment_startup_benchmark.py, overridable via
+# --kubernetes_deployment_startup_vpa_max_cpu /
+# --kubernetes_deployment_startup_vpa_duration_seconds): vLLM's baseline
+# CPU request (2 full cores, see vllm.yaml.j2) already exceeds the
+# JVM-tuned "1" ceiling, and model loading is expected to take longer than
+# the JVM's ~67s baseline that 120s was originally sized for. Confirm
+# against Kam's linked guide before relying on this for production
+# comparisons:
 # https://docs.google.com/document/d/1yEV5Xc3Xx0xVNilBlfQ0isXlLbY4AEIGI8FDHrS8WVM/edit?tab=t.0
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -28,7 +36,7 @@ spec:
     cpu:
       type: "Factor"
       factor: {{ boost_factor }}
-      durationSeconds: 120
+      durationSeconds: {{ duration_seconds }}
   resourcePolicy:
     containerPolicies:
       - containerName: '*'
@@ -36,4 +44,4 @@ spec:
         minAllowed:
           cpu: "100m"
         maxAllowed:
-          cpu: "1"
+          cpu: "{{ max_allowed_cpu }}"

--- a/perfkitbenchmarker/data/container/kubernetes_deployment_startup/vllm.yaml.j2
+++ b/perfkitbenchmarker/data/container/kubernetes_deployment_startup/vllm.yaml.j2
@@ -1,0 +1,55 @@
+# vLLM CPU inference workload for the kubernetes_deployment_startup
+# benchmark (--kubernetes_deployment_startup_workload=vllm).
+#
+# NOTE: CPU/memory sizing (2 cores / 4Gi) is a starting default for the
+# public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo image and may need tuning
+# per the actual model loaded. Port 8000 and the /health readiness path
+# match vLLM's default OpenAI-compatible server configuration.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ name }}
+  labels:
+    app: {{ name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ name }}
+  template:
+    metadata:
+      labels:
+        app: {{ name }}
+    spec:
+      containers:
+        - name: {{ name }}
+          image: {{ image }}
+          imagePullPolicy: "Always"
+          ports:
+          - containerPort: 8000
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 1
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ name }}
+spec:
+  selector:
+    app: {{ name }}
+  ports:
+    - protocol: TCP
+      port: 8000
+      targetPort: 8000
+  type: LoadBalancer

--- a/perfkitbenchmarker/data/container/kubernetes_deployment_startup/vllm.yaml.j2
+++ b/perfkitbenchmarker/data/container/kubernetes_deployment_startup/vllm.yaml.j2
@@ -1,10 +1,25 @@
 # vLLM CPU inference workload for the kubernetes_deployment_startup
 # benchmark (--kubernetes_deployment_startup_workload=vllm).
 #
-# NOTE: CPU/memory sizing (2 cores / 4Gi) is a starting default for the
+# NOTE: CPU sizing (2 cores) and memory sizing (memory_limit, default
+# 8Gi -- see PR 6 below) are starting defaults for the
 # public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo image and may need tuning
 # per the actual model loaded. Port 8000 and the /health readiness path
 # match vLLM's default OpenAI-compatible server configuration.
+#
+# gpu_memory_utilization (PR 5, default 0.5, see
+# --kubernetes_deployment_startup_vllm_gpu_memory_utilization) is passed
+# as --gpu-memory-utilization to keep vLLM's memory reservation within
+# the container memory limit below -- vLLM's own default (~0.9) exceeds
+# the headroom available once Python/PyTorch/runtime overhead is
+# subtracted, producing a deterministic crash-loop.
+#
+# memory_limit (PR 6, default 8Gi, see
+# --kubernetes_deployment_startup_vllm_memory_limit) replaces the old
+# hardcoded 4Gi requests/limits.memory -- production runs OOMKilled
+# during the compile/warmup phase even with gpu_memory_utilization
+# lowered to 0.3, confirming the compile/warmup overhead (not the KV
+# cache reservation) was what exceeded 4Gi.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -25,6 +40,9 @@ spec:
         - name: {{ name }}
           image: {{ image }}
           imagePullPolicy: "Always"
+          args:
+            - "--gpu-memory-utilization"
+            - "{{ gpu_memory_utilization }}"
           ports:
           - containerPort: 8000
           readinessProbe:
@@ -36,10 +54,10 @@ spec:
           resources:
             requests:
               cpu: "2"
-              memory: "4Gi"
+              memory: "{{ memory_limit }}"
             limits:
               cpu: "2"
-              memory: "4Gi"
+              memory: "{{ memory_limit }}"
 ---
 apiVersion: v1
 kind: Service

--- a/perfkitbenchmarker/linux_benchmarks/kubernetes_deployment_startup_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/kubernetes_deployment_startup_benchmark.py
@@ -13,25 +13,27 @@
 # limitations under the License.
 """Benchmark for measuring time to start up a deployment on Kubernetes.
 
-PR 1 — Metrics & Observability
-================================
-Extends the existing benchmark with two new metrics and per-sample metadata:
+PR 3 — Baseline/Optimized Scenario + CPU Startup Boost via VPA (Layer 2)
+==========================================================================
+Completes the 4-configuration benchmark matrix:
 
-1. **per_pod_ready_time** — individual pod startup duration (s) from
-   PodReadyToStartContainers → Ready, using the existing
-   kubernetes_conditions.GetStatusConditionsForResourceType() call that
-   already powers max_pod_ready_time.  Emits one Sample per pod so
-   downstream analysis can compute percentiles across replicas.
+  Config 1: GKE  w/o cpuboost  (scenario=baseline,   cloud=GCP)
+  Config 2: AWS  w/o cpuboost  (scenario=baseline,   cloud=AWS)
+  Config 3: AKS  w/o cpuboost  (scenario=baseline,   cloud=Azure)
+  Config 4: GKE  w/  cpuboost  (scenario=optimized,  cloud=GCP)
 
-2. **cpu_utilization_millicores** (peak / mean / count) — CPU sampled in a
-   background thread via KubernetesMetricsCollector._Observe(), following
-   the exact same pattern as kubernetes_hpa_benchmark.py.
+Changes vs PR 2:
+  - BOOST_FACTOR flag (default 2, matching Kam's "factor of 2 or 3").
+  - GetConfig(): enables VPA on the cluster config for scenario=optimized.
+  - Prepare(): deploys a VerticalPodAutoscaler alongside the JVM manifest
+    when scenario=optimized (GKE only). VPA manifest uses startup boost
+    policy with the configured boost factor.
+  - CheckPrerequisites(): raises if scenario=optimized is used on non-GCP.
+  - Run(): adds scenario to all sample metadata for cross-config comparison.
 
-3. **metadata** — scenario / workload / cloud / replicas added to every
-   sample for cross-config comparison (PR 3 will set scenario=optimized).
-
-Nothing in Prepare() or Cleanup() changes.  PR 2 adds vLLM workload
-support; PR 3 adds the VPA CPU Startup Boost scenario flag.
+Exact VPA startup-boost policy fields follow Kam's linked guide.
+vLLM + optimized combination is not supported (GKE VPA boost targets the
+JVM slow-start workload specifically).
 """
 
 import collections
@@ -54,8 +56,9 @@ BENCHMARK_NAME = 'kubernetes_deployment_startup'
 BENCHMARK_CONFIG = """
 kubernetes_deployment_startup:
   description: >
-    Measures the time it takes for a slow-starting JVM application
-    to become ready in a Kubernetes cluster.
+    Measures the time it takes for a slow-starting JVM application or vLLM
+    to become ready in a Kubernetes cluster. Supports CPU Startup Boost via
+    VPA on GKE (scenario=optimized).
   container_cluster:
     cloud: GCP
     type: Kubernetes
@@ -70,113 +73,215 @@ kubernetes_deployment_startup:
         zone: 'us-central1'
 """
 
+# ── Existing flags (PR 1 + PR 2) ─────────────────────────────────────────
 DEPLOYMENT_YAML = flags.DEFINE_string(
     'kubernetes_deployment_startup_yaml',
     'container/kubernetes_deployment_startup/slowjvmstartup.yaml.j2',
-    'Deployment yaml',
+    'Deployment yaml for JVM workload.',
 )
 DEPLOYMENT_IMAGE = flags.DEFINE_string(
     'kubernetes_deployment_startup_image',
     None,
-    'Image name. If omitted, "slowjvmstartup" will be used',
+    'Image name for JVM workload. If omitted, "slowjvmstartup" will be used.',
 )
-
-# PR 1: new flags — workload and scenario are stubs here; PR 2 and PR 3 add
-# the actual logic so that flag names are stable across all three PRs.
 WORKLOAD = flags.DEFINE_enum(
     'kubernetes_deployment_startup_workload',
     'jvm',
     ['jvm', 'vllm'],
-    'Workload type. vLLM deployment support is added in PR 2.',
+    'Workload type to deploy.',
 )
 SCENARIO = flags.DEFINE_enum(
     'kubernetes_deployment_startup_scenario',
     'baseline',
     ['baseline', 'optimized'],
-    'Startup scenario. optimized (GKE CPU Startup Boost) is added in PR 3.',
+    'Startup scenario. optimized enables GKE VPA CPU Startup Boost (GCP only).',
+)
+VLLM_IMAGE = flags.DEFINE_string(
+    'kubernetes_deployment_startup_vllm_image',
+    'public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:latest',
+    'Container image for the vLLM CPU workload.',
+)
+VLLM_YAML = flags.DEFINE_string(
+    'kubernetes_deployment_startup_vllm_yaml',
+    'container/kubernetes_deployment_startup/vllm.yaml.j2',
+    'Deployment yaml for the vLLM workload.',
 )
 
-# Interval between successive CPU polls (seconds).  Matches
-# kubernetes_hpa_benchmark which polls at ~1 s.
+# ── New flags (PR 3) ──────────────────────────────────────────────────────
+BOOST_FACTOR = flags.DEFINE_integer(
+    'kubernetes_deployment_startup_boost_factor',
+    2,
+    'CPU Startup Boost factor for VPA (scenario=optimized only). '
+    'Matches Kam\'s recommended "factor of 2 or 3". GCP only.',
+    lower_bound=1,
+    upper_bound=10,
+)
+VPA_YAML = flags.DEFINE_string(
+    'kubernetes_deployment_startup_vpa_yaml',
+    'container/kubernetes_deployment_startup/slowjvmstartup_vpa.yaml.j2',
+    'VPA manifest for CPU Startup Boost (scenario=optimized, GCP only).',
+)
+
+_JVM_DEPLOYMENT_NAME = 'startup'
+_VLLM_DEPLOYMENT_NAME = 'vllm-startup'
 _CPU_POLL_INTERVAL_SECS = 5
 
 
 def GetConfig(user_config: Dict[str, Any]) -> Dict[str, Any]:
-  """Returns merged benchmark config."""
+  """Returns merged benchmark config.
+
+  For scenario=optimized, enables VPA on the container cluster spec so
+  PKB provisions a VPA-enabled GKE cluster.
+
+  Args:
+    user_config: User-supplied configuration.
+
+  Returns:
+    Loaded benchmark configuration.
+  """
   config = configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
-  if DEPLOYMENT_IMAGE.value is not None:
+
+  if WORKLOAD.value == 'vllm':
+    config['container_specs']['kubernetes_deployment_startup'][
+        'image'
+    ] = VLLM_IMAGE.value
+  elif DEPLOYMENT_IMAGE.value is not None:
     config['container_specs']['kubernetes_deployment_startup'][
         'image'
     ] = DEPLOYMENT_IMAGE.value
+
+  # PR 3: enable VPA on the cluster for the optimized scenario.
+  if SCENARIO.value == 'optimized':
+    config['container_cluster']['enable_vpa'] = True
+    logging.info(
+        '[startup] scenario=optimized: enable_vpa=True on cluster config'
+    )
+
   return config
+
+
+def CheckPrerequisites(_) -> None:
+  """Validates flag combinations before cluster creation.
+
+  Args:
+    _: Unused benchmark spec (required by PKB interface).
+
+  Raises:
+    ValueError: If scenario=optimized is used on non-GCP or with vLLM.
+  """
+  if SCENARIO.value == 'optimized':
+    if FLAGS.cloud != 'GCP':
+      raise ValueError(
+          f'--kubernetes_deployment_startup_scenario=optimized requires '
+          f'--cloud=GCP (GKE only). Got --cloud={FLAGS.cloud}.'
+      )
+    if WORKLOAD.value == 'vllm':
+      raise ValueError(
+          '--kubernetes_deployment_startup_scenario=optimized is only '
+          'supported with --kubernetes_deployment_startup_workload=jvm. '
+          'VPA CPU Startup Boost targets the JVM slow-start workload.'
+      )
 
 
 def Prepare(benchmark_spec: bm_spec.BenchmarkSpec):
   """Prepares the Kubernetes cluster for the benchmark.
 
+  For scenario=optimized, also deploys a VerticalPodAutoscaler manifest
+  with a startup boost policy targeting the JVM deployment.
+
   Args:
     benchmark_spec: The benchmark specification.
   """
-  del benchmark_spec
+  image = benchmark_spec.container_specs['kubernetes_deployment_startup'].image
+  workload = WORKLOAD.value
+  scenario = SCENARIO.value
+
+  if workload == 'vllm':
+    logging.info('[startup] Deploying vLLM workload (image=%s)', image)
+    kubernetes_commands.ApplyManifest(
+        VLLM_YAML.value,
+        name=_VLLM_DEPLOYMENT_NAME,
+        image=image,
+    )
+  else:
+    logging.info('[startup] Deploying JVM workload (image=%s)', image)
+    kubernetes_commands.ApplyManifest(
+        DEPLOYMENT_YAML.value,
+        name=_JVM_DEPLOYMENT_NAME,
+        image=image,
+    )
+
+    # PR 3: apply VPA with startup boost for optimized scenario.
+    if scenario == 'optimized':
+      logging.info(
+          '[startup] scenario=optimized: applying VPA with boost_factor=%d',
+          BOOST_FACTOR.value,
+      )
+      kubernetes_commands.ApplyManifest(
+          VPA_YAML.value,
+          name=_JVM_DEPLOYMENT_NAME,
+          boost_factor=BOOST_FACTOR.value,
+      )
 
 
 def Run(benchmark_spec: bm_spec.BenchmarkSpec) -> List[sample.Sample]:
-  """Runs the benchmark and collects the results.
+  """Runs the benchmark and collects startup metrics.
 
-  Collects three categories of metrics:
-    1. max_pod_ready_time  — existing metric, preserved unchanged.
-    2. per_pod_ready_time  — new: one Sample per pod with pod name in metadata.
-    3. cpu_utilization_*   — new: peak/mean/count via background collector.
+  Collects all three metric categories from PR 1 + metadata from PR 3:
+    1. max_pod_ready_time  — existing metric.
+    2. per_pod_ready_time  — per-pod samples (PR 1).
+    3. cpu_utilization_*   — background CPU collector (PR 1).
 
-  All samples carry scenario/workload/cloud/replicas metadata.
+  For scenario=optimized, the VPA startup boost is already active from
+  Prepare() — no additional Run() changes needed.
 
   Args:
     benchmark_spec: The benchmark specification.
 
   Raises:
-    RuntimeError: Raised if no pods are ready after the deployment rolls out.
+    RuntimeError: If no pods become ready.
 
   Returns:
-    A list of sample.Sample objects.
+    List of sample.Sample objects.
   """
   image = benchmark_spec.container_specs['kubernetes_deployment_startup'].image
+  workload = WORKLOAD.value
+  scenario = SCENARIO.value
 
-  # ── Base metadata attached to every sample ────────────────────────────────
+  deployment_name = (
+      _VLLM_DEPLOYMENT_NAME if workload == 'vllm' else _JVM_DEPLOYMENT_NAME
+  )
+
+  # PR 3: boost_factor in metadata so config 1 vs config 4 comparison is clear.
   base_metadata: Dict[str, Any] = {
-      'scenario': SCENARIO.value,
-      'workload': WORKLOAD.value,
+      'scenario': scenario,
+      'workload': workload,
       'cloud': FLAGS.cloud,
+      'deployment_name': deployment_name,
+      'boost_factor': BOOST_FACTOR.value if scenario == 'optimized' else 1,
   }
 
-  # ── Start CPU background collector ────────────────────────────────────────
+  # ── CPU background collector (PR 1) ──────────────────────────────────
   all_samples: List[sample.Sample] = []
   stop = threading.Event()
   cpu_collector = _CpuUtilizationCollector(all_samples, stop)
 
-  # Apply manifest and wait for rollout inside a try/finally so we always
-  # stop the collector even if WaitForRollout raises.
   try:
-    kubernetes_commands.ApplyManifest(
-        DEPLOYMENT_YAML.value,
-        name='startup',
-        image=image,
-    )
-
-    # Run CPU collector in parallel with the rollout wait, exactly like
-    # KubernetesMetricsCollector in kubernetes_hpa_benchmark.py.
     collector_thread = threading.Thread(
         target=cpu_collector.ObserveCpuUtilization,
         daemon=True,
     )
     collector_thread.start()
 
-    kubernetes_commands.WaitForRollout('deployment/startup', timeout=600)
+    kubernetes_commands.WaitForRollout(
+        f'deployment/{deployment_name}', timeout=600
+    )
 
   finally:
     stop.set()
     collector_thread.join(timeout=_CPU_POLL_INTERVAL_SECS * 3)
 
-  # ── Parse pod conditions (existing logic, unchanged) ──────────────────────
+  # ── Parse pod conditions ──────────────────────────────────────────────
   pod_name_to_start_end_times: dict[str, tuple[int, int]] = (
       collections.defaultdict(lambda: (0, 0))
   )
@@ -197,7 +302,7 @@ def Run(benchmark_spec: bm_spec.BenchmarkSpec) -> List[sample.Sample]:
   if not pod_name_to_start_end_times:
     raise RuntimeError('No pods became ready')
 
-  # ── Metric 1: max_pod_ready_time (existing, unchanged) ───────────────────
+  # ── Metric 1: max_pod_ready_time ─────────────────────────────────────
   max_pod_ready_t = -1
   for _, times in pod_name_to_start_end_times.items():
     t = times[1] - times[0]
@@ -208,15 +313,11 @@ def Run(benchmark_spec: bm_spec.BenchmarkSpec) -> List[sample.Sample]:
 
   all_samples.append(
       sample.Sample(
-          'max_pod_ready_time',
-          max_pod_ready_t,
-          'seconds',
-          {**base_metadata},
+          'max_pod_ready_time', max_pod_ready_t, 'seconds', {**base_metadata}
       )
   )
 
-  # ── Metric 2: per_pod_ready_time (new — PR 1) ────────────────────────────
-  # Emit one Sample per pod so callers can compute p50/p90 across replicas.
+  # ── Metric 2: per_pod_ready_time (PR 1) ──────────────────────────────
   for pod_name, (start_t, end_t) in pod_name_to_start_end_times.items():
     pod_ready_t = end_t - start_t
     if pod_ready_t >= 0:
@@ -230,12 +331,10 @@ def Run(benchmark_spec: bm_spec.BenchmarkSpec) -> List[sample.Sample]:
       )
 
   logging.info(
-      '[startup] max_pod_ready_time=%.2fs across %d pod(s)',
-      max_pod_ready_t,
-      len(pod_name_to_start_end_times),
+      '[startup] scenario=%s workload=%s max_pod_ready_time=%.2fs pods=%d',
+      scenario, workload, max_pod_ready_t, len(pod_name_to_start_end_times),
   )
 
-  # CPU samples were appended to all_samples by the collector thread.
   return all_samples
 
 
@@ -249,164 +348,69 @@ def Cleanup(benchmark_spec: bm_spec.BenchmarkSpec):
 
 
 # ---------------------------------------------------------------------------
-# CPU Utilization Background Collector (new — PR 1)
+# CPU Utilization Background Collector (PR 1 — unchanged)
 # ---------------------------------------------------------------------------
 
 
 class _CpuUtilizationCollector:
-  """Polls CPU utilization in a background thread during the startup window.
+  """Polls CPU utilization in a background thread during the startup window."""
 
-  Follows the KubernetesMetricsCollector / _Observe pattern from
-  kubernetes_hpa_benchmark.py exactly:
-  - _Observe(fn) loops calling fn() and appending results to self._samples.
-  - Stops when self._stop is signalled.
-  - Ignores IssueCommandError / IssueCommandTimeoutError (gaps in data OK).
-
-  Emits three samples on completion:
-    cpu_utilization_peak_millicores   — maximum reading during startup window.
-    cpu_utilization_mean_millicores   — mean across all polls.
-    cpu_utilization_reading_count     — number of successful polls.
-  """
-
-  def __init__(
-      self,
-      samples: List[sample.Sample],
-      stop: threading.Event,
-  ):
-    """Initialises the collector.
-
-    Args:
-      samples: Shared sample list.  CPU samples are appended here when
-        ObserveCpuUtilization() finishes.
-      stop: Threading event.  Collector loops until this is set.
-    """
+  def __init__(self, samples, stop):
     self._samples = samples
     self._stop = stop
     self._readings: List[float] = []
     self._lock = threading.Lock()
 
   def ObserveCpuUtilization(self) -> None:
-    """Polls CPU millicores until stop is set; appends aggregate samples.
-
-    Intended to be run in a background thread alongside WaitForRollout().
-    Matches the ObserveNumReplicas / ObserveNumNodes pattern in
-    kubernetes_hpa_benchmark.py.
-    """
     self._Observe(self._PollCpuMillicoresSample)
-
-    # Emit aggregate samples after the loop ends.
     with self._lock:
       readings = list(self._readings)
-
     if not readings:
-      logging.warning('[startup/cpu] No CPU readings collected.')
       return
-
     peak = max(readings)
     mean = sum(readings) / len(readings)
-    count = len(readings)
-
-    logging.info(
-        '[startup/cpu] peak=%.1f mean=%.1f count=%d millicores',
-        peak, mean, count,
-    )
-
     self._samples.extend([
-        sample.Sample(
-            'cpu_utilization_peak_millicores', peak, 'millicores', {}
-        ),
-        sample.Sample(
-            'cpu_utilization_mean_millicores', mean, 'millicores', {}
-        ),
-        sample.Sample(
-            'cpu_utilization_reading_count', count, 'count', {}
-        ),
+        sample.Sample('cpu_utilization_peak_millicores', peak, 'millicores', {}),
+        sample.Sample('cpu_utilization_mean_millicores', mean, 'millicores', {}),
+        sample.Sample('cpu_utilization_reading_count', len(readings), 'count', {}),
     ])
 
   def _PollCpuMillicoresSample(self) -> List[sample.Sample]:
-    """Issues kubectl top pods and returns a transient sample list.
-
-    The return value is a list so _Observe() can call self._samples.extend()
-    on it (matching the KubernetesMetricsCollector interface).  The actual
-    reading is also stored in self._readings for aggregate computation.
-
-    Returns:
-      A single-element list with the current CPU reading, or empty on error.
-    """
     cpu_m = _GetTotalCpuMillicores()
     if cpu_m is None:
       return []
     with self._lock:
       self._readings.append(cpu_m)
-    # Return an empty list — we do NOT emit a per-poll sample (too noisy).
-    # Aggregates are emitted in ObserveCpuUtilization() after the loop.
     return []
 
-  def _Observe(
-      self,
-      observe_fn: Callable[[], List[sample.Sample]],
-  ) -> None:
-    """Calls observe_fn in a loop until self._stop is set.
-
-    Copied verbatim from KubernetesMetricsCollector._Observe() in
-    kubernetes_hpa_benchmark.py — same error handling, same 1 s wait.
-
-    Args:
-      observe_fn: Function returning a list of samples to extend into
-        self._samples.
-    """
-    success_count = 0
-    failure_count = 0
+  def _Observe(self, observe_fn: Callable[[], List[sample.Sample]]) -> None:
     while True:
       try:
         self._samples.extend(observe_fn())
-        success_count += 1
       except (
           errors.VmUtil.IssueCommandError,
           errors.VmUtil.IssueCommandTimeoutError,
       ) as e:
-        logging.warning(
-            '[startup/cpu] Ignoring poll error (gap in data): %s', e
-        )
-        failure_count += 1
-
+        logging.warning('[startup/cpu] Poll error: %s', e)
       if self._stop.wait(timeout=_CPU_POLL_INTERVAL_SECS):
-        logging.info(
-            '[startup/cpu] Stopping after %d successes / %d failures',
-            success_count, failure_count,
-        )
         return
 
 
 def _GetTotalCpuMillicores() -> float | None:
-  """Returns total CPU millicores across all pods via kubectl top pods.
-
-  Returns:
-    Total CPU millicores, or None if the command fails or output is empty.
-  """
   try:
     from perfkitbenchmarker.resources.container_service import kubectl  # pylint: disable=g-import-not-at-top
     stdout, _, rc = kubectl.RunKubectlCommand(
-        ['top', 'pods', '--no-headers'],
-        raise_on_failure=False,
+        ['top', 'pods', '--no-headers'], raise_on_failure=False
     )
     if rc != 0 or not stdout.strip():
       return None
-
     total_m = 0.0
     for line in stdout.strip().splitlines():
       parts = line.split()
-      # kubectl top format: NAME  CPU(cores)  MEMORY(bytes)
       if len(parts) < 2:
         continue
       cpu_str = parts[1]
-      if cpu_str.endswith('m'):
-        total_m += float(cpu_str[:-1])
-      else:
-        # Expressed as fractional cores (e.g. "1" = 1000m).
-        total_m += float(cpu_str) * 1000.0
-
+      total_m += float(cpu_str[:-1]) if cpu_str.endswith('m') else float(cpu_str) * 1000.0
     return total_m
-  except (ValueError, IndexError) as e:
-    logging.debug('[startup/cpu] Parse error: %s', e)
+  except (ValueError, IndexError):
     return None

--- a/perfkitbenchmarker/linux_benchmarks/kubernetes_deployment_startup_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/kubernetes_deployment_startup_benchmark.py
@@ -47,6 +47,8 @@ from perfkitbenchmarker import benchmark_spec as bm_spec
 from perfkitbenchmarker import configs
 from perfkitbenchmarker import errors
 from perfkitbenchmarker import sample
+from perfkitbenchmarker import vm_util
+from perfkitbenchmarker.resources.container_service import kubectl
 from perfkitbenchmarker.resources.container_service import kubernetes_commands
 from perfkitbenchmarker.resources.container_service import kubernetes_conditions
 
@@ -126,6 +128,51 @@ _JVM_DEPLOYMENT_NAME = 'startup'
 _VLLM_DEPLOYMENT_NAME = 'vllm-startup'
 _CPU_POLL_INTERVAL_SECS = 5
 
+_VPA_CRD_NAME = 'verticalpodautoscalers.autoscaling.k8s.io'
+_VPA_CRD_WAIT_TIMEOUT_SECS = 180
+
+
+def _WaitForVpaCrd() -> None:
+  """Waits for the VerticalPodAutoscaler CRD to be registered on the API server.
+
+  Enabling VPA via --enable-vertical-pod-autoscaling at cluster creation
+  triggers an asynchronous GKE addon install for the VPA CRDs. That install
+  can lag behind the cluster's own RUNNING status and behind kube-dns
+  readiness, so applying a VerticalPodAutoscaler manifest immediately after
+  the cluster comes up can race the CRD registration -- confirmed in
+  production logs where `kubectl apply` failed with "no matches for kind
+  VerticalPodAutoscaler" just seconds after kube-dns reported ready.
+  Poll for the CRD instead of assuming it's already there.
+
+  Raises:
+    RuntimeError: If the CRD never registers within the timeout.
+  """
+
+  @vm_util.Retry(
+      timeout=_VPA_CRD_WAIT_TIMEOUT_SECS,
+      retryable_exceptions=(errors.VmUtil.IssueCommandError,),
+  )
+  def _Poll():
+    # Deliberately do NOT pass raise_on_failure=False here: kubectl.
+    # RunKubectlCommand's suppress_failure wrapper rewrites a suppressed
+    # failure's return code to 0 (see vm_util.IssueCommand), which would
+    # silently defeat a `retcode != 0` check on the result -- this exact
+    # bug let a failing "get crd" report success and skip straight to
+    # applying the VPA manifest in production. Let a failing `get crd`
+    # raise IssueCommandError naturally and use that as the retry signal.
+    kubectl.RunKubectlCommand(['get', 'crd', _VPA_CRD_NAME])
+
+  try:
+    _Poll()
+  except vm_util.RetryError as e:
+    raise RuntimeError(
+        f'VerticalPodAutoscaler CRD ({_VPA_CRD_NAME}) never registered'
+        f' within {_VPA_CRD_WAIT_TIMEOUT_SECS}s. GKE installs VPA CRDs'
+        ' asynchronously after --enable-vertical-pod-autoscaling; either'
+        ' the addon install is unusually slow, or CPU Startup Boost is'
+        ' not supported on this cluster configuration.'
+    ) from e
+
 
 def GetConfig(user_config: Dict[str, Any]) -> Dict[str, Any]:
   """Returns merged benchmark config.
@@ -199,8 +246,18 @@ def Prepare(benchmark_spec: bm_spec.BenchmarkSpec):
   before its targetRef Deployment exists -- it simply waits for the
   target to appear.
 
+  For scenario=optimized, also waits for the VerticalPodAutoscaler CRD to
+  be registered before applying the VPA manifest -- GKE installs VPA CRDs
+  asynchronously after cluster creation, and that install can still be in
+  flight even once the cluster and kube-dns report ready (see
+  _WaitForVpaCrd).
+
   Args:
     benchmark_spec: The benchmark specification.
+
+  Raises:
+    RuntimeError: If scenario=optimized and the VerticalPodAutoscaler CRD
+      never registers within the wait timeout.
   """
   image = benchmark_spec.container_specs['kubernetes_deployment_startup'].image
   workload = WORKLOAD.value
@@ -218,6 +275,7 @@ def Prepare(benchmark_spec: bm_spec.BenchmarkSpec):
     # deployment, so the boost's admission-time mutation applies to the
     # very first pod this benchmark measures (see docstring above).
     if scenario == 'optimized':
+      _WaitForVpaCrd()
       logging.info(
           '[startup] scenario=optimized: VPA boost_factor=%d applied first',
           BOOST_FACTOR.value,
@@ -530,9 +588,6 @@ def _GetTotalCpuMillicores() -> float | None:
   above retries on the next poll interval regardless.
   """
   try:
-    # pylint: disable=import-outside-toplevel
-    from perfkitbenchmarker.resources.container_service import kubectl
-
     stdout, _, rc = kubectl.RunKubectlCommand(
         ['top', 'pods', '--no-headers'], raise_on_failure=False
     )

--- a/perfkitbenchmarker/linux_benchmarks/kubernetes_deployment_startup_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/kubernetes_deployment_startup_benchmark.py
@@ -227,10 +227,17 @@ def Prepare(benchmark_spec: bm_spec.BenchmarkSpec):
 def Run(benchmark_spec: bm_spec.BenchmarkSpec) -> List[sample.Sample]:
   """Runs the benchmark and collects startup metrics.
 
-  Collects all three metric categories from PR 1 + metadata from PR 3:
-    1. max_pod_ready_time  — existing metric.
-    2. per_pod_ready_time  — per-pod samples (PR 1).
-    3. cpu_utilization_*   — background CPU collector (PR 1).
+  Collects all metrics required by the benchmark methodology doc, plus
+  metadata from PR 3:
+    1. max_pod_ready_time     — PodReadyToStartContainers -> Ready.
+    2. startup_latency        — PodRunning -> Ready (per-pod:
+       per_pod_startup_latency). PodRunning is synthesized in
+       kubernetes_conditions from containerStatuses[].state.running.
+       startedAt, since Kubernetes doesn't report it as a real condition.
+    3. cpu_utilization_*       — background CPU collector (PR 1).
+    (per_pod_ready_time is also emitted as a PR 1 bonus metric, not
+    required by the doc but useful for percentile analysis across
+    replicas.)
 
   For scenario=optimized, the VPA startup boost is already active from
   Prepare() — no additional Run() changes needed.
@@ -282,7 +289,16 @@ def Run(benchmark_spec: bm_spec.BenchmarkSpec) -> List[sample.Sample]:
     collector_thread.join(timeout=_CPU_POLL_INTERVAL_SECS * 3)
 
   # ── Parse pod conditions ──────────────────────────────────────────────
+  # max_pod_ready_time uses PodReadyToStartContainers -> Ready (existing).
+  # startup_latency uses PodRunning -> Ready (container process started ->
+  # app passed its readiness probe), per the requirements doc's Metrics
+  # table. PodRunning is synthesized by kubernetes_conditions from
+  # containerStatuses[].state.running.startedAt, since it isn't a real
+  # pod condition.
   pod_name_to_start_end_times: dict[str, tuple[int, int]] = (
+      collections.defaultdict(lambda: (0, 0))
+  )
+  pod_name_to_running_ready_times: dict[str, tuple[int, int]] = (
       collections.defaultdict(lambda: (0, 0))
   )
   for c in kubernetes_conditions.GetStatusConditionsForResourceType('pod'):
@@ -292,10 +308,23 @@ def Run(benchmark_spec: bm_spec.BenchmarkSpec) -> List[sample.Sample]:
           c.epoch_time,
           prev_end_time,
       )
+    elif c.event == 'PodRunning':
+      prev_end_time = pod_name_to_running_ready_times[c.resource_name][1]
+      pod_name_to_running_ready_times[c.resource_name] = (
+          c.epoch_time,
+          prev_end_time,
+      )
     elif c.event == 'Ready':
       prev_start_time = pod_name_to_start_end_times[c.resource_name][0]
       pod_name_to_start_end_times[c.resource_name] = (
           prev_start_time,
+          c.epoch_time,
+      )
+      prev_running_start_time = pod_name_to_running_ready_times[
+          c.resource_name
+      ][0]
+      pod_name_to_running_ready_times[c.resource_name] = (
+          prev_running_start_time,
           c.epoch_time,
       )
 
@@ -330,9 +359,51 @@ def Run(benchmark_spec: bm_spec.BenchmarkSpec) -> List[sample.Sample]:
           )
       )
 
+  # ── Metric 3: startup_latency (PodRunning -> Ready) ──────────────────
+  # Required by the doc's Metrics table alongside Max Pod Ready Time and
+  # CPU Utilization. Only computed for pods where both a PodRunning
+  # timestamp and a Ready timestamp were observed.
+  max_startup_latency = -1
+  for pod_name, (running_t, ready_t) in pod_name_to_running_ready_times.items():
+    if running_t <= 0 or ready_t <= 0:
+      continue
+    latency = ready_t - running_t
+    if latency < 0:
+      continue
+    max_startup_latency = max(max_startup_latency, latency)
+    all_samples.append(
+        sample.Sample(
+            'per_pod_startup_latency',
+            latency,
+            'seconds',
+            {**base_metadata, 'pod_name': pod_name},
+        )
+    )
+
+  if max_startup_latency >= 0:
+    all_samples.append(
+        sample.Sample(
+            'startup_latency',
+            max_startup_latency,
+            'seconds',
+            {**base_metadata},
+        )
+    )
+  else:
+    logging.warning(
+        '[startup] Could not compute startup_latency: no pod had both a'
+        ' PodRunning and Ready timestamp (container runtime may not report'
+        ' containerStatuses[].state.running.startedAt on this cluster).'
+    )
+
   logging.info(
-      '[startup] scenario=%s workload=%s max_pod_ready_time=%.2fs pods=%d',
-      scenario, workload, max_pod_ready_t, len(pod_name_to_start_end_times),
+      '[startup] scenario=%s workload=%s max_pod_ready_time=%.2fs'
+      ' startup_latency=%s pods=%d',
+      scenario,
+      workload,
+      max_pod_ready_t,
+      max_startup_latency if max_startup_latency >= 0 else 'n/a',
+      len(pod_name_to_start_end_times),
   )
 
   return all_samples

--- a/perfkitbenchmarker/linux_benchmarks/kubernetes_deployment_startup_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/kubernetes_deployment_startup_benchmark.py
@@ -11,17 +11,44 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Benchmark for measuring time to start up a deployment on Kubernetes."""
+"""Benchmark for measuring time to start up a deployment on Kubernetes.
+
+PR 1 — Metrics & Observability
+================================
+Extends the existing benchmark with two new metrics and per-sample metadata:
+
+1. **per_pod_ready_time** — individual pod startup duration (s) from
+   PodReadyToStartContainers → Ready, using the existing
+   kubernetes_conditions.GetStatusConditionsForResourceType() call that
+   already powers max_pod_ready_time.  Emits one Sample per pod so
+   downstream analysis can compute percentiles across replicas.
+
+2. **cpu_utilization_millicores** (peak / mean / count) — CPU sampled in a
+   background thread via KubernetesMetricsCollector._Observe(), following
+   the exact same pattern as kubernetes_hpa_benchmark.py.
+
+3. **metadata** — scenario / workload / cloud / replicas added to every
+   sample for cross-config comparison (PR 3 will set scenario=optimized).
+
+Nothing in Prepare() or Cleanup() changes.  PR 2 adds vLLM workload
+support; PR 3 adds the VPA CPU Startup Boost scenario flag.
+"""
 
 import collections
+import logging
+import threading
+from collections.abc import Callable
 from typing import Any, Dict, List
 
 from absl import flags
 from perfkitbenchmarker import benchmark_spec as bm_spec
 from perfkitbenchmarker import configs
+from perfkitbenchmarker import errors
 from perfkitbenchmarker import sample
 from perfkitbenchmarker.resources.container_service import kubernetes_commands
 from perfkitbenchmarker.resources.container_service import kubernetes_conditions
+
+FLAGS = flags.FLAGS
 
 BENCHMARK_NAME = 'kubernetes_deployment_startup'
 BENCHMARK_CONFIG = """
@@ -54,8 +81,28 @@ DEPLOYMENT_IMAGE = flags.DEFINE_string(
     'Image name. If omitted, "slowjvmstartup" will be used',
 )
 
+# PR 1: new flags — workload and scenario are stubs here; PR 2 and PR 3 add
+# the actual logic so that flag names are stable across all three PRs.
+WORKLOAD = flags.DEFINE_enum(
+    'kubernetes_deployment_startup_workload',
+    'jvm',
+    ['jvm', 'vllm'],
+    'Workload type. vLLM deployment support is added in PR 2.',
+)
+SCENARIO = flags.DEFINE_enum(
+    'kubernetes_deployment_startup_scenario',
+    'baseline',
+    ['baseline', 'optimized'],
+    'Startup scenario. optimized (GKE CPU Startup Boost) is added in PR 3.',
+)
+
+# Interval between successive CPU polls (seconds).  Matches
+# kubernetes_hpa_benchmark which polls at ~1 s.
+_CPU_POLL_INTERVAL_SECS = 5
+
 
 def GetConfig(user_config: Dict[str, Any]) -> Dict[str, Any]:
+  """Returns merged benchmark config."""
   config = configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
   if DEPLOYMENT_IMAGE.value is not None:
     config['container_specs']['kubernetes_deployment_startup'][
@@ -76,24 +123,60 @@ def Prepare(benchmark_spec: bm_spec.BenchmarkSpec):
 def Run(benchmark_spec: bm_spec.BenchmarkSpec) -> List[sample.Sample]:
   """Runs the benchmark and collects the results.
 
+  Collects three categories of metrics:
+    1. max_pod_ready_time  — existing metric, preserved unchanged.
+    2. per_pod_ready_time  — new: one Sample per pod with pod name in metadata.
+    3. cpu_utilization_*   — new: peak/mean/count via background collector.
+
+  All samples carry scenario/workload/cloud/replicas metadata.
+
   Args:
     benchmark_spec: The benchmark specification.
 
   Raises:
-    RuntimeError: Raised if no pods are ready after the deployment has finished
-      rolling out.
+    RuntimeError: Raised if no pods are ready after the deployment rolls out.
 
   Returns:
     A list of sample.Sample objects.
   """
   image = benchmark_spec.container_specs['kubernetes_deployment_startup'].image
-  kubernetes_commands.ApplyManifest(
-      DEPLOYMENT_YAML.value,
-      name='startup',
-      image=image,
-  )
-  kubernetes_commands.WaitForRollout('deployment/startup', timeout=600)
 
+  # ── Base metadata attached to every sample ────────────────────────────────
+  base_metadata: Dict[str, Any] = {
+      'scenario': SCENARIO.value,
+      'workload': WORKLOAD.value,
+      'cloud': FLAGS.cloud,
+  }
+
+  # ── Start CPU background collector ────────────────────────────────────────
+  all_samples: List[sample.Sample] = []
+  stop = threading.Event()
+  cpu_collector = _CpuUtilizationCollector(all_samples, stop)
+
+  # Apply manifest and wait for rollout inside a try/finally so we always
+  # stop the collector even if WaitForRollout raises.
+  try:
+    kubernetes_commands.ApplyManifest(
+        DEPLOYMENT_YAML.value,
+        name='startup',
+        image=image,
+    )
+
+    # Run CPU collector in parallel with the rollout wait, exactly like
+    # KubernetesMetricsCollector in kubernetes_hpa_benchmark.py.
+    collector_thread = threading.Thread(
+        target=cpu_collector.ObserveCpuUtilization,
+        daemon=True,
+    )
+    collector_thread.start()
+
+    kubernetes_commands.WaitForRollout('deployment/startup', timeout=600)
+
+  finally:
+    stop.set()
+    collector_thread.join(timeout=_CPU_POLL_INTERVAL_SECS * 3)
+
+  # ── Parse pod conditions (existing logic, unchanged) ──────────────────────
   pod_name_to_start_end_times: dict[str, tuple[int, int]] = (
       collections.defaultdict(lambda: (0, 0))
   )
@@ -111,14 +194,49 @@ def Run(benchmark_spec: bm_spec.BenchmarkSpec) -> List[sample.Sample]:
           c.epoch_time,
       )
 
+  if not pod_name_to_start_end_times:
+    raise RuntimeError('No pods became ready')
+
+  # ── Metric 1: max_pod_ready_time (existing, unchanged) ───────────────────
   max_pod_ready_t = -1
   for _, times in pod_name_to_start_end_times.items():
     t = times[1] - times[0]
     max_pod_ready_t = max(max_pod_ready_t, t)
 
-  if max_pod_ready_t > -1:
-    return [sample.Sample('max_pod_ready_time', max_pod_ready_t, 'seconds', {})]
-  raise RuntimeError('No pods became ready')
+  if max_pod_ready_t < 0:
+    raise RuntimeError('No pods became ready')
+
+  all_samples.append(
+      sample.Sample(
+          'max_pod_ready_time',
+          max_pod_ready_t,
+          'seconds',
+          {**base_metadata},
+      )
+  )
+
+  # ── Metric 2: per_pod_ready_time (new — PR 1) ────────────────────────────
+  # Emit one Sample per pod so callers can compute p50/p90 across replicas.
+  for pod_name, (start_t, end_t) in pod_name_to_start_end_times.items():
+    pod_ready_t = end_t - start_t
+    if pod_ready_t >= 0:
+      all_samples.append(
+          sample.Sample(
+              'per_pod_ready_time',
+              pod_ready_t,
+              'seconds',
+              {**base_metadata, 'pod_name': pod_name},
+          )
+      )
+
+  logging.info(
+      '[startup] max_pod_ready_time=%.2fs across %d pod(s)',
+      max_pod_ready_t,
+      len(pod_name_to_start_end_times),
+  )
+
+  # CPU samples were appended to all_samples by the collector thread.
+  return all_samples
 
 
 def Cleanup(benchmark_spec: bm_spec.BenchmarkSpec):
@@ -128,3 +246,167 @@ def Cleanup(benchmark_spec: bm_spec.BenchmarkSpec):
     benchmark_spec: The benchmark specification.
   """
   del benchmark_spec
+
+
+# ---------------------------------------------------------------------------
+# CPU Utilization Background Collector (new — PR 1)
+# ---------------------------------------------------------------------------
+
+
+class _CpuUtilizationCollector:
+  """Polls CPU utilization in a background thread during the startup window.
+
+  Follows the KubernetesMetricsCollector / _Observe pattern from
+  kubernetes_hpa_benchmark.py exactly:
+  - _Observe(fn) loops calling fn() and appending results to self._samples.
+  - Stops when self._stop is signalled.
+  - Ignores IssueCommandError / IssueCommandTimeoutError (gaps in data OK).
+
+  Emits three samples on completion:
+    cpu_utilization_peak_millicores   — maximum reading during startup window.
+    cpu_utilization_mean_millicores   — mean across all polls.
+    cpu_utilization_reading_count     — number of successful polls.
+  """
+
+  def __init__(
+      self,
+      samples: List[sample.Sample],
+      stop: threading.Event,
+  ):
+    """Initialises the collector.
+
+    Args:
+      samples: Shared sample list.  CPU samples are appended here when
+        ObserveCpuUtilization() finishes.
+      stop: Threading event.  Collector loops until this is set.
+    """
+    self._samples = samples
+    self._stop = stop
+    self._readings: List[float] = []
+    self._lock = threading.Lock()
+
+  def ObserveCpuUtilization(self) -> None:
+    """Polls CPU millicores until stop is set; appends aggregate samples.
+
+    Intended to be run in a background thread alongside WaitForRollout().
+    Matches the ObserveNumReplicas / ObserveNumNodes pattern in
+    kubernetes_hpa_benchmark.py.
+    """
+    self._Observe(self._PollCpuMillicoresSample)
+
+    # Emit aggregate samples after the loop ends.
+    with self._lock:
+      readings = list(self._readings)
+
+    if not readings:
+      logging.warning('[startup/cpu] No CPU readings collected.')
+      return
+
+    peak = max(readings)
+    mean = sum(readings) / len(readings)
+    count = len(readings)
+
+    logging.info(
+        '[startup/cpu] peak=%.1f mean=%.1f count=%d millicores',
+        peak, mean, count,
+    )
+
+    self._samples.extend([
+        sample.Sample(
+            'cpu_utilization_peak_millicores', peak, 'millicores', {}
+        ),
+        sample.Sample(
+            'cpu_utilization_mean_millicores', mean, 'millicores', {}
+        ),
+        sample.Sample(
+            'cpu_utilization_reading_count', count, 'count', {}
+        ),
+    ])
+
+  def _PollCpuMillicoresSample(self) -> List[sample.Sample]:
+    """Issues kubectl top pods and returns a transient sample list.
+
+    The return value is a list so _Observe() can call self._samples.extend()
+    on it (matching the KubernetesMetricsCollector interface).  The actual
+    reading is also stored in self._readings for aggregate computation.
+
+    Returns:
+      A single-element list with the current CPU reading, or empty on error.
+    """
+    cpu_m = _GetTotalCpuMillicores()
+    if cpu_m is None:
+      return []
+    with self._lock:
+      self._readings.append(cpu_m)
+    # Return an empty list — we do NOT emit a per-poll sample (too noisy).
+    # Aggregates are emitted in ObserveCpuUtilization() after the loop.
+    return []
+
+  def _Observe(
+      self,
+      observe_fn: Callable[[], List[sample.Sample]],
+  ) -> None:
+    """Calls observe_fn in a loop until self._stop is set.
+
+    Copied verbatim from KubernetesMetricsCollector._Observe() in
+    kubernetes_hpa_benchmark.py — same error handling, same 1 s wait.
+
+    Args:
+      observe_fn: Function returning a list of samples to extend into
+        self._samples.
+    """
+    success_count = 0
+    failure_count = 0
+    while True:
+      try:
+        self._samples.extend(observe_fn())
+        success_count += 1
+      except (
+          errors.VmUtil.IssueCommandError,
+          errors.VmUtil.IssueCommandTimeoutError,
+      ) as e:
+        logging.warning(
+            '[startup/cpu] Ignoring poll error (gap in data): %s', e
+        )
+        failure_count += 1
+
+      if self._stop.wait(timeout=_CPU_POLL_INTERVAL_SECS):
+        logging.info(
+            '[startup/cpu] Stopping after %d successes / %d failures',
+            success_count, failure_count,
+        )
+        return
+
+
+def _GetTotalCpuMillicores() -> float | None:
+  """Returns total CPU millicores across all pods via kubectl top pods.
+
+  Returns:
+    Total CPU millicores, or None if the command fails or output is empty.
+  """
+  try:
+    from perfkitbenchmarker.resources.container_service import kubectl  # pylint: disable=g-import-not-at-top
+    stdout, _, rc = kubectl.RunKubectlCommand(
+        ['top', 'pods', '--no-headers'],
+        raise_on_failure=False,
+    )
+    if rc != 0 or not stdout.strip():
+      return None
+
+    total_m = 0.0
+    for line in stdout.strip().splitlines():
+      parts = line.split()
+      # kubectl top format: NAME  CPU(cores)  MEMORY(bytes)
+      if len(parts) < 2:
+        continue
+      cpu_str = parts[1]
+      if cpu_str.endswith('m'):
+        total_m += float(cpu_str[:-1])
+      else:
+        # Expressed as fractional cores (e.g. "1" = 1000m).
+        total_m += float(cpu_str) * 1000.0
+
+    return total_m
+  except (ValueError, IndexError) as e:
+    logging.debug('[startup/cpu] Parse error: %s', e)
+    return None

--- a/perfkitbenchmarker/linux_benchmarks/kubernetes_deployment_startup_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/kubernetes_deployment_startup_benchmark.py
@@ -31,9 +31,71 @@ Changes vs PR 2:
   - CheckPrerequisites(): raises if scenario=optimized is used on non-GCP.
   - Run(): adds scenario to all sample metadata for cross-config comparison.
 
+PR 4 — CPU Startup Boost for vLLM
+==========================================================================
+scenario=optimized is no longer JVM-only. AI/inference workloads spend a
+large share of startup loading models into memory, so the same GKE VPA
+CPU Startup Boost mechanism used for the JVM workload is now wired into
+the vLLM Prepare() path too -- same code, same
+--kubernetes_deployment_startup_scenario / _workload flags, just toggled
+per run.
+
+  - CheckPrerequisites(): no longer raises for workload=vllm; only the
+    cloud=GCP restriction remains for scenario=optimized.
+  - Prepare(): VPA apply-before-deployment ordering now runs for either
+    workload, targeting whichever Deployment name is active
+    (startup / vllm-startup).
+  - The VPA manifest's CPU ceiling (resourcePolicy.maxAllowed.cpu) and
+    startupBoost.cpu.durationSeconds are now template parameters instead
+    of hardcoded values -- vLLM's baseline CPU request (2 cores) already
+    exceeds the JVM-tuned ceiling of "1", and model loading is expected
+    to take longer than the JVM's ~67s baseline that the old fixed 120s
+    duration was sized for. New optional flags
+    (kubernetes_deployment_startup_vpa_max_cpu /
+    _vpa_duration_seconds) override the per-workload defaults if they
+    don't fit a given model/image.
+
+PR 5 — Fix vLLM crash-loop from default GPU memory utilization
+==========================================================================
+Production runs of workload=vllm crash-looped indefinitely (readiness
+probe never passed, deployment exceeded its progress deadline) with:
+  ValueError: Available memory on node 0 (2.12/4.0 GiB) on startup is
+  less than desired CPU memory utilization (0.92, 3.68 GiB).
+vLLM's CPU backend defaults --gpu-memory-utilization to ~0.9 (despite the
+GPU-sounding name, it also governs the CPU backend), which assumes far
+more headroom than this benchmark's 4Gi container memory limit provides
+once Python/PyTorch/runtime overhead is subtracted. Raising the memory
+limit to compensate would require an impractically large allocation (the
+observed ~1.88GiB of fixed overhead means the limit would need to be
+~23GiB just to satisfy the default 92% reservation) -- the container's
+memory limit was never the actual bottleneck, vLLM's default utilization
+fraction was.
+
+  - New VLLM_GPU_MEMORY_UTILIZATION flag
+    (kubernetes_deployment_startup_vllm_gpu_memory_utilization, default
+    0.5) passed to the vLLM container as a `--gpu-memory-utilization`
+    arg in vllm.yaml.j2, keeping the reservation within the headroom
+    actually available under the existing 4Gi limit.
+
+PR 6 — Fix vLLM OOMKill during compile/warmup (4Gi limit was too small)
+==========================================================================
+PR 5's fix stopped the deterministic startup ValueError, but production
+runs still OOMKilled (exit 137) a few minutes later, during the "Warming
+up model for the compilation..." phase -- confirmed via `kubectl
+describe pod` (State: Terminated, Reason: OOMKilled) and `kubectl top
+pods` showing RSS plateau right at the 4Gi limit before the pod reset.
+Lowering --gpu-memory-utilization from 0.5 to 0.3 (shrinking the KV
+cache reservation by ~800MiB) made no measurable difference to the
+observed peak (4041Mi vs 4044Mi) -- the overage comes from
+compile/warmup buffers, a cost that's largely fixed regardless of KV
+cache sizing, so gpu_memory_utilization alone can't fix it.
+
+  - New VLLM_MEMORY_LIMIT flag (kubernetes_deployment_startup_vllm_
+    memory_limit, default "8Gi") templated into vllm.yaml.j2's
+    requests/limits.memory (kept equal to preserve Guaranteed QoS),
+    replacing the old hardcoded 4Gi.
+
 Exact VPA startup-boost policy fields follow Kam's linked guide.
-vLLM + optimized combination is not supported (GKE VPA boost targets the
-JVM slow-start workload specifically).
 """
 
 import collections
@@ -109,6 +171,40 @@ VLLM_YAML = flags.DEFINE_string(
     'Deployment yaml for the vLLM workload.',
 )
 
+# ── New flags (PR 5) ──────────────────────────────────────────────────────
+VLLM_GPU_MEMORY_UTILIZATION = flags.DEFINE_float(
+    'kubernetes_deployment_startup_vllm_gpu_memory_utilization',
+    0.5,
+    "Fraction of the vLLM container's memory limit to reserve for model "
+    + "weights/KV cache -- vLLM's --gpu-memory-utilization flag, which "
+    + 'despite the name also governs the CPU backend. vLLM defaults to '
+    + "~0.9, which assumes far more headroom than this benchmark's 4Gi "
+    + 'container memory limit provides once Python/PyTorch/runtime '
+    + 'overhead is subtracted -- confirmed in production logs as a '
+    + 'deterministic crash-loop ("ValueError: Available memory ... is '
+    + 'less than desired CPU memory utilization"). 0.5 keeps the '
+    + 'reservation within the observed available headroom on a 4Gi limit.',
+    lower_bound=0.05,
+    upper_bound=0.95,
+)
+
+# ── New flags (PR 6) ──────────────────────────────────────────────────────
+VLLM_MEMORY_LIMIT = flags.DEFINE_string(
+    'kubernetes_deployment_startup_vllm_memory_limit',
+    '8Gi',
+    "vLLM container's requests/limits.memory (Kubernetes quantity, e.g."
+    + ' "8Gi"). Production runs OOMKilled (exit 137) against the prior'
+    + ' hardcoded 4Gi limit during the "Warming up model for the'
+    + ' compilation..." phase, even after lowering'
+    + ' --gpu-memory-utilization from 0.5 to 0.3 -- observed peak RSS'
+    + ' stayed ~4.0GiB in both cases (4041Mi vs 4044Mi), confirming the'
+    + ' overage is compile/warmup overhead largely independent of the KV'
+    + ' cache reservation, not something --gpu-memory-utilization alone'
+    + ' can fix. 8Gi keeps the pod Guaranteed QoS (requests == limits)'
+    + ' and fits comfortably on the n2-standard-4 nodes used for'
+    + ' baseline vLLM runs (~16GiB allocatable).',
+)
+
 # ── New flags (PR 3) ──────────────────────────────────────────────────────
 BOOST_FACTOR = flags.DEFINE_integer(
     'kubernetes_deployment_startup_boost_factor',
@@ -124,12 +220,52 @@ VPA_YAML = flags.DEFINE_string(
     'VPA manifest for CPU Startup Boost (scenario=optimized, GCP only).',
 )
 
+# ── New flags (PR 4) ──────────────────────────────────────────────────────
+VPA_MAX_CPU = flags.DEFINE_string(
+    'kubernetes_deployment_startup_vpa_max_cpu',
+    None,
+    'Ceiling for the VPA CPU Startup Boost '
+    + '(resourcePolicy.containerPolicies[0].maxAllowed.cpu). If unset, '
+    + 'defaults to "1" for --kubernetes_deployment_startup_workload=jvm and '
+    + '"4" for =vllm (scenario=optimized only) -- vLLM already requests 2 '
+    + 'full cores at baseline, which exceeds the JVM-tuned "1" ceiling.',
+)
+VPA_DURATION_SECONDS = flags.DEFINE_integer(
+    'kubernetes_deployment_startup_vpa_duration_seconds',
+    None,
+    'How long, in seconds, the VPA keeps the CPU boost applied before '
+    + 'scaling back down (startupBoost.cpu.durationSeconds). If unset, '
+    + 'defaults to 120 for workload=jvm and 300 for workload=vllm '
+    + '(scenario=optimized only) -- sized to comfortably exceed each '
+    + "workload's observed baseline startup time; a boost that reverts "
+    + 'before the workload is ready defeats the point.',
+    lower_bound=1,
+)
+
 _JVM_DEPLOYMENT_NAME = 'startup'
 _VLLM_DEPLOYMENT_NAME = 'vllm-startup'
 _CPU_POLL_INTERVAL_SECS = 5
 
 _VPA_CRD_NAME = 'verticalpodautoscalers.autoscaling.k8s.io'
 _VPA_CRD_WAIT_TIMEOUT_SECS = 180
+
+# PR 4: per-workload VPA sizing defaults, overridable via VPA_MAX_CPU /
+# VPA_DURATION_SECONDS. vLLM's baseline CPU request (2 cores, see
+# vllm.yaml.j2) already exceeds the JVM-tuned "1" ceiling, and model
+# loading is expected to take longer than the JVM's ~67s baseline that
+# 120s was originally sized for.
+_VPA_DEFAULT_MAX_CPU = {'jvm': '1', 'vllm': '4'}
+_VPA_DEFAULT_DURATION_SECONDS = {'jvm': 120, 'vllm': 300}
+
+
+def _GetVpaMaxCpu(workload: str) -> str:
+  """Returns the VPA CPU ceiling for the given workload."""
+  return VPA_MAX_CPU.value or _VPA_DEFAULT_MAX_CPU[workload]
+
+
+def _GetVpaDurationSeconds(workload: str) -> int:
+  """Returns the VPA boost duration (seconds) for the given workload."""
+  return VPA_DURATION_SECONDS.value or _VPA_DEFAULT_DURATION_SECONDS[workload]
 
 
 def _WaitForVpaCrd() -> None:
@@ -214,28 +350,23 @@ def CheckPrerequisites(_) -> None:
     _: Unused benchmark spec (required by PKB interface).
 
   Raises:
-    ValueError: If scenario=optimized is used on non-GCP or with vLLM.
+    ValueError: If scenario=optimized is used on a non-GCP cloud. (PR 4:
+      scenario=optimized is supported for both workload=jvm and
+      workload=vllm -- only the GKE/cloud restriction remains.)
   """
-  if SCENARIO.value == 'optimized':
-    if FLAGS.cloud != 'GCP':
-      raise ValueError(
-          '--kubernetes_deployment_startup_scenario=optimized requires '
-          f'--cloud=GCP (GKE only). Got --cloud={FLAGS.cloud}.'
-      )
-    if WORKLOAD.value == 'vllm':
-      raise ValueError(
-          '--kubernetes_deployment_startup_scenario=optimized is only '
-          'supported with --kubernetes_deployment_startup_workload=jvm. '
-          'VPA CPU Startup Boost targets the JVM slow-start workload.'
-      )
+  if SCENARIO.value == 'optimized' and FLAGS.cloud != 'GCP':
+    raise ValueError(
+        '--kubernetes_deployment_startup_scenario=optimized requires '
+        f'--cloud=GCP (GKE only). Got --cloud={FLAGS.cloud}.'
+    )
 
 
 def Prepare(benchmark_spec: bm_spec.BenchmarkSpec):
   """Prepares the Kubernetes cluster for the benchmark.
 
-  For scenario=optimized, first deploys a VerticalPodAutoscaler manifest
-  with a startup boost policy targeting the JVM deployment, and only then
-  deploys the JVM deployment itself.
+  For scenario=optimized (either workload, PR 4), first deploys a
+  VerticalPodAutoscaler manifest with a startup boost policy targeting
+  the active Deployment, and only then deploys the Deployment itself.
 
   Ordering matters here: GKE's CPU Startup Boost takes effect via a
   mutating admission webhook that intercepts *new* pod creation events.
@@ -262,6 +393,31 @@ def Prepare(benchmark_spec: bm_spec.BenchmarkSpec):
   image = benchmark_spec.container_specs['kubernetes_deployment_startup'].image
   workload = WORKLOAD.value
   scenario = SCENARIO.value
+  deployment_name = (
+      _VLLM_DEPLOYMENT_NAME if workload == 'vllm' else _JVM_DEPLOYMENT_NAME
+  )
+
+  # PR 4: apply VPA with startup boost for optimized scenario BEFORE the
+  # deployment, for either workload, so the boost's admission-time
+  # mutation applies to the very first pod this benchmark measures (see
+  # docstring above). Sizing (CPU ceiling / boost duration) is
+  # per-workload since vLLM's baseline CPU footprint and model-load time
+  # are both much larger than the JVM's.
+  if scenario == 'optimized':
+    _WaitForVpaCrd()
+    logging.info(
+        '[startup] scenario=optimized workload=%s: VPA boost_factor=%d'
+        + ' applied first',
+        workload,
+        BOOST_FACTOR.value,
+    )
+    kubernetes_commands.ApplyManifest(
+        VPA_YAML.value,
+        name=deployment_name,
+        boost_factor=BOOST_FACTOR.value,
+        max_allowed_cpu=_GetVpaMaxCpu(workload),
+        duration_seconds=_GetVpaDurationSeconds(workload),
+    )
 
   if workload == 'vllm':
     logging.info('[startup] Deploying vLLM workload (image=%s)', image)
@@ -269,23 +425,10 @@ def Prepare(benchmark_spec: bm_spec.BenchmarkSpec):
         VLLM_YAML.value,
         name=_VLLM_DEPLOYMENT_NAME,
         image=image,
+        gpu_memory_utilization=VLLM_GPU_MEMORY_UTILIZATION.value,
+        memory_limit=VLLM_MEMORY_LIMIT.value,
     )
   else:
-    # PR 3: apply VPA with startup boost for optimized scenario BEFORE the
-    # deployment, so the boost's admission-time mutation applies to the
-    # very first pod this benchmark measures (see docstring above).
-    if scenario == 'optimized':
-      _WaitForVpaCrd()
-      logging.info(
-          '[startup] scenario=optimized: VPA boost_factor=%d applied first',
-          BOOST_FACTOR.value,
-      )
-      kubernetes_commands.ApplyManifest(
-          VPA_YAML.value,
-          name=_JVM_DEPLOYMENT_NAME,
-          boost_factor=BOOST_FACTOR.value,
-      )
-
     logging.info('[startup] Deploying JVM workload (image=%s)', image)
     kubernetes_commands.ApplyManifest(
         DEPLOYMENT_YAML.value,

--- a/perfkitbenchmarker/linux_benchmarks/kubernetes_deployment_startup_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/kubernetes_deployment_startup_benchmark.py
@@ -111,8 +111,8 @@ VLLM_YAML = flags.DEFINE_string(
 BOOST_FACTOR = flags.DEFINE_integer(
     'kubernetes_deployment_startup_boost_factor',
     2,
-    'CPU Startup Boost factor for VPA (scenario=optimized only). '
-    'Matches Kam\'s recommended "factor of 2 or 3". GCP only.',
+    'CPU Startup Boost factor for VPA (scenario=optimized only, GCP only). '
+    + 'Matches Kam\'s recommended "factor of 2 or 3".',
     lower_bound=1,
     upper_bound=10,
 )
@@ -172,7 +172,7 @@ def CheckPrerequisites(_) -> None:
   if SCENARIO.value == 'optimized':
     if FLAGS.cloud != 'GCP':
       raise ValueError(
-          f'--kubernetes_deployment_startup_scenario=optimized requires '
+          '--kubernetes_deployment_startup_scenario=optimized requires '
           f'--cloud=GCP (GKE only). Got --cloud={FLAGS.cloud}.'
       )
     if WORKLOAD.value == 'vllm':
@@ -186,8 +186,18 @@ def CheckPrerequisites(_) -> None:
 def Prepare(benchmark_spec: bm_spec.BenchmarkSpec):
   """Prepares the Kubernetes cluster for the benchmark.
 
-  For scenario=optimized, also deploys a VerticalPodAutoscaler manifest
-  with a startup boost policy targeting the JVM deployment.
+  For scenario=optimized, first deploys a VerticalPodAutoscaler manifest
+  with a startup boost policy targeting the JVM deployment, and only then
+  deploys the JVM deployment itself.
+
+  Ordering matters here: GKE's CPU Startup Boost takes effect via a
+  mutating admission webhook that intercepts *new* pod creation events.
+  If the Deployment (and its first pod) were applied before the VPA
+  object exists, that pod's initial CPU request would never be boosted,
+  and this benchmark would end up measuring an unboosted startup even
+  though scenario=optimized was requested. The VPA is safe to create
+  before its targetRef Deployment exists -- it simply waits for the
+  target to appear.
 
   Args:
     benchmark_spec: The benchmark specification.
@@ -204,17 +214,12 @@ def Prepare(benchmark_spec: bm_spec.BenchmarkSpec):
         image=image,
     )
   else:
-    logging.info('[startup] Deploying JVM workload (image=%s)', image)
-    kubernetes_commands.ApplyManifest(
-        DEPLOYMENT_YAML.value,
-        name=_JVM_DEPLOYMENT_NAME,
-        image=image,
-    )
-
-    # PR 3: apply VPA with startup boost for optimized scenario.
+    # PR 3: apply VPA with startup boost for optimized scenario BEFORE the
+    # deployment, so the boost's admission-time mutation applies to the
+    # very first pod this benchmark measures (see docstring above).
     if scenario == 'optimized':
       logging.info(
-          '[startup] scenario=optimized: applying VPA with boost_factor=%d',
+          '[startup] scenario=optimized: VPA boost_factor=%d applied first',
           BOOST_FACTOR.value,
       )
       kubernetes_commands.ApplyManifest(
@@ -222,6 +227,13 @@ def Prepare(benchmark_spec: bm_spec.BenchmarkSpec):
           name=_JVM_DEPLOYMENT_NAME,
           boost_factor=BOOST_FACTOR.value,
       )
+
+    logging.info('[startup] Deploying JVM workload (image=%s)', image)
+    kubernetes_commands.ApplyManifest(
+        DEPLOYMENT_YAML.value,
+        name=_JVM_DEPLOYMENT_NAME,
+        image=image,
+    )
 
 
 def Run(benchmark_spec: bm_spec.BenchmarkSpec) -> List[sample.Sample]:
@@ -242,16 +254,24 @@ def Run(benchmark_spec: bm_spec.BenchmarkSpec) -> List[sample.Sample]:
   For scenario=optimized, the VPA startup boost is already active from
   Prepare() — no additional Run() changes needed.
 
+  Required metrics fail loudly rather than silently degrading: if a
+  metric can't be computed at all for the whole run, this raises instead
+  of logging a warning and returning partial results. (A silent warning
+  here is exactly what let a prior VPA-ordering bug ship a "successful"
+  optimized-scenario run that never actually applied the CPU boost.)
+
   Args:
     benchmark_spec: The benchmark specification.
 
   Raises:
-    RuntimeError: If no pods become ready.
+    RuntimeError: If no pods become ready, if no pod had both a
+      PodRunning and Ready timestamp (startup_latency uncomputable), or
+      if zero CPU utilization readings were collected all run.
 
   Returns:
     List of sample.Sample objects.
   """
-  image = benchmark_spec.container_specs['kubernetes_deployment_startup'].image
+  del benchmark_spec  # Image/deployment name are resolved via flags below.
   workload = WORKLOAD.value
   scenario = SCENARIO.value
 
@@ -272,10 +292,20 @@ def Run(benchmark_spec: bm_spec.BenchmarkSpec) -> List[sample.Sample]:
   all_samples: List[sample.Sample] = []
   stop = threading.Event()
   cpu_collector = _CpuUtilizationCollector(all_samples, stop)
+  collector_errors: List[BaseException] = []
+
+  def _RunCollector() -> None:
+    # Runs in a background thread: exceptions raised here (e.g. zero CPU
+    # readings collected all run) don't propagate to the main thread on
+    # their own, so capture and re-raise below once the thread is joined.
+    try:
+      cpu_collector.ObserveCpuUtilization()
+    except Exception as e:  # pylint: disable=broad-except
+      collector_errors.append(e)
 
   try:
     collector_thread = threading.Thread(
-        target=cpu_collector.ObserveCpuUtilization,
+        target=_RunCollector,
         daemon=True,
     )
     collector_thread.start()
@@ -287,6 +317,9 @@ def Run(benchmark_spec: bm_spec.BenchmarkSpec) -> List[sample.Sample]:
   finally:
     stop.set()
     collector_thread.join(timeout=_CPU_POLL_INTERVAL_SECS * 3)
+
+  if collector_errors:
+    raise collector_errors[0]
 
   # ── Parse pod conditions ──────────────────────────────────────────────
   # max_pod_ready_time uses PodReadyToStartContainers -> Ready (existing).
@@ -380,29 +413,29 @@ def Run(benchmark_spec: bm_spec.BenchmarkSpec) -> List[sample.Sample]:
         )
     )
 
-  if max_startup_latency >= 0:
-    all_samples.append(
-        sample.Sample(
-            'startup_latency',
-            max_startup_latency,
-            'seconds',
-            {**base_metadata},
-        )
-    )
-  else:
-    logging.warning(
-        '[startup] Could not compute startup_latency: no pod had both a'
+  if max_startup_latency < 0:
+    raise RuntimeError(
+        'Could not compute startup_latency: no pod had both a'
         ' PodRunning and Ready timestamp (container runtime may not report'
         ' containerStatuses[].state.running.startedAt on this cluster).'
     )
 
+  all_samples.append(
+      sample.Sample(
+          'startup_latency',
+          max_startup_latency,
+          'seconds',
+          {**base_metadata},
+      )
+  )
+
   logging.info(
       '[startup] scenario=%s workload=%s max_pod_ready_time=%.2fs'
-      ' startup_latency=%s pods=%d',
+      + ' startup_latency=%.2fs pods=%d',
       scenario,
       workload,
       max_pod_ready_t,
-      max_startup_latency if max_startup_latency >= 0 else 'n/a',
+      max_startup_latency,
       len(pod_name_to_start_end_times),
   )
 
@@ -433,17 +466,39 @@ class _CpuUtilizationCollector:
     self._lock = threading.Lock()
 
   def ObserveCpuUtilization(self) -> None:
+    """Polls CPU utilization for the duration of the run.
+
+    Transient poll failures (e.g. the Kubernetes Metrics API still
+    warming up on a freshly created cluster) are tolerated by _Observe
+    and simply retried. This only raises if the metric ends up with zero
+    data for the entire run -- the same standard applied to
+    startup_latency, so a total collection failure is surfaced as a
+    benchmark failure instead of silently shipping incomplete results.
+
+    Raises:
+      RuntimeError: If not a single CPU reading was collected all run.
+    """
     self._Observe(self._PollCpuMillicoresSample)
     with self._lock:
       readings = list(self._readings)
     if not readings:
-      return
+      raise RuntimeError(
+          'Collected zero CPU utilization readings for the entire run --'
+          ' the Kubernetes Metrics API may never have become available.'
+          ' cpu_utilization_peak/mean_millicores cannot be computed.'
+      )
     peak = max(readings)
     mean = sum(readings) / len(readings)
     self._samples.extend([
-        sample.Sample('cpu_utilization_peak_millicores', peak, 'millicores', {}),
-        sample.Sample('cpu_utilization_mean_millicores', mean, 'millicores', {}),
-        sample.Sample('cpu_utilization_reading_count', len(readings), 'count', {}),
+        sample.Sample(
+            'cpu_utilization_peak_millicores', peak, 'millicores', {}
+        ),
+        sample.Sample(
+            'cpu_utilization_mean_millicores', mean, 'millicores', {}
+        ),
+        sample.Sample(
+            'cpu_utilization_reading_count', len(readings), 'count', {}
+        ),
     ])
 
   def _PollCpuMillicoresSample(self) -> List[sample.Sample]:
@@ -468,8 +523,16 @@ class _CpuUtilizationCollector:
 
 
 def _GetTotalCpuMillicores() -> float | None:
+  """Returns summed CPU millicores across pods from `kubectl top`, or None.
+
+  Returns None (rather than raising) on any parse/command failure so a
+  single bad poll doesn't take down the whole collector loop; _Observe
+  above retries on the next poll interval regardless.
+  """
   try:
-    from perfkitbenchmarker.resources.container_service import kubectl  # pylint: disable=g-import-not-at-top
+    # pylint: disable=import-outside-toplevel
+    from perfkitbenchmarker.resources.container_service import kubectl
+
     stdout, _, rc = kubectl.RunKubectlCommand(
         ['top', 'pods', '--no-headers'], raise_on_failure=False
     )
@@ -481,7 +544,10 @@ def _GetTotalCpuMillicores() -> float | None:
       if len(parts) < 2:
         continue
       cpu_str = parts[1]
-      total_m += float(cpu_str[:-1]) if cpu_str.endswith('m') else float(cpu_str) * 1000.0
+      if cpu_str.endswith('m'):
+        total_m += float(cpu_str[:-1])
+      else:
+        total_m += float(cpu_str) * 1000.0
     return total_m
   except (ValueError, IndexError):
     return None

--- a/perfkitbenchmarker/resources/container_service/kubernetes_conditions.py
+++ b/perfkitbenchmarker/resources/container_service/kubernetes_conditions.py
@@ -64,12 +64,53 @@ class KubernetesStatusCondition:
     )
 
 
+def _GetPodRunningCondition(item: dict[str, Any]) -> dict[str, Any] | None:
+  """Synthesizes a 'PodRunning' pseudo-condition for a pod item.
+
+  Kubernetes does not report a 'PodRunning' entry in .status.conditions
+  (pod phase transitions aren't conditions). The closest equivalent
+  timestamp is when the pod's container(s) actually started running,
+  available at .status.containerStatuses[].state.running.startedAt. This
+  is used to compute Startup Latency (PodRunning -> Ready), distinct from
+  Max Pod Ready Time (PodReadyToStartContainers -> Ready).
+
+  For multi-container pods, the latest startedAt across containers is
+  used (the pod isn't fully "running" until all containers are).
+
+  Args:
+    item: A single pod item from `kubectl get pod -o json`.
+
+  Returns:
+    A synthetic condition dict compatible with KubernetesStatusCondition, or
+    None if no container has started running yet.
+  """
+  container_statuses = item.get('status', {}).get('containerStatuses', [])
+  started_at_times = [
+      cs['state']['running']['startedAt']
+      for cs in container_statuses
+      if 'running' in cs.get('state', {}) and cs['state']['running'].get(
+          'startedAt'
+      )
+  ]
+  if not started_at_times:
+    return None
+  return {
+      'type': 'PodRunning',
+      'lastTransitionTime': max(started_at_times),
+  }
+
+
 def GetStatusConditionsForResourceType(
     resource_type: str,
     resources_to_ignore: abc.Set[str] = frozenset(),
     suppress_logging: bool = False,
 ) -> list[KubernetesStatusCondition]:
   """Returns the status conditions for a resource type.
+
+  For pods, this also includes a synthetic 'PodRunning' condition (see
+  _GetPodRunningCondition) alongside the real .status.conditions entries,
+  so callers can compute Startup Latency the same way they compute
+  Max Pod Ready Time.
 
   Args:
     resource_type: The type of the resource to get the status conditions for.
@@ -103,6 +144,10 @@ def GetStatusConditionsForResourceType(
       ]
     name_to_metadata[name] = found_metadata
     conditions = item.get('status', {}).get('conditions')
+    if resource_type == 'pod':
+      pod_running_condition = _GetPodRunningCondition(item)
+      if pod_running_condition is not None:
+        conditions = list(conditions or []) + [pod_running_condition]
     if name is not None and conditions is not None:
       name_to_conditions[name] = conditions
 

--- a/tests/kubernetes_conditions_test.py
+++ b/tests/kubernetes_conditions_test.py
@@ -178,6 +178,108 @@ class KubernetesConditionsTest(pkb_common_test_case.PkbCommonTestCase):
     )
     self.assertLen(conditions, 2)
 
+  def testPodRunningSynthesizedFromContainerStatuses(self):
+    stdout = json.dumps({
+        'items': [{
+            'metadata': {'name': 'pod123'},
+            'status': {
+                'conditions': [
+                    {
+                        'lastProbeTime': None,
+                        'lastTransitionTime': '1970-01-01T00:01:19Z',
+                        'status': 'True',
+                        'type': 'Ready',
+                    },
+                ],
+                'containerStatuses': [{
+                    'name': 'main',
+                    'state': {
+                        'running': {'startedAt': '1970-01-01T00:01:05Z'}
+                    },
+                }],
+            },
+        }]
+    })
+    self.enter_context(
+        mock.patch.object(
+            kubectl,
+            'RunKubectlCommand',
+            return_value=(stdout, '', 0),
+        )
+    )
+    conditions = kubernetes_conditions.GetStatusConditionsForResourceType(
+        'pod',
+        frozenset(),
+    )
+    events = {c.event: c.epoch_time for c in conditions}
+    self.assertIn('PodRunning', events)
+    self.assertEqual(events['PodRunning'], 65)
+    self.assertEqual(events['Ready'], 79)
+
+  def testPodRunningUsesLatestContainerAmongMultiple(self):
+    stdout = json.dumps({
+        'items': [{
+            'metadata': {'name': 'pod123'},
+            'status': {
+                'conditions': [],
+                'containerStatuses': [
+                    {
+                        'name': 'sidecar',
+                        'state': {
+                            'running': {'startedAt': '1970-01-01T00:00:10Z'}
+                        },
+                    },
+                    {
+                        'name': 'main',
+                        'state': {
+                            'running': {'startedAt': '1970-01-01T00:00:20Z'}
+                        },
+                    },
+                ],
+            },
+        }]
+    })
+    self.enter_context(
+        mock.patch.object(
+            kubectl,
+            'RunKubectlCommand',
+            return_value=(stdout, '', 0),
+        )
+    )
+    conditions = kubernetes_conditions.GetStatusConditionsForResourceType(
+        'pod',
+        frozenset(),
+    )
+    running = [c for c in conditions if c.event == 'PodRunning']
+    self.assertLen(running, 1)
+    self.assertEqual(running[0].epoch_time, 20)
+
+  def testNoPodRunningWhenNoContainerIsRunningYet(self):
+    stdout = json.dumps({
+        'items': [{
+            'metadata': {'name': 'pod123'},
+            'status': {
+                'conditions': [],
+                'containerStatuses': [{
+                    'name': 'main',
+                    'state': {'waiting': {'reason': 'ContainerCreating'}},
+                }],
+            },
+        }]
+    })
+    self.enter_context(
+        mock.patch.object(
+            kubectl,
+            'RunKubectlCommand',
+            return_value=(stdout, '', 0),
+        )
+    )
+    conditions = kubernetes_conditions.GetStatusConditionsForResourceType(
+        'pod',
+        frozenset(),
+    )
+    self.assertEmpty(conditions)
+
   def testStatusConditionsWithInstanceType(self):
     stdout = json.dumps({
         'items': [

--- a/tests/linux_benchmarks/kubernetes_deployment_startup_benchmark_test.py
+++ b/tests/linux_benchmarks/kubernetes_deployment_startup_benchmark_test.py
@@ -1,4 +1,4 @@
-# Copyright 2024 PerfKitBenchmarker Authors. All rights reserved.
+# Copyright 2025 PerfKitBenchmarker Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,379 +11,438 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests for kubernetes_deployment_startup_benchmark and startup_metrics.
-
-PR 1 — Metrics & Observability (Layer 0)
-"""
+"""Tests for kubernetes_deployment_startup_benchmark (PR 1 + PR 2 + PR 3)."""
 
 import threading
-import time
 import unittest
 from unittest import mock
 
 from absl.testing import flagsaver
-from perfkitbenchmarker import benchmark_spec
 from perfkitbenchmarker import errors
-from perfkitbenchmarker import sample
-from perfkitbenchmarker.linux_benchmarks import kubernetes_deployment_startup_benchmark as bench
-from perfkitbenchmarker.linux_benchmarks import kubernetes_deployment_startup_benchmark as kdsb
-from perfkitbenchmarker.resources.container_service import kubernetes_commands
-from perfkitbenchmarker.resources.container_service import kubernetes_conditions
+from perfkitbenchmarker.linux_benchmarks import (
+    kubernetes_deployment_startup_benchmark as bench,
+)
 from tests import pkb_common_test_case
 
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-_BASE_METADATA = {
-    'workload': 'jvm',
-    'scenario': 'baseline',
-    'cloud': 'GCP',
-    'replicas': 1,
-    'namespace': 'default',
-    'app_label': 'slowjvmstartup',
-}
+def _MakeCondition(resource_name, event, epoch_time):
+  """Returns a mock KubernetesStatusCondition."""
+  c = mock.MagicMock()
+  c.resource_name = resource_name
+  c.event = event
+  c.epoch_time = epoch_time
+  return c
 
 
-def _MakePodJson(
-    pod_name: str,
-    scheduled_ts: str,
-    started_at: str | None = None,
-    ready_ts: str | None = None,
-) -> dict:
-  """Builds a minimal pod JSON dict for testing."""
-  conditions = [
-      {
-          'type': 'PodScheduled',
-          'status': 'True',
-          'lastTransitionTime': scheduled_ts,
-      }
-  ]
-  if ready_ts:
-    conditions.append({
-        'type': 'Ready',
-        'status': 'True',
-        'lastTransitionTime': ready_ts,
-    })
-
-  container_statuses = []
-  if started_at:
-    container_statuses = [{
-        'name': 'app',
-        'ready': True,
-        'state': {'running': {'startedAt': started_at}},
-    }]
-
-  return {
-      'metadata': {'name': pod_name},
-      'status': {
-          'startTime': scheduled_ts,
-          'conditions': conditions,
-          'containerStatuses': container_statuses,
-      },
+def _MakeSpec(image='slowjvmstartup'):
+  """Returns a mock BenchmarkSpec."""
+  bm = mock.MagicMock()
+  bm.container_specs = {
+      'kubernetes_deployment_startup': mock.MagicMock(image=image)
   }
+  return bm
+
+
+def _DefaultConditions():
+  return [
+      _MakeCondition('pod-0', 'PodReadyToStartContainers', 1000),
+      _MakeCondition('pod-0', 'Ready', 1030),
+  ]
+
+
+def _RunWithConditions(conditions, flag_kwargs=None):
+  """Runs bench.Run() with mocked kubectl calls."""
+  flag_kwargs = flag_kwargs or {'cloud': 'GCP'}
+  with mock.patch.object(
+      bench.kubernetes_commands, 'ApplyManifest'
+  ), mock.patch.object(
+      bench.kubernetes_commands, 'WaitForRollout'
+  ), mock.patch.object(
+      bench.kubernetes_conditions,
+      'GetStatusConditionsForResourceType',
+      return_value=conditions,
+  ), mock.patch.object(
+      bench, '_GetTotalCpuMillicores', return_value=None
+  ), flagsaver.flagsaver(**flag_kwargs):
+    return bench.Run(_MakeSpec())
 
 
 # ---------------------------------------------------------------------------
-# startup_metrics tests
+# PR 1: existing + new metrics
 # ---------------------------------------------------------------------------
 
 
-class StartupMetricsTest(pkb_common_test_case.PkbCommonTestCase):
+class MaxPodReadyTimeTest(pkb_common_test_case.PkbCommonTestCase):
+  """Tests for max_pod_ready_time metric (existing, preserved)."""
 
-  def testExtractLatencyFromContainerStartedAt(self):
-    """Prefers containerStatuses[0].state.running.startedAt over Ready cond."""
-    pod = _MakePodJson(
-        'pod-1',
-        scheduled_ts='2024-01-01T00:00:00Z',
-        started_at='2024-01-01T00:00:30Z',   # 30s latency
-        ready_ts='2024-01-01T00:00:35Z',      # 35s — should NOT be used
-    )
-    latency = startup_metrics._ExtractPodStartupLatency(pod)
-    self.assertAlmostEqual(latency, 30.0, places=1)
+  def testEmitsMaxPodReadyTime(self):
+    samples = _RunWithConditions(_DefaultConditions())
+    self.assertIn('max_pod_ready_time', {s.metric for s in samples})
 
-  def testExtractLatencyFallsBackToReadyCondition(self):
-    """Falls back to Ready condition when containerStatuses is absent."""
-    pod = _MakePodJson(
-        'pod-2',
-        scheduled_ts='2024-01-01T00:00:00Z',
-        ready_ts='2024-01-01T00:00:45Z',      # 45s latency via Ready cond
-    )
-    latency = startup_metrics._ExtractPodStartupLatency(pod)
-    self.assertAlmostEqual(latency, 45.0, places=1)
-
-  def testExtractLatencyReturnsNoneWhenNoReadyTimestamp(self):
-    """Returns None when no container-ready or Ready-condition timestamp exists."""
-    pod = _MakePodJson('pod-3', scheduled_ts='2024-01-01T00:00:00Z')
-    latency = startup_metrics._ExtractPodStartupLatency(pod)
-    self.assertIsNone(latency)
-
-  def testExtractLatencyReturnsNoneForNegativeLatency(self):
-    """Returns None when container-ready precedes scheduled (clock skew)."""
-    pod = _MakePodJson(
-        'pod-4',
-        scheduled_ts='2024-01-01T00:01:00Z',
-        started_at='2024-01-01T00:00:30Z',    # before scheduled → negative
-    )
-    latency = startup_metrics._ExtractPodStartupLatency(pod)
-    self.assertIsNone(latency)
-
-  def testLatenciesToSamplesEmitsAllStats(self):
-    """_LatenciesToSamples emits min/max/mean/p50/p90/p99/count."""
-    latencies = [10.0, 20.0, 30.0, 40.0, 50.0]
-    samples = startup_metrics._LatenciesToSamples(latencies, _BASE_METADATA)
-    metric_names = {s.metric for s in samples}
-    expected = {
-        'startup_latency_min',
-        'startup_latency_max',
-        'startup_latency_mean',
-        'startup_latency_p50',
-        'startup_latency_p90',
-        'startup_latency_p99',
-        'startup_latency_pod_count',
-    }
-    self.assertEqual(metric_names, expected)
-
-  def testLatenciesToSamplesValues(self):
-    """Verifies min/max/mean values are correct."""
-    latencies = [10.0, 20.0, 30.0]
-    samples = startup_metrics._LatenciesToSamples(latencies, _BASE_METADATA)
+  def testMaxPodReadyTimeValue(self):
+    conditions = [
+        _MakeCondition('pod-0', 'PodReadyToStartContainers', 1000),
+        _MakeCondition('pod-0', 'Ready', 1020),
+        _MakeCondition('pod-1', 'PodReadyToStartContainers', 1000),
+        _MakeCondition('pod-1', 'Ready', 1035),
+    ]
+    samples = _RunWithConditions(conditions)
     by_metric = {s.metric: s.value for s in samples}
-    self.assertAlmostEqual(by_metric['startup_latency_min'], 10.0)
-    self.assertAlmostEqual(by_metric['startup_latency_max'], 30.0)
-    self.assertAlmostEqual(by_metric['startup_latency_mean'], 20.0)
-    self.assertEqual(by_metric['startup_latency_pod_count'], 3)
+    self.assertAlmostEqual(by_metric['max_pod_ready_time'], 35)
 
-  def testLatenciesToSamplesCarryBaseMetadata(self):
-    """All samples carry the base metadata keys."""
-    latencies = [15.0]
-    samples = startup_metrics._LatenciesToSamples(latencies, _BASE_METADATA)
-    for s in samples:
-      for key in ('workload', 'scenario', 'cloud'):
-        self.assertIn(key, s.metadata)
+  def testRaisesWhenNoPodsReady(self):
+    with self.assertRaises(RuntimeError):
+      _RunWithConditions([])
 
-  def testGetStartupLatencySamplesEmptyOnKubectlError(self):
-    """Returns empty list when kubectl returns non-zero exit code."""
-    with mock.patch.object(
-        startup_metrics.kubectl, 'RunKubectlCommand',
-        return_value=('', 'error', 1),
-    ):
-      result = startup_metrics.GetStartupLatencySamples(
-          namespace='default', app_label='app', metadata=_BASE_METADATA
-      )
-    self.assertEqual(result, [])
 
-  def testGetStartupLatencySamplesEmptyOnBadJson(self):
-    """Returns empty list when kubectl output is not valid JSON."""
-    with mock.patch.object(
-        startup_metrics.kubectl, 'RunKubectlCommand',
-        return_value=('not json', '', 0),
-    ):
-      result = startup_metrics.GetStartupLatencySamples(
-          namespace='default', app_label='app', metadata=_BASE_METADATA
-      )
-    self.assertEqual(result, [])
+class PerPodReadyTimeTest(pkb_common_test_case.PkbCommonTestCase):
+  """Tests for per_pod_ready_time metric (PR 1)."""
+
+  def testEmitsOnePerPod(self):
+    conditions = [
+        _MakeCondition('pod-0', 'PodReadyToStartContainers', 1000),
+        _MakeCondition('pod-0', 'Ready', 1025),
+        _MakeCondition('pod-1', 'PodReadyToStartContainers', 1000),
+        _MakeCondition('pod-1', 'Ready', 1040),
+    ]
+    samples = _RunWithConditions(conditions)
+    per_pod = [s for s in samples if s.metric == 'per_pod_ready_time']
+    self.assertLen(per_pod, 2)
+
+  def testPerPodCarriesPodName(self):
+    conditions = [
+        _MakeCondition('pod-abc', 'PodReadyToStartContainers', 1000),
+        _MakeCondition('pod-abc', 'Ready', 1030),
+    ]
+    samples = _RunWithConditions(conditions)
+    per_pod = [s for s in samples if s.metric == 'per_pod_ready_time']
+    self.assertEqual(per_pod[0].metadata['pod_name'], 'pod-abc')
+
+
+class SampleMetadataTest(pkb_common_test_case.PkbCommonTestCase):
+  """Tests for sample metadata (PR 1)."""
+
+  def testAllSamplesCarryScenarioWorkloadCloud(self):
+    samples = _RunWithConditions(
+        _DefaultConditions(),
+        flag_kwargs={
+            'cloud': 'GCP',
+            'kubernetes_deployment_startup_scenario': 'baseline',
+            'kubernetes_deployment_startup_workload': 'jvm',
+        },
+    )
+    pod_samples = [
+        s for s in samples
+        if s.metric in ('max_pod_ready_time', 'per_pod_ready_time')
+    ]
+    for s in pod_samples:
+      self.assertEqual(s.metadata['scenario'], 'baseline')
+      self.assertEqual(s.metadata['workload'], 'jvm')
+      self.assertEqual(s.metadata['cloud'], 'GCP')
 
 
 # ---------------------------------------------------------------------------
-# _CpuUtilizationCollector tests
+# PR 1: CPU utilization collector
 # ---------------------------------------------------------------------------
 
 
 class CpuUtilizationCollectorTest(pkb_common_test_case.PkbCommonTestCase):
+  """Tests for _CpuUtilizationCollector (PR 1)."""
 
-  def setUp(self):
-    super().setUp()
-    self.spec = mock.Mock(spec=benchmark_spec.BenchmarkSpec)
-    self.spec.container_cluster = mock.Mock()
-    self.spec.container_specs = {
-        'kubernetes_deployment_startup': mock.Mock(image='test_image')
-    }
+  def _MakeCollector(self):
+    samples = []
+    stop = threading.Event()
+    collector = bench._CpuUtilizationCollector(samples, stop)
+    return collector, samples, stop
 
-  @mock.patch.object(kubernetes_commands, 'WaitForRollout')
-  @mock.patch.object(kubernetes_commands, 'ApplyManifest')
-  @mock.patch.object(
-      kubernetes_conditions, 'GetStatusConditionsForResourceType'
-  )
-  def testRun(
-      self, mock_get_conditions, mock_apply_manifest, mock_wait_for_rollout
-  ):
-    """Tests the Run method with mock pod data."""
-    mock_get_conditions.return_value = [
-        mock.Mock(
-            event='PodReadyToStartContainers',
-            resource_name='pod1',
-            epoch_time=10,
-        ),
-        mock.Mock(event='Ready', resource_name='pod1', epoch_time=20),
-        mock.Mock(
-            event='PodReadyToStartContainers',
-            resource_name='pod2',
-            epoch_time=12,
-        ),
-        mock.Mock(event='Ready', resource_name='pod2', epoch_time=25),
-    ]
-    result = kdsb.Run(self.spec)
+  def testEmitsPeakMeanCount(self):
+    collector, samples, stop = self._MakeCollector()
+    collector._readings = [100.0, 200.0, 300.0]
+    stop.set()
+    collector.ObserveCpuUtilization()
+    metrics = {s.metric for s in samples}
+    self.assertIn('cpu_utilization_peak_millicores', metrics)
+    self.assertIn('cpu_utilization_mean_millicores', metrics)
+    self.assertIn('cpu_utilization_reading_count', metrics)
 
-    mock_apply_manifest.assert_called_with(
-        kdsb.DEPLOYMENT_YAML.value, name='startup', image='test_image'
-    )
-    mock_wait_for_rollout.assert_called_with('deployment/startup', timeout=600)
-    self.assertLen(result, 1)
-    self.assertEqual(
-        result[0],
-        sample.Sample(
-            'max_pod_ready_time', 13, 'seconds', {}, result[0].timestamp
-        ),
-    )
-
-  @mock.patch.object(kubernetes_commands, 'WaitForRollout')
-  @mock.patch.object(kubernetes_commands, 'ApplyManifest')
-  @mock.patch.object(
-      kubernetes_conditions, 'GetStatusConditionsForResourceType'
-  )
-  def testRunNoPods(
-      self, mock_get_conditions, mock_apply_manifest, mock_wait_for_rollout
-  ):
-    """Tests the Run method when no pods are found."""
-    mock_get_conditions.return_value = []
-    with self.assertRaises(RuntimeError):
-      kdsb.Run(self.spec)
-
-    self.collector = bench._CpuUtilizationCollector(
-        namespace='default',
-        app_label='slowjvmstartup',
-        poll_interval=1,
-    )
-
-  def testCollectorAccumulatesReadings(self):
-    """Collector accumulates readings while running."""
-    call_count = [0]
-
-    def fake_poll():
-      call_count[0] += 1
-      return 250.0
-
-    with mock.patch.object(self.collector, '_PollCpuMillicores', side_effect=fake_poll):
-      self.collector.Start()
-      time.sleep(2.5)   # Allow ~2 polls at 1s interval
-      self.collector.Stop()
-
-    self.assertGreaterEqual(len(self.collector._readings), 1)
-
-  def testGetSamplesEmitsPeakAndMean(self):
-    """GetSamples emits cpu_utilization_peak and cpu_utilization_mean."""
-    self.collector._readings = [100.0, 200.0, 300.0]
-    samples = self.collector.GetSamples(_BASE_METADATA)
-    metric_names = {s.metric for s in samples}
-    self.assertIn('cpu_utilization_peak', metric_names)
-    self.assertIn('cpu_utilization_mean', metric_names)
-    self.assertIn('cpu_utilization_reading_count', metric_names)
-
-  def testGetSamplesValues(self):
-    """Peak = max, mean = average of readings."""
-    self.collector._readings = [100.0, 200.0, 300.0]
-    samples = self.collector.GetSamples(_BASE_METADATA)
+  def testPeakAndMeanValues(self):
+    collector, samples, stop = self._MakeCollector()
+    collector._readings = [100.0, 200.0, 300.0]
+    stop.set()
+    collector.ObserveCpuUtilization()
     by_metric = {s.metric: s.value for s in samples}
-    self.assertAlmostEqual(by_metric['cpu_utilization_peak'], 300.0)
-    self.assertAlmostEqual(by_metric['cpu_utilization_mean'], 200.0)
+    self.assertAlmostEqual(by_metric['cpu_utilization_peak_millicores'], 300.0)
+    self.assertAlmostEqual(by_metric['cpu_utilization_mean_millicores'], 200.0)
     self.assertEqual(by_metric['cpu_utilization_reading_count'], 3)
 
-  def testGetSamplesEmptyWhenNoReadings(self):
-    """Returns empty list when no readings collected."""
-    self.collector._readings = []
-    samples = self.collector.GetSamples(_BASE_METADATA)
+  def testNoSamplesWhenNoReadings(self):
+    collector, samples, stop = self._MakeCollector()
+    collector._readings = []
+    stop.set()
+    collector.ObserveCpuUtilization()
     self.assertEqual(samples, [])
 
-  def testGetSamplesCarryMetadata(self):
-    """All samples carry the base metadata and cpu-specific keys."""
-    self.collector._readings = [150.0]
-    samples = self.collector.GetSamples(_BASE_METADATA)
-    for s in samples:
-      self.assertIn('workload', s.metadata)
-      self.assertIn('scenario', s.metadata)
+  def testObserveIgnoresIssueCommandError(self):
+    collector, _, stop = self._MakeCollector()
+    call_count = [0]
 
-  def testPollCpuMillicoresParsesMilliSuffix(self):
-    """_PollCpuMillicores correctly parses '250m' → 250.0."""
-    fake_output = 'slowjvmstartup-abc   250m   128Mi\n'
-    with mock.patch.object(
-        bench.kubectl, 'RunKubectlCommand',
-        return_value=(fake_output, '', 0),
-    ):
-      result = self.collector._PollCpuMillicores()
-    self.assertAlmostEqual(result, 250.0)
+    def flaky():
+      call_count[0] += 1
+      if call_count[0] < 3:
+        raise errors.VmUtil.IssueCommandError('transient')
+      stop.set()
+      return []
 
-  def testPollCpuMillicoresParsesCoreSuffix(self):
-    """_PollCpuMillicores correctly parses '1' (core) → 1000.0 millicores."""
-    fake_output = 'slowjvmstartup-abc   1   512Mi\n'
-    with mock.patch.object(
-        bench.kubectl, 'RunKubectlCommand',
-        return_value=(fake_output, '', 0),
-    ):
-      result = self.collector._PollCpuMillicores()
-    self.assertAlmostEqual(result, 1000.0)
+    collector._Observe(flaky)
+    self.assertEqual(call_count[0], 3)
 
-  def testPollCpuMillicoresReturnsZeroOnError(self):
-    """_PollCpuMillicores returns 0.0 when kubectl returns non-zero rc."""
-    with mock.patch.object(
-        bench.kubectl, 'RunKubectlCommand',
-        return_value=('', 'error', 1),
-    ):
-      result = self.collector._PollCpuMillicores()
-    self.assertEqual(result, 0.0)
+  def testThreadSafety(self):
+    collector, _, _ = self._MakeCollector()
+    errs = []
 
-  def testCollectorIsThreadSafe(self):
-    """Concurrent Stop() and GetSamples() do not race."""
-    self.collector._readings = [100.0] * 50
-    errors = []
-
-    def read():
+    def append_readings():
       try:
-        self.collector.GetSamples(_BASE_METADATA)
+        for _ in range(50):
+          with collector._lock:
+            collector._readings.append(1.0)
       except Exception as e:  # pylint: disable=broad-except
-        errors.append(e)
+        errs.append(e)
 
-    threads = [threading.Thread(target=read) for _ in range(10)]
+    threads = [threading.Thread(target=append_readings) for _ in range(4)]
     for t in threads:
       t.start()
     for t in threads:
       t.join()
-
-    self.assertEqual(errors, [])
+    self.assertEqual(errs, [])
+    self.assertEqual(len(collector._readings), 200)
 
 
 # ---------------------------------------------------------------------------
-# Benchmark lifecycle tests
+# PR 1: _GetTotalCpuMillicores
 # ---------------------------------------------------------------------------
 
 
-class BenchmarkLifecycleTest(pkb_common_test_case.PkbCommonTestCase):
+class GetTotalCpuMillicoresTest(pkb_common_test_case.PkbCommonTestCase):
+  """Tests for _GetTotalCpuMillicores helper (PR 1)."""
+
+  def _MockKubectl(self, stdout, rc=0):
+    return mock.patch.object(
+        bench.kubectl, 'RunKubectlCommand',
+        return_value=(stdout, '', rc),
+    )
+
+  def testParsesMiliSuffix(self):
+    with self._MockKubectl('pod-abc   250m   128Mi\n'):
+      self.assertAlmostEqual(bench._GetTotalCpuMillicores(), 250.0)
+
+  def testParsesCoreSuffix(self):
+    with self._MockKubectl('pod-abc   1   512Mi\n'):
+      self.assertAlmostEqual(bench._GetTotalCpuMillicores(), 1000.0)
+
+  def testSumsMultiplePods(self):
+    with self._MockKubectl('pod-0   100m   64Mi\npod-1   150m   64Mi\n'):
+      self.assertAlmostEqual(bench._GetTotalCpuMillicores(), 250.0)
+
+  def testReturnsNoneOnError(self):
+    with self._MockKubectl('', rc=1):
+      self.assertIsNone(bench._GetTotalCpuMillicores())
+
+  def testReturnsNoneOnEmpty(self):
+    with self._MockKubectl(''):
+      self.assertIsNone(bench._GetTotalCpuMillicores())
+
+
+# ---------------------------------------------------------------------------
+# PR 2: vLLM workload
+# ---------------------------------------------------------------------------
+
+
+class VllmWorkloadTest(pkb_common_test_case.PkbCommonTestCase):
+  """Tests for vLLM workload support (PR 2)."""
+
+  @flagsaver.flagsaver(
+      kubernetes_deployment_startup_workload='vllm', cloud='GCP'
+  )
+  def testPrepareDeploysVllmManifest(self):
+    bm = _MakeSpec(image='public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:latest')
+    with mock.patch.object(
+        bench.kubernetes_commands, 'ApplyManifest'
+    ) as mock_apply:
+      bench.Prepare(bm)
+      call_args = mock_apply.call_args[0][0]
+      self.assertIn('vllm', call_args)
+
+  @flagsaver.flagsaver(
+      kubernetes_deployment_startup_workload='jvm', cloud='GCP'
+  )
+  def testPrepareDeploysJvmManifest(self):
+    with mock.patch.object(
+        bench.kubernetes_commands, 'ApplyManifest'
+    ) as mock_apply:
+      bench.Prepare(_MakeSpec())
+      call_args = mock_apply.call_args[0][0]
+      self.assertIn('slowjvmstartup', call_args)
+
+  @flagsaver.flagsaver(
+      kubernetes_deployment_startup_workload='vllm', cloud='GCP'
+  )
+  def testRunWaitsOnVllmDeployment(self):
+    with mock.patch.object(
+        bench.kubernetes_commands, 'ApplyManifest'
+    ), mock.patch.object(
+        bench.kubernetes_commands, 'WaitForRollout'
+    ) as mock_wait, mock.patch.object(
+        bench.kubernetes_conditions,
+        'GetStatusConditionsForResourceType',
+        return_value=_DefaultConditions(),
+    ), mock.patch.object(bench, '_GetTotalCpuMillicores', return_value=None):
+      bench.Run(_MakeSpec())
+      mock_wait.assert_called_with('deployment/vllm-startup', timeout=600)
+
+  @flagsaver.flagsaver(
+      kubernetes_deployment_startup_workload='jvm', cloud='GCP'
+  )
+  def testRunWaitsOnJvmDeployment(self):
+    with mock.patch.object(
+        bench.kubernetes_commands, 'ApplyManifest'
+    ), mock.patch.object(
+        bench.kubernetes_commands, 'WaitForRollout'
+    ) as mock_wait, mock.patch.object(
+        bench.kubernetes_conditions,
+        'GetStatusConditionsForResourceType',
+        return_value=_DefaultConditions(),
+    ), mock.patch.object(bench, '_GetTotalCpuMillicores', return_value=None):
+      bench.Run(_MakeSpec())
+      mock_wait.assert_called_with('deployment/startup', timeout=600)
+
+
+# ---------------------------------------------------------------------------
+# PR 3: VPA scenario + boost factor
+# ---------------------------------------------------------------------------
+
+
+class ScenarioTest(pkb_common_test_case.PkbCommonTestCase):
+  """Tests for VPA scenario and CPU Startup Boost (PR 3)."""
+
+  @flagsaver.flagsaver(
+      kubernetes_deployment_startup_scenario='optimized',
+      kubernetes_deployment_startup_workload='jvm',
+      cloud='GCP',
+  )
+  def testCheckPrerequisitesPassesOptimizedGcp(self):
+    bench.CheckPrerequisites(None)
+
+  @flagsaver.flagsaver(
+      kubernetes_deployment_startup_scenario='optimized',
+      kubernetes_deployment_startup_workload='jvm',
+      cloud='AWS',
+  )
+  def testCheckPrerequisitesRaisesOptimizedNonGcp(self):
+    with self.assertRaises(ValueError):
+      bench.CheckPrerequisites(None)
 
   @flagsaver.flagsaver(
       kubernetes_deployment_startup_scenario='optimized',
       kubernetes_deployment_startup_workload='vllm',
+      cloud='GCP',
   )
-  def testCheckPrerequisitesRaisesForOptimizedVllm(self):
-    """optimized + vLLM combination not supported in PR 1."""
+  def testCheckPrerequisitesRaisesOptimizedVllm(self):
     with self.assertRaises(ValueError):
       bench.CheckPrerequisites(None)
 
   @flagsaver.flagsaver(
       kubernetes_deployment_startup_scenario='baseline',
-      kubernetes_deployment_startup_workload='jvm',
+      cloud='AWS',
   )
-  def testCheckPrerequisitesPassesForBaselineJvm(self):
-    """baseline + jvm is always valid."""
-    bench.CheckPrerequisites(None)  # Should not raise
+  def testCheckPrerequisitesPassesBaselineAnyCloud(self):
+    bench.CheckPrerequisites(None)
 
   @flagsaver.flagsaver(
       kubernetes_deployment_startup_scenario='optimized',
       kubernetes_deployment_startup_workload='jvm',
+      cloud='GCP',
   )
-  def testCheckPrerequisitesPassesForOptimizedJvm(self):
-    """optimized + jvm is valid (VPA logic is added in PR 3)."""
-    bench.CheckPrerequisites(None)  # Should not raise
+  def testGetConfigEnablesVpa(self):
+    config = bench.GetConfig({})
+    self.assertTrue(config['container_cluster'].get('enable_vpa'))
+
+  @flagsaver.flagsaver(
+      kubernetes_deployment_startup_scenario='baseline',
+      cloud='GCP',
+  )
+  def testGetConfigNoVpaForBaseline(self):
+    config = bench.GetConfig({})
+    self.assertFalse(config['container_cluster'].get('enable_vpa', False))
+
+  @flagsaver.flagsaver(
+      kubernetes_deployment_startup_scenario='optimized',
+      kubernetes_deployment_startup_workload='jvm',
+      kubernetes_deployment_startup_boost_factor=2,
+      cloud='GCP',
+  )
+  def testPrepareAppliesVpaManifest(self):
+    apply_calls = []
+    with mock.patch.object(
+        bench.kubernetes_commands, 'ApplyManifest',
+        side_effect=lambda *a, **kw: apply_calls.append(a[0])
+    ):
+      bench.Prepare(_MakeSpec())
+    self.assertLen(apply_calls, 2)
+    self.assertTrue(any('vpa' in c for c in apply_calls))
+
+  @flagsaver.flagsaver(
+      kubernetes_deployment_startup_scenario='baseline',
+      kubernetes_deployment_startup_workload='jvm',
+      cloud='GCP',
+  )
+  def testPrepareSkipsVpaForBaseline(self):
+    apply_calls = []
+    with mock.patch.object(
+        bench.kubernetes_commands, 'ApplyManifest',
+        side_effect=lambda *a, **kw: apply_calls.append(a[0])
+    ):
+      bench.Prepare(_MakeSpec())
+    self.assertLen(apply_calls, 1)
+    self.assertFalse(any('vpa' in c for c in apply_calls))
+
+  @flagsaver.flagsaver(
+      kubernetes_deployment_startup_scenario='optimized',
+      kubernetes_deployment_startup_workload='jvm',
+      kubernetes_deployment_startup_boost_factor=3,
+      cloud='GCP',
+  )
+  def testBoostFactorInMetadata(self):
+    samples = _RunWithConditions(
+        _DefaultConditions(),
+        flag_kwargs={
+            'cloud': 'GCP',
+            'kubernetes_deployment_startup_scenario': 'optimized',
+            'kubernetes_deployment_startup_workload': 'jvm',
+            'kubernetes_deployment_startup_boost_factor': 3,
+        },
+    )
+    pod_samples = [s for s in samples if 'boost_factor' in s.metadata]
+    self.assertTrue(len(pod_samples) > 0)
+    for s in pod_samples:
+      self.assertEqual(s.metadata['boost_factor'], 3)
+
+  @flagsaver.flagsaver(
+      kubernetes_deployment_startup_scenario='baseline',
+      kubernetes_deployment_startup_workload='jvm',
+      cloud='GCP',
+  )
+  def testBoostFactorIsOneForBaseline(self):
+    samples = _RunWithConditions(
+        _DefaultConditions(),
+        flag_kwargs={
+            'cloud': 'GCP',
+            'kubernetes_deployment_startup_scenario': 'baseline',
+            'kubernetes_deployment_startup_workload': 'jvm',
+        },
+    )
+    pod_samples = [s for s in samples if 'boost_factor' in s.metadata]
+    for s in pod_samples:
+      self.assertEqual(s.metadata['boost_factor'], 1)
 
 
 if __name__ == '__main__':

--- a/tests/linux_benchmarks/kubernetes_deployment_startup_benchmark_test.py
+++ b/tests/linux_benchmarks/kubernetes_deployment_startup_benchmark_test.py
@@ -13,11 +13,15 @@
 # limitations under the License.
 """Tests for kubernetes_deployment_startup_benchmark (PR 1 + PR 2 + PR 3)."""
 
+import os
 import threading
 import unittest
 from unittest import mock
 
 from absl.testing import flagsaver
+import jinja2
+import yaml
+from perfkitbenchmarker import data
 from perfkitbenchmarker import errors
 from perfkitbenchmarker.linux_benchmarks import (
     kubernetes_deployment_startup_benchmark as bench,
@@ -117,6 +121,75 @@ class PerPodReadyTimeTest(pkb_common_test_case.PkbCommonTestCase):
     samples = _RunWithConditions(conditions)
     per_pod = [s for s in samples if s.metric == 'per_pod_ready_time']
     self.assertEqual(per_pod[0].metadata['pod_name'], 'pod-abc')
+
+
+class StartupLatencyTest(pkb_common_test_case.PkbCommonTestCase):
+  """Tests for the startup_latency metric (PodRunning -> Ready)."""
+
+  def testEmitsStartupLatency(self):
+    conditions = [
+        _MakeCondition('pod-0', 'PodReadyToStartContainers', 1000),
+        _MakeCondition('pod-0', 'PodRunning', 1005),
+        _MakeCondition('pod-0', 'Ready', 1030),
+    ]
+    samples = _RunWithConditions(conditions)
+    self.assertIn('startup_latency', {s.metric for s in samples})
+
+  def testStartupLatencyValue(self):
+    conditions = [
+        _MakeCondition('pod-0', 'PodRunning', 1005),
+        _MakeCondition('pod-0', 'Ready', 1030),
+    ]
+    samples = _RunWithConditions(conditions)
+    by_metric = {s.metric: s.value for s in samples}
+    self.assertAlmostEqual(by_metric['startup_latency'], 25)
+
+  def testStartupLatencyTakesMaxAcrossPods(self):
+    conditions = [
+        _MakeCondition('pod-0', 'PodRunning', 1000),
+        _MakeCondition('pod-0', 'Ready', 1020),
+        _MakeCondition('pod-1', 'PodRunning', 1000),
+        _MakeCondition('pod-1', 'Ready', 1040),
+    ]
+    samples = _RunWithConditions(conditions)
+    by_metric = {s.metric: s.value for s in samples}
+    self.assertAlmostEqual(by_metric['startup_latency'], 40)
+
+  def testEmitsOnePerPodStartupLatency(self):
+    conditions = [
+        _MakeCondition('pod-0', 'PodRunning', 1000),
+        _MakeCondition('pod-0', 'Ready', 1020),
+        _MakeCondition('pod-1', 'PodRunning', 1000),
+        _MakeCondition('pod-1', 'Ready', 1040),
+    ]
+    samples = _RunWithConditions(conditions)
+    per_pod = [s for s in samples if s.metric == 'per_pod_startup_latency']
+    self.assertLen(per_pod, 2)
+
+  def testDistinctFromMaxPodReadyTime(self):
+    # PodReadyToStartContainers is earlier than PodRunning (scheduling +
+    # image pull happen first), so startup_latency should be smaller than
+    # max_pod_ready_time for the same pod.
+    conditions = [
+        _MakeCondition('pod-0', 'PodReadyToStartContainers', 1000),
+        _MakeCondition('pod-0', 'PodRunning', 1015),
+        _MakeCondition('pod-0', 'Ready', 1030),
+    ]
+    samples = _RunWithConditions(conditions)
+    by_metric = {s.metric: s.value for s in samples}
+    self.assertAlmostEqual(by_metric['max_pod_ready_time'], 30)
+    self.assertAlmostEqual(by_metric['startup_latency'], 15)
+    self.assertLess(
+        by_metric['startup_latency'], by_metric['max_pod_ready_time']
+    )
+
+  def testNoStartupLatencyWhenPodRunningMissing(self):
+    # Cluster/runtime doesn't report containerStatuses startedAt (or the
+    # mock omits it) -- benchmark should still succeed on the other
+    # metrics, just skip startup_latency.
+    samples = _RunWithConditions(_DefaultConditions())
+    self.assertNotIn('startup_latency', {s.metric for s in samples})
+    self.assertIn('max_pod_ready_time', {s.metric for s in samples})
 
 
 class SampleMetadataTest(pkb_common_test_case.PkbCommonTestCase):
@@ -447,3 +520,69 @@ class ScenarioTest(pkb_common_test_case.PkbCommonTestCase):
 
 if __name__ == '__main__':
   unittest.main()
+
+
+# ---------------------------------------------------------------------------
+# Regression test: manifest files must actually exist on disk.
+#
+# All tests above mock kubernetes_commands.ApplyManifest, so none of them
+# ever resolve DEPLOYMENT_YAML/VLLM_YAML/VPA_YAML against the real `data/`
+# directory. That blind spot let PR 2 and PR 3 ship referencing
+# vllm.yaml.j2 and slowjvmstartup_vpa.yaml.j2 without ever committing them,
+# which only surfaced as a runtime ResourceNotFound crash in production.
+# These tests close that gap by calling data.ResourcePath() for real.
+# ---------------------------------------------------------------------------
+
+
+class ManifestResourceResolutionTest(pkb_common_test_case.PkbCommonTestCase):
+  """Confirms every manifest flag default resolves to a real, valid file."""
+
+  def testJvmManifestResolves(self):
+    path = data.ResourcePath(bench.DEPLOYMENT_YAML.value)
+    self.assertTrue(os.path.isfile(path))
+
+  def testVllmManifestResolves(self):
+    path = data.ResourcePath(bench.VLLM_YAML.value)
+    self.assertTrue(os.path.isfile(path))
+
+  def testVpaManifestResolves(self):
+    path = data.ResourcePath(bench.VPA_YAML.value)
+    self.assertTrue(os.path.isfile(path))
+
+  def testJvmManifestRendersValidYaml(self):
+    path = data.ResourcePath(bench.DEPLOYMENT_YAML.value)
+    env = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(os.path.dirname(path))
+    )
+    rendered = env.get_template(os.path.basename(path)).render(
+        name='startup', image='slowjvmstartup'
+    )
+    docs = list(yaml.safe_load_all(rendered))
+    self.assertEqual(docs[0]['kind'], 'Deployment')
+
+  def testVllmManifestRendersValidYaml(self):
+    path = data.ResourcePath(bench.VLLM_YAML.value)
+    env = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(os.path.dirname(path))
+    )
+    rendered = env.get_template(os.path.basename(path)).render(
+        name='vllm-startup',
+        image='public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:latest',
+    )
+    docs = list(yaml.safe_load_all(rendered))
+    self.assertEqual(docs[0]['kind'], 'Deployment')
+    self.assertEqual(docs[1]['kind'], 'Service')
+
+  def testVpaManifestRendersValidYamlWithBoostFactor(self):
+    path = data.ResourcePath(bench.VPA_YAML.value)
+    env = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(os.path.dirname(path))
+    )
+    rendered = env.get_template(os.path.basename(path)).render(
+        name='startup', boost_factor=3
+    )
+    docs = list(yaml.safe_load_all(rendered))
+    self.assertEqual(docs[0]['kind'], 'VerticalPodAutoscaler')
+    self.assertEqual(
+        docs[0]['spec']['startupBoost']['cpu']['factor'], 3
+    )

--- a/tests/linux_benchmarks/kubernetes_deployment_startup_benchmark_test.py
+++ b/tests/linux_benchmarks/kubernetes_deployment_startup_benchmark_test.py
@@ -48,14 +48,28 @@ def _MakeSpec(image='slowjvmstartup'):
 
 
 def _DefaultConditions():
+  # Includes a PodRunning entry so startup_latency is always computable by
+  # default -- tests that specifically exercise the "PodRunning missing"
+  # failure path build their own conditions list without it.
   return [
       _MakeCondition('pod-0', 'PodReadyToStartContainers', 1000),
+      _MakeCondition('pod-0', 'PodRunning', 1015),
       _MakeCondition('pod-0', 'Ready', 1030),
   ]
 
 
-def _RunWithConditions(conditions, flag_kwargs=None):
-  """Runs bench.Run() with mocked kubectl calls."""
+def _RunWithConditions(conditions, flag_kwargs=None, cpu_millicores=100.0):
+  """Runs bench.Run() with mocked kubectl calls.
+
+  Args:
+    conditions: Pod status conditions to return from
+      GetStatusConditionsForResourceType.
+    flag_kwargs: Flags to set via flagsaver.
+    cpu_millicores: Value _GetTotalCpuMillicores should return on every
+      poll. Defaults to a real value (not None) so cpu_utilization is
+      computable by default -- tests exercising the "zero CPU readings"
+      failure path override this to None explicitly.
+  """
   flag_kwargs = flag_kwargs or {'cloud': 'GCP'}
   with mock.patch.object(
       bench.kubernetes_commands, 'ApplyManifest'
@@ -66,8 +80,10 @@ def _RunWithConditions(conditions, flag_kwargs=None):
       'GetStatusConditionsForResourceType',
       return_value=conditions,
   ), mock.patch.object(
-      bench, '_GetTotalCpuMillicores', return_value=None
-  ), flagsaver.flagsaver(**flag_kwargs):
+      bench, '_GetTotalCpuMillicores', return_value=cpu_millicores
+  ), flagsaver.flagsaver(
+      **flag_kwargs
+  ):
     return bench.Run(_MakeSpec())
 
 
@@ -86,8 +102,10 @@ class MaxPodReadyTimeTest(pkb_common_test_case.PkbCommonTestCase):
   def testMaxPodReadyTimeValue(self):
     conditions = [
         _MakeCondition('pod-0', 'PodReadyToStartContainers', 1000),
+        _MakeCondition('pod-0', 'PodRunning', 1010),
         _MakeCondition('pod-0', 'Ready', 1020),
         _MakeCondition('pod-1', 'PodReadyToStartContainers', 1000),
+        _MakeCondition('pod-1', 'PodRunning', 1010),
         _MakeCondition('pod-1', 'Ready', 1035),
     ]
     samples = _RunWithConditions(conditions)
@@ -105,8 +123,10 @@ class PerPodReadyTimeTest(pkb_common_test_case.PkbCommonTestCase):
   def testEmitsOnePerPod(self):
     conditions = [
         _MakeCondition('pod-0', 'PodReadyToStartContainers', 1000),
+        _MakeCondition('pod-0', 'PodRunning', 1010),
         _MakeCondition('pod-0', 'Ready', 1025),
         _MakeCondition('pod-1', 'PodReadyToStartContainers', 1000),
+        _MakeCondition('pod-1', 'PodRunning', 1010),
         _MakeCondition('pod-1', 'Ready', 1040),
     ]
     samples = _RunWithConditions(conditions)
@@ -116,6 +136,7 @@ class PerPodReadyTimeTest(pkb_common_test_case.PkbCommonTestCase):
   def testPerPodCarriesPodName(self):
     conditions = [
         _MakeCondition('pod-abc', 'PodReadyToStartContainers', 1000),
+        _MakeCondition('pod-abc', 'PodRunning', 1010),
         _MakeCondition('pod-abc', 'Ready', 1030),
     ]
     samples = _RunWithConditions(conditions)
@@ -183,13 +204,18 @@ class StartupLatencyTest(pkb_common_test_case.PkbCommonTestCase):
         by_metric['startup_latency'], by_metric['max_pod_ready_time']
     )
 
-  def testNoStartupLatencyWhenPodRunningMissing(self):
-    # Cluster/runtime doesn't report containerStatuses startedAt (or the
-    # mock omits it) -- benchmark should still succeed on the other
-    # metrics, just skip startup_latency.
-    samples = _RunWithConditions(_DefaultConditions())
-    self.assertNotIn('startup_latency', {s.metric for s in samples})
-    self.assertIn('max_pod_ready_time', {s.metric for s in samples})
+  def testRaisesWhenPodRunningMissing(self):
+    # Per review: if the cluster/runtime never reports containerStatuses
+    # startedAt for any pod, startup_latency can't be computed at all --
+    # this must fail loudly rather than silently succeeding with the
+    # metric missing (a silent warning here is exactly what let the VPA
+    # ordering bug ship an unboosted "optimized" run undetected).
+    conditions = [
+        _MakeCondition('pod-0', 'PodReadyToStartContainers', 1000),
+        _MakeCondition('pod-0', 'Ready', 1030),
+    ]
+    with self.assertRaises(RuntimeError):
+      _RunWithConditions(conditions)
 
 
 class SampleMetadataTest(pkb_common_test_case.PkbCommonTestCase):
@@ -205,7 +231,8 @@ class SampleMetadataTest(pkb_common_test_case.PkbCommonTestCase):
         },
     )
     pod_samples = [
-        s for s in samples
+        s
+        for s in samples
         if s.metric in ('max_pod_ready_time', 'per_pod_ready_time')
     ]
     for s in pod_samples:
@@ -248,11 +275,14 @@ class CpuUtilizationCollectorTest(pkb_common_test_case.PkbCommonTestCase):
     self.assertAlmostEqual(by_metric['cpu_utilization_mean_millicores'], 200.0)
     self.assertEqual(by_metric['cpu_utilization_reading_count'], 3)
 
-  def testNoSamplesWhenNoReadings(self):
+  def testRaisesWhenNoReadings(self):
+    # Per review: zero CPU readings for the whole run must fail loudly
+    # rather than silently shipping results with cpu_utilization missing.
     collector, samples, stop = self._MakeCollector()
     collector._readings = []
     stop.set()
-    collector.ObserveCpuUtilization()
+    with self.assertRaises(RuntimeError):
+      collector.ObserveCpuUtilization()
     self.assertEqual(samples, [])
 
   def testObserveIgnoresIssueCommandError(self):
@@ -268,6 +298,13 @@ class CpuUtilizationCollectorTest(pkb_common_test_case.PkbCommonTestCase):
 
     collector._Observe(flaky)
     self.assertEqual(call_count[0], 3)
+
+  def testRunRaisesWhenCpuCollectionFailsEntirely(self):
+    # End-to-end: bench.Run() runs the collector on a background thread,
+    # so this also verifies the collector's RuntimeError is captured and
+    # re-raised on the main thread rather than silently disappearing.
+    with self.assertRaises(RuntimeError):
+      _RunWithConditions(_DefaultConditions(), cpu_millicores=None)
 
   def testThreadSafety(self):
     collector, _, _ = self._MakeCollector()
@@ -300,7 +337,8 @@ class GetTotalCpuMillicoresTest(pkb_common_test_case.PkbCommonTestCase):
 
   def _MockKubectl(self, stdout, rc=0):
     return mock.patch.object(
-        bench.kubectl, 'RunKubectlCommand',
+        bench.kubectl,
+        'RunKubectlCommand',
         return_value=(stdout, '', rc),
     )
 
@@ -368,7 +406,9 @@ class VllmWorkloadTest(pkb_common_test_case.PkbCommonTestCase):
         bench.kubernetes_conditions,
         'GetStatusConditionsForResourceType',
         return_value=_DefaultConditions(),
-    ), mock.patch.object(bench, '_GetTotalCpuMillicores', return_value=None):
+    ), mock.patch.object(
+        bench, '_GetTotalCpuMillicores', return_value=100.0
+    ):
       bench.Run(_MakeSpec())
       mock_wait.assert_called_with('deployment/vllm-startup', timeout=600)
 
@@ -384,7 +424,9 @@ class VllmWorkloadTest(pkb_common_test_case.PkbCommonTestCase):
         bench.kubernetes_conditions,
         'GetStatusConditionsForResourceType',
         return_value=_DefaultConditions(),
-    ), mock.patch.object(bench, '_GetTotalCpuMillicores', return_value=None):
+    ), mock.patch.object(
+        bench, '_GetTotalCpuMillicores', return_value=100.0
+    ):
       bench.Run(_MakeSpec())
       mock_wait.assert_called_with('deployment/startup', timeout=600)
 
@@ -456,12 +498,45 @@ class ScenarioTest(pkb_common_test_case.PkbCommonTestCase):
   def testPrepareAppliesVpaManifest(self):
     apply_calls = []
     with mock.patch.object(
-        bench.kubernetes_commands, 'ApplyManifest',
-        side_effect=lambda *a, **kw: apply_calls.append(a[0])
+        bench.kubernetes_commands,
+        'ApplyManifest',
+        side_effect=lambda *a, **kw: apply_calls.append(a[0]),
     ):
       bench.Prepare(_MakeSpec())
     self.assertLen(apply_calls, 2)
     self.assertTrue(any('vpa' in c for c in apply_calls))
+
+  @flagsaver.flagsaver(
+      kubernetes_deployment_startup_scenario='optimized',
+      kubernetes_deployment_startup_workload='jvm',
+      kubernetes_deployment_startup_boost_factor=2,
+      cloud='GCP',
+  )
+  def testPrepareAppliesVpaBeforeDeployment(self):
+    # Regression test: GKE CPU Startup Boost only mutates a pod's CPU
+    # request at admission time, for pods created AFTER the VPA object
+    # exists. If the Deployment (and its first pod) were applied before
+    # the VPA, the boost would never apply to the pod this benchmark
+    # measures -- which is exactly what happened in the config 4 run that
+    # showed no improvement over baseline. The VPA must be applied first.
+    apply_calls = []
+    with mock.patch.object(
+        bench.kubernetes_commands,
+        'ApplyManifest',
+        side_effect=lambda *a, **kw: apply_calls.append(a[0]),
+    ):
+      bench.Prepare(_MakeSpec())
+    self.assertLen(apply_calls, 2)
+    vpa_index = next(i for i, c in enumerate(apply_calls) if 'vpa' in c)
+    deployment_index = next(
+        i for i, c in enumerate(apply_calls) if 'vpa' not in c
+    )
+    self.assertLess(
+        vpa_index,
+        deployment_index,
+        'VPA manifest must be applied before the JVM deployment manifest,'
+        ' otherwise CPU Startup Boost cannot affect the measured pod.',
+    )
 
   @flagsaver.flagsaver(
       kubernetes_deployment_startup_scenario='baseline',
@@ -471,8 +546,9 @@ class ScenarioTest(pkb_common_test_case.PkbCommonTestCase):
   def testPrepareSkipsVpaForBaseline(self):
     apply_calls = []
     with mock.patch.object(
-        bench.kubernetes_commands, 'ApplyManifest',
-        side_effect=lambda *a, **kw: apply_calls.append(a[0])
+        bench.kubernetes_commands,
+        'ApplyManifest',
+        side_effect=lambda *a, **kw: apply_calls.append(a[0]),
     ):
       bench.Prepare(_MakeSpec())
     self.assertLen(apply_calls, 1)
@@ -583,6 +659,4 @@ class ManifestResourceResolutionTest(pkb_common_test_case.PkbCommonTestCase):
     )
     docs = list(yaml.safe_load_all(rendered))
     self.assertEqual(docs[0]['kind'], 'VerticalPodAutoscaler')
-    self.assertEqual(
-        docs[0]['spec']['startupBoost']['cpu']['factor'], 3
-    )
+    self.assertEqual(docs[0]['spec']['startupBoost']['cpu']['factor'], 3)

--- a/tests/linux_benchmarks/kubernetes_deployment_startup_benchmark_test.py
+++ b/tests/linux_benchmarks/kubernetes_deployment_startup_benchmark_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests for kubernetes_deployment_startup_benchmark (PR 1 + PR 2 + PR 3)."""
+"""Tests for kubernetes_deployment_startup_benchmark (PR 1-4)."""
 
 import os
 import threading
@@ -461,9 +461,12 @@ class ScenarioTest(pkb_common_test_case.PkbCommonTestCase):
       kubernetes_deployment_startup_workload='vllm',
       cloud='GCP',
   )
-  def testCheckPrerequisitesRaisesOptimizedVllm(self):
-    with self.assertRaises(ValueError):
-      bench.CheckPrerequisites(None)
+  def testCheckPrerequisitesPassesOptimizedVllm(self):
+    # PR 4: vLLM now supports scenario=optimized too -- CPU Startup Boost
+    # also benefits AI/inference workloads, which spend significant
+    # startup time loading models into memory (same admission-time boost
+    # mechanism as JVM). Only the cloud=GCP restriction still applies.
+    bench.CheckPrerequisites(None)
 
   @flagsaver.flagsaver(
       kubernetes_deployment_startup_scenario='baseline',
@@ -599,6 +602,265 @@ class ScenarioTest(pkb_common_test_case.PkbCommonTestCase):
 
 
 # ---------------------------------------------------------------------------
+# PR 4: CPU Startup Boost for vLLM
+#
+# scenario=optimized was previously JVM-only (CheckPrerequisites raised for
+# workload=vllm). Rich's guidance: AI/inference workloads spend a lot of
+# startup time loading models into memory, so they should benefit from the
+# same CPU Startup Boost mechanism -- just with workload-specific sizing,
+# since vLLM's baseline CPU request (2 cores) and expected startup time are
+# both much larger than the JVM's.
+# ---------------------------------------------------------------------------
+
+
+class VllmOptimizedScenarioTest(pkb_common_test_case.PkbCommonTestCase):
+  """Tests for scenario=optimized with workload=vllm (PR 4)."""
+
+  def _MakeVllmSpec(self):
+    return _MakeSpec(
+        image='public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:latest'
+    )
+
+  @flagsaver.flagsaver(
+      kubernetes_deployment_startup_scenario='optimized',
+      kubernetes_deployment_startup_workload='vllm',
+      kubernetes_deployment_startup_boost_factor=2,
+      cloud='GCP',
+  )
+  def testPrepareAppliesVpaBeforeVllmDeployment(self):
+    apply_calls = []
+    apply_kwargs = []
+
+    def _record(*args, **kwargs):
+      apply_calls.append(args[0])
+      apply_kwargs.append(kwargs)
+
+    with mock.patch.object(
+        bench.kubernetes_commands, 'ApplyManifest', side_effect=_record
+    ), mock.patch.object(
+        bench.kubectl, 'RunKubectlCommand', return_value=('', '', 0)
+    ):
+      bench.Prepare(self._MakeVllmSpec())
+
+    self.assertLen(apply_calls, 2)
+    vpa_index = next(i for i, c in enumerate(apply_calls) if 'vpa' in c)
+    deployment_index = next(i for i, c in enumerate(apply_calls) if 'vllm' in c)
+    self.assertLess(
+        vpa_index,
+        deployment_index,
+        'VPA manifest must be applied before the vLLM deployment manifest,'
+        ' otherwise CPU Startup Boost cannot affect the measured pod.',
+    )
+    # The VPA must target the vLLM deployment name, not the JVM one.
+    self.assertEqual(apply_kwargs[vpa_index]['name'], 'vllm-startup')
+
+  @flagsaver.flagsaver(
+      kubernetes_deployment_startup_scenario='optimized',
+      kubernetes_deployment_startup_workload='vllm',
+      cloud='GCP',
+  )
+  def testPrepareUsesVllmVpaSizingDefaults(self):
+    captured = {}
+
+    def _record(*args, **kwargs):
+      if 'vpa' in args[0]:
+        captured.update(kwargs)
+
+    with mock.patch.object(
+        bench.kubernetes_commands, 'ApplyManifest', side_effect=_record
+    ), mock.patch.object(
+        bench.kubectl, 'RunKubectlCommand', return_value=('', '', 0)
+    ):
+      bench.Prepare(self._MakeVllmSpec())
+
+    # vLLM's baseline 2-core request exceeds the JVM-tuned "1" ceiling, and
+    # model loading is expected to take longer than the JVM's ~67s baseline
+    # -- these defaults must differ from the JVM ones, not be shared.
+    self.assertEqual(
+        captured['max_allowed_cpu'], bench._VPA_DEFAULT_MAX_CPU['vllm']
+    )
+    self.assertEqual(
+        captured['duration_seconds'],
+        bench._VPA_DEFAULT_DURATION_SECONDS['vllm'],
+    )
+    self.assertNotEqual(
+        bench._VPA_DEFAULT_MAX_CPU['vllm'], bench._VPA_DEFAULT_MAX_CPU['jvm']
+    )
+
+  @flagsaver.flagsaver(
+      kubernetes_deployment_startup_scenario='optimized',
+      kubernetes_deployment_startup_workload='jvm',
+      cloud='GCP',
+  )
+  def testPrepareUsesJvmVpaSizingDefaults(self):
+    captured = {}
+
+    def _record(*args, **kwargs):
+      if 'vpa' in args[0]:
+        captured.update(kwargs)
+
+    with mock.patch.object(
+        bench.kubernetes_commands, 'ApplyManifest', side_effect=_record
+    ), mock.patch.object(
+        bench.kubectl, 'RunKubectlCommand', return_value=('', '', 0)
+    ):
+      bench.Prepare(_MakeSpec())
+
+    self.assertEqual(
+        captured['max_allowed_cpu'], bench._VPA_DEFAULT_MAX_CPU['jvm']
+    )
+    self.assertEqual(
+        captured['duration_seconds'],
+        bench._VPA_DEFAULT_DURATION_SECONDS['jvm'],
+    )
+
+  @flagsaver.flagsaver(
+      kubernetes_deployment_startup_scenario='optimized',
+      kubernetes_deployment_startup_workload='vllm',
+      kubernetes_deployment_startup_vpa_max_cpu='6',
+      kubernetes_deployment_startup_vpa_duration_seconds=400,
+      cloud='GCP',
+  )
+  def testVpaSizingOverridableViaFlags(self):
+    captured = {}
+
+    def _record(*args, **kwargs):
+      if 'vpa' in args[0]:
+        captured.update(kwargs)
+
+    with mock.patch.object(
+        bench.kubernetes_commands, 'ApplyManifest', side_effect=_record
+    ), mock.patch.object(
+        bench.kubectl, 'RunKubectlCommand', return_value=('', '', 0)
+    ):
+      bench.Prepare(self._MakeVllmSpec())
+
+    self.assertEqual(captured['max_allowed_cpu'], '6')
+    self.assertEqual(captured['duration_seconds'], 400)
+
+  @flagsaver.flagsaver(
+      kubernetes_deployment_startup_scenario='optimized',
+      kubernetes_deployment_startup_workload='vllm',
+      cloud='GCP',
+  )
+  def testPrepareUsesGpuMemoryUtilizationDefault(self):
+    # PR 5: Prepare() must forward the gpu_memory_utilization flag to the
+    # vLLM deployment manifest, otherwise vLLM's own ~0.9 default crash-loops
+    # against the container's 4Gi memory limit.
+    captured = {}
+
+    def _record(*args, **kwargs):
+      if 'vllm' in args[0]:
+        captured.update(kwargs)
+
+    with mock.patch.object(
+        bench.kubernetes_commands, 'ApplyManifest', side_effect=_record
+    ), mock.patch.object(
+        bench.kubectl, 'RunKubectlCommand', return_value=('', '', 0)
+    ):
+      bench.Prepare(self._MakeVllmSpec())
+
+    self.assertEqual(
+        captured['gpu_memory_utilization'],
+        bench.VLLM_GPU_MEMORY_UTILIZATION.default,
+    )
+
+  @flagsaver.flagsaver(
+      kubernetes_deployment_startup_scenario='optimized',
+      kubernetes_deployment_startup_workload='vllm',
+      kubernetes_deployment_startup_vllm_gpu_memory_utilization=0.3,
+      cloud='GCP',
+  )
+  def testPrepareGpuMemoryUtilizationOverridableViaFlag(self):
+    captured = {}
+
+    def _record(*args, **kwargs):
+      if 'vllm' in args[0]:
+        captured.update(kwargs)
+
+    with mock.patch.object(
+        bench.kubernetes_commands, 'ApplyManifest', side_effect=_record
+    ), mock.patch.object(
+        bench.kubectl, 'RunKubectlCommand', return_value=('', '', 0)
+    ):
+      bench.Prepare(self._MakeVllmSpec())
+
+    self.assertEqual(captured['gpu_memory_utilization'], 0.3)
+
+  @flagsaver.flagsaver(
+      kubernetes_deployment_startup_scenario='optimized',
+      kubernetes_deployment_startup_workload='vllm',
+      cloud='GCP',
+  )
+  def testPrepareUsesMemoryLimitDefault(self):
+    # PR 6: Prepare() must forward the memory_limit flag to the vLLM
+    # deployment manifest -- the old hardcoded 4Gi OOMKilled during vLLM's
+    # compile/warmup phase.
+    captured = {}
+
+    def _record(*args, **kwargs):
+      if 'vllm' in args[0]:
+        captured.update(kwargs)
+
+    with mock.patch.object(
+        bench.kubernetes_commands, 'ApplyManifest', side_effect=_record
+    ), mock.patch.object(
+        bench.kubectl, 'RunKubectlCommand', return_value=('', '', 0)
+    ):
+      bench.Prepare(self._MakeVllmSpec())
+
+    self.assertEqual(captured['memory_limit'], bench.VLLM_MEMORY_LIMIT.default)
+
+  @flagsaver.flagsaver(
+      kubernetes_deployment_startup_scenario='optimized',
+      kubernetes_deployment_startup_workload='vllm',
+      kubernetes_deployment_startup_vllm_memory_limit='12Gi',
+      cloud='GCP',
+  )
+  def testPrepareMemoryLimitOverridableViaFlag(self):
+    captured = {}
+
+    def _record(*args, **kwargs):
+      if 'vllm' in args[0]:
+        captured.update(kwargs)
+
+    with mock.patch.object(
+        bench.kubernetes_commands, 'ApplyManifest', side_effect=_record
+    ), mock.patch.object(
+        bench.kubectl, 'RunKubectlCommand', return_value=('', '', 0)
+    ):
+      bench.Prepare(self._MakeVllmSpec())
+
+    self.assertEqual(captured['memory_limit'], '12Gi')
+
+  @flagsaver.flagsaver(
+      kubernetes_deployment_startup_scenario='optimized',
+      kubernetes_deployment_startup_workload='vllm',
+      cloud='GCP',
+  )
+  def testRunWaitsOnVllmDeploymentWhenOptimized(self):
+    # Regression guard: the vLLM branch of Prepare()/Run() must keep
+    # waiting on the vllm-startup deployment (not startup) once VPA support
+    # was wired into that branch too.
+    with mock.patch.object(
+        bench.kubernetes_commands, 'ApplyManifest'
+    ), mock.patch.object(
+        bench.kubectl, 'RunKubectlCommand', return_value=('', '', 0)
+    ), mock.patch.object(
+        bench.kubernetes_commands, 'WaitForRollout'
+    ) as mock_wait, mock.patch.object(
+        bench.kubernetes_conditions,
+        'GetStatusConditionsForResourceType',
+        return_value=_DefaultConditions(),
+    ), mock.patch.object(
+        bench, '_GetTotalCpuMillicores', return_value=100.0
+    ):
+      bench.Prepare(self._MakeVllmSpec())
+      bench.Run(self._MakeVllmSpec())
+      mock_wait.assert_called_with('deployment/vllm-startup', timeout=600)
+
+
+# ---------------------------------------------------------------------------
 # PR 3: VPA CRD registration race fix
 #
 # Enabling VPA via --enable-vertical-pod-autoscaling triggers an
@@ -702,10 +964,35 @@ class ManifestResourceResolutionTest(pkb_common_test_case.PkbCommonTestCase):
     rendered = env.get_template(os.path.basename(path)).render(
         name='vllm-startup',
         image='public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:latest',
+        gpu_memory_utilization=bench.VLLM_GPU_MEMORY_UTILIZATION.default,
+        memory_limit=bench.VLLM_MEMORY_LIMIT.default,
     )
     docs = list(yaml.safe_load_all(rendered))
     self.assertEqual(docs[0]['kind'], 'Deployment')
     self.assertEqual(docs[1]['kind'], 'Service')
+    # PR 5: --gpu-memory-utilization must be passed to the vLLM container,
+    # otherwise the process defaults to ~0.9 and crash-loops against the
+    # container memory limit below.
+    container_args = docs[0]['spec']['template']['spec']['containers'][0][
+        'args'
+    ]
+    self.assertIn('--gpu-memory-utilization', container_args)
+    self.assertEqual(
+        container_args[container_args.index('--gpu-memory-utilization') + 1],
+        str(bench.VLLM_GPU_MEMORY_UTILIZATION.default),
+    )
+    # PR 6: requests/limits.memory must reflect memory_limit (Guaranteed
+    # QoS -- requests == limits), otherwise the pod OOMKills during vLLM's
+    # compile/warmup phase against the old hardcoded 4Gi.
+    resources = docs[0]['spec']['template']['spec']['containers'][0][
+        'resources'
+    ]
+    self.assertEqual(
+        resources['requests']['memory'], bench.VLLM_MEMORY_LIMIT.default
+    )
+    self.assertEqual(
+        resources['limits']['memory'], bench.VLLM_MEMORY_LIMIT.default
+    )
 
   def testVpaManifestRendersValidYamlWithBoostFactor(self):
     path = data.ResourcePath(bench.VPA_YAML.value)
@@ -713,8 +1000,46 @@ class ManifestResourceResolutionTest(pkb_common_test_case.PkbCommonTestCase):
         loader=jinja2.FileSystemLoader(os.path.dirname(path))
     )
     rendered = env.get_template(os.path.basename(path)).render(
-        name='startup', boost_factor=3
+        name='startup',
+        boost_factor=3,
+        max_allowed_cpu=bench._VPA_DEFAULT_MAX_CPU['jvm'],
+        duration_seconds=bench._VPA_DEFAULT_DURATION_SECONDS['jvm'],
     )
     docs = list(yaml.safe_load_all(rendered))
     self.assertEqual(docs[0]['kind'], 'VerticalPodAutoscaler')
     self.assertEqual(docs[0]['spec']['startupBoost']['cpu']['factor'], 3)
+    self.assertEqual(
+        docs[0]['spec']['startupBoost']['cpu']['durationSeconds'], 120
+    )
+    self.assertEqual(
+        docs[0]['spec']['resourcePolicy']['containerPolicies'][0]['maxAllowed'][
+            'cpu'
+        ],
+        '1',
+    )
+
+  def testVpaManifestRendersValidYamlForVllmSizing(self):
+    # PR 4: same template, targeting the vLLM deployment name with vLLM's
+    # (larger) CPU ceiling and boost duration.
+    path = data.ResourcePath(bench.VPA_YAML.value)
+    env = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(os.path.dirname(path))
+    )
+    rendered = env.get_template(os.path.basename(path)).render(
+        name='vllm-startup',
+        boost_factor=2,
+        max_allowed_cpu=bench._VPA_DEFAULT_MAX_CPU['vllm'],
+        duration_seconds=bench._VPA_DEFAULT_DURATION_SECONDS['vllm'],
+    )
+    docs = list(yaml.safe_load_all(rendered))
+    self.assertEqual(docs[0]['kind'], 'VerticalPodAutoscaler')
+    self.assertEqual(docs[0]['spec']['targetRef']['name'], 'vllm-startup')
+    self.assertEqual(
+        docs[0]['spec']['resourcePolicy']['containerPolicies'][0]['maxAllowed'][
+            'cpu'
+        ],
+        '4',
+    )
+    self.assertEqual(
+        docs[0]['spec']['startupBoost']['cpu']['durationSeconds'], 300
+    )

--- a/tests/linux_benchmarks/kubernetes_deployment_startup_benchmark_test.py
+++ b/tests/linux_benchmarks/kubernetes_deployment_startup_benchmark_test.py
@@ -1,4 +1,4 @@
-# Copyright 2025 PerfKitBenchmarker Authors. All rights reserved.
+# Copyright 2024 PerfKitBenchmarker Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,22 +11,187 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Tests for kubernetes_deployment_startup_benchmark and startup_metrics.
 
+PR 1 — Metrics & Observability (Layer 0)
+"""
+
+import threading
+import time
 import unittest
 from unittest import mock
 
+from absl.testing import flagsaver
 from perfkitbenchmarker import benchmark_spec
+from perfkitbenchmarker import errors
 from perfkitbenchmarker import sample
+from perfkitbenchmarker.linux_benchmarks import kubernetes_deployment_startup_benchmark as bench
 from perfkitbenchmarker.linux_benchmarks import kubernetes_deployment_startup_benchmark as kdsb
 from perfkitbenchmarker.resources.container_service import kubernetes_commands
 from perfkitbenchmarker.resources.container_service import kubernetes_conditions
 from tests import pkb_common_test_case
 
 
-class KubernetesDeploymentStartupBenchmarkTest(
-    pkb_common_test_case.PkbCommonTestCase
-):
-  """Tests for the kubernetes_deployment_startup_benchmark."""
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_BASE_METADATA = {
+    'workload': 'jvm',
+    'scenario': 'baseline',
+    'cloud': 'GCP',
+    'replicas': 1,
+    'namespace': 'default',
+    'app_label': 'slowjvmstartup',
+}
+
+
+def _MakePodJson(
+    pod_name: str,
+    scheduled_ts: str,
+    started_at: str | None = None,
+    ready_ts: str | None = None,
+) -> dict:
+  """Builds a minimal pod JSON dict for testing."""
+  conditions = [
+      {
+          'type': 'PodScheduled',
+          'status': 'True',
+          'lastTransitionTime': scheduled_ts,
+      }
+  ]
+  if ready_ts:
+    conditions.append({
+        'type': 'Ready',
+        'status': 'True',
+        'lastTransitionTime': ready_ts,
+    })
+
+  container_statuses = []
+  if started_at:
+    container_statuses = [{
+        'name': 'app',
+        'ready': True,
+        'state': {'running': {'startedAt': started_at}},
+    }]
+
+  return {
+      'metadata': {'name': pod_name},
+      'status': {
+          'startTime': scheduled_ts,
+          'conditions': conditions,
+          'containerStatuses': container_statuses,
+      },
+  }
+
+
+# ---------------------------------------------------------------------------
+# startup_metrics tests
+# ---------------------------------------------------------------------------
+
+
+class StartupMetricsTest(pkb_common_test_case.PkbCommonTestCase):
+
+  def testExtractLatencyFromContainerStartedAt(self):
+    """Prefers containerStatuses[0].state.running.startedAt over Ready cond."""
+    pod = _MakePodJson(
+        'pod-1',
+        scheduled_ts='2024-01-01T00:00:00Z',
+        started_at='2024-01-01T00:00:30Z',   # 30s latency
+        ready_ts='2024-01-01T00:00:35Z',      # 35s — should NOT be used
+    )
+    latency = startup_metrics._ExtractPodStartupLatency(pod)
+    self.assertAlmostEqual(latency, 30.0, places=1)
+
+  def testExtractLatencyFallsBackToReadyCondition(self):
+    """Falls back to Ready condition when containerStatuses is absent."""
+    pod = _MakePodJson(
+        'pod-2',
+        scheduled_ts='2024-01-01T00:00:00Z',
+        ready_ts='2024-01-01T00:00:45Z',      # 45s latency via Ready cond
+    )
+    latency = startup_metrics._ExtractPodStartupLatency(pod)
+    self.assertAlmostEqual(latency, 45.0, places=1)
+
+  def testExtractLatencyReturnsNoneWhenNoReadyTimestamp(self):
+    """Returns None when no container-ready or Ready-condition timestamp exists."""
+    pod = _MakePodJson('pod-3', scheduled_ts='2024-01-01T00:00:00Z')
+    latency = startup_metrics._ExtractPodStartupLatency(pod)
+    self.assertIsNone(latency)
+
+  def testExtractLatencyReturnsNoneForNegativeLatency(self):
+    """Returns None when container-ready precedes scheduled (clock skew)."""
+    pod = _MakePodJson(
+        'pod-4',
+        scheduled_ts='2024-01-01T00:01:00Z',
+        started_at='2024-01-01T00:00:30Z',    # before scheduled → negative
+    )
+    latency = startup_metrics._ExtractPodStartupLatency(pod)
+    self.assertIsNone(latency)
+
+  def testLatenciesToSamplesEmitsAllStats(self):
+    """_LatenciesToSamples emits min/max/mean/p50/p90/p99/count."""
+    latencies = [10.0, 20.0, 30.0, 40.0, 50.0]
+    samples = startup_metrics._LatenciesToSamples(latencies, _BASE_METADATA)
+    metric_names = {s.metric for s in samples}
+    expected = {
+        'startup_latency_min',
+        'startup_latency_max',
+        'startup_latency_mean',
+        'startup_latency_p50',
+        'startup_latency_p90',
+        'startup_latency_p99',
+        'startup_latency_pod_count',
+    }
+    self.assertEqual(metric_names, expected)
+
+  def testLatenciesToSamplesValues(self):
+    """Verifies min/max/mean values are correct."""
+    latencies = [10.0, 20.0, 30.0]
+    samples = startup_metrics._LatenciesToSamples(latencies, _BASE_METADATA)
+    by_metric = {s.metric: s.value for s in samples}
+    self.assertAlmostEqual(by_metric['startup_latency_min'], 10.0)
+    self.assertAlmostEqual(by_metric['startup_latency_max'], 30.0)
+    self.assertAlmostEqual(by_metric['startup_latency_mean'], 20.0)
+    self.assertEqual(by_metric['startup_latency_pod_count'], 3)
+
+  def testLatenciesToSamplesCarryBaseMetadata(self):
+    """All samples carry the base metadata keys."""
+    latencies = [15.0]
+    samples = startup_metrics._LatenciesToSamples(latencies, _BASE_METADATA)
+    for s in samples:
+      for key in ('workload', 'scenario', 'cloud'):
+        self.assertIn(key, s.metadata)
+
+  def testGetStartupLatencySamplesEmptyOnKubectlError(self):
+    """Returns empty list when kubectl returns non-zero exit code."""
+    with mock.patch.object(
+        startup_metrics.kubectl, 'RunKubectlCommand',
+        return_value=('', 'error', 1),
+    ):
+      result = startup_metrics.GetStartupLatencySamples(
+          namespace='default', app_label='app', metadata=_BASE_METADATA
+      )
+    self.assertEqual(result, [])
+
+  def testGetStartupLatencySamplesEmptyOnBadJson(self):
+    """Returns empty list when kubectl output is not valid JSON."""
+    with mock.patch.object(
+        startup_metrics.kubectl, 'RunKubectlCommand',
+        return_value=('not json', '', 0),
+    ):
+      result = startup_metrics.GetStartupLatencySamples(
+          namespace='default', app_label='app', metadata=_BASE_METADATA
+      )
+    self.assertEqual(result, [])
+
+
+# ---------------------------------------------------------------------------
+# _CpuUtilizationCollector tests
+# ---------------------------------------------------------------------------
+
+
+class CpuUtilizationCollectorTest(pkb_common_test_case.PkbCommonTestCase):
 
   def setUp(self):
     super().setUp()
@@ -85,6 +250,140 @@ class KubernetesDeploymentStartupBenchmarkTest(
     mock_get_conditions.return_value = []
     with self.assertRaises(RuntimeError):
       kdsb.Run(self.spec)
+
+    self.collector = bench._CpuUtilizationCollector(
+        namespace='default',
+        app_label='slowjvmstartup',
+        poll_interval=1,
+    )
+
+  def testCollectorAccumulatesReadings(self):
+    """Collector accumulates readings while running."""
+    call_count = [0]
+
+    def fake_poll():
+      call_count[0] += 1
+      return 250.0
+
+    with mock.patch.object(self.collector, '_PollCpuMillicores', side_effect=fake_poll):
+      self.collector.Start()
+      time.sleep(2.5)   # Allow ~2 polls at 1s interval
+      self.collector.Stop()
+
+    self.assertGreaterEqual(len(self.collector._readings), 1)
+
+  def testGetSamplesEmitsPeakAndMean(self):
+    """GetSamples emits cpu_utilization_peak and cpu_utilization_mean."""
+    self.collector._readings = [100.0, 200.0, 300.0]
+    samples = self.collector.GetSamples(_BASE_METADATA)
+    metric_names = {s.metric for s in samples}
+    self.assertIn('cpu_utilization_peak', metric_names)
+    self.assertIn('cpu_utilization_mean', metric_names)
+    self.assertIn('cpu_utilization_reading_count', metric_names)
+
+  def testGetSamplesValues(self):
+    """Peak = max, mean = average of readings."""
+    self.collector._readings = [100.0, 200.0, 300.0]
+    samples = self.collector.GetSamples(_BASE_METADATA)
+    by_metric = {s.metric: s.value for s in samples}
+    self.assertAlmostEqual(by_metric['cpu_utilization_peak'], 300.0)
+    self.assertAlmostEqual(by_metric['cpu_utilization_mean'], 200.0)
+    self.assertEqual(by_metric['cpu_utilization_reading_count'], 3)
+
+  def testGetSamplesEmptyWhenNoReadings(self):
+    """Returns empty list when no readings collected."""
+    self.collector._readings = []
+    samples = self.collector.GetSamples(_BASE_METADATA)
+    self.assertEqual(samples, [])
+
+  def testGetSamplesCarryMetadata(self):
+    """All samples carry the base metadata and cpu-specific keys."""
+    self.collector._readings = [150.0]
+    samples = self.collector.GetSamples(_BASE_METADATA)
+    for s in samples:
+      self.assertIn('workload', s.metadata)
+      self.assertIn('scenario', s.metadata)
+
+  def testPollCpuMillicoresParsesMilliSuffix(self):
+    """_PollCpuMillicores correctly parses '250m' → 250.0."""
+    fake_output = 'slowjvmstartup-abc   250m   128Mi\n'
+    with mock.patch.object(
+        bench.kubectl, 'RunKubectlCommand',
+        return_value=(fake_output, '', 0),
+    ):
+      result = self.collector._PollCpuMillicores()
+    self.assertAlmostEqual(result, 250.0)
+
+  def testPollCpuMillicoresParsesCoreSuffix(self):
+    """_PollCpuMillicores correctly parses '1' (core) → 1000.0 millicores."""
+    fake_output = 'slowjvmstartup-abc   1   512Mi\n'
+    with mock.patch.object(
+        bench.kubectl, 'RunKubectlCommand',
+        return_value=(fake_output, '', 0),
+    ):
+      result = self.collector._PollCpuMillicores()
+    self.assertAlmostEqual(result, 1000.0)
+
+  def testPollCpuMillicoresReturnsZeroOnError(self):
+    """_PollCpuMillicores returns 0.0 when kubectl returns non-zero rc."""
+    with mock.patch.object(
+        bench.kubectl, 'RunKubectlCommand',
+        return_value=('', 'error', 1),
+    ):
+      result = self.collector._PollCpuMillicores()
+    self.assertEqual(result, 0.0)
+
+  def testCollectorIsThreadSafe(self):
+    """Concurrent Stop() and GetSamples() do not race."""
+    self.collector._readings = [100.0] * 50
+    errors = []
+
+    def read():
+      try:
+        self.collector.GetSamples(_BASE_METADATA)
+      except Exception as e:  # pylint: disable=broad-except
+        errors.append(e)
+
+    threads = [threading.Thread(target=read) for _ in range(10)]
+    for t in threads:
+      t.start()
+    for t in threads:
+      t.join()
+
+    self.assertEqual(errors, [])
+
+
+# ---------------------------------------------------------------------------
+# Benchmark lifecycle tests
+# ---------------------------------------------------------------------------
+
+
+class BenchmarkLifecycleTest(pkb_common_test_case.PkbCommonTestCase):
+
+  @flagsaver.flagsaver(
+      kubernetes_deployment_startup_scenario='optimized',
+      kubernetes_deployment_startup_workload='vllm',
+  )
+  def testCheckPrerequisitesRaisesForOptimizedVllm(self):
+    """optimized + vLLM combination not supported in PR 1."""
+    with self.assertRaises(ValueError):
+      bench.CheckPrerequisites(None)
+
+  @flagsaver.flagsaver(
+      kubernetes_deployment_startup_scenario='baseline',
+      kubernetes_deployment_startup_workload='jvm',
+  )
+  def testCheckPrerequisitesPassesForBaselineJvm(self):
+    """baseline + jvm is always valid."""
+    bench.CheckPrerequisites(None)  # Should not raise
+
+  @flagsaver.flagsaver(
+      kubernetes_deployment_startup_scenario='optimized',
+      kubernetes_deployment_startup_workload='jvm',
+  )
+  def testCheckPrerequisitesPassesForOptimizedJvm(self):
+    """optimized + jvm is valid (VPA logic is added in PR 3)."""
+    bench.CheckPrerequisites(None)  # Should not raise
 
 
 if __name__ == '__main__':

--- a/tests/linux_benchmarks/kubernetes_deployment_startup_benchmark_test.py
+++ b/tests/linux_benchmarks/kubernetes_deployment_startup_benchmark_test.py
@@ -501,6 +501,8 @@ class ScenarioTest(pkb_common_test_case.PkbCommonTestCase):
         bench.kubernetes_commands,
         'ApplyManifest',
         side_effect=lambda *a, **kw: apply_calls.append(a[0]),
+    ), mock.patch.object(
+        bench.kubectl, 'RunKubectlCommand', return_value=('', '', 0)
     ):
       bench.Prepare(_MakeSpec())
     self.assertLen(apply_calls, 2)
@@ -524,6 +526,8 @@ class ScenarioTest(pkb_common_test_case.PkbCommonTestCase):
         bench.kubernetes_commands,
         'ApplyManifest',
         side_effect=lambda *a, **kw: apply_calls.append(a[0]),
+    ), mock.patch.object(
+        bench.kubectl, 'RunKubectlCommand', return_value=('', '', 0)
     ):
       bench.Prepare(_MakeSpec())
     self.assertLen(apply_calls, 2)
@@ -592,6 +596,60 @@ class ScenarioTest(pkb_common_test_case.PkbCommonTestCase):
     pod_samples = [s for s in samples if 'boost_factor' in s.metadata]
     for s in pod_samples:
       self.assertEqual(s.metadata['boost_factor'], 1)
+
+
+# ---------------------------------------------------------------------------
+# PR 3: VPA CRD registration race fix
+#
+# Enabling VPA via --enable-vertical-pod-autoscaling triggers an
+# asynchronous GKE addon install for the VPA CRDs, which can lag behind the
+# cluster's own RUNNING status and kube-dns readiness. A production run
+# (config 4) hit exactly this: `kubectl apply` for the VerticalPodAutoscaler
+# manifest failed with "no matches for kind VerticalPodAutoscaler" just a
+# few seconds after kube-dns reported ready, because the CRD wasn't
+# registered yet. _WaitForVpaCrd polls for the CRD before Prepare() applies
+# the VPA manifest, instead of assuming it's already there.
+# ---------------------------------------------------------------------------
+
+
+class WaitForVpaCrdTest(pkb_common_test_case.PkbCommonTestCase):
+  """Tests for _WaitForVpaCrd (VPA CRD registration race fix)."""
+
+  def testSucceedsWhenCrdAlreadyRegistered(self):
+    with mock.patch.object(
+        bench.kubectl, 'RunKubectlCommand', return_value=('', '', 0)
+    ) as mock_kubectl:
+      bench._WaitForVpaCrd()
+    # Must NOT pass raise_on_failure=False: kubectl.RunKubectlCommand's
+    # suppress_failure wrapper rewrites a suppressed failure's return code
+    # to 0, which would silently defeat any retcode-based readiness check
+    # -- this is exactly the bug that shipped in the first version of this
+    # fix (a failing "get crd" was reported as success). _WaitForVpaCrd
+    # must rely on RunKubectlCommand raising naturally instead.
+    mock_kubectl.assert_called_once_with(['get', 'crd', bench._VPA_CRD_NAME])
+
+  def testRaisesRuntimeErrorWhenCrdNeverRegisters(self):
+    # A short timeout keeps this test fast: vm_util.Retry checks the
+    # deadline before sleeping, so with timeout << poll_interval it raises
+    # on the very first failed poll instead of actually waiting.
+    #
+    # side_effect (a raised IssueCommandError), not return_value with an
+    # rc=1 tuple: kubectl.RunKubectlCommand's suppress_failure wrapper
+    # rewrites a suppressed failure's return code to 0, so a mock that
+    # just returns rc=1 would not reproduce the real "get crd" failure
+    # mode -- this distinction is exactly what let the CRD-wait fix ship
+    # with a check that could never actually trigger.
+    with mock.patch.object(
+        bench, '_VPA_CRD_WAIT_TIMEOUT_SECS', 1
+    ), mock.patch.object(
+        bench.kubectl,
+        'RunKubectlCommand',
+        side_effect=errors.VmUtil.IssueCommandError(
+            'Error from server (NotFound)'
+        ),
+    ):
+      with self.assertRaises(RuntimeError):
+        bench._WaitForVpaCrd()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
PR 3 of 3 — Baseline/Optimized Scenario + CPU Startup Boost via VPA.

**Stacked on PR #6865 (PR 1) and PR #6867 (PR 2).** Please review after both merge.

**Completes the 4-configuration benchmark matrix:**
- Config 1: GKE w/o cpuboost (`scenario=baseline, cloud=GCP`)
- Config 2: AWS w/o cpuboost (`scenario=baseline, cloud=AWS`)
- Config 3: AKS w/o cpuboost (`scenario=baseline, cloud=Azure`)
- Config 4: GKE w/ cpuboost (`scenario=optimized, cloud=GCP`)

**Changes:**
- `--kubernetes_deployment_startup_boost_factor` flag (default 2, per Kam's guide).
- `CheckPrerequisites()`: raises if `scenario=optimized` on non-GCP or with vLLM.
- `GetConfig()`: sets `enable_vpa=True` for `scenario=optimized`.
- `Prepare()`: applies VPA manifest with `cpuBoostFactor` for optimized scenario.
- `Run()`: adds `boost_factor` to all sample metadata for cross-config comparison.
- `slowjvmstartup_vpa.yaml.j2`: VPA with startup boost policy targeting the JVM deployment.

**Note:** Exact VPA startup-boost policy fields follow Kam's linked guide.