### PR TITLE
Warmpool & Deletion Benchmarks

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/kubernetes/agentic/k8s_deletion_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/kubernetes/agentic/k8s_deletion_benchmark.py
@@ -1,0 +1,511 @@
+# Copyright 2026 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""PKB Benchmark: GKE Agent Deletion & Cleanup .
+
+Atomic single-point measurement of bulk deletion efficiency and IP
+reclamation on a pre-provisioned GKE cluster with gVisor isolation.
+Provisions N sandbox pods via SandboxWarmPool, then bulk-deletes them
+and measures per-pod deletion latency, aggregate deletion stats, and
+IP address reclamation timing.
+
+This benchmark is designed to be invoked repeatedly by an external sweep
+controller that varies the batch_size parameter across iterations to find
+the deletion saturation point.
+
+Usage:
+  python pkb.py --benchmarks=gke_deletion \\
+                --k8s_deletion_batch_size=100 \\
+                --k8s_deletion_warmpool_name=python-sandbox-warmpool \\
+                --k8s_deletion_pod_label=sandbox=python-sandbox-example \\
+                --k8s_deletion_poll_interval_s=1.0 \\
+                --k8s_deletion_provision_timeout_s=120.0 \\
+                --k8s_deletion_drain_timeout_s=300.0 \\
+                --k8s_agentic_namespace=agentic \\
+                --gke_machine_type=c4-standard-8
+
+Samples emitted (per run):
+  - gke_deletion_provision_time              (seconds)
+  - gke_deletion_total_drain_time            (seconds)
+  - gke_deletion_latency_p50                 (seconds)
+  - gke_deletion_latency_p95                 (seconds)
+  - gke_deletion_latency_p99                 (seconds)
+  - gke_deletion_latency_max                 (seconds)
+  - gke_deletion_rate                        (pods/sec)
+  - gke_deletion_ip_before                   (count)
+  - gke_deletion_ip_after                    (count)
+  - gke_deletion_ip_reclaim_time             (seconds)
+  - gke_deletion_final_running_count         (count)
+  - gke_deletion_wall_time                   (seconds)
+"""
+
+from __future__ import annotations
+
+
+import json
+import logging
+import time
+import uuid
+
+from absl import flags
+from perfkitbenchmarker import sample
+from perfkitbenchmarker import configs
+from perfkitbenchmarker.linux_benchmarks.kubernetes.agentic import (
+    k8s_benchmark_utils as utils,
+)
+from perfkitbenchmarker.linux_benchmarks.kubernetes.agentic import (
+    gke_deploy_utils as deploy_utils,
+)
+
+FLAGS = flags.FLAGS
+
+BENCHMARK_NAME = "k8s_deletion"
+BENCHMARK_CONFIG = """
+k8s_deletion:
+  description: >
+    Atomic single-point bulk deletion and IP reclamation measurement on a
+    pre-provisioned GKE cluster with gVisor isolation.
+  flags: {}
+  container_registry: {}
+  container_specs: {}
+  container_cluster: {}
+"""
+
+# ---------------------------------------------------------------------------
+# Benchmark-specific flags
+# ---------------------------------------------------------------------------
+
+flags.DEFINE_integer(
+    "k8s_deletion_batch_size",
+    100,
+    "Number of sandbox pods to provision then bulk-delete.",
+)
+
+flags.DEFINE_string(
+    "k8s_deletion_warmpool_name",
+    "python-sandbox-warmpool",
+    "SandboxWarmPool resource name.",
+)
+
+flags.DEFINE_string(
+    "k8s_deletion_pod_label",
+    "sandbox=python-sandbox-example",
+    "Label selector for warm pool pods.",
+)
+
+flags.DEFINE_float(
+    "k8s_deletion_poll_interval_s",
+    1.0,
+    "Seconds between kubectl polls during deletion.",
+)
+
+flags.DEFINE_float(
+    "k8s_deletion_provision_timeout_s",
+    120.0,
+    "Max seconds to wait for pods to reach Running before deletion.",
+)
+
+flags.DEFINE_float(
+    "k8s_deletion_drain_timeout_s",
+    300.0,
+    "Max seconds to wait for all pods to terminate after scale-to-0.",
+)
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+def GetConfig(user_config: dict) -> dict:
+    """Load and return benchmark config.
+
+    No vm_groups — PKB skips Provision() and Teardown().
+    """
+    return configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
+
+
+def Prepare(benchmark_spec: object) -> None:
+    """Deploy workloads onto the cluster."""
+    benchmark_spec.always_call_cleanup = True
+    logging.info("=== Prepare: deploying workloads ===")
+    deploy_utils.DeployWorkloads(benchmark_spec)
+    utils.EnsurePortForward()
+    logging.info("Prepare complete.")
+
+
+def Run(benchmark_spec: object) -> list[sample.Sample]:
+    """Provision N pods, bulk-delete, measure deletion latency and IP reclamation.
+
+    Returns:
+      List of sample.Sample objects.
+    """
+    utils.set_benchmark_spec(benchmark_spec)
+
+    ns = FLAGS.k8s_agentic_namespace
+    batch_size = FLAGS.k8s_deletion_batch_size
+    warmpool_name = FLAGS.k8s_deletion_warmpool_name
+    label = FLAGS.k8s_deletion_pod_label
+    poll_interval = FLAGS.k8s_deletion_poll_interval_s
+    provision_timeout = FLAGS.k8s_deletion_provision_timeout_s
+    drain_timeout = FLAGS.k8s_deletion_drain_timeout_s
+
+    logging.info("=== Run: batch_size=%d ===", batch_size)
+
+    # Drain to 0 for clean measurement (moved from Prepare for sweep compatibility)
+    utils.DrainWarmPool(ns, warmpool_name, label, timeout=int(drain_timeout))
+    time.sleep(2)
+
+    t_wall_start = time.monotonic()
+
+    # 1. Provision N pods
+    logging.info("Provisioning %d pods...", batch_size)
+    provision_start = time.monotonic()
+    _PatchReplicas(ns, warmpool_name, batch_size)
+
+    deadline = time.time() + provision_timeout
+    while time.time() < deadline:
+        running = utils.CountPods(ns, label, phase="Running")
+        pct = (running / batch_size * 100) if batch_size > 0 else 0
+        logging.info("Provisioning... %d/%d (%.0f%%)", running, batch_size, pct)
+        if running >= batch_size:
+            break
+        time.sleep(3)
+
+    provision_time = time.monotonic() - provision_start
+    final_running = utils.CountPods(ns, label, phase="Running")
+
+    logging.info(
+        "Provisioned %d/%d pods in %.1fs",
+        final_running,
+        batch_size,
+        provision_time,
+    )
+
+    # If not all pods reached Running, this is a failure
+    if final_running < batch_size:
+        raise RuntimeError(
+            f"Provisioning failed: only {final_running}/{batch_size} pods "
+            f"reached Running within {provision_timeout}s"
+        )
+
+    # 2. Record pod names and IP count before deletion
+    pod_names_before = set(_GetPodNames(ns, label))
+    ip_before = _CountAllocatedIPs(ns, label)
+
+    logging.info(
+        "Recorded %d pods, %d IPs allocated",
+        len(pod_names_before),
+        ip_before,
+    )
+
+    # Brief settle
+    time.sleep(1)
+
+    # 3. Bulk delete: scale to 0
+    logging.info("Scaling to 0 (bulk delete of %d pods)...", len(pod_names_before))
+    _PatchReplicas(ns, warmpool_name, 0)
+
+    # 4. Poll: track pod disappearance and IP reclamation
+    t_delete = time.monotonic()
+    deadline_drain = t_delete + drain_timeout
+    pod_gone_times = {}  # pod_name -> elapsed_s when first absent
+    ip_reclaim_time = None
+
+    while time.time() < deadline_drain:
+        elapsed = time.monotonic() - t_delete
+
+        # Current pod names still present
+        current_pods = set(_GetPodNames(ns, label))
+        remaining = len(current_pods)
+
+        # Track which pods have disappeared
+        gone_now = pod_names_before - current_pods
+        for pn in gone_now:
+            if pn not in pod_gone_times:
+                pod_gone_times[pn] = elapsed
+
+        # IP count (scoped to warm pool label)
+        ips = _CountAllocatedIPs(ns, label)
+        if ip_reclaim_time is None and ips == 0:
+            ip_reclaim_time = elapsed
+
+        deleted = len(pod_names_before) - remaining
+        pct = (deleted / len(pod_names_before) * 100) if pod_names_before else 0
+        logging.info(
+            "[%.1fs] Deleted: %d/%d (%.0f%%)  IPs: %d",
+            elapsed,
+            deleted,
+            len(pod_names_before),
+            pct,
+            ips,
+        )
+
+        if remaining == 0:
+            break
+
+        time.sleep(poll_interval)
+
+    total_drain_time = time.monotonic() - t_delete
+
+    # Pods we never saw disappear (stuck) get the full drain time
+    for pn in pod_names_before:
+        if pn not in pod_gone_times:
+            pod_gone_times[pn] = total_drain_time
+
+    # 5. Compute per-pod deletion latencies
+    deletion_latencies = sorted(pod_gone_times.values())
+    n = len(deletion_latencies)
+
+    ip_after = _CountAllocatedIPs(ns, label)
+    deletion_rate = (
+        (len(pod_names_before) / total_drain_time) if total_drain_time > 0 else 0
+    )
+
+    logging.info(
+        "Drain complete: %.1fs, rate=%.1f pods/sec, IPs: %d->%d",
+        total_drain_time,
+        deletion_rate,
+        ip_before,
+        ip_after,
+    )
+
+    wall_time = time.monotonic() - t_wall_start
+
+    # 6. Build samples
+    run_id = str(uuid.uuid4())[:8]
+
+    extra = {
+        "run_id": run_id,
+        "batch_size": batch_size,
+        "final_running_count": final_running,
+        "ip_before": ip_before,
+        "ip_after": ip_after,
+        "wall_time_s": round(wall_time, 2),
+    }
+
+    samples = []
+
+    samples.append(
+        utils.MakeSample(
+            f"{BENCHMARK_NAME}_provision_time",
+            round(provision_time, 2),
+            "seconds",
+            ns,
+            extra,
+        )
+    )
+    samples.append(
+        utils.MakeSample(
+            f"{BENCHMARK_NAME}_total_drain_time",
+            round(total_drain_time, 2),
+            "seconds",
+            ns,
+            extra,
+        )
+    )
+
+    if n > 0:
+        samples.append(
+            utils.MakeSample(
+                f"{BENCHMARK_NAME}_latency_p50",
+                round(_Percentile(deletion_latencies, 50), 3),
+                "seconds",
+                ns,
+                extra,
+            )
+        )
+        samples.append(
+            utils.MakeSample(
+                f"{BENCHMARK_NAME}_latency_p95",
+                round(_Percentile(deletion_latencies, 95), 3),
+                "seconds",
+                ns,
+                extra,
+            )
+        )
+        samples.append(
+            utils.MakeSample(
+                f"{BENCHMARK_NAME}_latency_p99",
+                round(_Percentile(deletion_latencies, 99), 3),
+                "seconds",
+                ns,
+                extra,
+            )
+        )
+        samples.append(
+            utils.MakeSample(
+                f"{BENCHMARK_NAME}_latency_max",
+                round(deletion_latencies[-1], 3),
+                "seconds",
+                ns,
+                extra,
+            )
+        )
+
+    samples.append(
+        utils.MakeSample(
+            f"{BENCHMARK_NAME}_rate",
+            round(deletion_rate, 2),
+            "pods/sec",
+            ns,
+            extra,
+        )
+    )
+    samples.append(
+        utils.MakeSample(
+            f"{BENCHMARK_NAME}_ip_before",
+            float(ip_before),
+            "count",
+            ns,
+            extra,
+        )
+    )
+    samples.append(
+        utils.MakeSample(
+            f"{BENCHMARK_NAME}_ip_after",
+            float(ip_after),
+            "count",
+            ns,
+            extra,
+        )
+    )
+
+    if ip_reclaim_time is not None:
+        samples.append(
+            utils.MakeSample(
+                f"{BENCHMARK_NAME}_ip_reclaim_time",
+                round(ip_reclaim_time, 2),
+                "seconds",
+                ns,
+                extra,
+            )
+        )
+
+    samples.append(
+        utils.MakeSample(
+            f"{BENCHMARK_NAME}_final_running_count",
+            float(final_running),
+            "count",
+            ns,
+            extra,
+        )
+    )
+    samples.append(
+        utils.MakeSample(
+            f"{BENCHMARK_NAME}_wall_time",
+            round(wall_time, 2),
+            "seconds",
+            ns,
+            extra,
+        )
+    )
+
+    logging.info("Emitted %d samples for batch_size=%d.", len(samples), batch_size)
+    psi_data = utils.ScrapePsi(ns)
+    for k, v in psi_data.items():
+        samples.append(utils.MakeSample(f"{BENCHMARK_NAME}_{k}", v, "percent", ns, extra))
+
+    return samples
+
+
+def Cleanup(benchmark_spec: object) -> None:
+    """Best-effort drain of warm pool after measurement."""
+    ns = FLAGS.k8s_agentic_namespace
+    warmpool_name = FLAGS.k8s_deletion_warmpool_name
+    label = FLAGS.k8s_deletion_pod_label
+
+    logging.info("Cleanup: draining warm pool to 0.")
+    utils.DrainWarmPool(ns, warmpool_name, label, timeout=int(FLAGS.k8s_deletion_drain_timeout_s))
+    utils.StopPortForward()
+    logging.info("Cleanup complete.")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _PatchReplicas(namespace: str, warmpool_name: str, replicas: int) -> None:
+    """Patch SandboxWarmPool to a specific replica count."""
+    patch_json = json.dumps({"spec": {"replicas": replicas}})
+    utils.RunKubectl(
+        [
+            "patch",
+            "sandboxwarmpool",
+            warmpool_name,
+            "-n",
+            namespace,
+            "--type=merge",
+            f"-p={patch_json}",
+        ],
+        raise_on_failure=False,
+    )
+
+
+def _GetPodNames(namespace: str, label: str) -> list[str]:
+    """Return list of pod names matching the label selector."""
+    stdout, _, rc = utils.RunKubectl(
+        [
+            "get",
+            "pods",
+            "-n",
+            namespace,
+            "-l",
+            label,
+            "-o",
+            "jsonpath={.items[*].metadata.name}",
+        ],
+        timeout=30,
+        raise_on_failure=False,
+    )
+    if not stdout or not stdout.strip():
+        return []
+    return stdout.split()
+
+
+def _CountAllocatedIPs(namespace: str, label: str) -> int:
+    """Count pod IPs currently allocated for pods matching the label.
+
+    Scoped to the warm pool label to accurately measure IPAM release
+    efficiency for the specific pods being deleted.
+    """
+    stdout, _, rc = utils.RunKubectl(
+        [
+            "get",
+            "pods",
+            "-n",
+            namespace,
+            "-l",
+            label,
+            "-o",
+            "jsonpath={.items[*].status.podIP}",
+        ],
+        timeout=30,
+        raise_on_failure=False,
+    )
+    if not stdout or not stdout.strip():
+        return 0
+    return len([ip for ip in stdout.split() if ip])
+
+
+def _Percentile(sorted_values: list[float], pct: float) -> float:
+    """Calculate percentile (0-100) with linear interpolation."""
+    if not sorted_values:
+        return 0.0
+    idx = (pct / 100) * (len(sorted_values) - 1)
+    lo = int(idx)
+    hi = min(lo + 1, len(sorted_values) - 1)
+    frac = idx - lo
+    return sorted_values[lo] * (1 - frac) + sorted_values[hi] * frac

--- a/perfkitbenchmarker/linux_benchmarks/kubernetes/agentic/k8s_deletion_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/kubernetes/agentic/k8s_deletion_benchmark.py
@@ -1,0 +1,530 @@
+# Copyright 2026 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""PKB Benchmark: GKE Agent Deletion & Cleanup .
+
+Atomic single-point measurement of bulk deletion efficiency and IP
+reclamation on a pre-provisioned GKE cluster with gVisor isolation.
+Provisions N sandbox pods via SandboxWarmPool, then bulk-deletes them
+and measures per-pod deletion latency, aggregate deletion stats, and
+IP address reclamation timing.
+
+This benchmark is designed to be invoked repeatedly by an external sweep
+controller that varies the batch_size parameter across iterations to find
+the deletion saturation point.
+
+Usage:
+  python pkb.py --benchmarks=gke_deletion \\
+                --k8s_deletion_batch_size=100 \\
+                --k8s_deletion_warmpool_name=python-sandbox-warmpool \\
+                --k8s_deletion_pod_label=sandbox=python-sandbox-example \\
+                --k8s_deletion_poll_interval_s=1.0 \\
+                --k8s_deletion_provision_timeout_s=120.0 \\
+                --k8s_deletion_drain_timeout_s=300.0 \\
+                --k8s_agentic_namespace=agentic \\
+                --gke_machine_type=c4-standard-8
+
+Samples emitted (per run):
+  - gke_deletion_provision_time              (seconds)
+  - gke_deletion_total_drain_time            (seconds)
+  - gke_deletion_latency_p50                 (seconds)
+  - gke_deletion_latency_p95                 (seconds)
+  - gke_deletion_latency_p99                 (seconds)
+  - gke_deletion_latency_max                 (seconds)
+  - gke_deletion_rate                        (pods/sec)
+  - gke_deletion_ip_before                   (count)
+  - gke_deletion_ip_after                    (count)
+  - gke_deletion_ip_reclaim_time             (seconds)
+  - gke_deletion_final_running_count         (count)
+  - gke_deletion_wall_time                   (seconds)
+"""
+
+from __future__ import annotations
+
+
+import json
+import logging
+import time
+import uuid
+
+from absl import flags
+from perfkitbenchmarker import sample
+from perfkitbenchmarker import configs
+from perfkitbenchmarker.linux_benchmarks.kubernetes.agentic import (
+    k8s_benchmark_utils as utils,
+)
+from perfkitbenchmarker.linux_benchmarks.kubernetes.agentic import (
+    gke_deploy_utils as deploy_utils,
+)
+
+FLAGS = flags.FLAGS
+
+BENCHMARK_NAME = "k8s_deletion"
+BENCHMARK_CONFIG = """
+k8s_deletion:
+  description: >
+    Atomic single-point bulk deletion and IP reclamation measurement on a
+    pre-provisioned GKE cluster with gVisor isolation.
+  flags: {}
+  container_registry: {}
+  container_specs: {}
+  container_cluster: {}
+"""
+
+# ---------------------------------------------------------------------------
+# Benchmark-specific flags
+# ---------------------------------------------------------------------------
+
+flags.DEFINE_integer(
+    "k8s_deletion_batch_size",
+    100,
+    "Number of sandbox pods to provision then bulk-delete.",
+)
+
+flags.DEFINE_string(
+    "k8s_deletion_warmpool_name",
+    "python-sandbox-warmpool",
+    "SandboxWarmPool resource name.",
+)
+
+flags.DEFINE_string(
+    "k8s_deletion_pod_label",
+    "sandbox=python-sandbox-example",
+    "Label selector for warm pool pods.",
+)
+
+flags.DEFINE_float(
+    "k8s_deletion_poll_interval_s",
+    1.0,
+    "Seconds between kubectl polls during deletion.",
+)
+
+flags.DEFINE_float(
+    "k8s_deletion_provision_timeout_s",
+    120.0,
+    "Max seconds to wait for pods to reach Running before deletion.",
+)
+
+flags.DEFINE_float(
+    "k8s_deletion_drain_timeout_s",
+    300.0,
+    "Max seconds to wait for all pods to terminate after scale-to-0.",
+)
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+def GetConfig(user_config: dict) -> dict:
+    """Load and return benchmark config.
+
+    No vm_groups — PKB skips Provision() and Teardown().
+    """
+    return configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
+
+
+def Prepare(benchmark_spec: object) -> None:
+    """Deploy workloads onto the cluster."""
+    benchmark_spec.always_call_cleanup = True
+    logging.info("=== Prepare: deploying workloads ===")
+    deploy_utils.DeployWorkloads(benchmark_spec)
+    utils.EnsurePortForward()
+    logging.info("Prepare complete.")
+
+
+def Run(benchmark_spec: object) -> list[sample.Sample]:
+    """Provision N pods, bulk-delete, measure deletion latency and IP reclamation.
+
+    Returns:
+      List of sample.Sample objects.
+    """
+    utils.set_benchmark_spec(benchmark_spec)
+
+    ns = FLAGS.k8s_agentic_namespace
+    batch_size = FLAGS.k8s_deletion_batch_size
+    warmpool_name = FLAGS.k8s_deletion_warmpool_name
+    label = FLAGS.k8s_deletion_pod_label
+    poll_interval = FLAGS.k8s_deletion_poll_interval_s
+    provision_timeout = FLAGS.k8s_deletion_provision_timeout_s
+    drain_timeout = FLAGS.k8s_deletion_drain_timeout_s
+
+    logging.info("=== Run: batch_size=%d ===", batch_size)
+
+    # Drain to 0 for clean measurement (moved from Prepare for sweep compatibility)
+    utils.DrainWarmPool(ns, warmpool_name, label, timeout=int(drain_timeout))
+    time.sleep(2)  # Brief buffer to let K8s API cache settle after drain
+
+    t_wall_start = time.monotonic()
+
+    # 1. Provision N pods
+    logging.info("Provisioning %d pods...", batch_size)
+    provision_start = time.monotonic()
+    _PatchReplicas(ns, warmpool_name, batch_size)
+
+    deadline = time.monotonic() + provision_timeout
+    while time.monotonic() < deadline:
+        running = utils.CountPods(ns, label, phase="Running")
+        pct = (running / batch_size * 100) if batch_size > 0 else 0
+        logging.info("Provisioning... %d/%d (%.0f%%)", running, batch_size, pct)
+        if running >= batch_size:
+            break
+        time.sleep(poll_interval)
+
+    provision_time = time.monotonic() - provision_start
+    final_running = utils.CountPods(ns, label, phase="Running")
+
+    logging.info(
+        "Provisioned %d/%d pods in %.1fs",
+        final_running,
+        batch_size,
+        provision_time,
+    )
+
+    # If not all pods reached Running, this is a failure
+    if final_running < batch_size:
+        raise RuntimeError(
+            f"Provisioning failed: only {final_running}/{batch_size} pods "
+            f"reached Running within {provision_timeout}s"
+        )
+
+    # 2. Record pod names and IP count before deletion
+    pod_names_before = set(_GetPodNames(ns, label))
+    ip_before = _CountAllocatedIPs(ns, label)
+
+    logging.info(
+        "Recorded %d pods, %d IPs allocated",
+        len(pod_names_before),
+        ip_before,
+    )
+
+    # Brief settle
+    time.sleep(1)
+
+    # 3. Bulk delete: scale to 0
+    logging.info("Scaling to 0 (bulk delete of %d pods)...", len(pod_names_before))
+    _PatchReplicas(ns, warmpool_name, 0)
+
+    # 4. Poll: track pod disappearance and IP reclamation
+    t_delete = time.monotonic()
+    deadline_drain = t_delete + drain_timeout
+    pod_gone_times = {}  # pod_name -> elapsed_s when first absent
+    ip_reclaim_time = None
+
+    while time.monotonic() < deadline_drain:
+        elapsed = time.monotonic() - t_delete
+
+        # Current pod names still present
+        current_pods = set(_GetPodNames(ns, label))
+        remaining = len(current_pods)
+
+        # Track which pods have disappeared
+        gone_now = pod_names_before - current_pods
+        for pn in gone_now:
+            if pn not in pod_gone_times:
+                pod_gone_times[pn] = elapsed
+
+        # IP count (scoped to warm pool label)
+        ips = _CountAllocatedIPs(ns, label)
+        if ip_reclaim_time is None and ips == 0:
+            ip_reclaim_time = elapsed
+
+        deleted = len(pod_names_before) - remaining
+        pct = (deleted / len(pod_names_before) * 100) if pod_names_before else 0
+        logging.info(
+            "[%.1fs] Deleted: %d/%d (%.0f%%)  IPs: %d",
+            elapsed,
+            deleted,
+            len(pod_names_before),
+            pct,
+            ips,
+        )
+
+        if remaining == 0:
+            break
+
+        time.sleep(poll_interval)
+
+    total_drain_time = time.monotonic() - t_delete
+
+    # Pods we never saw disappear (stuck) get the full drain time
+    stuck_pods_count = 0
+    for pn in pod_names_before:
+        if pn not in pod_gone_times:
+            pod_gone_times[pn] = total_drain_time
+            stuck_pods_count += 1
+
+    # 5. Compute per-pod deletion latencies
+    deletion_latencies = sorted(pod_gone_times.values())
+    n = len(deletion_latencies)
+
+    ip_after = _CountAllocatedIPs(ns, label)
+    actual_deleted = len(pod_names_before) - stuck_pods_count
+    deletion_rate = (
+        (actual_deleted / total_drain_time) if total_drain_time > 0 else 0
+    )
+
+    logging.info(
+        "Drain complete: %.1fs, rate=%.1f pods/sec, IPs: %d->%d",
+        total_drain_time,
+        deletion_rate,
+        ip_before,
+        ip_after,
+    )
+
+    wall_time = time.monotonic() - t_wall_start
+
+    # 6. Build samples
+    run_id = str(uuid.uuid4())[:8]
+
+    # Dictionary of extra metadata key-value pairs appended to every sample.
+    # Used for downstream dashboard filtering and correlating runs.
+    extra = {
+        "run_id": run_id,
+        "batch_size": batch_size,
+        "final_running_count": final_running,
+        "ip_before": ip_before,
+        "ip_after": ip_after,
+        "wall_time_s": round(wall_time, 2),
+    }
+
+    samples = []
+
+    samples.append(
+        utils.MakeSample(
+            f"{BENCHMARK_NAME}_provision_time",
+            round(provision_time, 2),
+            "seconds",
+            ns,
+            extra,
+        )
+    )
+    samples.append(
+        utils.MakeSample(
+            f"{BENCHMARK_NAME}_total_drain_time",
+            round(total_drain_time, 2),
+            "seconds",
+            ns,
+            extra,
+        )
+    )
+
+    if n > 0:
+        samples.append(
+            utils.MakeSample(
+                f"{BENCHMARK_NAME}_latency_p50",
+                round(_Percentile(deletion_latencies, 50), 3),
+                "seconds",
+                ns,
+                extra,
+            )
+        )
+        samples.append(
+            utils.MakeSample(
+                f"{BENCHMARK_NAME}_latency_p95",
+                round(_Percentile(deletion_latencies, 95), 3),
+                "seconds",
+                ns,
+                extra,
+            )
+        )
+        samples.append(
+            utils.MakeSample(
+                f"{BENCHMARK_NAME}_latency_p99",
+                round(_Percentile(deletion_latencies, 99), 3),
+                "seconds",
+                ns,
+                extra,
+            )
+        )
+        samples.append(
+            utils.MakeSample(
+                f"{BENCHMARK_NAME}_latency_max",
+                round(deletion_latencies[-1], 3),
+                "seconds",
+                ns,
+                extra,
+            )
+        )
+
+    samples.append(
+        utils.MakeSample(
+            f"{BENCHMARK_NAME}_stuck_pods_count",
+            float(stuck_pods_count),
+            "count",
+            ns,
+            extra,
+        )
+    )
+    samples.append(
+        utils.MakeSample(
+            f"{BENCHMARK_NAME}_rate",
+            round(deletion_rate, 2),
+            "pods/sec",
+            ns,
+            extra,
+        )
+    )
+    samples.append(
+        utils.MakeSample(
+            f"{BENCHMARK_NAME}_ip_before",
+            float(ip_before),
+            "count",
+            ns,
+            extra,
+        )
+    )
+    samples.append(
+        utils.MakeSample(
+            f"{BENCHMARK_NAME}_ip_after",
+            float(ip_after),
+            "count",
+            ns,
+            extra,
+        )
+    )
+
+    if ip_reclaim_time is not None:
+        samples.append(
+            utils.MakeSample(
+                f"{BENCHMARK_NAME}_ip_reclaim_time",
+                round(ip_reclaim_time, 2),
+                "seconds",
+                ns,
+                extra,
+            )
+        )
+
+    samples.append(
+        utils.MakeSample(
+            f"{BENCHMARK_NAME}_final_running_count",
+            float(final_running),
+            "count",
+            ns,
+            extra,
+        )
+    )
+    samples.append(
+        utils.MakeSample(
+            f"{BENCHMARK_NAME}_wall_time",
+            round(wall_time, 2),
+            "seconds",
+            ns,
+            extra,
+        )
+    )
+
+    logging.info("Emitted %d samples for batch_size=%d.", len(samples), batch_size)
+    psi_data = utils.ScrapePsi(ns)
+    for k, v in psi_data.items():
+        samples.append(utils.MakeSample(f"{BENCHMARK_NAME}_{k}", v, "percent", ns, extra))
+
+    return samples
+
+
+def Cleanup(benchmark_spec: object) -> None:
+    """Best-effort drain of warm pool after measurement."""
+    ns = FLAGS.k8s_agentic_namespace
+    warmpool_name = FLAGS.k8s_deletion_warmpool_name
+    label = FLAGS.k8s_deletion_pod_label
+
+    logging.info("Cleanup: draining warm pool to 0.")
+    utils.DrainWarmPool(ns, warmpool_name, label, timeout=int(FLAGS.k8s_deletion_drain_timeout_s))
+    utils.StopPortForward()
+    logging.info("Cleanup complete.")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _PatchReplicas(namespace: str, warmpool_name: str, replicas: int) -> None:
+    """Patch SandboxWarmPool to a specific replica count."""
+    patch_json = json.dumps({"spec": {"replicas": replicas}})
+    utils.RunKubectl(
+        [
+            "patch",
+            "sandboxwarmpool",
+            warmpool_name,
+            "-n",
+            namespace,
+            "--type=merge",
+            f"-p={patch_json}",
+        ],
+        raise_on_failure=False,
+    )
+
+
+def _GetPodNames(namespace: str, label: str) -> list[str]:
+    """Return list of pod names matching the label selector."""
+    stdout, _, rc = utils.RunKubectl(
+        [
+            "get",
+            "pods",
+            "-n",
+            namespace,
+            "-l",
+            label,
+            "-o",
+            "jsonpath={.items[*].metadata.name}",
+        ],
+        timeout=30,
+        raise_on_failure=False,
+    )
+    if rc != 0:
+        logging.warning("kubectl get pods failed during poll, assuming pods still exist.")
+        return ["__API_ERROR__"]
+    if not stdout or not stdout.strip():
+        return []
+    return stdout.split()
+
+
+def _CountAllocatedIPs(namespace: str, label: str) -> int:
+    """Count pod IPs currently allocated for pods matching the label.
+
+    Scoped to the warm pool label to accurately measure IPAM release
+    efficiency for the specific pods being deleted.
+    """
+    stdout, _, rc = utils.RunKubectl(
+        [
+            "get",
+            "pods",
+            "-n",
+            namespace,
+            "-l",
+            label,
+            "-o",
+            "jsonpath={.items[*].status.podIP}",
+        ],
+        timeout=30,
+        raise_on_failure=False,
+    )
+    if rc != 0:
+        return -1
+    if not stdout or not stdout.strip():
+        return 0
+    return len([ip for ip in stdout.split() if ip])
+
+
+def _Percentile(sorted_values: list[float], pct: float) -> float:
+    """Calculate percentile (0-100) with linear interpolation."""
+    if not sorted_values:
+        return 0.0
+    idx = (pct / 100) * (len(sorted_values) - 1)
+    lo = int(idx)
+    hi = min(lo + 1, len(sorted_values) - 1)
+    frac = idx - lo
+    return sorted_values[lo] * (1 - frac) + sorted_values[hi] * frac

--- a/perfkitbenchmarker/linux_benchmarks/kubernetes/agentic/k8s_warmpool_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/kubernetes/agentic/k8s_warmpool_benchmark.py
@@ -1,0 +1,464 @@
+# Copyright 2026 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""PKB Benchmark: GKE Agent Warmpool Scale-Up.
+
+Atomic single-point measurement of warm pool provisioning speed on a
+pre-provisioned GKE cluster.  Measures how quickly N sandbox pods can be
+provisioned from zero via the SandboxWarmPool controller.  No agent API
+is needed; this benchmark interacts directly with the Kubernetes API.
+
+This benchmark is designed to be invoked repeatedly by an external sweep
+controller that varies the target_replicas parameter across iterations to
+find the provisioning saturation point.
+
+Usage:
+  python pkb.py --benchmarks=gke_warmpool \
+                --k8s_warmpool_target_replicas=100 \
+                --k8s_warmpool_name=python-sandbox-warmpool \
+                --k8s_warmpool_pod_label=sandbox=python-sandbox-example \
+                --k8s_warmpool_ready_threshold_s=300 \
+                --k8s_warmpool_poll_interval_s=2.0 \
+                --k8s_warmpool_drain_timeout_s=300 \
+                --k8s_agentic_namespace=agentic \
+                --gke_machine_type=c4-standard-8
+
+Samples emitted (per run):
+  - gke_warmpool_total_time_to_ready         (seconds)
+  - gke_warmpool_refill_rate                 (pods/sec)
+  - gke_warmpool_drain_time                  (seconds)
+  - gke_warmpool_first_pod_running           (seconds)
+  - gke_warmpool_final_running_count         (count)
+  - gke_warmpool_final_pending_count         (count)
+  - gke_warmpool_time_to_created_p50         (seconds)
+  - gke_warmpool_time_to_created_p95         (seconds)
+  - gke_warmpool_time_to_created_max         (seconds)
+  - gke_warmpool_time_to_created_count       (count)
+  - gke_warmpool_time_to_scheduled_p50       (seconds)
+  - gke_warmpool_time_to_scheduled_p95       (seconds)
+  - gke_warmpool_time_to_scheduled_max       (seconds)
+  - gke_warmpool_time_to_scheduled_count     (count)
+  - gke_warmpool_time_to_running_p50         (seconds)
+  - gke_warmpool_time_to_running_p95         (seconds)
+  - gke_warmpool_time_to_running_max         (seconds)
+  - gke_warmpool_time_to_running_count       (count)
+  - gke_warmpool_wall_time                   (seconds)
+"""
+
+from __future__ import annotations
+
+
+import json
+import logging
+import time
+import uuid
+
+from absl import flags
+from perfkitbenchmarker import sample
+from datetime import datetime, timezone
+from perfkitbenchmarker import configs
+from perfkitbenchmarker.linux_benchmarks.kubernetes.agentic import (
+    k8s_benchmark_utils as utils,
+)
+from perfkitbenchmarker.linux_benchmarks.kubernetes.agentic import (
+    gke_deploy_utils as deploy_utils,
+)
+
+FLAGS = flags.FLAGS
+
+BENCHMARK_NAME = "k8s_warmpool"
+BENCHMARK_CONFIG = """
+k8s_warmpool:
+  description: >
+    Atomic single-point warm pool scale-up measurement on a
+    pre-provisioned GKE cluster with gVisor isolation.
+  flags: {}
+  container_registry: {}
+  container_specs: {}
+  container_cluster: {}
+"""
+
+# ---------------------------------------------------------------------------
+# Benchmark-specific flags
+# ---------------------------------------------------------------------------
+
+flags.DEFINE_integer(
+    "k8s_warmpool_target_replicas",
+    100,
+    "Number of warm pool replicas to provision from zero.",
+)
+
+flags.DEFINE_string(
+    "k8s_warmpool_name",
+    "python-sandbox-warmpool",
+    "SandboxWarmPool resource name.",
+)
+
+flags.DEFINE_string(
+    "k8s_warmpool_pod_label",
+    "sandbox=python-sandbox-example",
+    "Label selector for warm pool pods.",
+)
+
+flags.DEFINE_float(
+    "k8s_warmpool_ready_threshold_s",
+    300.0,
+    "Max seconds allowed for all pods to reach Running.",
+)
+
+flags.DEFINE_float(
+    "k8s_warmpool_poll_interval_s",
+    2.0,
+    "Seconds between kubectl polls during provisioning.",
+)
+
+flags.DEFINE_float(
+    "k8s_warmpool_drain_timeout_s",
+    300.0,
+    "Max seconds to wait for drain to 0.",
+)
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+def GetConfig(user_config: dict) -> dict:
+    """Load and return benchmark config.
+
+    No vm_groups — PKB skips Provision() and Teardown().
+    """
+    return configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
+
+
+def Prepare(benchmark_spec: object) -> None:
+    """Deploy workloads onto the cluster."""
+    benchmark_spec.always_call_cleanup = True
+    logging.info("=== Prepare: deploying workloads ===")
+    deploy_utils.DeployWorkloads(benchmark_spec)
+    utils.EnsurePortForward()
+    logging.info("Prepare complete.")
+
+
+def Run(benchmark_spec: object) -> list[sample.Sample]:
+    """Scale warm pool from 0 to target and measure provisioning time.
+
+    Returns:
+      List of sample.Sample objects.
+    """
+    utils.set_benchmark_spec(benchmark_spec)
+
+    ns = FLAGS.k8s_agentic_namespace
+    target = FLAGS.k8s_warmpool_target_replicas
+    warmpool_name = FLAGS.k8s_warmpool_name
+    label = FLAGS.k8s_warmpool_pod_label
+    threshold_s = FLAGS.k8s_warmpool_ready_threshold_s
+    poll_interval = FLAGS.k8s_warmpool_poll_interval_s
+
+    # Drain to 0 for clean measurement (moved from Prepare for sweep compatibility)
+    utils.DrainWarmPool(ns, warmpool_name, label, timeout=int(FLAGS.k8s_warmpool_drain_timeout_s))
+    time.sleep(3)
+
+    logging.info("=== Run: scaling %s to %d replicas ===", warmpool_name, target)
+
+    t_wall_start = time.monotonic()
+
+    # 1. Measure drain time (should be near-zero since Prepare drained)
+    t0 = time.monotonic()
+    utils.DrainWarmPool(ns, warmpool_name, label, timeout=int(FLAGS.k8s_warmpool_drain_timeout_s))
+    drain_time_s = round(time.monotonic() - t0, 2)
+
+    time.sleep(2)
+
+    # 2. Scale up
+    logging.info("Patching %s replicas -> %d", warmpool_name, target)
+    patch_json = json.dumps({"spec": {"replicas": target}})
+    utils.RunKubectl(
+        [
+            "patch",
+            "sandboxwarmpool",
+            warmpool_name,
+            "-n",
+            ns,
+            "--type=merge",
+            f"-p={patch_json}",
+        ]
+    )
+
+    # 3. Poll until ready or timeout
+    t_scale = time.monotonic()
+    scale_start_epoch = time.time()
+    deadline = t_scale + threshold_s
+    first_pod_time = None
+
+    while time.monotonic() < deadline:
+        elapsed = time.monotonic() - t_scale
+        running = utils.CountPods(ns, label, "Running")
+        pending = utils.CountPods(ns, label, "Pending")
+
+        if first_pod_time is None and running > 0:
+            first_pod_time = elapsed
+
+        pct = (running / target * 100) if target > 0 else 0
+        logging.info(
+            "[%.1fs] Running: %d/%d (%.0f%%)  Pending: %d",
+            elapsed,
+            running,
+            target,
+            pct,
+            pending,
+        )
+
+        if running >= target:
+            break
+
+        time.sleep(poll_interval)
+
+    total_time = round(time.monotonic() - t_scale, 2)
+    final_running = utils.CountPods(ns, label, "Running")
+    final_pending = utils.CountPods(ns, label, "Pending")
+    rate = round(final_running / total_time, 2) if total_time > 0 else 0
+
+    logging.info(
+        "Scale-up complete: %d/%d Running in %.1fs (%.1f pods/sec)",
+        final_running,
+        target,
+        total_time,
+        rate,
+    )
+
+    # 4. Scrape pod lifecycle timestamps
+    lifecycle = _ScrapeLifecycle(ns, label, scale_start_epoch)
+
+    wall_time = round(time.monotonic() - t_wall_start, 2)
+
+    # 5. Build samples
+    run_id = str(uuid.uuid4())[:8]
+
+    # Dictionary of extra metadata key-value pairs appended to every sample.
+    # Used for downstream dashboard filtering and correlating runs.
+    extra = {
+        "run_id": run_id,
+        "target_replicas": target,
+        "final_running_count": final_running,
+        "final_pending_count": final_pending,
+        "wall_time_s": wall_time,
+    }
+
+    samples = []
+
+    samples.append(
+        utils.MakeSample(
+            f"{BENCHMARK_NAME}_total_time_to_ready",
+            total_time,
+            "seconds",
+            ns,
+            extra,
+        )
+    )
+    samples.append(
+        utils.MakeSample(
+            f"{BENCHMARK_NAME}_refill_rate",
+            rate,
+            "pods/sec",
+            ns,
+            extra,
+        )
+    )
+    samples.append(
+        utils.MakeSample(
+            f"{BENCHMARK_NAME}_drain_time",
+            drain_time_s,
+            "seconds",
+            ns,
+            extra,
+        )
+    )
+
+    if first_pod_time is not None:
+        samples.append(
+            utils.MakeSample(
+                f"{BENCHMARK_NAME}_first_pod_running",
+                round(first_pod_time, 2),
+                "seconds",
+                ns,
+                extra,
+            )
+        )
+
+    samples.append(
+        utils.MakeSample(
+            f"{BENCHMARK_NAME}_final_running_count",
+            float(final_running),
+            "count",
+            ns,
+            extra,
+        )
+    )
+    samples.append(
+        utils.MakeSample(
+            f"{BENCHMARK_NAME}_final_pending_count",
+            float(final_pending),
+            "count",
+            ns,
+            extra,
+        )
+    )
+
+    # Pod lifecycle percentiles
+    _EmitLifecycleSamples(samples, lifecycle, ns, extra)
+
+    # Wall time
+    samples.append(
+        utils.MakeSample(
+            f"{BENCHMARK_NAME}_wall_time",
+            wall_time,
+            "seconds",
+            ns,
+            extra,
+        )
+    )
+
+    logging.info("Emitted %d samples for target_replicas=%d.", len(samples), target)
+    psi_data = utils.ScrapePsi(ns)
+    for k, v in psi_data.items():
+        samples.append(utils.MakeSample(f"{BENCHMARK_NAME}_{k}", v, "percent", ns, extra))
+
+    return samples
+
+
+def Cleanup(benchmark_spec: object) -> None:
+    """Drain warm pool back to 0 after measurement."""
+    ns = FLAGS.k8s_agentic_namespace
+    warmpool_name = FLAGS.k8s_warmpool_name
+    label = FLAGS.k8s_warmpool_pod_label
+
+    logging.info("Cleanup: draining warm pool to 0.")
+    utils.DrainWarmPool(ns, warmpool_name, label, timeout=int(FLAGS.k8s_warmpool_drain_timeout_s))
+    utils.StopPortForward()
+    logging.info("Cleanup complete.")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ScrapeLifecycle(namespace: str, label: str, scale_start_epoch: float) -> dict:
+    """Scrape pod metadata to compute time-to-created/scheduled/running.
+
+    Returns a dict with P50/P95/max/count for each phase relative to
+    scale_start_epoch.
+    """
+    stdout, _, rc = utils.RunKubectl(
+        ["get", "pods", "-n", namespace, "-l", label, "-o", "json"],
+        timeout=60,
+        raise_on_failure=False,
+    )
+    if rc != 0 or not stdout:
+        return {}
+
+    pods = json.loads(stdout).get("items", [])
+    created_deltas = []
+    scheduled_deltas = []
+    running_deltas = []
+
+    for pod in pods:
+        meta = pod.get("metadata", {})
+        status = pod.get("status", {})
+
+        # creationTimestamp -> time-to-created
+        created_str = meta.get("creationTimestamp")
+        if created_str:
+            created_ts = datetime.fromisoformat(
+                created_str.replace("Z", "+00:00")
+            ).timestamp()
+            created_deltas.append(created_ts - scale_start_epoch)
+
+        # PodScheduled condition -> time-to-scheduled
+        conditions = status.get("conditions", [])
+        for cond in conditions:
+            if cond.get("type") == "PodScheduled" and cond.get("status") == "True":
+                ts_str = cond.get("lastTransitionTime")
+                if ts_str:
+                    ts = datetime.fromisoformat(
+                        ts_str.replace("Z", "+00:00")
+                    ).timestamp()
+                    scheduled_deltas.append(ts - scale_start_epoch)
+            if cond.get("type") == "Ready" and cond.get("status") == "True":
+                ts_str = cond.get("lastTransitionTime")
+                if ts_str:
+                    ts = datetime.fromisoformat(
+                        ts_str.replace("Z", "+00:00")
+                    ).timestamp()
+                    running_deltas.append(ts - scale_start_epoch)
+
+    def _pcts(vals):
+        if not vals:
+            return {}
+        vals.sort()
+        n = len(vals)
+        return {
+            "p50": round(vals[n // 2], 2),
+            "p95": round(vals[int(n * 0.95)], 2) if n > 1 else round(vals[-1], 2),
+            "max": round(vals[-1], 2),
+            "count": n,
+        }
+
+    return {
+        "time_to_created_s": _pcts(created_deltas),
+        "time_to_scheduled_s": _pcts(scheduled_deltas),
+        "time_to_running_s": _pcts(running_deltas),
+    }
+
+
+def _EmitLifecycleSamples(samples: list, lifecycle: dict, namespace: str, extra: dict) -> None:
+    """Emit pod lifecycle percentile samples for all three phases.
+    
+    Unlike the generic EmitPercentileStats utility which parses flat API
+    responses, this is a specialized helper that parses the nested dictionary 
+    structure returned by _ScrapeLifecycle() containing P50/P95/Max metrics 
+    for pod creation, scheduling, and running phases.
+    """
+    _PHASE_MAP = [
+        ("time_to_created_s", "time_to_created"),
+        ("time_to_scheduled_s", "time_to_scheduled"),
+        ("time_to_running_s", "time_to_running"),
+    ]
+    for lifecycle_key, metric_base in _PHASE_MAP:
+        phase_data = lifecycle.get(lifecycle_key, {})
+        for stat in ("p50", "p95", "max"):
+            val = phase_data.get(stat)
+            if val is not None:
+                samples.append(
+                    utils.MakeSample(
+                        f"{BENCHMARK_NAME}_{metric_base}_{stat}",
+                        val,
+                        "seconds",
+                        namespace,
+                        extra,
+                    )
+                )
+        count = phase_data.get("count")
+        if count is not None:
+            samples.append(
+                utils.MakeSample(
+                    f"{BENCHMARK_NAME}_{metric_base}_count",
+                    float(count),
+                    "count",
+                    namespace,
+                    extra,
+                )
+            )

--- a/perfkitbenchmarker/linux_benchmarks/kubernetes/agentic/k8s_warmpool_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/kubernetes/agentic/k8s_warmpool_benchmark.py
@@ -1,0 +1,456 @@
+# Copyright 2026 PerfKitBenchmarker Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""PKB Benchmark: GKE Agent Warmpool Scale-Up.
+
+Atomic single-point measurement of warm pool provisioning speed on a
+pre-provisioned GKE cluster.  Measures how quickly N sandbox pods can be
+provisioned from zero via the SandboxWarmPool controller.  No agent API
+is needed; this benchmark interacts directly with the Kubernetes API.
+
+This benchmark is designed to be invoked repeatedly by an external sweep
+controller that varies the target_replicas parameter across iterations to
+find the provisioning saturation point.
+
+Usage:
+  python pkb.py --benchmarks=gke_warmpool \
+                --k8s_warmpool_target_replicas=100 \
+                --k8s_warmpool_name=python-sandbox-warmpool \
+                --k8s_warmpool_pod_label=sandbox=python-sandbox-example \
+                --k8s_warmpool_ready_threshold_s=300 \
+                --k8s_warmpool_poll_interval_s=2.0 \
+                --k8s_warmpool_drain_timeout_s=300 \
+                --k8s_agentic_namespace=agentic \
+                --gke_machine_type=c4-standard-8
+
+Samples emitted (per run):
+  - gke_warmpool_total_time_to_ready         (seconds)
+  - gke_warmpool_refill_rate                 (pods/sec)
+  - gke_warmpool_drain_time                  (seconds)
+  - gke_warmpool_first_pod_running           (seconds)
+  - gke_warmpool_final_running_count         (count)
+  - gke_warmpool_final_pending_count         (count)
+  - gke_warmpool_time_to_created_p50         (seconds)
+  - gke_warmpool_time_to_created_p95         (seconds)
+  - gke_warmpool_time_to_created_max         (seconds)
+  - gke_warmpool_time_to_created_count       (count)
+  - gke_warmpool_time_to_scheduled_p50       (seconds)
+  - gke_warmpool_time_to_scheduled_p95       (seconds)
+  - gke_warmpool_time_to_scheduled_max       (seconds)
+  - gke_warmpool_time_to_scheduled_count     (count)
+  - gke_warmpool_time_to_running_p50         (seconds)
+  - gke_warmpool_time_to_running_p95         (seconds)
+  - gke_warmpool_time_to_running_max         (seconds)
+  - gke_warmpool_time_to_running_count       (count)
+  - gke_warmpool_wall_time                   (seconds)
+"""
+
+from __future__ import annotations
+
+
+import json
+import logging
+import time
+import uuid
+
+from absl import flags
+from perfkitbenchmarker import sample
+from datetime import datetime, timezone
+from perfkitbenchmarker import configs
+from perfkitbenchmarker.linux_benchmarks.kubernetes.agentic import (
+    k8s_benchmark_utils as utils,
+)
+from perfkitbenchmarker.linux_benchmarks.kubernetes.agentic import (
+    gke_deploy_utils as deploy_utils,
+)
+
+FLAGS = flags.FLAGS
+
+BENCHMARK_NAME = "k8s_warmpool"
+BENCHMARK_CONFIG = """
+k8s_warmpool:
+  description: >
+    Atomic single-point warm pool scale-up measurement on a
+    pre-provisioned GKE cluster with gVisor isolation.
+  flags: {}
+  container_registry: {}
+  container_specs: {}
+  container_cluster: {}
+"""
+
+# ---------------------------------------------------------------------------
+# Benchmark-specific flags
+# ---------------------------------------------------------------------------
+
+flags.DEFINE_integer(
+    "k8s_warmpool_target_replicas",
+    100,
+    "Number of warm pool replicas to provision from zero.",
+)
+
+flags.DEFINE_string(
+    "k8s_warmpool_name",
+    "python-sandbox-warmpool",
+    "SandboxWarmPool resource name.",
+)
+
+flags.DEFINE_string(
+    "k8s_warmpool_pod_label",
+    "sandbox=python-sandbox-example",
+    "Label selector for warm pool pods.",
+)
+
+flags.DEFINE_float(
+    "k8s_warmpool_ready_threshold_s",
+    300.0,
+    "Max seconds allowed for all pods to reach Running.",
+)
+
+flags.DEFINE_float(
+    "k8s_warmpool_poll_interval_s",
+    2.0,
+    "Seconds between kubectl polls during provisioning.",
+)
+
+flags.DEFINE_float(
+    "k8s_warmpool_drain_timeout_s",
+    300.0,
+    "Max seconds to wait for drain to 0.",
+)
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+def GetConfig(user_config: dict) -> dict:
+    """Load and return benchmark config.
+
+    No vm_groups — PKB skips Provision() and Teardown().
+    """
+    return configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
+
+
+def Prepare(benchmark_spec: object) -> None:
+    """Deploy workloads onto the cluster."""
+    benchmark_spec.always_call_cleanup = True
+    logging.info("=== Prepare: deploying workloads ===")
+    deploy_utils.DeployWorkloads(benchmark_spec)
+    utils.EnsurePortForward()
+    logging.info("Prepare complete.")
+
+
+def Run(benchmark_spec: object) -> list[sample.Sample]:
+    """Scale warm pool from 0 to target and measure provisioning time.
+
+    Returns:
+      List of sample.Sample objects.
+    """
+    utils.set_benchmark_spec(benchmark_spec)
+
+    ns = FLAGS.k8s_agentic_namespace
+    target = FLAGS.k8s_warmpool_target_replicas
+    warmpool_name = FLAGS.k8s_warmpool_name
+    label = FLAGS.k8s_warmpool_pod_label
+    threshold_s = FLAGS.k8s_warmpool_ready_threshold_s
+    poll_interval = FLAGS.k8s_warmpool_poll_interval_s
+
+    # Drain to 0 for clean measurement (moved from Prepare for sweep compatibility)
+    utils.DrainWarmPool(ns, warmpool_name, label, timeout=int(FLAGS.k8s_warmpool_drain_timeout_s))
+    time.sleep(3)
+
+    logging.info("=== Run: scaling %s to %d replicas ===", warmpool_name, target)
+
+    t_wall_start = time.monotonic()
+
+    # 1. Measure drain time (should be near-zero since Prepare drained)
+    t0 = time.monotonic()
+    utils.DrainWarmPool(ns, warmpool_name, label, timeout=int(FLAGS.k8s_warmpool_drain_timeout_s))
+    drain_time_s = round(time.monotonic() - t0, 2)
+
+    time.sleep(2)
+
+    # 2. Scale up
+    logging.info("Patching %s replicas -> %d", warmpool_name, target)
+    patch_json = json.dumps({"spec": {"replicas": target}})
+    utils.RunKubectl(
+        [
+            "patch",
+            "sandboxwarmpool",
+            warmpool_name,
+            "-n",
+            ns,
+            "--type=merge",
+            f"-p={patch_json}",
+        ]
+    )
+
+    # 3. Poll until ready or timeout
+    t_scale = time.monotonic()
+    scale_start_epoch = time.time()
+    deadline = t_scale + threshold_s
+    first_pod_time = None
+
+    while time.time() < deadline:
+        elapsed = time.monotonic() - t_scale
+        running = utils.CountPods(ns, label, "Running")
+        pending = utils.CountPods(ns, label, "Pending")
+
+        if first_pod_time is None and running > 0:
+            first_pod_time = elapsed
+
+        pct = (running / target * 100) if target > 0 else 0
+        logging.info(
+            "[%.1fs] Running: %d/%d (%.0f%%)  Pending: %d",
+            elapsed,
+            running,
+            target,
+            pct,
+            pending,
+        )
+
+        if running >= target:
+            break
+
+        time.sleep(poll_interval)
+
+    total_time = round(time.monotonic() - t_scale, 2)
+    final_running = utils.CountPods(ns, label, "Running")
+    final_pending = utils.CountPods(ns, label, "Pending")
+    rate = round(final_running / total_time, 2) if total_time > 0 else 0
+
+    logging.info(
+        "Scale-up complete: %d/%d Running in %.1fs (%.1f pods/sec)",
+        final_running,
+        target,
+        total_time,
+        rate,
+    )
+
+    # 4. Scrape pod lifecycle timestamps
+    lifecycle = _ScrapeLifecycle(ns, label, scale_start_epoch)
+
+    wall_time = round(time.monotonic() - t_wall_start, 2)
+
+    # 5. Build samples
+    run_id = str(uuid.uuid4())[:8]
+
+    extra = {
+        "run_id": run_id,
+        "target_replicas": target,
+        "final_running_count": final_running,
+        "final_pending_count": final_pending,
+        "wall_time_s": wall_time,
+    }
+
+    samples = []
+
+    samples.append(
+        utils.MakeSample(
+            f"{BENCHMARK_NAME}_total_time_to_ready",
+            total_time,
+            "seconds",
+            ns,
+            extra,
+        )
+    )
+    samples.append(
+        utils.MakeSample(
+            f"{BENCHMARK_NAME}_refill_rate",
+            rate,
+            "pods/sec",
+            ns,
+            extra,
+        )
+    )
+    samples.append(
+        utils.MakeSample(
+            f"{BENCHMARK_NAME}_drain_time",
+            drain_time_s,
+            "seconds",
+            ns,
+            extra,
+        )
+    )
+
+    if first_pod_time is not None:
+        samples.append(
+            utils.MakeSample(
+                f"{BENCHMARK_NAME}_first_pod_running",
+                round(first_pod_time, 2),
+                "seconds",
+                ns,
+                extra,
+            )
+        )
+
+    samples.append(
+        utils.MakeSample(
+            f"{BENCHMARK_NAME}_final_running_count",
+            float(final_running),
+            "count",
+            ns,
+            extra,
+        )
+    )
+    samples.append(
+        utils.MakeSample(
+            f"{BENCHMARK_NAME}_final_pending_count",
+            float(final_pending),
+            "count",
+            ns,
+            extra,
+        )
+    )
+
+    # Pod lifecycle percentiles
+    _EmitLifecycleSamples(samples, lifecycle, ns, extra)
+
+    # Wall time
+    samples.append(
+        utils.MakeSample(
+            f"{BENCHMARK_NAME}_wall_time",
+            wall_time,
+            "seconds",
+            ns,
+            extra,
+        )
+    )
+
+    logging.info("Emitted %d samples for target_replicas=%d.", len(samples), target)
+    psi_data = utils.ScrapePsi(ns)
+    for k, v in psi_data.items():
+        samples.append(utils.MakeSample(f"{BENCHMARK_NAME}_{k}", v, "percent", ns, extra))
+
+    return samples
+
+
+def Cleanup(benchmark_spec: object) -> None:
+    """Drain warm pool back to 0 after measurement."""
+    ns = FLAGS.k8s_agentic_namespace
+    warmpool_name = FLAGS.k8s_warmpool_name
+    label = FLAGS.k8s_warmpool_pod_label
+
+    logging.info("Cleanup: draining warm pool to 0.")
+    utils.DrainWarmPool(ns, warmpool_name, label, timeout=int(FLAGS.k8s_warmpool_drain_timeout_s))
+    utils.StopPortForward()
+    logging.info("Cleanup complete.")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ScrapeLifecycle(namespace: str, label: str, scale_start_epoch: float) -> dict:
+    """Scrape pod metadata to compute time-to-created/scheduled/running.
+
+    Returns a dict with P50/P95/max/count for each phase relative to
+    scale_start_epoch.
+    """
+    stdout, _, rc = utils.RunKubectl(
+        ["get", "pods", "-n", namespace, "-l", label, "-o", "json"],
+        timeout=60,
+        raise_on_failure=False,
+    )
+    if rc != 0 or not stdout:
+        return {}
+
+    pods = json.loads(stdout).get("items", [])
+    created_deltas = []
+    scheduled_deltas = []
+    running_deltas = []
+
+    for pod in pods:
+        meta = pod.get("metadata", {})
+        status = pod.get("status", {})
+
+        # creationTimestamp -> time-to-created
+        created_str = meta.get("creationTimestamp")
+        if created_str:
+            created_ts = datetime.fromisoformat(
+                created_str.replace("Z", "+00:00")
+            ).timestamp()
+            created_deltas.append(created_ts - scale_start_epoch)
+
+        # PodScheduled condition -> time-to-scheduled
+        conditions = status.get("conditions", [])
+        for cond in conditions:
+            if cond.get("type") == "PodScheduled" and cond.get("status") == "True":
+                ts_str = cond.get("lastTransitionTime")
+                if ts_str:
+                    ts = datetime.fromisoformat(
+                        ts_str.replace("Z", "+00:00")
+                    ).timestamp()
+                    scheduled_deltas.append(ts - scale_start_epoch)
+            if cond.get("type") == "Ready" and cond.get("status") == "True":
+                ts_str = cond.get("lastTransitionTime")
+                if ts_str:
+                    ts = datetime.fromisoformat(
+                        ts_str.replace("Z", "+00:00")
+                    ).timestamp()
+                    running_deltas.append(ts - scale_start_epoch)
+
+    def _pcts(vals):
+        if not vals:
+            return {}
+        vals.sort()
+        n = len(vals)
+        return {
+            "p50": round(vals[n // 2], 2),
+            "p95": round(vals[int(n * 0.95)], 2) if n > 1 else round(vals[-1], 2),
+            "max": round(vals[-1], 2),
+            "count": n,
+        }
+
+    return {
+        "time_to_created_s": _pcts(created_deltas),
+        "time_to_scheduled_s": _pcts(scheduled_deltas),
+        "time_to_running_s": _pcts(running_deltas),
+    }
+
+
+def _EmitLifecycleSamples(samples: list, lifecycle: dict, namespace: str, extra: dict) -> None:
+    """Emit pod lifecycle percentile samples for all three phases."""
+    _PHASE_MAP = [
+        ("time_to_created_s", "time_to_created"),
+        ("time_to_scheduled_s", "time_to_scheduled"),
+        ("time_to_running_s", "time_to_running"),
+    ]
+    for lifecycle_key, metric_base in _PHASE_MAP:
+        phase_data = lifecycle.get(lifecycle_key, {})
+        for stat in ("p50", "p95", "max"):
+            val = phase_data.get(stat)
+            if val is not None:
+                samples.append(
+                    utils.MakeSample(
+                        f"{BENCHMARK_NAME}_{metric_base}_{stat}",
+                        val,
+                        "seconds",
+                        namespace,
+                        extra,
+                    )
+                )
+        count = phase_data.get("count")
+        if count is not None:
+            samples.append(
+                utils.MakeSample(
+                    f"{BENCHMARK_NAME}_{metric_base}_count",
+                    float(count),
+                    "count",
+                    namespace,
+                    extra,
+                )
+            )


### PR DESCRIPTION
**Files:** 2 new files
- `perfkitbenchmarker/linux_benchmarks/kubernetes/agentic/k8s_warmpool_benchmark.py`
- `perfkitbenchmarker/linux_benchmarks/kubernetes/agentic/k8s_deletion_benchmark.py`

**Description:** Adds two infrastructure lifecycle benchmarks:

**Warmpool Scale-Up:** Measures how quickly N sandbox pods can be provisioned from zero via the SandboxWarmPool controller. Scrapes pod lifecycle timestamps (creationTimestamp, PodScheduled condition, Ready condition) for time-to-created/scheduled/running percentiles. No agent API needed — interacts directly with the Kubernetes API.

**Deletion & Cleanup:** Measures bulk deletion efficiency and IP address reclamation. Provisions N pods via SandboxWarmPool, bulk-deletes them by scaling to zero, and tracks per-pod deletion latency and IPAM release timing. Tests whether "Terminating" pods hold IP addresses longer than expected.