### PR TITLE
GKE Infrastructure Extensions

### DIFF
--- a/perfkitbenchmarker/providers/gcp/flags.py
+++ b/perfkitbenchmarker/providers/gcp/flags.py
@@ -592,6 +592,21 @@ GKE_CLUSTER_IPV4_CIDR_SIZE = flags.DEFINE_integer(
     ' the size derived from max_vm_count. Use when the cluster will scale'
     ' beyond the default node pool (e.g. kubernetes_node_scale with 5k nodes).',
 )
+
+
+GKE_ADDITIONAL_FLAGS = flags.DEFINE_list(
+    'gke_additional_flags',
+    [],
+    'Additional flags to pass to gcloud container clusters create. '
+    'Example: --gke_additional_flags=--enable-pod-snapshots,--enable-dataplane-v2',
+)
+
+GKE_ADDITIONAL_NODEPOOL_FLAGS = flags.DEFINE_list(
+    'gke_additional_nodepool_flags',
+    [],
+    'Additional flags to pass to gcloud container node-pools create. '
+    'Example: --gke_additional_nodepool_flags=--max-pods-per-node=250',
+)
 GCE_PERFORMANCE_MONITORING_UNIT = flags.DEFINE_enum(
     'gce_performance_monitoring_unit',
     None,
@@ -639,6 +654,12 @@ GCS_FUSE_ENABLE_METADATA_CACHE = flags.DEFINE_boolean(
     'gcs_fuse_enable_metadata_cache',
     False,
     'Whether to enable metadata cache for gcs fuse.',
+)
+SKIP_CONTAINER_IMAGE_BUILD = flags.DEFINE_bool(
+    'skip_container_image_build',
+    False,
+    'Skip container image builds during provision. Use when images are '
+    'pre-built. The image tag is still computed but no build runs.',
 )
 
 

--- a/perfkitbenchmarker/providers/gcp/google_kubernetes_engine.py
+++ b/perfkitbenchmarker/providers/gcp/google_kubernetes_engine.py
@@ -119,15 +119,64 @@ class GoogleArtifactRegistry(container_registry.BaseContainerRegistry):
         f'--location={self.region}',
     ).Issue()
 
-  def RemoteBuild(self, image: container.ContainerImage):
-    """Builds the image remotely."""
-    if not gcp_flags.CONTAINER_REMOTE_BUILD_CONFIG.value:
-      full_tag = self.GetFullRegistryTag(image.name)
-    else:
-      full_tag = gcp_flags.CONTAINER_REMOTE_BUILD_CONFIG.value
-    build_cmd = util.GcloudCommand(
-        self, 'builds', 'submit', '--tag', full_tag, image.directory
+
+  def _WaitForRepository(self, timeout=300, poll_interval=5):
+    """Wait for the AR repository to be queryable.
+
+    After creation, AR repos may not be immediately visible to Cloud
+    Build workers in other zones. Polls until confirmed, preventing
+    push failures during RemoteBuild().
+    """
+    repo_name = self.name
+    location = self.region
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+      describe_cmd = util.GcloudCommand(
+          self, 'artifacts', 'repositories', 'describe', repo_name,
+          '--location', location,
+      )
+      stdout, _, retcode = describe_cmd.Issue(
+          raise_on_failure=False, timeout=15,
+      )
+      if retcode == 0 and stdout.strip():
+        logging.info('AR repo %s confirmed available.', repo_name)
+        return
+      logging.info(
+          'Waiting for AR repo %s to propagate (%ds remaining)...',
+          repo_name, int(deadline - time.time()),
+      )
+      time.sleep(poll_interval)
+    logging.warning(
+        'AR repo %s not confirmed after %ds. Proceeding anyway.',
+        repo_name, timeout,
     )
+
+  def RemoteBuild(self, image: container.ContainerImage):
+    """Builds the image remotely.
+
+    If --container_remote_build_config is set, uses it as the
+    --config argument to `gcloud builds submit` and passes the
+    image tag via --substitutions _IMAGE=<tag>.
+    Otherwise uses the simple --tag shorthand.
+    """
+    full_tag = self.GetFullRegistryTag(image.name)
+    if gcp_flags.SKIP_CONTAINER_IMAGE_BUILD.value:
+      logging.info('Skipping container image build (--skip_container_image_build). '
+                   'Assuming image exists: %s', full_tag)
+      return
+    self._WaitForRepository()
+    if gcp_flags.CONTAINER_REMOTE_BUILD_CONFIG.value:
+      build_cmd = util.GcloudCommand(
+          self, 'builds', 'submit',
+          '--config', gcp_flags.CONTAINER_REMOTE_BUILD_CONFIG.value,
+          '--substitutions', f'_IMAGE={full_tag}',
+          '--suppress-logs',
+          image.directory,
+      )
+    else:
+      build_cmd = util.GcloudCommand(
+          self, 'builds', 'submit', '--tag', full_tag, '--suppress-logs', image.directory,
+      )
     build_cmd.Issue(timeout=None)
 
 
@@ -512,6 +561,10 @@ class GkeCluster(BaseGkeCluster):
     if self.enable_aam:
       cmd.args.append('--auto-monitoring-scope=ALL')
 
+    # Add arbitrary additional flags (e.g., --enable-pod-snapshots)
+    for additional_flag in gcp_flags.GKE_ADDITIONAL_FLAGS.value:
+      cmd.args.append(additional_flag)
+
     self._RunClusterCreateCommand(cmd)
     self._GetKubeconfig()
     self._CreateCustomComputeClass(self.default_nodepool)
@@ -527,6 +580,11 @@ class GkeCluster(BaseGkeCluster):
           'container', 'node-pools', 'create', name, '--cluster', self.name
       )
       self._AddNodeParamsToCmd(nodepool, cmd)
+
+      # Add arbitrary additional node pool flags (e.g., --max-pods-per-node=250)
+      for additional_flag in gcp_flags.GKE_ADDITIONAL_NODEPOOL_FLAGS.value:
+        cmd.args.append(additional_flag)
+
       self._IssueResourceCreationCommand(cmd)
       self._CreateCustomComputeClass(nodepool)
 

--- a/perfkitbenchmarker/providers/gcp/google_kubernetes_engine.py
+++ b/perfkitbenchmarker/providers/gcp/google_kubernetes_engine.py
@@ -119,15 +119,71 @@ class GoogleArtifactRegistry(container_registry.BaseContainerRegistry):
         f'--location={self.region}',
     ).Issue()
 
-  def RemoteBuild(self, image: container.ContainerImage):
-    """Builds the image remotely."""
-    if not gcp_flags.CONTAINER_REMOTE_BUILD_CONFIG.value:
-      full_tag = self.GetFullRegistryTag(image.name)
-    else:
-      full_tag = gcp_flags.CONTAINER_REMOTE_BUILD_CONFIG.value
-    build_cmd = util.GcloudCommand(
-        self, 'builds', 'submit', '--tag', full_tag, image.directory
+
+  def _WaitForRepository(self, timeout=300, poll_interval=5):
+    """Wait for the AR repository to be queryable.
+
+    After creation, AR repos may not be immediately visible to Cloud
+    Build workers in other zones. Polls until confirmed, preventing
+    push failures during RemoteBuild().
+    
+    Args:
+      timeout: The maximum time in seconds to wait for the repository to be queryable.
+      poll_interval: The time in seconds to wait between polling attempts.    
+    """
+    repo_name = self.name
+    location = self.region
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+      describe_cmd = util.GcloudCommand(
+          self, 'artifacts', 'repositories', 'describe', repo_name,
+          '--location', location,
+      )
+      stdout, _, retcode = describe_cmd.Issue(
+          raise_on_failure=False, timeout=15,
+      )
+      if retcode == 0 and stdout.strip():
+        logging.info('AR repo %s confirmed available.', repo_name)
+        return
+      logging.info(
+          'Waiting for AR repo %s to propagate (%ds remaining)...',
+          repo_name, int(deadline - time.time()),
+      )
+      time.sleep(poll_interval)
+    logging.warning(
+        'AR repo %s not confirmed after %ds. Proceeding anyway.',
+        repo_name, timeout,
     )
+
+  def RemoteBuild(self, image: container.ContainerImage):
+    """Builds the image remotely.
+
+    If --container_remote_build_config is set, uses it as the
+    --config argument to `gcloud builds submit` and passes the
+    image tag via --substitutions _IMAGE=<tag>.
+    Otherwise uses the simple --tag shorthand.
+    
+    Args:
+      image: The container image object containing the name and directory to build.
+    """
+    full_tag = self.GetFullRegistryTag(image.name)
+    if gcp_flags.SKIP_CONTAINER_IMAGE_BUILD.value:
+      logging.info('Skipping container image build (--skip_container_image_build). '
+                   'Assuming image exists: %s', full_tag)
+      return
+    self._WaitForRepository()
+    if gcp_flags.CONTAINER_REMOTE_BUILD_CONFIG.value:
+      build_cmd = util.GcloudCommand(
+          self, 'builds', 'submit',
+          '--config', gcp_flags.CONTAINER_REMOTE_BUILD_CONFIG.value,
+          '--substitutions', f'_IMAGE={full_tag}',
+          '--suppress-logs',
+          image.directory,
+      )
+    else:
+      build_cmd = util.GcloudCommand(
+          self, 'builds', 'submit', '--tag', full_tag, '--suppress-logs', image.directory,
+      )
     build_cmd.Issue(timeout=None)
 
 
@@ -512,6 +568,10 @@ class GkeCluster(BaseGkeCluster):
     if self.enable_aam:
       cmd.args.append('--auto-monitoring-scope=ALL')
 
+    # Add arbitrary additional flags (e.g., --enable-pod-snapshots)
+    for additional_flag in gcp_flags.GKE_ADDITIONAL_FLAGS.value:
+      cmd.args.append(additional_flag)
+
     self._RunClusterCreateCommand(cmd)
     self._GetKubeconfig()
     self._CreateCustomComputeClass(self.default_nodepool)
@@ -527,6 +587,11 @@ class GkeCluster(BaseGkeCluster):
           'container', 'node-pools', 'create', name, '--cluster', self.name
       )
       self._AddNodeParamsToCmd(nodepool, cmd)
+
+      # Add arbitrary additional node pool flags (e.g., --max-pods-per-node=250)
+      for additional_flag in gcp_flags.GKE_ADDITIONAL_NODEPOOL_FLAGS.value:
+        cmd.args.append(additional_flag)
+
       self._IssueResourceCreationCommand(cmd)
       self._CreateCustomComputeClass(nodepool)
 


### PR DESCRIPTION
**Files:** 2 files modified (no new files)
- `perfkitbenchmarker/providers/gcp/flags.py` — 3 new flags
- `perfkitbenchmarker/providers/gcp/google_kubernetes_engine.py` — `RemoteBuild()` enhancement + GKE flag passthrough

**Description:** Extends PKB's GKE provider with three capabilities needed by downstream benchmarks:
1. `--gke_additional_flags` / `--gke_additional_nodepool_flags` — pass arbitrary flags to `gcloud container clusters create` and `node-pools create` (e.g., `--enable-pod-snapshots`, `--max-pods-per-node=250`)
2. `--skip_container_image_build` — skip `RemoteBuild()` when images are pre-built (needed for cross-architecture builds)
3. `RemoteBuild()` support for `--container_remote_build_config` — uses `gcloud builds submit --config <yaml> --substitutions _IMAGE=<tag>` instead of `--tag` (needed for ARM64 cross-compilation via Cloud Build)