### PR TITLE
Variant Configs & Sweep Tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@
 .DS_Store
 /site/
 .cache/
+.adk
+tmp/

--- a/perfkitbenchmarker/data/k8s_agents/config/agentic_benchmark_config.yaml
+++ b/perfkitbenchmarker/data/k8s_agents/config/agentic_benchmark_config.yaml
@@ -1,0 +1,150 @@
+# Agentic Benchmark Configuration for GKE
+# Used with: --benchmark_config_file=perfkitbenchmarker/data/k8s_agents/config/agentic_benchmark_config.yaml
+#
+# User/environment-specific flags that MUST be passed on CLI:
+#   --project=<project>
+#   --owner=<owner>
+#   --gce_network_name=<user>-agentic-vpc
+#   --gke_additional_flags="--workload-pool=<project>.svc.id.goog,--subnetwork=<user>-agentic-subnet,--enable-master-authorized-networks,--master-authorized-networks=$(curl -s ifconfig.me)/32"
+#
+# Per-run flags:
+#   --run_stage=provision|prepare|run,cleanup|teardown
+#   --run_uri=<unique_id>
+#   --temp_dir=<path>
+#
+# Benchmark-specific sweep parameters (vary per run):
+#   --k8s_python_density_concurrent_sandbox_count=N
+#   --k8s_snapshot_preload_mb=N
+#   etc.
+
+# ===========================================================================
+# Shared configuration (defined once, referenced by all benchmarks via YAML
+# anchors). PKB ignores top-level keys that don't match a benchmark name.
+# ===========================================================================
+
+_shared_flags: &shared_flags
+  # --- Cluster creation flags ---
+  gke_additional_flags:
+    - "--enable-pod-snapshots"
+    - "--enable-dataplane-v2"
+    - "--enable-private-nodes"
+    - "--enable-ip-alias"
+    - "--master-ipv4-cidr=172.16.0.0/28"
+  gke_additional_nodepool_flags:
+    - "--max-pods-per-node=250"
+  container_cluster_version: "1.36.0-gke.3070003"
+  gke_enable_shielded_nodes: false
+  gce_subnet_region: "us-central1"
+
+  # --- Agentic workload flags ---
+  k8s_agentic_namespace: "agentic"
+  agent_sandbox_version: "v0.4.6"
+  k8s_agentic_gvisor: true
+  k8s_agentic_agent_api_url: "http://localhost:8080"
+
+_shared_cluster: &shared_cluster
+  cloud: GCP
+  type: Kubernetes
+  vm_count: 1
+  vm_spec:
+    GCP:
+      machine_type: c4-standard-8
+      zone: us-central1-a
+      boot_disk_type: hyperdisk-balanced
+      boot_disk_size: 50
+  nodepools:
+    sandbox:
+      vm_count: 1
+      vm_spec:
+        GCP:
+          machine_type: c4-standard-8
+          zone: us-central1-a
+          boot_disk_type: hyperdisk-balanced
+          boot_disk_size: 100
+      sandbox_config:
+        type: gvisor
+
+_shared_registry: &shared_registry
+  cloud: GCP
+  spec:
+    GCP:
+      zone: us-central1-a
+
+
+_shared_container_specs: &shared_container_specs
+  adk_agent:
+    image: agentic/adk-agent
+
+# ===========================================================================
+# Benchmark definitions (each references the shared anchors above)
+# ===========================================================================
+
+k8s_python_density:
+  flags:
+    <<: *shared_flags
+  container_registry:
+    <<: *shared_registry
+  container_specs:
+    <<: *shared_container_specs
+  container_cluster:
+    <<: *shared_cluster
+
+k8s_chromium_density:
+  flags:
+    <<: *shared_flags
+  container_registry:
+    <<: *shared_registry
+  container_specs:
+    <<: *shared_container_specs
+  container_cluster:
+    <<: *shared_cluster
+
+k8s_payload:
+  flags:
+    <<: *shared_flags
+  container_registry:
+    <<: *shared_registry
+  container_specs:
+    <<: *shared_container_specs
+  container_cluster:
+    <<: *shared_cluster
+
+k8s_qps:
+  flags:
+    <<: *shared_flags
+  container_registry:
+    <<: *shared_registry
+  container_specs:
+    <<: *shared_container_specs
+  container_cluster:
+    <<: *shared_cluster
+
+k8s_snapshot:
+  flags:
+    <<: *shared_flags
+  container_registry:
+    <<: *shared_registry
+  container_specs:
+    <<: *shared_container_specs
+  container_cluster:
+    <<: *shared_cluster
+
+k8s_warmpool:
+  flags:
+    <<: *shared_flags
+  container_registry:
+    <<: *shared_registry
+  container_specs:
+    <<: *shared_container_specs
+  container_cluster:
+    <<: *shared_cluster
+
+k8s_deletion:
+  flags:
+    <<: *shared_flags
+  container_registry:
+    <<: *shared_registry
+  container_specs:
+    <<: *shared_container_specs
+  container_cluster:
+    <<: *shared_cluster

--- a/perfkitbenchmarker/data/k8s_agents/config/variants/baseline.yaml
+++ b/perfkitbenchmarker/data/k8s_agents/config/variants/baseline.yaml
@@ -1,0 +1,346 @@
+# UC-B Baseline: c4-standard-8, gVisor, all defaults
+# No tuning knobs applied. This is the reference measurement.
+
+k8s_python_density:
+  description: >
+    UC-B Baseline: Python sandbox density on c4-standard-8 with default settings.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "baseline"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_chromium_density:
+  description: >
+    UC-C Baseline: Chromium Browser Density on c4-standard-8 with default settings.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "baseline"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_payload:
+  description: >
+    UC-D Baseline: Payload Transfer on c4-standard-8 with default settings.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "baseline"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_qps:
+  description: >
+    UC-F Baseline: QPS Saturation on c4-standard-8 with default settings.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "baseline"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_warmpool:
+  description: >
+    UC-E Baseline: Warmpool Scale-Up on c4-standard-8 with default settings.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "baseline"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_deletion:
+  description: >
+    UC-G Baseline: Deletion & Cleanup on c4-standard-8 with default settings.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "baseline"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_snapshot:
+  description: >
+    UC-A Baseline: Pod Snapshot saturation on c4-standard-8 with default settings.
+  flags:
+    gke_additional_flags:
+      - "--enable-pod-snapshots"
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "baseline"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor

--- a/perfkitbenchmarker/data/k8s_agents/config/variants/c4a_arm.yaml
+++ b/perfkitbenchmarker/data/k8s_agents/config/variants/c4a_arm.yaml
@@ -1,0 +1,399 @@
+# UC-B Variant 9: C4A (ARM)
+# Knob: c4a-standard-8 (Arm Neoverse)
+# Expected: Different gVisor syscall overhead on ARM ISA
+# PREREQUISITES:
+#   1. Run gke_prerequisites.py with --target_arch=arm64
+#   2. Uses --node-architecture-taint-behavior=none on BOTH node pools
+#      to prevent the automatic kubernetes.io/arch=arm64:NoSchedule taint
+#      that blocks amd64-default pods from scheduling.
+#
+# WHY on both pools:
+#   - Default pool: ADK agent, router, agent-sandbox-controller need to schedule here
+#   - Sandbox pool: sandbox pods need to schedule here
+#   Without removing the taint from both, pods have nowhere to go.
+
+k8s_python_density:
+  description: >
+    UC-B Var-9: C4A (ARM Neoverse) c4a-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--node-architecture-taint-behavior=none"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--node-architecture-taint-behavior=none"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "c4a-arm"
+    container_remote_build_config: "perfkitbenchmarker/data/docker/agentic/adk-agent/cloudbuild-arm64.yaml"
+    target_arch: "arm64"
+    container_cluster_architecture:
+      - "linux/arm64"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4a-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4a-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_chromium_density:
+  description: >
+    UC-C Var-9: C4A (ARM Neoverse) c4a-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--node-architecture-taint-behavior=none"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--node-architecture-taint-behavior=none"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "c4a-arm"
+    container_remote_build_config: "perfkitbenchmarker/data/docker/agentic/adk-agent/cloudbuild-arm64.yaml"
+    target_arch: "arm64"
+    container_cluster_architecture:
+      - "linux/arm64"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4a-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4a-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_payload:
+  description: >
+    UC-D Var-9: C4A (ARM Neoverse) c4a-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--node-architecture-taint-behavior=none"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--node-architecture-taint-behavior=none"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "c4a-arm"
+    container_remote_build_config: "perfkitbenchmarker/data/docker/agentic/adk-agent/cloudbuild-arm64.yaml"
+    target_arch: "arm64"
+    container_cluster_architecture:
+      - "linux/arm64"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4a-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4a-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_qps:
+  description: >
+    UC-F Var-9: C4A (ARM Neoverse) c4a-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--node-architecture-taint-behavior=none"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--node-architecture-taint-behavior=none"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "c4a-arm"
+    container_remote_build_config: "perfkitbenchmarker/data/docker/agentic/adk-agent/cloudbuild-arm64.yaml"
+    target_arch: "arm64"
+    container_cluster_architecture:
+      - "linux/arm64"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4a-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4a-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_warmpool:
+  description: >
+    UC-E Var-9: C4A (ARM Neoverse) c4a-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--node-architecture-taint-behavior=none"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--node-architecture-taint-behavior=none"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "c4a-arm"
+    container_remote_build_config: "perfkitbenchmarker/data/docker/agentic/adk-agent/cloudbuild-arm64.yaml"
+    target_arch: "arm64"
+    container_cluster_architecture:
+      - "linux/arm64"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4a-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4a-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_deletion:
+  description: >
+    UC-G Var-9: C4A (ARM Neoverse) c4a-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--node-architecture-taint-behavior=none"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--node-architecture-taint-behavior=none"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "c4a-arm"
+    container_remote_build_config: "perfkitbenchmarker/data/docker/agentic/adk-agent/cloudbuild-arm64.yaml"
+    target_arch: "arm64"
+    container_cluster_architecture:
+      - "linux/arm64"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4a-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4a-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_snapshot:
+  description: >
+    UC-A Var-9: C4A (ARM Neoverse) c4a-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-pod-snapshots"
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--node-architecture-taint-behavior=none"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--node-architecture-taint-behavior=none"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "c4a-arm"
+    container_remote_build_config: "perfkitbenchmarker/data/docker/agentic/adk-agent/cloudbuild-arm64.yaml"
+    target_arch: "arm64"
+    container_cluster_architecture:
+      - "linux/arm64"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4a-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4a-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor

--- a/perfkitbenchmarker/data/k8s_agents/config/variants/c4d_amd.yaml
+++ b/perfkitbenchmarker/data/k8s_agents/config/variants/c4d_amd.yaml
@@ -1,0 +1,347 @@
+# UC-B Variant 8: C4D (AMD)
+# Knob: c4d-standard-8 (AMD EPYC)
+# Expected: Different gVisor overhead on AMD microarchitecture
+
+k8s_python_density:
+  description: >
+    UC-B Var-8: C4D (AMD EPYC) c4d-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "c4d-amd"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4d-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4d-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_chromium_density:
+  description: >
+    UC-C Var-8: C4D (AMD EPYC) c4d-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "c4d-amd"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4d-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4d-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_payload:
+  description: >
+    UC-D Var-8: C4D (AMD EPYC) c4d-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "c4d-amd"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4d-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4d-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_qps:
+  description: >
+    UC-F Var-8: C4D (AMD EPYC) c4d-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "c4d-amd"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4d-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4d-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_warmpool:
+  description: >
+    UC-E Var-8: C4D (AMD EPYC) c4d-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "c4d-amd"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4d-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4d-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_deletion:
+  description: >
+    UC-G Var-8: C4D (AMD EPYC) c4d-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "c4d-amd"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4d-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4d-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_snapshot:
+  description: >
+    UC-A Var-8: C4D (AMD EPYC) c4d-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-pod-snapshots"
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "c4d-amd"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4d-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4d-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor

--- a/perfkitbenchmarker/data/k8s_agents/config/variants/hyperdisk_200gb.yaml
+++ b/perfkitbenchmarker/data/k8s_agents/config/variants/hyperdisk_200gb.yaml
@@ -1,0 +1,348 @@
+# UC-B Variant 4: Larger hyperdisk-balanced (200GB)
+# Knob: 200GB hyperdisk-balanced boot disk (2x default)
+# Expected: More IOPS/throughput for pod creation and image layer extraction
+# Note: C4 machines only support hyperdisk-balanced, NOT pd-ssd
+
+k8s_python_density:
+  description: >
+    UC-B Var-4: hyperdisk-balanced 200GB boot disk on c4-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "hyperdisk-200gb"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 200
+        sandbox_config:
+          type: gvisor
+
+k8s_chromium_density:
+  description: >
+    UC-C Var-4: hyperdisk-balanced 200GB boot disk on c4-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "hyperdisk-200gb"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 200
+        sandbox_config:
+          type: gvisor
+
+k8s_payload:
+  description: >
+    UC-D Var-4: hyperdisk-balanced 200GB boot disk on c4-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "hyperdisk-200gb"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 200
+        sandbox_config:
+          type: gvisor
+
+k8s_qps:
+  description: >
+    UC-F Var-4: hyperdisk-balanced 200GB boot disk on c4-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "hyperdisk-200gb"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 200
+        sandbox_config:
+          type: gvisor
+
+k8s_warmpool:
+  description: >
+    UC-E Var-4: hyperdisk-balanced 200GB boot disk on c4-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "hyperdisk-200gb"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 200
+        sandbox_config:
+          type: gvisor
+
+k8s_deletion:
+  description: >
+    UC-G Var-4: hyperdisk-balanced 200GB boot disk on c4-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "hyperdisk-200gb"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 200
+        sandbox_config:
+          type: gvisor
+
+k8s_snapshot:
+  description: >
+    UC-A Var-4: hyperdisk-balanced 200GB boot disk on c4-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-pod-snapshots"
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "hyperdisk-200gb"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 200
+        sandbox_config:
+          type: gvisor

--- a/perfkitbenchmarker/data/k8s_agents/config/variants/kubelet_pulls.yaml
+++ b/perfkitbenchmarker/data/k8s_agents/config/variants/kubelet_pulls.yaml
@@ -1,0 +1,354 @@
+# UC-B Variant 1: Kubelet image pull + GC tuning
+# Knobs: maxParallelImagePulls=5, imageGc thresholds lowered
+# Expected: Faster warm pool provisioning via parallel pulls + aggressive GC
+
+k8s_python_density:
+  description: >
+    UC-B Var-1: Kubelet parallel image pulls + image GC tuning on c4-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--system-config-from-file=perfkitbenchmarker/data/k8s_agents/config/variants/tuning/kubelet_parallel_pulls.yaml"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "kubelet-pulls"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_chromium_density:
+  description: >
+    UC-C Var-1: Kubelet parallel image pulls + image GC tuning on c4-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--system-config-from-file=perfkitbenchmarker/data/k8s_agents/config/variants/tuning/kubelet_parallel_pulls.yaml"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "kubelet-pulls"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_payload:
+  description: >
+    UC-D Var-1: Kubelet parallel image pulls + image GC tuning on c4-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--system-config-from-file=perfkitbenchmarker/data/k8s_agents/config/variants/tuning/kubelet_parallel_pulls.yaml"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "kubelet-pulls"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_qps:
+  description: >
+    UC-F Var-1: Kubelet parallel image pulls + image GC tuning on c4-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--system-config-from-file=perfkitbenchmarker/data/k8s_agents/config/variants/tuning/kubelet_parallel_pulls.yaml"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "kubelet-pulls"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_warmpool:
+  description: >
+    UC-E Var-1: Kubelet parallel image pulls + image GC tuning on c4-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--system-config-from-file=perfkitbenchmarker/data/k8s_agents/config/variants/tuning/kubelet_parallel_pulls.yaml"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "kubelet-pulls"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_deletion:
+  description: >
+    UC-G Var-1: Kubelet parallel image pulls + image GC tuning on c4-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--system-config-from-file=perfkitbenchmarker/data/k8s_agents/config/variants/tuning/kubelet_parallel_pulls.yaml"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "kubelet-pulls"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_snapshot:
+  description: >
+    UC-A Var-1: Kubelet parallel image pulls + image GC tuning on c4-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-pod-snapshots"
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--system-config-from-file=perfkitbenchmarker/data/k8s_agents/config/variants/tuning/kubelet_parallel_pulls.yaml"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "kubelet-pulls"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor

--- a/perfkitbenchmarker/data/k8s_agents/config/variants/larger_vm.yaml
+++ b/perfkitbenchmarker/data/k8s_agents/config/variants/larger_vm.yaml
@@ -1,0 +1,347 @@
+# UC-B Variant 3: Larger VM (c4-standard-16)
+# Knob: 16 vCPUs instead of 8
+# Expected: Higher density ceiling before CEL degrades
+
+k8s_python_density:
+  description: >
+    UC-B Var-3: c4-standard-16 (2x CPU headroom).
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "c4-standard-16"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-16
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-16
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_chromium_density:
+  description: >
+    UC-C Var-3: c4-standard-16 (2x CPU headroom).
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "c4-standard-16"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-16
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-16
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_payload:
+  description: >
+    UC-D Var-3: c4-standard-16 (2x CPU headroom).
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "c4-standard-16"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-16
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-16
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_qps:
+  description: >
+    UC-F Var-3: c4-standard-16 (2x CPU headroom).
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "c4-standard-16"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-16
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-16
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_warmpool:
+  description: >
+    UC-E Var-3: c4-standard-16 (2x CPU headroom).
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "c4-standard-16"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-16
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-16
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_deletion:
+  description: >
+    UC-G Var-3: c4-standard-16 (2x CPU headroom).
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "c4-standard-16"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-16
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-16
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_snapshot:
+  description: >
+    UC-A Var-3: c4-standard-16 (2x CPU headroom).
+  flags:
+    gke_additional_flags:
+      - "--enable-pod-snapshots"
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "c4-standard-16"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-16
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-16
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor

--- a/perfkitbenchmarker/data/k8s_agents/config/variants/multi_node.yaml
+++ b/perfkitbenchmarker/data/k8s_agents/config/variants/multi_node.yaml
@@ -1,0 +1,327 @@
+# UC-B Variant 10: Multi-node sandbox pool (2 nodes)
+# Knob: vm_count: 2 on sandbox node pool (default: 1)
+# Expected: Higher density ceiling, faster warmpool provisioning,
+#           better scheduling throughput across 2 nodes
+
+k8s_python_density:
+  description: >
+    Var-10: 2-node sandbox pool (c4-standard-8 x2) for multi-node scaling.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+    container_cluster_version: "1.35.5-gke.1057002"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "multi-node-2x"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 2
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_chromium_density:
+  description: >
+    Var-10: 2-node sandbox pool (c4-standard-8 x2) for multi-node scaling.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+    container_cluster_version: "1.35.5-gke.1057002"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "multi-node-2x"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 2
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_payload:
+  description: >
+    Var-10: 2-node sandbox pool (c4-standard-8 x2) for multi-node scaling.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+    container_cluster_version: "1.35.5-gke.1057002"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "multi-node-2x"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 2
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_qps:
+  description: >
+    Var-10: 2-node sandbox pool (c4-standard-8 x2) for multi-node scaling.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+    container_cluster_version: "1.35.5-gke.1057002"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "multi-node-2x"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 2
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_warmpool:
+  description: >
+    Var-10: 2-node sandbox pool (c4-standard-8 x2) for multi-node scaling.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+    container_cluster_version: "1.35.5-gke.1057002"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "multi-node-2x"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 2
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_deletion:
+  description: >
+    Var-10: 2-node sandbox pool (c4-standard-8 x2) for multi-node scaling.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+    container_cluster_version: "1.35.5-gke.1057002"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "multi-node-2x"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 2
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_snapshot:
+  description: >
+    Var-10: 2-node sandbox pool (c4-standard-8 x2) for multi-node scaling.
+  flags:
+    gke_additional_flags:
+      - "--enable-pod-snapshots"
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+    container_cluster_version: "1.35.5-gke.1057002"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "multi-node-2x"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 2
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor

--- a/perfkitbenchmarker/data/k8s_agents/config/variants/overlay_none.yaml
+++ b/perfkitbenchmarker/data/k8s_agents/config/variants/overlay_none.yaml
@@ -1,0 +1,347 @@
+# UC-B Variant 2: gVisor overlay2=none
+# Knob: dev.gvisor.spec.overlay2=none (applied via kubectl patch after Prepare)
+# Expected: Possible improvement in import CEL (fewer FS layers)
+
+k8s_python_density:
+  description: >
+    UC-B Var-2: gVisor overlay2=none on c4-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "overlay-none"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_chromium_density:
+  description: >
+    UC-C Var-2: gVisor overlay2=none on c4-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "overlay-none"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_payload:
+  description: >
+    UC-D Var-2: gVisor overlay2=none on c4-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "overlay-none"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_qps:
+  description: >
+    UC-F Var-2: gVisor overlay2=none on c4-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "overlay-none"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_warmpool:
+  description: >
+    UC-E Var-2: gVisor overlay2=none on c4-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "overlay-none"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_deletion:
+  description: >
+    UC-G Var-2: gVisor overlay2=none on c4-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "overlay-none"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_snapshot:
+  description: >
+    UC-A Var-2: gVisor overlay2=none on c4-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-pod-snapshots"
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "overlay-none"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor

--- a/perfkitbenchmarker/data/k8s_agents/config/variants/sched_tuning.yaml
+++ b/perfkitbenchmarker/data/k8s_agents/config/variants/sched_tuning.yaml
@@ -1,0 +1,347 @@
+# UC-B Variant 6: Kernel scheduler tuning
+# Knobs: sched_migration_cost_ns, sched_min_granularity_ns (applied via DaemonSet)
+# Expected: Reduced context switching at high density
+
+k8s_python_density:
+  description: >
+    UC-B Var-6: Kernel scheduler tuning on c4-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "sched-tuning"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_chromium_density:
+  description: >
+    UC-C Var-6: Kernel scheduler tuning on c4-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "sched-tuning"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_payload:
+  description: >
+    UC-D Var-6: Kernel scheduler tuning on c4-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "sched-tuning"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_qps:
+  description: >
+    UC-F Var-6: Kernel scheduler tuning on c4-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "sched-tuning"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_warmpool:
+  description: >
+    UC-E Var-6: Kernel scheduler tuning on c4-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "sched-tuning"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_deletion:
+  description: >
+    UC-G Var-6: Kernel scheduler tuning on c4-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "sched-tuning"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_snapshot:
+  description: >
+    UC-A Var-6: Kernel scheduler tuning on c4-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-pod-snapshots"
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "sched-tuning"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor

--- a/perfkitbenchmarker/data/k8s_agents/config/variants/swap.yaml
+++ b/perfkitbenchmarker/data/k8s_agents/config/variants/swap.yaml
@@ -1,0 +1,355 @@
+# UC-B Variant 7: Swap enabled
+# Knobs: Node swap + swappiness=15
+# Expected: Higher density ceiling at cost of tail latency
+# Requires: GKE >= 1.34.1-gke.1341000, Burstable QoS pods only
+
+k8s_python_density:
+  description: >
+    UC-B Var-7: Node swap enabled on c4-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--system-config-from-file=perfkitbenchmarker/data/k8s_agents/config/variants/tuning/swap_config.yaml"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "swap"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_chromium_density:
+  description: >
+    UC-C Var-7: Node swap enabled on c4-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--system-config-from-file=perfkitbenchmarker/data/k8s_agents/config/variants/tuning/swap_config.yaml"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "swap"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_payload:
+  description: >
+    UC-D Var-7: Node swap enabled on c4-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--system-config-from-file=perfkitbenchmarker/data/k8s_agents/config/variants/tuning/swap_config.yaml"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "swap"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_qps:
+  description: >
+    UC-F Var-7: Node swap enabled on c4-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--system-config-from-file=perfkitbenchmarker/data/k8s_agents/config/variants/tuning/swap_config.yaml"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "swap"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_warmpool:
+  description: >
+    UC-E Var-7: Node swap enabled on c4-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--system-config-from-file=perfkitbenchmarker/data/k8s_agents/config/variants/tuning/swap_config.yaml"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "swap"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_deletion:
+  description: >
+    UC-G Var-7: Node swap enabled on c4-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--system-config-from-file=perfkitbenchmarker/data/k8s_agents/config/variants/tuning/swap_config.yaml"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "swap"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_snapshot:
+  description: >
+    UC-A Var-7: Node swap enabled on c4-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-pod-snapshots"
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--system-config-from-file=perfkitbenchmarker/data/k8s_agents/config/variants/tuning/swap_config.yaml"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "swap"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor

--- a/perfkitbenchmarker/data/k8s_agents/config/variants/thp.yaml
+++ b/perfkitbenchmarker/data/k8s_agents/config/variants/thp.yaml
@@ -1,0 +1,356 @@
+# UC-B Variant 5: Transparent Hugepages (THP) enabled system-wide
+# Knob: THP=always + defrag=defer
+# Expected: Reduced TLB misses for Python memory-intensive workloads
+# Risk: Higher memory usage, possible compaction latency
+# Note: Original Kata variant removed - GKE --sandbox only supports gvisor.
+
+k8s_python_density:
+  description: >
+    UC-B Var-5: Transparent Hugepages (THP=always) on c4-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--system-config-from-file=perfkitbenchmarker/data/k8s_agents/config/variants/tuning/thp_config.yaml"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "thp-always"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_chromium_density:
+  description: >
+    UC-C Var-5: Transparent Hugepages (THP=always) on c4-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--system-config-from-file=perfkitbenchmarker/data/k8s_agents/config/variants/tuning/thp_config.yaml"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "thp-always"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_payload:
+  description: >
+    UC-D Var-5: Transparent Hugepages (THP=always) on c4-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--system-config-from-file=perfkitbenchmarker/data/k8s_agents/config/variants/tuning/thp_config.yaml"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "thp-always"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_qps:
+  description: >
+    UC-F Var-5: Transparent Hugepages (THP=always) on c4-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--system-config-from-file=perfkitbenchmarker/data/k8s_agents/config/variants/tuning/thp_config.yaml"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "thp-always"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_warmpool:
+  description: >
+    UC-E Var-5: Transparent Hugepages (THP=always) on c4-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--system-config-from-file=perfkitbenchmarker/data/k8s_agents/config/variants/tuning/thp_config.yaml"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "thp-always"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_deletion:
+  description: >
+    UC-G Var-5: Transparent Hugepages (THP=always) on c4-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--system-config-from-file=perfkitbenchmarker/data/k8s_agents/config/variants/tuning/thp_config.yaml"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "thp-always"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor
+
+k8s_snapshot:
+  description: >
+    UC-A Var-5: Transparent Hugepages (THP=always) on c4-standard-8.
+  flags:
+    gke_additional_flags:
+      - "--enable-pod-snapshots"
+      - "--enable-dataplane-v2"
+      - "--enable-ip-alias"
+      - "--release-channel=None"
+    gke_additional_nodepool_flags:
+      - "--max-pods-per-node=250"
+      - "--system-config-from-file=perfkitbenchmarker/data/k8s_agents/config/variants/tuning/thp_config.yaml"
+      - "--no-enable-autoupgrade"
+      - "--no-enable-autorepair"
+    container_cluster_version: "1.36.0-gke.3070003"
+    gce_subnet_region: "us-east1"
+    k8s_agentic_namespace: "agentic"
+    agent_sandbox_version: "v0.4.6"
+    k8s_agentic_gvisor: true
+    k8s_agentic_agent_api_url: "http://localhost:8080"
+    k8s_agentic_benchmark_note: "thp-always"
+  container_registry:
+    cloud: GCP
+    spec:
+      GCP:
+        zone: us-east1-c
+  container_specs:
+    adk_agent:
+      image: agentic/adk-agent
+  container_cluster:
+    cloud: GCP
+    type: Kubernetes
+    vm_count: 1
+    vm_spec:
+      GCP:
+        machine_type: c4-standard-8
+        zone: us-east1-c
+        boot_disk_type: hyperdisk-balanced
+        boot_disk_size: 50
+    nodepools:
+      sandbox:
+        vm_count: 1
+        vm_spec:
+          GCP:
+            machine_type: c4-standard-8
+            zone: us-east1-c
+            boot_disk_type: hyperdisk-balanced
+            boot_disk_size: 100
+        sandbox_config:
+          type: gvisor

--- a/perfkitbenchmarker/data/k8s_agents/config/variants/tuning/kubelet_parallel_pulls.yaml
+++ b/perfkitbenchmarker/data/k8s_agents/config/variants/tuning/kubelet_parallel_pulls.yaml
@@ -1,0 +1,9 @@
+# Kubelet config for parallel image pulls + image GC tuning
+# Applied via --system-config-from-file on node pool creation
+#
+# GKE-supported kubelet fields only.
+# serializeImagePulls, registryPullQPS, registryBurst are NOT exposed by GKE.
+kubeletConfig:
+  maxParallelImagePulls: 5
+  imageGcHighThresholdPercent: 70
+  imageGcLowThresholdPercent: 50

--- a/perfkitbenchmarker/data/k8s_agents/config/variants/tuning/sched_tuner_daemonset.yaml.j2
+++ b/perfkitbenchmarker/data/k8s_agents/config/variants/tuning/sched_tuner_daemonset.yaml.j2
@@ -1,0 +1,49 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: sched-tuner
+  namespace: {{ ns }}
+spec:
+  selector:
+    matchLabels:
+      app: sched-tuner
+  template:
+    metadata:
+      labels:
+        app: sched-tuner
+    spec:
+      nodeSelector:
+        pkb_nodepool: sandbox
+      tolerations:
+      - key: "sandbox.gke.io/runtime"
+        operator: "Equal"
+        value: "gvisor"
+        effect: "NoSchedule"
+      hostPID: true
+      initContainers:
+      - name: sysctl-tuner
+        image: busybox:1.36
+        command: ["sh", "-c"]
+        args:
+          - |
+            echo 2212926 > /proc/sys/kernel/sched_migration_cost_ns
+            echo 4656091 > /proc/sys/kernel/sched_min_granularity_ns
+            echo 26403982 > /proc/sys/kernel/sched_wakeup_granularity_ns
+            echo "Scheduler tunables applied."
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: proc
+          mountPath: /proc
+      containers:
+      - name: pause
+        image: registry.k8s.io/pause:3.9
+        resources:
+          requests:
+            cpu: "1m"
+            memory: "4Mi"
+      volumes:
+      - name: proc
+        hostPath:
+          path: /proc

--- a/perfkitbenchmarker/data/k8s_agents/config/variants/tuning/sched_tuner_daemonset.yaml.j2
+++ b/perfkitbenchmarker/data/k8s_agents/config/variants/tuning/sched_tuner_daemonset.yaml.j2
@@ -1,0 +1,55 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: sched-tuner
+  namespace: {{ ns }}
+spec:
+  selector:
+    matchLabels:
+      app: sched-tuner
+  template:
+    metadata:
+      labels:
+        app: sched-tuner
+    spec:
+      nodeSelector:
+        pkb_nodepool: sandbox
+      tolerations:
+      - key: "sandbox.gke.io/runtime"
+        operator: "Equal"
+        value: "gvisor"
+        effect: "NoSchedule"
+      hostPID: true
+      initContainers:
+      - name: sysctl-tuner
+        image: busybox:1.36
+        command: ["sh", "-c"]
+        args:
+          - |
+            # Standard Linux/GKE Defaults:
+            # sched_migration_cost_ns: 500000
+            # sched_min_granularity_ns: 3000000
+            # sched_wakeup_granularity_ns: 4000000
+
+            # Tuned values for high-density container workloads:
+            echo 2212926 > /proc/sys/kernel/sched_migration_cost_ns
+            echo 4656091 > /proc/sys/kernel/sched_min_granularity_ns
+            echo 26403982 > /proc/sys/kernel/sched_wakeup_granularity_ns
+            echo "Scheduler tunables applied."
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: proc
+          mountPath: /proc
+      containers:
+      - name: pause
+        image: registry.k8s.io/pause:3.9
+        resources:
+          requests:
+            cpu: "1m"
+            memory: "4Mi"
+      volumes:
+      - name: proc
+        hostPath:
+          path: /proc

--- a/perfkitbenchmarker/data/k8s_agents/config/variants/tuning/swap_config.yaml
+++ b/perfkitbenchmarker/data/k8s_agents/config/variants/tuning/swap_config.yaml
@@ -1,0 +1,9 @@
+# Node swap configuration for UC-B Variant 7
+# Applied via --system-config-from-file (NOT --linux-config)
+# Requires GKE >= 1.34.1-gke.1341000
+# Only Burstable QoS pods can use swap
+linuxConfig:
+  swapConfig:
+    enabled: true
+  sysctl:
+    vm.swappiness: '15'

--- a/perfkitbenchmarker/data/k8s_agents/config/variants/tuning/thp_config.yaml
+++ b/perfkitbenchmarker/data/k8s_agents/config/variants/tuning/thp_config.yaml
@@ -1,0 +1,7 @@
+# Transparent Hugepages configuration
+# THP=always can reduce TLB misses for memory-intensive workloads
+# Default is 'madvise' (only MADV_HUGEPAGE regions)
+# Risk: may increase memory usage and cause latency spikes during compaction
+linuxConfig:
+  transparentHugepageEnabled: TRANSPARENT_HUGEPAGE_ENABLED_ALWAYS
+  transparentHugepageDefrag: TRANSPARENT_HUGEPAGE_DEFRAG_DEFER

--- a/perfkitbenchmarker/data/k8s_agents/config/variants/variant_reference_guide.md
+++ b/perfkitbenchmarker/data/k8s_agents/config/variants/variant_reference_guide.md
@@ -1,0 +1,305 @@
+# Optimization Variant Reference Guide
+
+## Baseline Configuration
+
+All variants are compared against this reference:
+
+| Parameter | Baseline Value |
+|-----------|---------------|
+| Machine type | c4-standard-8 (4 cores / 8 vCPUs, 30 GB RAM) |
+| Boot disk | hyperdisk-balanced, 100 GB (sandbox pool) |
+| Runtime | gVisor (GKE Sandbox) |
+| GKE version | 1.35.5-gke.1057002 |
+| Platform | xemu (Google's hardware-accelerated, default) |
+| Filesystem | lisafs + directfs + exclusive (all defaults) |
+| Overlay | root:self (disk-backed, host page cache) |
+| THP | madvise (default) |
+| Swap | disabled |
+| Kubelet | default settings |
+| Scheduler | default kernel tunables |
+| Sandbox nodes | 1 |
+
+---
+
+## Variant Descriptions
+
+### var1 — Kubelet Parallel Image Pulls + Image GC
+
+**What changes vs baseline:**
+- `maxParallelImagePulls: 5` (default: 1 — serial pulls)
+- `imageGcHighThresholdPercent: 70` (default: 85)
+- `imageGcLowThresholdPercent: 50` (default: 80)
+- Applied via `--system-config-from-file` on sandbox node pool creation
+
+**What it tests:** Whether parallelizing container image pulls and aggressively garbage-collecting unused images improves pod creation throughput. The hypothesis is that serial image pulls bottleneck warm pool provisioning when many pods start simultaneously.
+
+| Benchmark | Expected Influence | Rationale |
+|-----------|-------------------|-----------|
+| k8s_python_density | None | Measures in-sandbox execution, not pod creation |
+| k8s_chromium_density | None | Same — measures browser interaction after pod is running |
+| k8s_payload | None | Measures data transfer, not pod creation |
+| k8s_qps | Indirect | Faster image pulls -> faster warm pool refill -> sustained QPS |
+| **k8s_warmpool** | **Direct** | **Parallel pulls directly accelerate bulk pod provisioning** |
+| k8s_deletion | None | Image GC may help disk cleanup, but deletion is IPAM-bound |
+| k8s_snapshot | Indirect | Faster pod creation after restore, but restore is CRIU-bound |
+
+---
+
+### var2 — gVisor overlay2=none
+
+**What changes vs baseline:**
+- `dev.gvisor.spec.overlay2: none` (default: `root:self`)
+- Applied via `kubectl patch sandboxtemplate` post-prepare
+- Removes the overlay filesystem layer — sandbox writes go directly to the container's rootfs
+
+**What it tests:** Whether removing the overlay2 filesystem layer reduces I/O overhead for file-heavy operations. The hypothesis is that overlay adds latency to every file open/stat/read through extra indirection layers.
+
+| Benchmark | Expected Influence | Rationale |
+|-----------|-------------------|-----------|
+| k8s_python_density | Harmful | Import CEL worsens — loses page cache sharing |
+| k8s_chromium_density | Likely harmful | Chrome loads many shared libs — same cache loss |
+| k8s_payload | Possible | Stdout write path may differ, but payload is memory to stdout |
+| k8s_qps | None | QPS measures scheduling, not filesystem |
+| k8s_warmpool | None | Pod creation doesn't depend on overlay mode |
+| k8s_deletion | None | Deletion is pod lifecycle, not filesystem |
+| k8s_snapshot | Unknown | Snapshot captures filesystem state — overlay=none may reduce snapshot size but slow restore |
+
+---
+
+### var3 — c4-standard-16 (2x CPU)
+
+**What changes vs baseline:**
+- Machine type: `c4-standard-16` (8 cores / 16 vCPUs, 60 GB RAM)
+- Both default pool and sandbox pool upgraded
+- 2x CPU, 2x RAM vs baseline
+
+**What it tests:** Whether doubling available compute resources directly reduces execution latency and raises the density ceiling. This is the "throw hardware at it" variant — establishes whether the bottleneck is CPU-bound.
+
+| Benchmark | Expected Influence | Rationale |
+|-----------|-------------------|-----------|
+| **k8s_python_density** | **Strong improvement** | **CPU-bound workload directly benefits from 2x cores** |
+| **k8s_chromium_density** | **Strong improvement** | **Chrome rendering + JS execution are CPU-bound** |
+| **k8s_payload** | **Moderate improvement** | **base64 serialization is CPU-bound** |
+| **k8s_qps** | **Moderate improvement** | **More CPU headroom for concurrent sandbox lifecycle ops** |
+| **k8s_warmpool** | **Moderate improvement** | **Faster container init, more scheduling headroom** |
+| k8s_deletion | Minor | Deletion is control-plane/IPAM bound, not node CPU |
+| **k8s_snapshot** | **Moderate improvement** | **CRIU restore + gVisor init are CPU-intensive** |
+
+---
+
+### var4 — Hyperdisk-balanced 200 GB
+
+**What changes vs baseline:**
+- Sandbox pool boot disk: `hyperdisk-balanced 200 GB` (default: 100 GB)
+- Larger disk = more baseline IOPS (hyperdisk scales with size)
+- No change to machine type
+
+**What it tests:** Whether increased disk I/O throughput improves pod creation speed and file-heavy operations. Hyperdisk-balanced IOPS scale with provisioned size, so 200 GB provides ~2x the IOPS of 100 GB.
+
+| Benchmark | Expected Influence | Rationale |
+|-----------|-------------------|-----------|
+| k8s_python_density | None | CPU-bound workload, disk irrelevant after pod starts |
+| k8s_chromium_density | Minor | Chrome writes temp files, but execution is CPU-bound |
+| k8s_payload | None | Payload goes through stdout, not disk |
+| k8s_qps | Minor | Pod creation involves image layer extraction (disk I/O) |
+| **k8s_warmpool** | **Moderate** | **Bulk pod creation extracts image layers — disk IOPS matters** |
+| k8s_deletion | Minor | Pod cleanup involves filesystem teardown |
+| **k8s_snapshot** | **Direct** | **Snapshot write/restore is GCS-bound but local staging uses disk** |
+
+---
+
+### var5 — Transparent Hugepages (THP=always)
+
+**What changes vs baseline:**
+- `transparentHugepageEnabled: ALWAYS` (default: `madvise`)
+- `transparentHugepageDefrag: DEFER` (default: varies)
+- Applied via `--system-config-from-file` on sandbox node pool
+
+**What it tests:** Whether using 2 MB huge pages instead of 4 KB pages reduces TLB (Translation Lookaside Buffer) misses for memory-intensive workloads. The hypothesis is that Python's memory allocator and gVisor's sentry benefit from fewer page table entries.
+
+| Benchmark | Expected Influence | Rationale |
+|-----------|-------------------|-----------|
+| k8s_python_density | Harmful at density | Compaction stalls worsen with more pods |
+| k8s_chromium_density | Likely harmful | Chrome's multi-process model amplifies compaction |
+| k8s_payload | Unknown | Large memory allocations might benefit, but compaction risk |
+| k8s_qps | Harmful | Compaction during pod creation adds latency |
+| k8s_warmpool | Harmful | Bulk pod creation triggers heavy compaction |
+| k8s_deletion | None | Deletion doesn't allocate memory |
+| k8s_snapshot | Unknown | Snapshot restore allocates large memory blocks — could help or hurt |
+
+---
+
+### var6 — Kernel Scheduler Tuning
+
+**What changes vs baseline:**
+- `sched_migration_cost_ns: 2212926` (higher = less eager migration between cores)
+- `sched_min_granularity_ns: 4656091` (larger time slices)
+- `sched_wakeup_granularity_ns: 26403982` (less preemption on wakeup)
+- Applied via privileged DaemonSet writing to `/proc/sys/kernel/sched_*`
+
+**What it tests:** Whether reducing context-switch frequency improves throughput for many concurrent containers. The hypothesis is that at high density, the default scheduler switches between gVisor sentry processes too aggressively, wasting CPU on context switches.
+
+| Benchmark | Expected Influence | Rationale |
+|-----------|-------------------|-----------|
+| k8s_python_density | Harmful | Larger time slices increase scheduling unfairness at high density |
+| k8s_chromium_density | Likely harmful | Chrome's multi-process model needs responsive scheduling |
+| k8s_payload | Neutral | Single-threaded transfer, scheduling less relevant |
+| k8s_qps | Harmful | Slower preemption delays sandbox claim processing |
+| k8s_warmpool | Unknown | Could help or hurt bulk pod init depending on contention pattern |
+| k8s_deletion | None | Deletion is API-server/kubelet bound, not scheduler |
+| k8s_snapshot | Unknown | CRIU restore is single-threaded, may not be affected |
+
+---
+
+### var7 — Swap Enabled
+
+**What changes vs baseline:**
+- `swapConfig.enabled: true`
+- `vm.swappiness: 15` (low — only swap under memory pressure)
+- Applied via `--system-config-from-file`
+- Only Burstable QoS pods can use swap (Guaranteed QoS pods are excluded)
+
+**What it tests:** Whether enabling swap allows higher pod density by offloading cold memory pages to disk. The hypothesis is that at very high density, some sandbox memory (e.g., imported-but-idle Python modules) can be swapped out to make room for more pods.
+
+| Benchmark | Expected Influence | Rationale |
+|-----------|-------------------|-----------|
+| k8s_python_density | Neutral (unless memory-bound) | Only helps if density exceeds RAM capacity |
+| k8s_chromium_density | **Possible** | **Chrome is memory-hungry (~100-200 MB/instance) — swap could extend density ceiling** |
+| k8s_payload | None | Payload size is small relative to RAM |
+| k8s_qps | None | QPS is scheduling-bound, not memory-bound |
+| k8s_warmpool | Minor | More pods can fit if memory is the constraint |
+| k8s_deletion | None | Deletion doesn't allocate memory |
+| k8s_snapshot | Minor | Swap could allow larger preload sizes before OOM |
+
+---
+
+### var8 — C4D AMD (c4d-standard-8)
+
+**What changes vs baseline:**
+- Machine type: `c4d-standard-8` (AMD EPYC, same vCPU/RAM as baseline)
+- Different CPU microarchitecture (AMD vs Intel)
+- Same core count, same memory
+
+**What it tests:** Whether AMD's CPU microarchitecture handles gVisor's syscall interception more efficiently than Intel's. gVisor's sentry traps every syscall via hardware virtualization extensions — AMD and Intel implement these differently (AMD-V vs VT-x).
+
+| Benchmark | Expected Influence | Rationale |
+|-----------|-------------------|-----------|
+| **k8s_python_density** | **Strong improvement** | **Syscall interception is the core overhead — AMD handles it better** |
+| **k8s_chromium_density** | **Strong improvement** | **Chrome makes many syscalls — same benefit** |
+| **k8s_payload** | **Moderate improvement** | **stdout write is a syscall through gVisor** |
+| **k8s_qps** | **Moderate improvement** | **Sandbox lifecycle involves many syscalls** |
+| **k8s_warmpool** | **Minor** | **Pod creation is control-plane bound, not syscall bound** |
+| k8s_deletion | Minor | Deletion is API-server bound |
+| **k8s_snapshot** | **Moderate improvement** | **CRIU restore + gVisor init involve heavy syscall activity** |
+
+---
+
+### var9 — C4A ARM (c4a-standard-8)
+
+**What changes vs baseline:**
+- Machine type: `c4a-standard-8` (ARM Neoverse, same vCPU/RAM as baseline)
+- Entirely different ISA (ARM64 vs x86_64)
+- Requires ARM container images (cross-compiled via QEMU)
+- `--node-architecture-taint-behavior=none` on both pools
+
+**What it tests:** Whether ARM's instruction set architecture provides different gVisor overhead characteristics. ARM has a different syscall ABI and virtualization model — gVisor's sentry may behave differently.
+
+| Benchmark | Expected Influence | Rationale |
+|-----------|-------------------|-----------|
+| **k8s_python_density** | **Unknown** | **ARM syscall ABI differs — could be better or worse** |
+| **k8s_chromium_density** | **Unknown** | **Chrome on ARM is less mature — may have different perf profile** |
+| k8s_payload | Unknown | ARM memory bandwidth differs |
+| k8s_qps | Unknown | Scheduling overhead may differ |
+| k8s_warmpool | Unknown | Pod creation speed on ARM nodes |
+| k8s_deletion | Unknown | Likely similar to x86 (API-server bound) |
+| k8s_snapshot | Unknown | CRIU on ARM may have different characteristics |
+
+---
+
+### var10 — Multi-Node Sandbox Pool (2x c4-standard-8)
+
+**What changes vs baseline:**
+- Sandbox node pool: `vm_count: 2` (default: 1)
+- Same machine type per node (c4-standard-8)
+- Default pool stays at 1 node
+- Total sandbox capacity: 2x CPU, 2x RAM, 2x disk across 2 nodes
+
+**What it tests:** Whether distributing sandbox pods across multiple nodes improves provisioning speed, scheduling throughput, and density ceiling. Every previous test ran on a single sandbox node — this tests whether the bottleneck is per-node resource saturation or control-plane scheduling.
+
+Key questions this variant answers:
+- Does warmpool provisioning scale linearly with nodes? (2 nodes = 2x pods/sec?)
+- Does QPS saturation point double with 2 nodes?
+- Does deletion/IP reclamation improve with pods spread across nodes?
+- Is the GKE scheduler or the node the bottleneck at high density?
+
+| Benchmark | Expected Influence | Rationale |
+|-----------|-------------------|-----------|
+| k8s_python_density | Moderate | Pods spread across 2 nodes — each node at ~half density, less CPU contention |
+| **k8s_warmpool** | **Strong** | **Pod creation parallelized across 2 kubelets** |
+| **k8s_qps** | **Strong** | **Warm pool spans 2 nodes — 2x capacity before drain** |
+| k8s_payload | Minor | Payload transfer is per-sandbox, not affected by node count |
+| k8s_chromium_density | Moderate | Chrome pods spread across nodes — more total RAM |
+| **k8s_deletion** | **Moderate** | **IPAM reclamation distributed across 2 nodes** |
+| **k8s_snapshot** | **Moderate** | **Snapshot/restore parallelized across nodes** |
+
+---
+
+## Expansion Plan: Which Variants to Test Per Benchmark
+
+Based on the analysis above, here's the recommended test matrix. Only variants with a plausible positive or unknown influence are included — proven-harmful variants (var2, var5, var6) are excluded.
+
+### Priority Matrix
+
+| Benchmark | Priority Variants | Why |
+|-----------|------------------|-----|
+| **k8s_warmpool** | var1, var3, var4, var8, var10 | Pod creation speed: kubelet (var1), CPU (var3), disk IOPS (var4), AMD (var8), multi-node (var10) |
+| **k8s_qps** | var3, var8, var10 | Scheduling throughput: CPU-bound; multi-node doubles capacity |
+| **k8s_payload** | var3, var8 | Serialization is CPU-bound, syscall overhead matters |
+| **k8s_chromium_density** | var3, var7, var8 | CPU (var3), memory ceiling (var7), AMD syscalls (var8) |
+| **k8s_deletion** | var4, var10, baseline | Disk cleanup + IPAM — multi-node distributes pressure |
+| **k8s_snapshot** | var3, var4, var8 | CRIU restore is CPU+disk, AMD may help |
+
+### Variants to Skip for Non-Density Benchmarks
+
+| Variant | Reason to Skip |
+|---------|---------------|
+| var2 (overlay2=none) | Harmful everywhere — loses page cache sharing |
+| var5 (THP=always) | Harmful at density — compaction stalls |
+| var6 (sched tuning) | Harmful — defaults are better for containers |
+
+### Suggested Sweep Values Per Benchmark
+
+| Benchmark | Sweep Parameter | Suggested Values | Rationale |
+|-----------|----------------|-----------------|-----------|
+| k8s_python_density | concurrent_sandbox_count | 1, 10, 50, 100, 150, 200 | Find saturation curve |
+| k8s_chromium_density | concurrent_sessions | 1, 2, 4, 8, 12, 16 | Chrome is much heavier per instance |
+| k8s_payload | payload_size_mb | 0.01, 0.1, 1, 5, 10, 50 | Find bandwidth saturation |
+| k8s_qps | target_qps | 1, 5, 10, 20, 50, 100 | Find scheduling saturation |
+| k8s_warmpool | target_replicas | 10, 50, 100, 200, 500 | Find provisioning ceiling |
+| k8s_deletion | batch_size | 10, 50, 100, 200, 500 | Find cleanup bottleneck |
+| k8s_snapshot | preload_mb | 10, 50, 100, 500, 1000 | Find snapshot size limit |
+
+### Execution Order Recommendation
+
+1. **k8s_warmpool** (var1, var3, var4, var8, var10) — fastest to run, no agent API needed
+2. **k8s_qps** (var3, var8, var10) — quick runs, tests scheduling
+3. **k8s_payload** (var3, var8) — moderate duration
+4. **k8s_chromium_density** (var3, var7, var8) — needs chromium warm pool
+5. **k8s_deletion** (baseline, var4, var10) — needs bulk provisioning first
+6. **k8s_snapshot** (var3, var4, var8) — needs snapshot infrastructure
+
+### Full Test Matrix (Y = Run)
+
+| Variant | k8s_python_density | k8s_warmpool | k8s_qps | k8s_payload | k8s_chromium_density | k8s_deletion | k8s_snapshot |
+|---------|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
+| baseline | Y | Y | Y | Y | Y | Y | Y |
+| var1 (kubelet) | Y | Y | | | | | |
+| var2 (overlay) | Y | | | | | | |
+| var3 (2x CPU) | Y | Y | Y | Y | Y | | Y |
+| var4 (disk) | Y | Y | | | | Y | Y |
+| var5 (THP) | Y | | | | | | |
+| var6 (sched) | Y | | | | | | |
+| var7 (swap) | Y | | | | Y | | |
+| var8 (AMD) | Y | Y | Y | Y | Y | | Y |
+| var9 (ARM) | Y | | | | | | |
+| var10 (multi-node) | Y | Y | Y | | | Y | Y |

--- a/perfkitbenchmarker/scripts/agentic/analyze.py
+++ b/perfkitbenchmarker/scripts/agentic/analyze.py
@@ -1,0 +1,635 @@
+#!/usr/bin/env python3
+"""Optimization Sweep Results Analyzer.
+
+Parses PKB NDJSON results from all variants, computes deltas vs baseline,
+and generates a markdown report with tables and recommendations.
+
+Aggregates multiple runs of the same sweep value using the Median to filter noise.
+Generates a Saturation Matrix integrating PSI (Pressure Stall Information) data.
+"""
+
+import argparse
+import csv
+import json
+import os
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+
+# ============================================================
+# Benchmark Registry
+# ============================================================
+
+BENCHMARK_REGISTRY = {
+    "k8s_python_density": {
+        "sweep_label": "density",
+        "metric_prefix": "k8s_python_density_",
+        "verdict_metric": "k8s_python_density_sandbox_total_cel_mean_ms",
+        "description": "Python Sandbox Density",
+    },
+    "k8s_chromium_density": {
+        "sweep_label": "density",
+        "metric_prefix": "k8s_chromium_density_",
+        "verdict_metric": "k8s_chromium_density_interaction_mean_ms",
+        "description": "Chromium Browser Density",
+    },
+    "k8s_payload": {
+        "sweep_label": "payload_size_mb",
+        "metric_prefix": "k8s_payload_",
+        "verdict_metric": "k8s_payload_sandbox_transfer_time_mean_ms",
+        "description": "Payload Transfer",
+    },
+    "k8s_qps": {
+        "sweep_label": "target_qps",
+        "metric_prefix": "k8s_qps_",
+        "verdict_metric": "k8s_qps_ttfe_mean_ms",
+        "description": "QPS Saturation",
+    },
+    "k8s_warmpool": {
+        "sweep_label": "target_replicas",
+        "metric_prefix": "k8s_warmpool_",
+        "verdict_metric": "k8s_warmpool_total_time_to_ready_s",
+        "description": "Warmpool Scale-Up",
+    },
+    "k8s_deletion": {
+        "sweep_label": "batch_size",
+        "metric_prefix": "k8s_deletion_",
+        "verdict_metric": "k8s_deletion_total_drain_time_s",
+        "description": "Deletion & Cleanup",
+    },
+    "k8s_snapshot": {
+        "sweep_label": "preload_mb",
+        "metric_prefix": "k8s_snapshot_",
+        "verdict_metric": "k8s_snapshot_ttfe_p50_s",
+        "description": "Pod Snapshot",
+    },
+}
+
+
+# ============================================================
+# Variant Descriptions
+# ============================================================
+
+VARIANT_DESC = {
+    "baseline": "Baseline (c4-standard-8, gVisor defaults)",
+    "kubelet_pulls": "Kubelet tuning (maxParallelImagePulls=5, image GC)",
+    "overlay_none": "gVisor overlay2=none",
+    "larger_vm": "c4-standard-16 (2x CPU)",
+    "hyperdisk_200gb": "hyperdisk-balanced 200GB",
+    "thp": "Transparent Hugepages (THP=always)",
+    "sched_tuning": "Kernel scheduler tuning",
+    "swap": "Swap enabled (swappiness=15)",
+    "c4d_amd": "C4D AMD (c4d-standard-8)",
+    "c4a_arm": "C4A ARM (c4a-standard-8)",
+    "multi_node": "Multi-node sandbox pool (2x c4-standard-8)",
+    "combined": "Combined best knobs",
+}
+
+
+# ============================================================
+# Parsing
+# ============================================================
+
+
+def parse_labels(labels_str):
+    result = {}
+    if not labels_str:
+        return result
+    for part in labels_str.split(","):
+        part = part.strip().strip("|")
+        if ":" in part:
+            key, _, val = part.partition(":")
+            result[key.strip()] = val.strip()
+    return result
+
+
+def short_name(metric, prefix):
+    if metric.startswith(prefix):
+        return metric[len(prefix):]
+    return metric
+
+
+def auto_discover_prefix(metrics):
+    if not metrics:
+        return ""
+    prefix = os.path.commonprefix(list(metrics))
+    last_underscore = prefix.rfind("_")
+    if last_underscore > 0:
+        return prefix[:last_underscore + 1]
+    return prefix
+
+
+def auto_discover_sweep_label(results_dir):
+    skip_labels = {"note", "machine_type", "gvisor", "namespace"}
+    runs_dir = Path(results_dir) / "runs"
+    if not runs_dir.is_dir():
+        return "density"
+
+    for variant_dir in sorted(runs_dir.iterdir()):
+        if not variant_dir.is_dir():
+            continue
+        for pattern in [variant_dir / "perfkitbenchmarker_results.json"]:
+            if not pattern.is_file():
+                continue
+            with open(pattern, "r") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        record = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    labels = parse_labels(record.get("labels", ""))
+                    for key, val in labels.items():
+                        if key in skip_labels:
+                            continue
+                        try:
+                            float(val)
+                            return key
+                        except (ValueError, TypeError):
+                            continue
+    return "density"
+
+
+def load_variant_data(results_dir, metric_prefix, sweep_label, benchmark):
+    all_data = {}
+    import re
+    bench_short = benchmark.replace("k8s_", "")[:4]
+
+    # Map 4-char, 8-char, and 12-char variant prefixes to variant names
+    prefix_to_variant = {}
+    for v in VARIANT_DESC.keys():
+        clean_var = re.sub(r"[^a-zA-Z0-9]", "", v)
+        prefix_to_variant[clean_var[:4]] = v
+        prefix_to_variant[clean_var[:8]] = v
+        prefix_to_variant[clean_var[:12]] = v
+
+    runs_dir = Path(results_dir) / "runs"
+    if not runs_dir.is_dir():
+        print(f"  No runs/ directory found in {results_dir}")
+        return all_data
+
+    for variant_dir in sorted(runs_dir.iterdir()):
+        if not variant_dir.is_dir():
+            continue
+        raw_name = variant_dir.name
+        variant_name = raw_name
+
+        # Extract the variant by matching the prefix after the benchmark short name
+        if raw_name.startswith(bench_short):
+            remainder = raw_name[len(bench_short):]
+            for length in [8, 4]:
+                if remainder[:length] in prefix_to_variant:
+                    variant_name = prefix_to_variant[remainder[:length]]
+                    break
+
+        results_file = variant_dir / "perfkitbenchmarker_results.json"
+        if not results_file.is_file():
+            continue
+
+        print(f"  Loading {variant_name} from {results_file}")
+
+        run_groups = defaultdict(dict)
+        line_count = 0
+        metric_count = 0
+
+        with open(results_file, "r") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+
+                line_count += 1
+                metric = record.get("metric", "")
+                value = record.get("value")
+                labels = parse_labels(record.get("labels", ""))
+
+                if not metric.startswith(metric_prefix):
+                    continue
+
+                sweep_val = labels.get(sweep_label)
+                if sweep_val is None:
+                    continue
+
+                try:
+                    sweep_val = float(sweep_val)
+                    if sweep_val == int(sweep_val):
+                        sweep_val = int(sweep_val)
+                except (ValueError, TypeError):
+                    pass
+
+                rid = labels.get("run_id", "")
+                group_key = (sweep_val, rid)
+                run_groups[group_key][metric] = value
+                metric_count += 1
+
+        if not run_groups:
+            print(f"    WARNING: no benchmark metrics found ({line_count} total lines)")
+            continue
+
+        sweep_val_runs = defaultdict(list)
+        for (sv, rid), metrics in sorted(run_groups.items()):
+            sweep_val_runs[sv].append(metrics)
+
+        all_data[variant_name] = dict(sweep_val_runs)
+        sweep_keys = sorted(all_data[variant_name].keys(), key=lambda k: (str(k), k))
+        print(f"    {metric_count} samples, {len(run_groups)} runs, keys: {sweep_keys}")
+
+    return all_data
+
+
+def discover_metrics(all_data):
+    all_metrics = set()
+    for variant_data in all_data.values():
+        for runs in variant_data.values():
+            for metrics in runs:
+                all_metrics.update(metrics.keys())
+    return sorted(all_metrics)
+
+
+def get_median(values):
+    if not values:
+        return None
+    s = sorted(values)
+    n = len(s)
+    if n % 2 == 1:
+        return s[n // 2]
+    return (s[n // 2 - 1] + s[n // 2]) / 2.0
+
+
+def aggregate_runs(runs, all_metrics):
+    aggregated = {}
+    for metric in all_metrics:
+        vals = [r[metric] for r in runs if metric in r and r[metric] is not None]
+        if vals:
+            aggregated[metric] = get_median(vals)
+    return aggregated
+
+
+def compute_deltas(all_data, all_metrics, baseline_name="baseline"):
+    baseline = all_data.get(baseline_name)
+    if not baseline:
+        print(f"WARNING: baseline '{baseline_name}' not found in data")
+        return {}, {}
+
+    aggregated_data = {}
+    for variant, sweep_values in all_data.items():
+        aggregated_data[variant] = {}
+        for sv, runs in sweep_values.items():
+            aggregated_data[variant][sv] = aggregate_runs(runs, all_metrics)
+
+    deltas = {}
+    for variant, sweep_values in aggregated_data.items():
+        if variant == baseline_name:
+            continue
+        deltas[variant] = {}
+        for sv, metrics in sweep_values.items():
+            deltas[variant][sv] = {}
+            baseline_metrics = aggregated_data[baseline_name].get(sv, {})
+            for metric, value in metrics.items():
+                base_val = baseline_metrics.get(metric)
+                if base_val is not None and base_val != 0:
+                    delta_pct = ((value - base_val) / abs(base_val)) * 100
+                else:
+                    delta_pct = None
+                deltas[variant][sv][metric] = {
+                    "value": value,
+                    "baseline": base_val,
+                    "delta_pct": delta_pct,
+                }
+    return aggregated_data, deltas
+
+
+def format_delta(delta_pct):
+    if delta_pct is None:
+        return "N/A"
+    sign = "+" if delta_pct > 0 else ""
+    if delta_pct < -5:
+        indicator = " faster"
+    elif delta_pct > 5:
+        indicator = " slower"
+    else:
+        indicator = " (flat)"
+    return f"{sign}{delta_pct:.1f}%{indicator}"
+
+
+def format_value(value):
+    if value is None:
+        return "—"
+    if isinstance(value, float):
+        if value >= 1000:
+            return f"{value:.1f}"
+        return f"{value:.2f}"
+    return str(value)
+
+
+def format_value_with_delta(value, delta_pct):
+    if value is None:
+        return "—"
+    base = format_value(value)
+    if delta_pct is not None:
+        sign = "+" if delta_pct > 0 else ""
+        return f"{base} ({sign}{delta_pct:.1f}%)"
+    return base
+
+
+# ============================================================
+# Report Generation
+# ============================================================
+
+
+def generate_report(benchmark, description, sweep_label, metric_prefix,
+                    verdict_metric, aggregated_data, deltas, all_metrics, output_dir):
+    os.makedirs(output_dir, exist_ok=True)
+
+    baseline = aggregated_data.get("baseline", {})
+    sweep_vals = sorted(set(sv for v in aggregated_data.values() for sv in v.keys()))
+    variants = [v for v in sorted(aggregated_data.keys()) if v != "baseline"]
+
+    lines = []
+    lines.append(f"# {description} Optimization — Results Report")
+    lines.append("")
+    lines.append("## Overview")
+    lines.append("")
+    lines.append(f"- **Benchmark**: {benchmark}")
+    lines.append(f"- **Sweep parameter**: {sweep_label}")
+    lines.append(f"- **Sweep values tested**: {sweep_vals}")
+    lines.append(f"- **Variants**: {len(aggregated_data)} ({len(variants)} + baseline)")
+    lines.append(f"- **Metrics discovered**: {len(all_metrics)}")
+    lines.append("- **Aggregation**: Values shown are the **Median** across multiple runs to filter noise.")
+    lines.append("")
+
+    lines.append("## Variants Tested")
+    lines.append("")
+    lines.append("| Variant | Description |")
+    lines.append("|---------|-------------|")
+    lines.append(f"| baseline | {VARIANT_DESC.get('baseline', '')} |")
+    for v in variants:
+        lines.append(f"| {v} | {VARIANT_DESC.get(v, '')} |")
+    lines.append("")
+
+    # ============================================================
+    # Saturation & Verdict Matrix (New)
+    # ============================================================
+    lines.append("## Saturation & Verdict Matrix")
+    lines.append("")
+    lines.append(f"Shows the **{short_name(verdict_metric, metric_prefix)}** delta vs baseline across the saturation curve.")
+    lines.append("Includes **CPU Contention (PSI)** to identify when the node becomes CPU-starved.")
+    lines.append("Format: `[Delta %] <br> *(CPU PSI: X%)*`")
+    lines.append("")
+
+    # Find the CPU PSI metric (avg10 is best for immediate contention)
+    psi_metric = next((m for m in all_metrics if "psi_cpu_some_avg10" in m), None)
+
+    header = "| Variant | " + " | ".join(f"{sweep_label}={sv}" for sv in sweep_vals) + " |"
+    sep = "|--------|" + "|".join("------:" for _ in sweep_vals) + "|"
+    lines.append(header)
+    lines.append(sep)
+
+    for variant in variants:
+        row = f"| **{variant}** |"
+        for sv in sweep_vals:
+            v_deltas = deltas.get(variant, {}).get(sv, {})
+            d_info = v_deltas.get(verdict_metric, {})
+            delta = d_info.get("delta_pct")
+
+            psi_val = aggregated_data.get(variant, {}).get(sv, {}).get(psi_metric) if psi_metric else None
+
+            cell = ""
+            if delta is not None:
+                icon = "✅" if delta < -5 else ("❌" if delta > 5 else "➖")
+                cell += f"{icon} **{delta:+.1f}%**"
+            else:
+                cell += "N/A"
+
+            if psi_val is not None:
+                cell += f"<br>*(CPU: {psi_val:.1f}%)*"
+
+            row += f" {cell} |"
+        lines.append(row)
+    lines.append("")
+
+    lines.append("## Baseline Absolute Values (Median)")
+    lines.append("")
+
+    baseline_metrics = [m for m in all_metrics if any(m in baseline.get(sv, {}) for sv in sweep_vals)]
+    if baseline_metrics:
+        header = "| Metric | " + " | ".join(f"{sweep_label}={sv}" for sv in sweep_vals) + " |"
+        sep = "|--------|" + "|".join("------:" for _ in sweep_vals) + "|"
+        lines.append(header)
+        lines.append(sep)
+        for metric in baseline_metrics:
+            row = f"| {short_name(metric, metric_prefix)} |"
+            for sv in sweep_vals:
+                val = baseline.get(sv, {}).get(metric)
+                row += f" {format_value(val)} |"
+            lines.append(row)
+        lines.append("")
+
+    lines.append("## Summary: Delta vs Baseline")
+    lines.append("")
+    lines.append("Percentage change vs baseline. Negative = faster/less (better for latency metrics).")
+    lines.append("Threshold: ±5% considered significant.")
+    lines.append("")
+
+    for sv in sweep_vals:
+        lines.append(f"### {sweep_label} = {sv}")
+        lines.append("")
+
+        active_variants = [v for v in variants if sv in aggregated_data.get(v, {})]
+        if not active_variants:
+            lines.append("*No variant data at this sweep value.*")
+            lines.append("")
+            continue
+
+        available_metrics = [m for m in all_metrics
+                           if any(m in deltas.get(v, {}).get(sv, {}) for v in active_variants)]
+
+        if not available_metrics:
+            lines.append("*No metrics available.*")
+            lines.append("")
+            continue
+
+        header = "| Metric | " + " | ".join(active_variants) + " |"
+        sep = "|--------|" + "|".join("------:" for _ in active_variants) + "|"
+        lines.append(header)
+        lines.append(sep)
+
+        for metric in available_metrics:
+            row = f"| {short_name(metric, metric_prefix)} |"
+            for v in active_variants:
+                d_info = deltas.get(v, {}).get(sv, {}).get(metric, {})
+                delta = d_info.get("delta_pct")
+                row += f" {format_delta(delta)} |"
+            lines.append(row)
+        lines.append("")
+
+    lines.append("## Per-Variant Detailed Analysis")
+    lines.append("")
+
+    for variant in variants:
+        v_data = aggregated_data.get(variant, {})
+        v_deltas = deltas.get(variant, {})
+        if not v_data:
+            continue
+
+        lines.append(f"### {variant}: {VARIANT_DESC.get(variant, '')}")
+        lines.append("")
+
+        v_sweep_vals = sorted(v_data.keys())
+        available_metrics = [m for m in all_metrics
+                           if any(m in v_data.get(sv, {}) for sv in v_sweep_vals)]
+
+        if not available_metrics:
+            lines.append("*No metrics available.*")
+            lines.append("")
+            continue
+
+        header = "| Metric | " + " | ".join(f"{sweep_label}={sv}" for sv in v_sweep_vals) + " |"
+        sep = "|--------|" + "|".join("------:" for _ in v_sweep_vals) + "|"
+        lines.append(header)
+        lines.append(sep)
+
+        for metric in available_metrics:
+            row = f"| {short_name(metric, metric_prefix)} |"
+            for sv in v_sweep_vals:
+                val = v_data.get(sv, {}).get(metric)
+                d_info = v_deltas.get(sv, {}).get(metric, {})
+                delta = d_info.get("delta_pct")
+                row += f" {format_value_with_delta(val, delta)} |"
+            lines.append(row)
+        lines.append("")
+
+    report_path = os.path.join(output_dir, f"{benchmark}_report.md")
+    with open(report_path, "w") as f:
+        f.write("\n".join(lines))
+    print(f"\nReport written to: {report_path}")
+    return report_path
+
+
+def export_csv(benchmark, metric_prefix, sweep_label, all_data, deltas,
+               all_metrics, output_dir):
+    os.makedirs(output_dir, exist_ok=True)
+    csv_path = os.path.join(output_dir, f"{benchmark}_raw_data.csv")
+
+    rows = []
+    for variant, sweep_values in sorted(all_data.items()):
+        for sweep_val, runs in sorted(sweep_values.items()):
+            for run_idx, metrics in enumerate(runs, 1):
+                for metric in all_metrics:
+                    value = metrics.get(metric)
+                    if value is None:
+                        continue
+                    d_info = deltas.get(variant, {}).get(sweep_val, {}).get(metric, {})
+                    rows.append({
+                        "variant": variant,
+                        "sweep_label": sweep_label,
+                        "sweep_value": sweep_val,
+                        "run_index": run_idx,
+                        "metric": metric,
+                        "metric_short": short_name(metric, metric_prefix),
+                        "value": value,
+                        "median_baseline_value": d_info.get("baseline", ""),
+                        "delta_pct_vs_median": round(d_info["delta_pct"], 2) if d_info.get("delta_pct") is not None else "",
+                    })
+
+    if rows:
+        fieldnames = ["variant", "sweep_label", "sweep_value", "run_index", "metric",
+                      "metric_short", "value", "median_baseline_value", "delta_pct_vs_median"]
+        with open(csv_path, "w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames)
+            writer.writeheader()
+            writer.writerows(rows)
+        print(f"CSV written to: {csv_path} ({len(rows)} rows)")
+    return csv_path
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Optimization Sweep Results Analyzer")
+    parser.add_argument("--benchmark", required=True)
+    parser.add_argument("--results-dir", default=None)
+    parser.add_argument("--output-dir", default=None)
+    parser.add_argument("--baseline", default="baseline")
+    args = parser.parse_args()
+
+    benchmark = args.benchmark
+    results_dir = args.results_dir or os.path.join("results", "pkb", benchmark)
+    output_dir = args.output_dir or os.path.join("reports", benchmark)
+
+    registry = BENCHMARK_REGISTRY.get(benchmark, {})
+    description = registry.get("description", benchmark)
+    metric_prefix = registry.get("metric_prefix", f"{benchmark}_")
+    verdict_metric = registry.get("verdict_metric", "")
+    sweep_label = registry.get("sweep_label", "")
+
+    print("=" * 60)
+    print("Optimization Sweep Results Analyzer")
+    print("=" * 60)
+
+    if not os.path.isdir(results_dir):
+        print(f"ERROR: Results directory not found: {results_dir}")
+        sys.exit(1)
+
+    if not sweep_label:
+        sweep_label = auto_discover_sweep_label(results_dir)
+
+    all_data = load_variant_data(results_dir, metric_prefix, sweep_label, benchmark)
+
+    if not all_data:
+        all_metrics_raw = set()
+        runs_dir = Path(results_dir) / "runs"
+        if runs_dir.is_dir():
+          for variant_dir in sorted(runs_dir.iterdir()):
+            if not variant_dir.is_dir():
+                continue
+            for pattern in [variant_dir / "perfkitbenchmarker_results.json"]:
+                if not pattern.is_file():
+                    continue
+                with open(pattern, "r") as f:
+                    for line in f:
+                        if not line.strip(): continue
+                        try:
+                            record = json.loads(line)
+                            if record.get("metric"):
+                                all_metrics_raw.add(record["metric"])
+                        except json.JSONDecodeError:
+                            continue
+
+        if all_metrics_raw:
+            metric_prefix = auto_discover_prefix(all_metrics_raw)
+            all_data = load_variant_data(results_dir, metric_prefix, sweep_label, benchmark)
+
+    if not all_data:
+        print("ERROR: No data loaded. Check results directory.")
+        sys.exit(1)
+
+    all_metrics = discover_metrics(all_data)
+
+    if not verdict_metric and all_metrics:
+        for m in all_metrics:
+            if "mean" in m and "wall_time" not in m:
+                verdict_metric = m
+                break
+        if not verdict_metric:
+            verdict_metric = all_metrics[0]
+
+    aggregated_data, deltas = compute_deltas(all_data, all_metrics, args.baseline)
+
+    report_path = generate_report(
+        benchmark, description, sweep_label, metric_prefix,
+        verdict_metric, aggregated_data, deltas, all_metrics, output_dir,
+    )
+
+    csv_path = export_csv(
+        benchmark, metric_prefix, sweep_label,
+        all_data, deltas, all_metrics, output_dir,
+    )
+
+if __name__ == "__main__":
+    main()

--- a/perfkitbenchmarker/scripts/agentic/analyze.py
+++ b/perfkitbenchmarker/scripts/agentic/analyze.py
@@ -1,0 +1,652 @@
+#!/usr/bin/env python3
+"""Optimization Sweep Results Analyzer.
+
+Parses PKB NDJSON results from all variants, computes deltas vs baseline,
+and generates a markdown report with tables and recommendations.
+
+Aggregates multiple runs of the same sweep value using the Median to filter noise.
+Generates a Saturation Matrix integrating PSI (Pressure Stall Information) data.
+"""
+
+import argparse
+import csv
+import json
+import os
+import sys
+import statistics
+from collections import defaultdict
+from pathlib import Path
+
+
+# ============================================================
+# Benchmark Registry
+# ============================================================
+
+BENCHMARK_REGISTRY = {
+    "k8s_python_density": {
+        "sweep_label": "density",
+        "metric_prefix": "k8s_python_density_",
+        "verdict_metric": "k8s_python_density_sandbox_total_cel_mean_ms",
+        "description": "Python Sandbox Density",
+    },
+    "k8s_chromium_density": {
+        "sweep_label": "density",
+        "metric_prefix": "k8s_chromium_density_",
+        "verdict_metric": "k8s_chromium_density_interaction_mean_ms",
+        "description": "Chromium Browser Density",
+    },
+    "k8s_payload": {
+        "sweep_label": "payload_size_mb",
+        "metric_prefix": "k8s_payload_",
+        "verdict_metric": "k8s_payload_sandbox_transfer_time_mean_ms",
+        "description": "Payload Transfer",
+    },
+    "k8s_qps": {
+        "sweep_label": "target_qps",
+        "metric_prefix": "k8s_qps_",
+        "verdict_metric": "k8s_qps_ttfe_mean_ms",
+        "description": "QPS Saturation",
+    },
+    "k8s_warmpool": {
+        "sweep_label": "target_replicas",
+        "metric_prefix": "k8s_warmpool_",
+        "verdict_metric": "k8s_warmpool_total_time_to_ready_s",
+        "description": "Warmpool Scale-Up",
+    },
+    "k8s_deletion": {
+        "sweep_label": "batch_size",
+        "metric_prefix": "k8s_deletion_",
+        "verdict_metric": "k8s_deletion_total_drain_time_s",
+        "description": "Deletion & Cleanup",
+    },
+    "k8s_snapshot": {
+        "sweep_label": "preload_mb",
+        "metric_prefix": "k8s_snapshot_",
+        "verdict_metric": "k8s_snapshot_ttfe_p50_s",
+        "description": "Pod Snapshot",
+    },
+}
+
+
+# ============================================================
+# Variant Descriptions
+# ============================================================
+
+VARIANT_DESC = {
+    "baseline": "Baseline (c4-standard-8, gVisor defaults)",
+    "kubelet_pulls": "Kubelet tuning (maxParallelImagePulls=5, image GC)",
+    "overlay_none": "gVisor overlay2=none",
+    "larger_vm": "c4-standard-16 (2x CPU)",
+    "hyperdisk_200gb": "hyperdisk-balanced 200GB",
+    "thp": "Transparent Hugepages (THP=always)",
+    "sched_tuning": "Kernel scheduler tuning",
+    "swap": "Swap enabled (swappiness=15)",
+    "c4d_amd": "C4D AMD (c4d-standard-8)",
+    "c4a_arm": "C4A ARM (c4a-standard-8)",
+    "multi_node": "Multi-node sandbox pool (2x c4-standard-8)",
+    "combined": "Combined best knobs",
+}
+
+
+# ============================================================
+# Parsing
+# ============================================================
+
+
+def parse_labels(labels_str):
+    result = {}
+    if not labels_str:
+        return result
+    for part in labels_str.split(","):
+        part = part.strip().strip("|")
+        if ":" in part:
+            key, _, val = part.partition(":")
+            result[key.strip()] = val.strip()
+    return result
+
+
+def short_name(metric, prefix):
+    if metric.startswith(prefix):
+        return metric[len(prefix):]
+    return metric
+
+
+def auto_discover_prefix(metrics):
+    if not metrics:
+        return ""
+    prefix = os.path.commonprefix(list(metrics))
+    last_underscore = prefix.rfind("_")
+    if last_underscore > 0:
+        return prefix[:last_underscore + 1]
+    return prefix
+
+
+def auto_discover_sweep_label(results_dir):
+    skip_labels = {"note", "machine_type", "gvisor", "namespace"}
+    runs_dir = Path(results_dir) / "runs"
+    if not runs_dir.is_dir():
+        return "density"
+
+    for variant_dir in sorted(runs_dir.iterdir()):
+        if not variant_dir.is_dir():
+            continue
+        for pattern in [variant_dir / "perfkitbenchmarker_results.json"]:
+            if not pattern.is_file():
+                continue
+            with open(pattern, "r") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        record = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    labels = parse_labels(record.get("labels", ""))
+                    for key, val in labels.items():
+                        if key in skip_labels:
+                            continue
+                        try:
+                            float(val)
+                            return key
+                        except (ValueError, TypeError):
+                            continue
+    return "density"
+
+
+def load_variant_data(results_dir, metric_prefix, sweep_label, benchmark):
+    all_data = {}
+    import re
+    bench_short = benchmark.replace("k8s_", "")[:4]
+
+    # Map clean variant names to original variant names
+    prefix_to_variant = {}
+    for v in VARIANT_DESC.keys():
+        clean_var = re.sub(r"[^a-zA-Z0-9]", "", v)
+        prefix_to_variant[clean_var[:4]] = v
+        prefix_to_variant[clean_var] = v
+
+    runs_dir = Path(results_dir) / "runs"
+    if not runs_dir.is_dir():
+        print(f"  No runs/ directory found in {results_dir}")
+        return all_data
+
+    for variant_dir in sorted(runs_dir.iterdir()):
+        if not variant_dir.is_dir():
+            continue
+        raw_name = variant_dir.name
+        variant_name = raw_name
+
+        # Extract the variant by matching the prefix after the benchmark short name
+        if raw_name.startswith(bench_short):
+            remainder = raw_name[len(bench_short):]
+            # Match longest prefix first to avoid partial matches
+            for prefix in sorted(prefix_to_variant.keys(), key=len, reverse=True):
+                if remainder.startswith(prefix):
+                    variant_name = prefix_to_variant[prefix]
+                    break
+
+        results_file = variant_dir / "perfkitbenchmarker_results.json"
+        if not results_file.is_file():
+            continue
+
+        print(f"  Loading {variant_name} from {results_file}")
+
+        run_groups = defaultdict(dict)
+        line_count = 0
+        metric_count = 0
+
+        with open(results_file, "r") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+
+                line_count += 1
+                metric = record.get("metric", "")
+                value = record.get("value")
+                labels = parse_labels(record.get("labels", ""))
+
+                if not metric.startswith(metric_prefix):
+                    continue
+
+                sweep_val = labels.get(sweep_label)
+                if sweep_val is None:
+                    continue
+
+                try:
+                    sweep_val = float(sweep_val)
+                    if sweep_val == int(sweep_val):
+                        sweep_val = int(sweep_val)
+                except (ValueError, TypeError):
+                    pass
+
+                rid = labels.get("run_id", "")
+                group_key = (sweep_val, rid)
+                run_groups[group_key][metric] = value
+                metric_count += 1
+
+        if not run_groups:
+            print(f"    WARNING: no benchmark metrics found ({line_count} total lines)")
+            continue
+
+        sweep_val_runs = defaultdict(list)
+        for (sv, rid), metrics in sorted(run_groups.items()):
+            sweep_val_runs[sv].append(metrics)
+
+        all_data[variant_name] = dict(sweep_val_runs)
+        sweep_keys = sorted(all_data[variant_name].keys(), key=lambda k: (str(k), k))
+        print(f"    {metric_count} samples, {len(run_groups)} runs, keys: {sweep_keys}")
+
+    return all_data
+
+
+def discover_metrics(all_data):
+    all_metrics = set()
+    for variant_data in all_data.values():
+        for runs in variant_data.values():
+            for metrics in runs:
+                all_metrics.update(metrics.keys())
+    return sorted(all_metrics)
+
+
+def aggregate_runs(runs, all_metrics):
+    aggregated = {}
+    for metric in all_metrics:
+        vals = [r[metric] for r in runs if metric in r and r[metric] is not None]
+        if vals:
+            aggregated[metric] = statistics.median(vals)
+    return aggregated
+
+
+def compute_deltas(all_data, all_metrics, baseline_name="baseline"):
+    baseline = all_data.get(baseline_name)
+    if not baseline:
+        print(f"WARNING: baseline '{baseline_name}' not found in data")
+        return {}, {}
+
+    aggregated_data = {}
+    for variant, sweep_values in all_data.items():
+        aggregated_data[variant] = {}
+        for sv, runs in sweep_values.items():
+            aggregated_data[variant][sv] = aggregate_runs(runs, all_metrics)
+
+    deltas = {}
+    for variant, sweep_values in aggregated_data.items():
+        if variant == baseline_name:
+            continue
+        deltas[variant] = {}
+        for sv, metrics in sweep_values.items():
+            deltas[variant][sv] = {}
+            baseline_metrics = aggregated_data[baseline_name].get(sv, {})
+            for metric, value in metrics.items():
+                base_val = baseline_metrics.get(metric)
+                if base_val is not None and base_val != 0:
+                    delta_pct = ((value - base_val) / abs(base_val)) * 100
+                else:
+                    delta_pct = None
+                deltas[variant][sv][metric] = {
+                    "value": value,
+                    "baseline": base_val,
+                    "delta_pct": delta_pct,
+                }
+    return aggregated_data, deltas
+
+
+def format_delta(delta_pct):
+    if delta_pct is None:
+        return "N/A"
+    sign = "+" if delta_pct > 0 else ""
+    if delta_pct < -5:
+        indicator = " faster"
+    elif delta_pct > 5:
+        indicator = " slower"
+    else:
+        indicator = " (flat)"
+    return f"{sign}{delta_pct:.1f}%{indicator}"
+
+
+def format_value(value):
+    if value is None:
+        return "—"
+    if isinstance(value, float):
+        if value >= 1000:
+            return f"{value:.1f}"
+        return f"{value:.2f}"
+    return str(value)
+
+
+def format_value_with_delta(value, delta_pct):
+    if value is None:
+        return "—"
+    base = format_value(value)
+    if delta_pct is not None:
+        sign = "+" if delta_pct > 0 else ""
+        return f"{base} ({sign}{delta_pct:.1f}%)"
+    return base
+
+
+# ============================================================
+# Report Generation
+# ============================================================
+
+
+def generate_report(benchmark, description, sweep_label, metric_prefix,
+                    verdict_metric, aggregated_data, deltas, all_metrics, output_dir):
+    os.makedirs(output_dir, exist_ok=True)
+
+    baseline = aggregated_data.get("baseline", {})
+    sweep_vals = sorted(set(sv for v in aggregated_data.values() for sv in v.keys()))
+    variants = [v for v in sorted(aggregated_data.keys()) if v != "baseline"]
+
+    lines = []
+    lines.append(f"# {description} Optimization — Results Report")
+    lines.append("")
+    lines.append("## Overview")
+    lines.append("")
+    lines.append(f"- **Benchmark**: {benchmark}")
+    lines.append(f"- **Sweep parameter**: {sweep_label}")
+    lines.append(f"- **Sweep values tested**: {sweep_vals}")
+    lines.append(f"- **Variants**: {len(aggregated_data)} ({len(variants)} + baseline)")
+    lines.append(f"- **Metrics discovered**: {len(all_metrics)}")
+    lines.append("- **Aggregation**: Values shown are the **Median** across multiple runs to filter noise.")
+    lines.append("")
+
+    lines.append("## Variants Tested")
+    lines.append("")
+    lines.append("| Variant | Description |")
+    lines.append("|---------|-------------|")
+    lines.append(f"| baseline | {VARIANT_DESC.get('baseline', '')} |")
+    for v in variants:
+        lines.append(f"| {v} | {VARIANT_DESC.get(v, '')} |")
+    lines.append("")
+
+    # ============================================================
+    # Saturation & Verdict Matrix (New)
+    # ============================================================
+    lines.append("## Saturation & Verdict Matrix")
+    lines.append("")
+    lines.append(f"Shows the **{short_name(verdict_metric, metric_prefix)}** delta vs baseline across the saturation curve.")
+    lines.append("Includes relevant **Pressure Stall Information (PSI)** to identify node-level starvation.")
+    lines.append("Format: `[Delta %] <br> *(PSI: X%)*`")
+    lines.append("")
+
+    # Auto-detect relevant PSI metrics (only show if pressure > 0.5% at any point)
+    psi_metrics_to_show = []
+    for psi_type, label in [("cpu", "CPU"), ("memory", "Mem"), ("io", "IO")]:
+        metric_name = next((m for m in all_metrics if f"psi_{psi_type}_some_avg10" in m), None)
+        if metric_name:
+            is_relevant = False
+            for variant in variants + ["baseline"]:
+                for sv in sweep_vals:
+                    val = aggregated_data.get(variant, {}).get(sv, {}).get(metric_name)
+                    if val is not None and val > 0.5:
+                        is_relevant = True
+                        break
+                if is_relevant: break
+            
+            if is_relevant:
+                psi_metrics_to_show.append((label, metric_name))
+                
+    # Fallback: if no resource was pressured, default to showing CPU
+    if not psi_metrics_to_show:
+        cpu_metric = next((m for m in all_metrics if "psi_cpu_some_avg10" in m), None)
+        if cpu_metric:
+            psi_metrics_to_show.append(("CPU", cpu_metric))
+
+    header = "| Variant | " + " | ".join(f"{sweep_label}={sv}" for sv in sweep_vals) + " |"
+    sep = "|--------|" + "|".join("------:" for _ in sweep_vals) + "|"
+    lines.append(header)
+    lines.append(sep)
+
+    for variant in variants:
+        row = f"| **{variant}** |"
+        for sv in sweep_vals:
+            v_deltas = deltas.get(variant, {}).get(sv, {})
+            d_info = v_deltas.get(verdict_metric, {})
+            delta = d_info.get("delta_pct")
+
+            cell = ""
+            if delta is not None:
+                icon = "✅" if delta < -5 else ("❌" if delta > 5 else "➖")
+                cell += f"{icon} **{delta:+.1f}%**"
+            else:
+                cell += "N/A"
+
+            # Append all relevant PSI metrics
+            psi_strings = []
+            for label, metric_name in psi_metrics_to_show:
+                if metric_name:
+                    val = aggregated_data.get(variant, {}).get(sv, {}).get(metric_name)
+                    if val is not None:
+                        psi_strings.append(f"{label}: {val:.1f}%")
+            
+            if psi_strings:
+                cell += f"<br>*({', '.join(psi_strings)})*"
+
+            row += f" {cell} |"
+        lines.append(row)
+    lines.append("")
+
+    lines.append("## Baseline Absolute Values (Median)")
+    lines.append("")
+
+    baseline_metrics = [m for m in all_metrics if any(m in baseline.get(sv, {}) for sv in sweep_vals)]
+    if baseline_metrics:
+        header = "| Metric | " + " | ".join(f"{sweep_label}={sv}" for sv in sweep_vals) + " |"
+        sep = "|--------|" + "|".join("------:" for _ in sweep_vals) + "|"
+        lines.append(header)
+        lines.append(sep)
+        for metric in baseline_metrics:
+            row = f"| {short_name(metric, metric_prefix)} |"
+            for sv in sweep_vals:
+                val = baseline.get(sv, {}).get(metric)
+                row += f" {format_value(val)} |"
+            lines.append(row)
+        lines.append("")
+
+    lines.append("## Summary: Delta vs Baseline")
+    lines.append("")
+    lines.append("Percentage change vs baseline. Negative = faster/less (better for latency metrics).")
+    lines.append("Threshold: ±5% considered significant.")
+    lines.append("")
+
+    for sv in sweep_vals:
+        lines.append(f"### {sweep_label} = {sv}")
+        lines.append("")
+
+        active_variants = [v for v in variants if sv in aggregated_data.get(v, {})]
+        if not active_variants:
+            lines.append("*No variant data at this sweep value.*")
+            lines.append("")
+            continue
+
+        available_metrics = [m for m in all_metrics
+                           if any(m in deltas.get(v, {}).get(sv, {}) for v in active_variants)]
+
+        if not available_metrics:
+            lines.append("*No metrics available.*")
+            lines.append("")
+            continue
+
+        header = "| Metric | " + " | ".join(active_variants) + " |"
+        sep = "|--------|" + "|".join("------:" for _ in active_variants) + "|"
+        lines.append(header)
+        lines.append(sep)
+
+        for metric in available_metrics:
+            row = f"| {short_name(metric, metric_prefix)} |"
+            for v in active_variants:
+                d_info = deltas.get(v, {}).get(sv, {}).get(metric, {})
+                delta = d_info.get("delta_pct")
+                row += f" {format_delta(delta)} |"
+            lines.append(row)
+        lines.append("")
+
+    lines.append("## Per-Variant Detailed Analysis")
+    lines.append("")
+
+    for variant in variants:
+        v_data = aggregated_data.get(variant, {})
+        v_deltas = deltas.get(variant, {})
+        if not v_data:
+            continue
+
+        lines.append(f"### {variant}: {VARIANT_DESC.get(variant, '')}")
+        lines.append("")
+
+        v_sweep_vals = sorted(v_data.keys())
+        available_metrics = [m for m in all_metrics
+                           if any(m in v_data.get(sv, {}) for sv in v_sweep_vals)]
+
+        if not available_metrics:
+            lines.append("*No metrics available.*")
+            lines.append("")
+            continue
+
+        header = "| Metric | " + " | ".join(f"{sweep_label}={sv}" for sv in v_sweep_vals) + " |"
+        sep = "|--------|" + "|".join("------:" for _ in v_sweep_vals) + "|"
+        lines.append(header)
+        lines.append(sep)
+
+        for metric in available_metrics:
+            row = f"| {short_name(metric, metric_prefix)} |"
+            for sv in v_sweep_vals:
+                val = v_data.get(sv, {}).get(metric)
+                d_info = v_deltas.get(sv, {}).get(metric, {})
+                delta = d_info.get("delta_pct")
+                row += f" {format_value_with_delta(val, delta)} |"
+            lines.append(row)
+        lines.append("")
+
+    report_path = os.path.join(output_dir, f"{benchmark}_report.md")
+    with open(report_path, "w") as f:
+        f.write("\n".join(lines))
+    print(f"\nReport written to: {report_path}")
+    return report_path
+
+
+def export_csv(benchmark, metric_prefix, sweep_label, all_data, deltas,
+               all_metrics, output_dir):
+    os.makedirs(output_dir, exist_ok=True)
+    csv_path = os.path.join(output_dir, f"{benchmark}_raw_data.csv")
+
+    rows = []
+    for variant, sweep_values in sorted(all_data.items()):
+        for sweep_val, runs in sorted(sweep_values.items()):
+            for run_idx, metrics in enumerate(runs, 1):
+                for metric in all_metrics:
+                    value = metrics.get(metric)
+                    if value is None:
+                        continue
+                    d_info = deltas.get(variant, {}).get(sweep_val, {}).get(metric, {})
+                    rows.append({
+                        "variant": variant,
+                        "sweep_label": sweep_label,
+                        "sweep_value": sweep_val,
+                        "run_index": run_idx,
+                        "metric": metric,
+                        "metric_short": short_name(metric, metric_prefix),
+                        "value": value,
+                        "median_baseline_value": d_info.get("baseline", ""),
+                        "delta_pct_vs_median": round(d_info["delta_pct"], 2) if d_info.get("delta_pct") is not None else "",
+                    })
+
+    if rows:
+        fieldnames = ["variant", "sweep_label", "sweep_value", "run_index", "metric",
+                      "metric_short", "value", "median_baseline_value", "delta_pct_vs_median"]
+        with open(csv_path, "w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames)
+            writer.writeheader()
+            writer.writerows(rows)
+        print(f"CSV written to: {csv_path} ({len(rows)} rows)")
+    return csv_path
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Optimization Sweep Results Analyzer")
+    parser.add_argument("--benchmark", required=True)
+    parser.add_argument("--results-dir", default=None)
+    parser.add_argument("--output-dir", default=None)
+    parser.add_argument("--baseline", default="baseline")
+    args = parser.parse_args()
+
+    benchmark = args.benchmark
+    results_dir = args.results_dir or os.path.join("results", "pkb", benchmark)
+    output_dir = args.output_dir or os.path.join("reports", benchmark)
+
+    registry = BENCHMARK_REGISTRY.get(benchmark, {})
+    description = registry.get("description", benchmark)
+    metric_prefix = registry.get("metric_prefix", f"{benchmark}_")
+    verdict_metric = registry.get("verdict_metric", "")
+    sweep_label = registry.get("sweep_label", "")
+
+    print("=" * 60)
+    print("Optimization Sweep Results Analyzer")
+    print("=" * 60)
+
+    if not os.path.isdir(results_dir):
+        print(f"ERROR: Results directory not found: {results_dir}")
+        sys.exit(1)
+
+    if not sweep_label:
+        sweep_label = auto_discover_sweep_label(results_dir)
+
+    all_data = load_variant_data(results_dir, metric_prefix, sweep_label, benchmark)
+
+    if not all_data:
+        all_metrics_raw = set()
+        runs_dir = Path(results_dir) / "runs"
+        if runs_dir.is_dir():
+          for variant_dir in sorted(runs_dir.iterdir()):
+            if not variant_dir.is_dir():
+                continue
+            for pattern in [variant_dir / "perfkitbenchmarker_results.json"]:
+                if not pattern.is_file():
+                    continue
+                with open(pattern, "r") as f:
+                    for line in f:
+                        if not line.strip(): continue
+                        try:
+                            record = json.loads(line)
+                            if record.get("metric"):
+                                all_metrics_raw.add(record["metric"])
+                        except json.JSONDecodeError:
+                            continue
+
+        if all_metrics_raw:
+            metric_prefix = auto_discover_prefix(all_metrics_raw)
+            all_data = load_variant_data(results_dir, metric_prefix, sweep_label, benchmark)
+
+    if not all_data:
+        print("ERROR: No data loaded. Check results directory.")
+        sys.exit(1)
+
+    all_metrics = discover_metrics(all_data)
+
+    if not verdict_metric and all_metrics:
+        for m in all_metrics:
+            if "mean" in m and "wall_time" not in m:
+                verdict_metric = m
+                break
+        if not verdict_metric:
+            verdict_metric = all_metrics[0]
+
+    aggregated_data, deltas = compute_deltas(all_data, all_metrics, args.baseline)
+
+    report_path = generate_report(
+        benchmark, description, sweep_label, metric_prefix,
+        verdict_metric, aggregated_data, deltas, all_metrics, output_dir,
+    )
+
+    csv_path = export_csv(
+        benchmark, metric_prefix, sweep_label,
+        all_data, deltas, all_metrics, output_dir,
+    )
+
+if __name__ == "__main__":
+    main()

--- a/perfkitbenchmarker/scripts/agentic/sweep.py
+++ b/perfkitbenchmarker/scripts/agentic/sweep.py
@@ -1,0 +1,1055 @@
+#!/usr/bin/env python3
+"""Optimization Sweep Runner - Multi-Benchmark.
+
+Runs baseline + variant benchmarks for any GKE agentic benchmark.
+Supports both Static sweeps (comma-separated lists) and Binary Search sweeps
+to automatically find the saturation point based on a target metric threshold.
+
+Usage (Static):
+  python sweep.py --project my-project --benchmark k8s_python_density --variant baseline --sweep-values 20,40,60,80
+
+Usage (Binary Search):
+  python sweep.py --project my-project --benchmark k8s_python_density --variant baseline \
+      --search-mode binary --search-min 10 --search-max 200 --search-convergence 5 \
+      --threshold-metric k8s_python_density_sandbox_total_cel_mean_ms --threshold-value 2000.0
+"""
+
+import argparse
+import json
+import re
+import ipaddress
+import logging
+import os
+import statistics
+import subprocess
+import sys
+import time
+import urllib.request
+import yaml
+from jinja2 import Template as Jinja2Template
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+# ============================================================
+# Path Resolution
+# ============================================================
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def _find_repo_root():
+    d = SCRIPT_DIR
+    for _ in range(10):
+        if os.path.isfile(os.path.join(d, "pkb.py")) and os.path.isdir(
+            os.path.join(d, "perfkitbenchmarker")
+        ):
+            return d
+        parent = os.path.dirname(d)
+        if parent == d:
+            break
+        d = parent
+    return None
+
+
+REPO_ROOT = _find_repo_root()
+if not REPO_ROOT:
+    logger.error(
+        "Cannot find pkb.py. Ensure this script is inside the PerfKitBenchmarker repo."
+    )
+    sys.exit(1)
+
+CONFIG_DIR = os.path.join(
+    REPO_ROOT, "perfkitbenchmarker", "data", "k8s_agents", "config", "variants"
+)
+RESULTS_BASE = os.path.join(REPO_ROOT, "results", "pkb")
+TUNING_DIR = os.path.join(CONFIG_DIR, "tuning")
+PKB_CMD = "pkb.py"
+
+# ============================================================
+# Benchmark Registry
+# ============================================================
+BENCHMARKS = {
+    "k8s_python_density": {
+        "sweep_flag": "--k8s_python_density_concurrent_sandbox_count",
+        "sweep_label": "density",
+        "warmpool": "python-sandbox-warmpool",
+        "pod_label": "sandbox=python-sandbox-example",
+        "default_sweep": [1, 4, 8, 16, 32],
+        "drain_between": True,
+    },
+    "k8s_chromium_density": {
+        "sweep_flag": "--k8s_chromium_density_concurrent_sessions",
+        "sweep_label": "density",
+        "warmpool": "chromium-sandbox-warmpool",
+        "pod_label": "sandbox=chromium-sandbox-example",
+        "default_sweep": [1, 2, 4, 8],
+        "drain_between": True,
+    },
+    "k8s_payload": {
+        "sweep_flag": "--k8s_payload_size_mb",
+        "sweep_label": "payload_size_mb",
+        "warmpool": "python-sandbox-warmpool",
+        "pod_label": "sandbox=python-sandbox-example",
+        "default_sweep": [0.01, 0.1, 1, 5, 10],
+        "drain_between": True,
+    },
+    "k8s_qps": {
+        "sweep_flag": "--k8s_qps_target_qps",
+        "sweep_label": "target_qps",
+        "warmpool": "python-sandbox-warmpool",
+        "pod_label": "sandbox=python-sandbox-example",
+        "default_sweep": [1, 5, 10, 20, 50],
+        "drain_between": True,
+    },
+    "k8s_warmpool": {
+        "sweep_flag": "--k8s_warmpool_target_replicas",
+        "sweep_label": "target_replicas",
+        "warmpool": "python-sandbox-warmpool",
+        "pod_label": "sandbox=python-sandbox-example",
+        "default_sweep": [10, 50, 100, 200, 500],
+        "drain_between": True,
+    },
+    "k8s_deletion": {
+        "sweep_flag": "--k8s_deletion_batch_size",
+        "sweep_label": "batch_size",
+        "warmpool": "python-sandbox-warmpool",
+        "pod_label": "sandbox=python-sandbox-example",
+        "default_sweep": [10, 50, 100, 200, 500],
+        "drain_between": True,
+    },
+    "k8s_snapshot": {
+        "sweep_flag": "--k8s_snapshot_preload_mb",
+        "sweep_label": "preload_mb",
+        "warmpool": None,
+        "pod_label": "app=snapshot-benchmark-workload",
+        "default_sweep": [10, 50, 100, 500, 1000],
+        "drain_between": False,
+    },
+}
+
+# ============================================================
+# Variant Registry
+# ============================================================
+ALL_VARIANTS = [
+    "baseline",
+    "kubelet_pulls",
+    "overlay_none",
+    "larger_vm",
+    "hyperdisk_200gb",
+    "thp",
+    "sched_tuning",
+    "swap",
+    "c4d_amd",
+    "c4a_arm",
+    "multi_node",
+    "combined",
+]
+
+VARIANT_CONFIGS = {v: f"{v}.yaml" for v in ALL_VARIANTS}
+
+VARIANT_DESC = {
+    "baseline": "Baseline: c4-standard-8, gVisor, defaults",
+    "kubelet_pulls": "Kubelet parallel pulls + image GC",
+    "overlay_none": "gVisor overlay2=none",
+    "larger_vm": "c4-standard-16 (2x CPU)",
+    "hyperdisk_200gb": "hyperdisk-balanced 200GB",
+    "thp": "Transparent Hugepages (THP=always)",
+    "sched_tuning": "Kernel scheduler tuning",
+    "swap": "Swap enabled (swappiness=15)",
+    "c4d_amd": "C4D AMD (c4d-standard-8)",
+    "c4a_arm": "C4A ARM (c4a-standard-8)",
+    "multi_node": "Multi-node sandbox pool (2x c4-standard-8)",
+    "combined": "Combined best knobs",
+}
+
+
+# ============================================================
+# Helpers
+# ============================================================
+def get_my_ip():
+    # GKE master-authorized-networks accepts IPv4 CIDRs only, so an IPv6 answer
+    # (what ifconfig.me returns on a dual-stack network) must be rejected rather
+    # than passed through as "<addr>/32".
+    endpoints = (
+        "https://api.ipify.org",
+        "https://ipv4.icanhazip.com",
+        "https://ifconfig.me",
+    )
+    for url in endpoints:
+        try:
+            ip = urllib.request.urlopen(url, timeout=10).read().decode().strip()
+            ipaddress.IPv4Address(ip)
+            return ip
+        except Exception:
+            continue
+    raise RuntimeError(
+        "Could not determine a public IPv4 address from any of: "
+        + ", ".join(endpoints)
+        + ". An IPv4 address is required for --master-authorized-networks."
+    )
+
+
+def run_cmd(cmd, check=True):
+    logger.info("CMD: %s", cmd)
+    result = subprocess.run(cmd, shell=True)
+    if check and result.returncode != 0:
+        logger.error("Command failed (rc=%d)", result.returncode)
+        sys.exit(1)
+    return result.returncode
+
+
+def drain_warmpool(warmpool_name, pod_label, namespace):
+    if not warmpool_name:
+        return
+    logger.info("Draining warm pool %s to 0", warmpool_name)
+    run_cmd(
+        f'kubectl patch sandboxwarmpool {warmpool_name} -n {namespace} --type=merge -p \'{{"spec":{{"replicas":0}}}}\'',
+        check=False,
+    )
+    run_cmd(
+        f"kubectl delete sandboxclaims --all -n {namespace} --ignore-not-found=true",
+        check=False,
+    )
+    for _ in range(100):
+        result = subprocess.run(
+            f"kubectl get pods -n {namespace} -l {pod_label} --no-headers 2>/dev/null | wc -l",
+            shell=True,
+            capture_output=True,
+            text=True,
+        )
+        try:
+            count = int(result.stdout.strip())
+        except ValueError:
+            count = 0
+        if count == 0:
+            logger.info("Warm pool drained (0 pods)")
+            return
+        logger.info("  Draining... %d pods remaining", count)
+        time.sleep(3)
+    logger.warning("Drain timeout: pods may still be terminating")
+
+
+def _read_yaml_flags(config_path, benchmark, flag_name, flag_type="list"):
+    empty = [] if flag_type == "list" else None
+    try:
+        with open(config_path, "r") as f:
+            data = yaml.safe_load(f)
+        if not data:
+            return empty
+        bench_config = data.get(benchmark)
+        if bench_config is None:
+            for _, bench_config in data.items():
+                if isinstance(bench_config, dict):
+                    break
+            else:
+                return empty
+        if not isinstance(bench_config, dict):
+            return empty
+        fl = bench_config.get("flags", {})
+        if not isinstance(fl, dict):
+            return empty
+        value = fl.get(flag_name)
+        if value is None:
+            return empty
+        if flag_type == "list":
+            if isinstance(value, list):
+                return [str(v).strip() for v in value if v]
+            return [str(value).strip()]
+        else:
+            return str(value).strip()
+    except Exception as e:
+        logger.warning("Could not read %s from %s: %s", flag_name, config_path, e)
+        return empty
+
+
+def get_variant_uri(benchmark, variant):
+    bench_short = benchmark.replace("k8s_", "")[:4]
+    clean_var = re.sub(r"[^a-zA-Z0-9]", "", variant)[:4]
+    owner = re.sub(r"[^a-z0-9]", "", os.environ.get("USER", "default").lower())[:4]
+    return f"{bench_short}{clean_var}{owner}"
+
+
+def run_pkb(
+    benchmark,
+    variant,
+    stage,
+    args,
+    extra_flags=None,
+    passthrough_flags=None,
+    check=True,
+):
+    config = os.path.join(CONFIG_DIR, VARIANT_CONFIGS[variant])
+    uri = get_variant_uri(benchmark, variant)
+    results = os.path.join(RESULTS_BASE, benchmark)
+    os.makedirs(results, exist_ok=True)
+
+    parts = [
+        "python " + PKB_CMD,
+        "--benchmarks=" + benchmark,
+        "--run_stage=" + stage,
+        "--project=" + args.project,
+        "--benchmark_config_file=" + config,
+        "--run_uri=" + uri,
+        "--json_write_mode=a",
+        "--temp_dir=" + results,
+    ]
+
+    if "provision" in stage:
+        parts.append("--owner=" + args.owner)
+        if args.network:
+            parts.append("--gce_network_name=" + args.network)
+        my_ip = get_my_ip()
+        gke_flag_list = [
+            "--enable-master-authorized-networks",
+            "--master-authorized-networks=" + my_ip + "/32",
+        ]
+        if args.subnet:
+            gke_flag_list.append("--subnetwork=" + args.subnet)
+
+        yaml_gke_flags = _read_yaml_flags(config, benchmark, "gke_additional_flags")
+        for yf in yaml_gke_flags:
+            if yf not in gke_flag_list:
+                gke_flag_list.append(yf)
+        parts.append("--gke_additional_flags=" + ",".join(gke_flag_list))
+        yaml_nodepool_flags = _read_yaml_flags(
+            config, benchmark, "gke_additional_nodepool_flags"
+        )
+        if yaml_nodepool_flags:
+            parts.append(
+                "--gke_additional_nodepool_flags=" + ",".join(yaml_nodepool_flags)
+            )
+
+    if "teardown" in stage and args.network:
+        parts.append("--gce_network_name=" + args.network)
+
+    if extra_flags:
+        parts.append(extra_flags)
+    if passthrough_flags:
+        parts.extend(passthrough_flags)
+
+    cmd = " ".join(parts)
+    return run_cmd(cmd, check=check)
+
+
+def get_results_path(benchmark, variant):
+    uri = get_variant_uri(benchmark, variant)
+    return os.path.join(
+        RESULTS_BASE, benchmark, "runs", uri, "perfkitbenchmarker_results.json"
+    )
+
+
+def count_result_lines(benchmark, variant):
+    """Line count of the results NDJSON, used to isolate one run's output.
+
+    PKB appends to a single file per run_uri (--json_write_mode=a), so records
+    from earlier probes at the same density are still present. Callers snapshot
+    this before a run and pass it as start_line so a crashed run reads as
+    "no metrics" instead of silently inheriting an earlier probe's value.
+    """
+    path = get_results_path(benchmark, variant)
+    if not os.path.exists(path):
+        return 0
+    with open(path, "r") as f:
+        return sum(1 for _ in f)
+
+
+def get_metric_from_results(
+    benchmark, variant, sweep_label, sweep_val, target_metric, start_line=0
+):
+    """Parse the PKB JSON output to find the metric and return (value, all_found_metrics)."""
+    results_file = get_results_path(benchmark, variant)
+
+    if not os.path.exists(results_file):
+        return None, []
+
+    latest_val = None
+    all_metrics = set()
+
+    with open(results_file, "r") as f:
+        for _ in range(start_line):
+            if f.readline() == "":
+                break
+        for line in f:
+            if not line.strip():
+                continue
+            try:
+                record = json.loads(line)
+                labels_str = record.get("labels", "")
+                labels = {}
+                for part in labels_str.split(","):
+                    part = part.strip().strip("|")
+                    if ":" in part:
+                        k, _, v = part.partition(":")
+                        labels[k.strip()] = v.strip()
+
+                record_sweep_val = labels.get(sweep_label)
+                if record_sweep_val is not None:
+                    try:
+                        record_sweep_val = float(record_sweep_val)
+                    except ValueError:
+                        pass
+
+                    if record_sweep_val == float(sweep_val):
+                        metric_name = record.get("metric")
+                        if metric_name:
+                            all_metrics.add(metric_name)
+                            if metric_name == target_metric:
+                                latest_val = record.get("value")
+            except json.JSONDecodeError:
+                continue
+
+    return latest_val, sorted(list(all_metrics))
+
+
+# ============================================================
+# Stage Handlers
+# ============================================================
+def do_provision(benchmark, variant, args, passthrough_flags=None):
+    logger.info("=== PROVISION: %s / %s ===", benchmark, variant)
+    run_pkb(benchmark, variant, "provision", args, passthrough_flags=passthrough_flags)
+
+
+def do_prepare(benchmark, variant, args, passthrough_flags=None):
+    logger.info("=== PREPARE: %s / %s ===", benchmark, variant)
+    run_pkb(benchmark, variant, "prepare", args, passthrough_flags=passthrough_flags)
+    apply_variant_extras(variant, args.namespace)
+
+
+def do_static_sweep(benchmark, variant, sweep_values, args, passthrough_flags=None):
+    bench_cfg = BENCHMARKS[benchmark]
+    sweep_flag = bench_cfg["sweep_flag"]
+    warmpool = bench_cfg["warmpool"]
+    pod_label = bench_cfg["pod_label"]
+    do_drain = bench_cfg["drain_between"]
+
+    logger.info(
+        "=== STATIC SWEEP: %s / %s -- values: %s ===", benchmark, variant, sweep_values
+    )
+    failed = []
+    try:
+        for val in sweep_values:
+            logger.info("--- %s=%s ---", sweep_flag, val)
+            extra = f"{sweep_flag}={val}"
+            rc = run_pkb(
+                benchmark,
+                variant,
+                "run,cleanup",
+                args,
+                extra_flags=extra,
+                passthrough_flags=passthrough_flags,
+                check=False,
+            )
+            if rc != 0:
+                logger.warning("value=%s failed (rc=%d), continuing", val, rc)
+                failed.append(val)
+            if do_drain and warmpool:
+                logger.info("Draining between sweep levels...")
+                drain_warmpool(warmpool, pod_label, args.namespace)
+                time.sleep(5)
+    finally:
+        if do_drain and warmpool:
+            logger.info("Final safety drain after sweep")
+            drain_warmpool(warmpool, pod_label, args.namespace)
+
+    if failed:
+        logger.warning("Failed sweep values: %s", failed)
+    else:
+        logger.info("All sweep values completed successfully")
+
+
+def _probe_once(
+    benchmark, variant, args, bench_cfg, mid, passthrough_flags
+):
+    """Run one measurement at `mid`. Returns (metric_val, found_metrics).
+
+    metric_val is None when the run produced no usable measurement (crash), which
+    the caller must treat differently from a measured SLA breach.
+    """
+    start_line = count_result_lines(benchmark, variant)
+    run_pkb(
+        benchmark,
+        variant,
+        "run,cleanup",
+        args,
+        extra_flags=f"{bench_cfg['sweep_flag']}={mid}",
+        passthrough_flags=passthrough_flags,
+        check=False,
+    )
+
+    if bench_cfg["drain_between"] and bench_cfg["warmpool"]:
+        logger.info("Draining between sweep levels...")
+        drain_warmpool(bench_cfg["warmpool"], bench_cfg["pod_label"], args.namespace)
+        time.sleep(5)
+
+    return get_metric_from_results(
+        benchmark,
+        variant,
+        bench_cfg["sweep_label"],
+        mid,
+        args.threshold_metric,
+        start_line=start_line,
+    )
+
+
+def evaluate_probe(
+    benchmark, variant, args, bench_cfg, mid, threshold, passthrough_flags
+):
+    """Decide PASS/FAIL at `mid`, re-running only on failure.
+
+    Asymmetric by design: a false FAIL is unrecoverable under bisection because it
+    truncates the whole upper branch, while a false PASS only sends the search
+    higher. So passes are accepted immediately and only failures pay for repeats.
+
+    But a false PASS is NOT harmless, because the reported answer is the highest
+    density that passed — so a false PASS at the boundary becomes the verdict rather
+    than self-correcting. Accepting the first passing re-run therefore biases the
+    reported threshold upward, by roughly one bisection step.
+
+    `--failure-retries` is the guard: it is the number of confirming re-runs, and
+    ALL of them must pass. Default 2, because one failure plus one pass is an observed
+    rate of 1/2 — an interval wide enough to be uninformative about whether the
+    threshold is met.
+
+    Requiring all N to pass also makes a genuine failure *cheaper*, not dearer: the
+    first non-passing confirmation ends the probe, since all-must-pass can no longer
+    be met. A saturated density therefore costs 2 runs, where accept-on-any-pass
+    spent 3.
+
+    Returns (passed, decision_value, samples, note).
+    """
+    samples = []
+    metric_val, found_metrics = _probe_once(
+        benchmark, variant, args, bench_cfg, mid, passthrough_flags
+    )
+    samples.append(metric_val)
+
+    if metric_val is not None and metric_val <= threshold:
+        return True, metric_val, samples, ""
+
+    if metric_val is None and not found_metrics:
+        note = "crash"
+    elif metric_val is None:
+        # Metric absent while other metrics were emitted: usually a partially
+        # failed run (aggregates suppressed, PSI still emitted), not a typo.
+        note = "no-metric"
+    else:
+        note = "over-threshold"
+
+    required = args.failure_retries
+    confirmed = 0
+    for attempt in range(1, required + 1):
+        logger.info(
+            "Probe at %s failed (%s). Confirmation re-run %d of %d — all must pass.",
+            mid,
+            note,
+            attempt,
+            required,
+        )
+        retry_val, _ = _probe_once(
+            benchmark, variant, args, bench_cfg, mid, passthrough_flags
+        )
+        samples.append(retry_val)
+        if retry_val is None or retry_val > threshold:
+            # All confirmations must pass, so one miss settles it. Stop here rather
+            # than spending the rest of the budget on a verdict that cannot change.
+            logger.info(
+                "Confirmation %d of %d did not pass (%s) — failure stands.",
+                attempt,
+                required,
+                retry_val,
+            )
+            if confirmed:
+                note = f"{note}-unconfirmed-{confirmed}of{required}"
+            break
+        confirmed += 1
+        logger.info(
+            "Confirmation %d of %d PASSED (%s <= %s).",
+            attempt,
+            required,
+            retry_val,
+            threshold,
+        )
+    else:
+        if required:
+            logger.info(
+                "All %d confirmations passed at %s — the first result was noise.",
+                required,
+                mid,
+            )
+            return True, samples[-1], samples, f"pass-on-{required}-confirmations"
+
+    measured = [s for s in samples if s is not None]
+    decision_value = _aggregate(measured, args) if measured else None
+    return False, decision_value, samples, note
+
+
+def _aggregate(values, args):
+    """Combine repeated measurements at one density into a decision value."""
+    if len(values) == 1:
+        return values[0]
+    mode = args.retry_aggregate
+    if mode == "median":
+        return statistics.median(values)
+    if mode == "mean":
+        return statistics.fmean(values)
+    if mode == "min":
+        return min(values)
+    if mode == "max":
+        return max(values)
+    if mode == "weighted":
+        # Weights apply oldest-first and are renormalised to len(values).
+        weights = [float(w) for w in args.retry_weights.split(",")]
+        weights = (weights + [weights[-1]] * len(values))[: len(values)]
+        total = sum(weights)
+        return sum(v * w for v, w in zip(values, weights)) / total
+    return values[-1]
+
+
+def do_binary_search(benchmark, variant, args, passthrough_flags=None):
+    bench_cfg = BENCHMARKS[benchmark]
+    sweep_flag = bench_cfg["sweep_flag"]
+    sweep_label = bench_cfg["sweep_label"]
+    warmpool = bench_cfg["warmpool"]
+    pod_label = bench_cfg["pod_label"]
+    do_drain = bench_cfg["drain_between"]
+
+    is_float = (
+        "." in args.search_min
+        or "." in args.search_max
+        or "." in args.search_convergence
+    )
+    low = float(args.search_min) if is_float else int(args.search_min)
+    high = float(args.search_max) if is_float else int(args.search_max)
+    convergence = (
+        float(args.search_convergence) if is_float else int(args.search_convergence)
+    )
+    target_metric = args.threshold_metric
+    threshold = args.threshold_value
+
+    if convergence <= 0:
+        sys.exit(
+            "--search-convergence must be > 0; a value of 0 never terminates "
+            "and each iteration costs a full benchmark run."
+        )
+    if low >= high:
+        sys.exit(f"--search-min ({low}) must be < --search-max ({high}).")
+    if args.failure_retries < 0:
+        sys.exit("--failure-retries must be >= 0.")
+
+    logger.info("=== BINARY SEARCH SWEEP: %s / %s ===", benchmark, variant)
+    logger.info("  Range: [%s, %s], Convergence: %s", low, high, convergence)
+    logger.info("  Target: %s <= %s", target_metric, threshold)
+    logger.info(
+        "  Confirmations to overturn a failure: %d (all must pass, aggregate=%s)",
+        args.failure_retries,
+        args.retry_aggregate,
+    )
+    if args.failure_retries == 1:
+        logger.warning(
+            "  --failure-retries=1: one FAIL plus one PASS will be recorded as a "
+            "PASS. That is an observed rate of 1/2 (95%% CI 9-91%%) and says nothing "
+            "about meeting the threshold, so the reported optimum will be biased "
+            "upward. Prefer the default of 2."
+        )
+
+    best_val = None
+    lowest_fail = None
+    search_history = []
+    step_num = 1
+
+    try:
+        while (high - low) >= convergence:
+            mid = low + (high - low) / 2.0
+            if not is_float:
+                mid = int(mid)
+
+            current_range = f"[{low}, {high}]"
+            logger.info(
+                "--- Binary Search Step %d: Testing %s=%s (Range: %s) ---",
+                step_num,
+                sweep_flag,
+                mid,
+                current_range,
+            )
+
+            passed, decision_value, samples, note = evaluate_probe(
+                benchmark,
+                variant,
+                args,
+                bench_cfg,
+                mid,
+                threshold,
+                passthrough_flags,
+            )
+
+            metric_val_str = "N/A" if decision_value is None else str(decision_value)
+            if len(samples) > 1:
+                metric_val_str += (
+                    " (" + ", ".join("N/A" if s is None else f"{s:g}" for s in samples) + ")"
+                )
+
+            if passed:
+                logger.info(
+                    "Density %s PASSED (%s <= %s). Searching higher.",
+                    mid,
+                    decision_value,
+                    threshold,
+                )
+                status = "Success" if not note else f"Success ({note})"
+                best_val = mid
+                if is_float:
+                    low = mid
+                else:
+                    low = mid + 1
+            else:
+                if note == "crash":
+                    logger.warning(
+                        "Density %s produced no metrics after %d attempt(s) — "
+                        "treating as saturation. NOTE: an infrastructure failure is "
+                        "indistinguishable from saturation here; check the run log.",
+                        mid,
+                        len(samples),
+                    )
+                    status = "Crashed/No Data"
+                elif note == "no-metric":
+                    logger.warning(
+                        "Metric '%s' absent at density %s though other metrics were "
+                        "emitted — partial run failure. Treating as saturation. If this "
+                        "occurs at EVERY density, check --threshold-metric for a typo.",
+                        target_metric,
+                        mid,
+                    )
+                    status = "Partial/No Metric"
+                else:
+                    logger.info(
+                        "Density %s FAILED (%s > %s). Searching lower.",
+                        mid,
+                        decision_value,
+                        threshold,
+                    )
+                    status = "Failed SLA"
+                lowest_fail = mid if lowest_fail is None else min(lowest_fail, mid)
+                if is_float:
+                    high = mid
+                else:
+                    high = mid - 1
+
+            search_history.append(
+                {
+                    "Step": step_num,
+                    "Search Range": current_range,
+                    f"Target {sweep_label}": mid,
+                    target_metric: metric_val_str,
+                    "Threshold": threshold,
+                    "Status": status,
+                }
+            )
+
+            step_num += 1
+
+            if not is_float and low > high:
+                break
+
+    finally:
+        if do_drain and warmpool:
+            logger.info("Final safety drain after sweep")
+            drain_warmpool(warmpool, pod_label, args.namespace)
+
+    # Output Binary Search History Table to STDOUT
+    if search_history:
+        headers = [
+            "Step",
+            "Search Range",
+            f"Target {sweep_label}",
+            target_metric,
+            "Threshold",
+            "Status",
+        ]
+
+        # Calculate column widths
+        col_widths = {h: len(h) for h in headers}
+        for row in search_history:
+            for h in headers:
+                col_widths[h] = max(col_widths[h], len(str(row[h])))
+
+        def format_row(row_dict):
+            return (
+                "| "
+                + " | ".join(str(row_dict[h]).ljust(col_widths[h]) for h in headers)
+                + " |"
+            )
+
+        header_str = format_row({h: h for h in headers})
+        separator_str = "|" + "|".join("-" * (col_widths[h] + 2) for h in headers) + "|"
+
+        print("\n" + "=" * len(header_str))
+        print("BINARY SEARCH HISTORY")
+        print("=" * len(header_str))
+        print(header_str)
+        print(separator_str)
+        for row in search_history:
+            print(format_row(row))
+        print("=" * len(header_str) + "\n")
+
+    # Persist the search history next to the results so a verdict can be audited
+    # after the fact; previously it existed only on stdout.
+    try:
+        history_path = os.path.join(
+            os.path.dirname(get_results_path(benchmark, variant)),
+            "search_history.json",
+        )
+        with open(history_path, "w") as f:
+            json.dump(
+                {
+                    "benchmark": benchmark,
+                    "variant": variant,
+                    "threshold_metric": target_metric,
+                    "threshold_value": threshold,
+                    "search_min": args.search_min,
+                    "search_max": args.search_max,
+                    "convergence": convergence,
+                    "failure_retries": args.failure_retries,
+                    "retry_aggregate": args.retry_aggregate,
+                    "optimal": best_val,
+                    "lowest_failing": lowest_fail,
+                    "steps": search_history,
+                },
+                f,
+                indent=2,
+            )
+        logger.info("Search history written to %s", history_path)
+    except OSError as e:
+        logger.warning("Could not write search history: %s", e)
+
+    if best_val is not None:
+        # Report the bracket, not just the point estimate: the true threshold lies
+        # between the highest pass and the lowest fail, and is only resolved to
+        # within `convergence`.
+        if lowest_fail is not None:
+            logger.info(
+                "=== BINARY SEARCH COMPLETE: Optimal %s = %s "
+                "(highest passing; lowest failing = %s; true threshold in [%s, %s), "
+                "resolved to +/-%s) ===",
+                sweep_label,
+                best_val,
+                lowest_fail,
+                best_val,
+                lowest_fail,
+                convergence,
+            )
+        else:
+            logger.info(
+                "=== BINARY SEARCH COMPLETE: Optimal %s = %s "
+                "(no failure observed — the true threshold is at or above "
+                "--search-max=%s, so this is a LOWER BOUND, not a ceiling) ===",
+                sweep_label,
+                best_val,
+                args.search_max,
+            )
+    else:
+        logger.warning(
+            "=== BINARY SEARCH COMPLETE: No value satisfied the threshold. "
+            "Every probe failed, including the lowest (%s) — the true threshold is "
+            "at or below --search-min, so widen the range downward. ===",
+            args.search_min,
+        )
+
+
+def do_teardown(benchmark, variant, args, passthrough_flags=None):
+    logger.info("=== TEARDOWN: %s / %s ===", benchmark, variant)
+    run_pkb(benchmark, variant, "teardown", args, passthrough_flags=passthrough_flags)
+
+
+def apply_variant_extras(variant, namespace):
+    if variant == "overlay_none":
+        logger.info("Patching SandboxTemplate: overlay2=none")
+        patch_json = '{"spec":{"podTemplate":{"metadata":{"annotations":{"dev.gvisor.spec.overlay2":"none"}}}}}'
+        run_cmd(
+            f"kubectl patch sandboxtemplate python-sandbox-template -n {namespace} --type=merge -p '{patch_json}'",
+            check=False,
+        )
+        time.sleep(10)
+
+    if variant == "sched_tuning":
+        logger.info("Applying scheduler tuning DaemonSet")
+        j2_path = os.path.join(TUNING_DIR, "sched_tuner_daemonset.yaml.j2")
+        with open(j2_path, "r") as f:
+            rendered = Jinja2Template(f.read()).render(ns=namespace)
+        rendered_path = os.path.join(TUNING_DIR, "tmp", "sched_tuner_daemonset.yaml")
+        os.makedirs(os.path.dirname(rendered_path), exist_ok=True)
+        with open(rendered_path, "w") as f:
+            f.write(rendered)
+        run_cmd("kubectl apply -f " + rendered_path, check=False)
+        run_cmd(
+            f"kubectl rollout status daemonset/sched-tuner -n {namespace} --timeout=60s",
+            check=False,
+        )
+        time.sleep(5)
+
+
+# ============================================================
+# Main
+# ============================================================
+def main():
+    parser = argparse.ArgumentParser(
+        description="Optimization Sweep Runner - Multi-Benchmark",
+        epilog="Pass additional PKB flags after --: sweep.py ... -- --flag1=val1",
+    )
+    parser.add_argument("--project", required=True, help="GCP Project ID")
+    parser.add_argument("--region", default="us-east1", help="GCP Region")
+    parser.add_argument("--owner", default=os.environ.get("USER", "default"), help="Owner tag for resources")
+    parser.add_argument("--network", default=None, help="Existing VPC network name")
+    parser.add_argument("--subnet", default=None, help="Existing Subnet name")
+    parser.add_argument("--namespace", default="agentic", help="Kubernetes namespace")
+    parser.add_argument(
+        "--benchmark",
+        required=True,
+        choices=sorted(BENCHMARKS.keys()),
+        help="PKB benchmark name",
+    )
+    parser.add_argument("--variant", action="append", default=[], help="Variant to run")
+    parser.add_argument("--all", action="store_true", help="Run all variants.")
+    parser.add_argument(
+        "--stages",
+        default="provision,prepare,run,teardown",
+        help="Comma-separated stages.",
+    )
+
+    # Static Sweep
+    parser.add_argument(
+        "--sweep-values",
+        default=None,
+        help="Comma-separated sweep values (Static mode).",
+    )
+
+    # Binary Search Sweep
+    parser.add_argument(
+        "--search-mode",
+        choices=["static", "binary"],
+        default="static",
+        help="Sweep mode (static or binary).",
+    )
+    parser.add_argument("--search-min", default="1", help="Binary search min value.")
+    parser.add_argument("--search-max", default="100", help="Binary search max value.")
+    parser.add_argument(
+        "--search-convergence", default="1", help="Binary search convergence/step size."
+    )
+    parser.add_argument(
+        "--threshold-metric",
+        default="k8s_python_density_sandbox_total_cel_mean_ms",
+        help="Metric to evaluate for binary search.",
+    )
+    parser.add_argument(
+        "--threshold-value",
+        type=float,
+        default=2000.0,
+        help="Maximum acceptable value for the metric.",
+    )
+    parser.add_argument(
+        "--failure-retries",
+        type=int,
+        default=2,
+        help=(
+            "Number of confirming re-runs on a FAILED probe. ALL of them must pass "
+            "for the failure to be overturned. Default 2; use 0 for single-shot, "
+            "where a failure is final. A first-sample pass is always accepted "
+            "immediately, so a clean sweep costs nothing extra. Why all-must-pass: "
+            "the reported optimum is the highest passing density, so accepting the "
+            "first passing re-run lets one noisy sample at the boundary become the "
+            "verdict rather than self-correcting, biasing the result upward by about "
+            "one bisection step. All-must-pass also makes a real failure cheaper — "
+            "the first non-passing confirmation ends the probe."
+        ),
+    )
+    parser.add_argument(
+        "--retry-aggregate",
+        default="median",
+        choices=["median", "mean", "min", "max", "weighted", "last"],
+        help=(
+            "How to combine repeated measurements at one density into the reported "
+            "value once all retries have failed. Note this only affects reporting: "
+            "any single passing re-run already short-circuits to PASS."
+        ),
+    )
+    parser.add_argument(
+        "--retry-weights",
+        default="0.2,0.8",
+        help=(
+            "Comma-separated weights for --retry-aggregate=weighted, applied "
+            "oldest-measurement-first and renormalised (e.g. '0.2,0.8' trusts the "
+            "re-run over the initial measurement)."
+        ),
+    )
+
+    args, passthrough = parser.parse_known_args()
+    passthrough_flags = [f for f in passthrough if f != "--"] if passthrough else None
+
+    benchmark = args.benchmark
+    bench_cfg = BENCHMARKS[benchmark]
+
+    if getattr(args, "all"):
+        variants = list(ALL_VARIANTS)
+    elif args.variant:
+        variants = args.variant
+    else:
+        logger.error("Specify --variant <name> or --all")
+        sys.exit(1)
+
+    for v in variants:
+        if v not in VARIANT_CONFIGS:
+            logger.error(
+                "Unknown variant: %s. Available: %s", v, ", ".join(ALL_VARIANTS)
+            )
+            sys.exit(1)
+
+    stages = [s.strip() for s in args.stages.split(",")]
+    valid_stages = {"provision", "prepare", "run", "teardown"}
+    for s in stages:
+        if s not in valid_stages:
+            logger.error("Unknown stage: %s", s)
+            sys.exit(1)
+
+    logger.info("OPTIMIZATION SWEEP")
+    logger.info("  Project:    %s", args.project)
+    logger.info("  Region:     %s", args.region)
+    logger.info("  Network:    %s", args.network or "(PKB Managed)")
+    logger.info("  Subnet:     %s", args.subnet or "(PKB Managed)")
+    logger.info("  Namespace:  %s", args.namespace)
+    logger.info("  Benchmark:  %s", benchmark)
+    logger.info("  Sweep flag: %s", bench_cfg["sweep_flag"])
+    logger.info("  Variants:   %s", variants)
+    logger.info("  Stages:     %s", stages)
+    logger.info("  Mode:       %s", args.search_mode)
+
+    for variant in variants:
+        logger.info("")
+        logger.info("=" * 60)
+        logger.info("  %s / %s: %s", benchmark, variant, VARIANT_DESC.get(variant, ""))
+        logger.info("=" * 60)
+
+        if "provision" in stages:
+            do_provision(benchmark, variant, args, passthrough_flags)
+        if "prepare" in stages:
+            do_prepare(benchmark, variant, args, passthrough_flags)
+        if "run" in stages:
+            if args.search_mode == "binary":
+                do_binary_search(benchmark, variant, args, passthrough_flags)
+            else:
+                if args.sweep_values:
+                    raw = [v.strip() for v in args.sweep_values.split(",")]
+                    sweep_values = [float(v) if "." in v else int(v) for v in raw]
+                else:
+                    sweep_values = list(bench_cfg["default_sweep"])
+                do_static_sweep(
+                    benchmark, variant, sweep_values, args, passthrough_flags
+                )
+        if "teardown" in stages:
+            do_teardown(benchmark, variant, args, passthrough_flags)
+
+        logger.info("=== %s / %s COMPLETE ===", benchmark, variant)
+
+    logger.info("ALL DONE. Results in: %s/", os.path.join(RESULTS_BASE, benchmark))
+
+
+if __name__ == "__main__":
+    main()

--- a/perfkitbenchmarker/scripts/agentic/sweep.py
+++ b/perfkitbenchmarker/scripts/agentic/sweep.py
@@ -1,0 +1,1046 @@
+#!/usr/bin/env python3
+"""Optimization Sweep Runner - Multi-Benchmark.
+
+Runs baseline + variant benchmarks for any GKE agentic benchmark.
+Supports both Static sweeps (comma-separated lists) and Binary Search sweeps
+to automatically find the saturation point based on a target metric threshold.
+
+Usage (Static):
+  python sweep.py --project my-project --benchmark k8s_python_density --variant baseline --sweep-values 20,40,60,80
+
+Usage (Binary Search):
+  python sweep.py --project my-project --benchmark k8s_python_density --variant baseline \
+      --search-mode binary --search-min 10 --search-max 200 --search-convergence 5 \
+      --threshold-metric k8s_python_density_sandbox_total_cel_mean_ms --threshold-value 2000.0
+"""
+
+import argparse
+import json
+import re
+import ipaddress
+import logging
+import os
+import statistics
+import subprocess
+import sys
+import time
+import urllib.request
+import yaml
+from jinja2 import Template as Jinja2Template
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+# ============================================================
+# Path Resolution
+# ============================================================
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def _find_repo_root():
+    d = SCRIPT_DIR
+    for _ in range(10):
+        if os.path.isfile(os.path.join(d, "pkb.py")) and os.path.isdir(
+            os.path.join(d, "perfkitbenchmarker")
+        ):
+            return d
+        parent = os.path.dirname(d)
+        if parent == d:
+            break
+        d = parent
+    return None
+
+
+REPO_ROOT = _find_repo_root()
+if not REPO_ROOT:
+    logger.error(
+        "Cannot find pkb.py. Ensure this script is inside the PerfKitBenchmarker repo."
+    )
+    sys.exit(1)
+
+CONFIG_DIR = os.path.join(
+    REPO_ROOT, "perfkitbenchmarker", "data", "k8s_agents", "config", "variants"
+)
+RESULTS_BASE = os.path.join(REPO_ROOT, "results", "pkb")
+TUNING_DIR = os.path.join(CONFIG_DIR, "tuning")
+PKB_CMD = "pkb.py"
+
+# ============================================================
+# Benchmark Registry
+# ============================================================
+BENCHMARKS = {
+    "k8s_python_density": {
+        "sweep_flag": "--k8s_python_density_concurrent_sandbox_count",
+        "sweep_label": "density",
+        "warmpool": "python-sandbox-warmpool",
+        "pod_label": "sandbox=python-sandbox-example",
+        "default_sweep": [1, 4, 8, 16, 32],
+        "drain_between": True,
+    },
+    "k8s_chromium_density": {
+        "sweep_flag": "--k8s_chromium_density_concurrent_sessions",
+        "sweep_label": "density",
+        "warmpool": "chromium-sandbox-warmpool",
+        "pod_label": "sandbox=chromium-sandbox-example",
+        "default_sweep": [1, 2, 4, 8],
+        "drain_between": True,
+    },
+    "k8s_payload": {
+        "sweep_flag": "--k8s_payload_size_mb",
+        "sweep_label": "payload_size_mb",
+        "warmpool": "python-sandbox-warmpool",
+        "pod_label": "sandbox=python-sandbox-example",
+        "default_sweep": [0.01, 0.1, 1, 5, 10],
+        "drain_between": True,
+    },
+    "k8s_qps": {
+        "sweep_flag": "--k8s_qps_target_qps",
+        "sweep_label": "target_qps",
+        "warmpool": "python-sandbox-warmpool",
+        "pod_label": "sandbox=python-sandbox-example",
+        "default_sweep": [1, 5, 10, 20, 50],
+        "drain_between": True,
+    },
+    "k8s_warmpool": {
+        "sweep_flag": "--k8s_warmpool_target_replicas",
+        "sweep_label": "target_replicas",
+        "warmpool": "python-sandbox-warmpool",
+        "pod_label": "sandbox=python-sandbox-example",
+        "default_sweep": [10, 50, 100, 200, 500],
+        "drain_between": True,
+    },
+    "k8s_deletion": {
+        "sweep_flag": "--k8s_deletion_batch_size",
+        "sweep_label": "batch_size",
+        "warmpool": "python-sandbox-warmpool",
+        "pod_label": "sandbox=python-sandbox-example",
+        "default_sweep": [10, 50, 100, 200, 500],
+        "drain_between": True,
+    },
+    "k8s_snapshot": {
+        "sweep_flag": "--k8s_snapshot_preload_mb",
+        "sweep_label": "preload_mb",
+        "warmpool": None,
+        "pod_label": "app=snapshot-benchmark-workload",
+        "default_sweep": [10, 50, 100, 500, 1000],
+        "drain_between": False,
+    },
+}
+
+# ============================================================
+# Variant Registry
+# ============================================================
+ALL_VARIANTS = [
+    "baseline",
+    "kubelet_pulls",
+    "overlay_none",
+    "larger_vm",
+    "hyperdisk_200gb",
+    "thp",
+    "sched_tuning",
+    "swap",
+    "c4d_amd",
+    "c4a_arm",
+    "multi_node",
+    "combined",
+]
+
+VARIANT_CONFIGS = {v: f"{v}.yaml" for v in ALL_VARIANTS}
+
+VARIANT_DESC = {
+    "baseline": "Baseline: c4-standard-8, gVisor, defaults",
+    "kubelet_pulls": "Kubelet parallel pulls + image GC",
+    "overlay_none": "gVisor overlay2=none",
+    "larger_vm": "c4-standard-16 (2x CPU)",
+    "hyperdisk_200gb": "hyperdisk-balanced 200GB",
+    "thp": "Transparent Hugepages (THP=always)",
+    "sched_tuning": "Kernel scheduler tuning",
+    "swap": "Swap enabled (swappiness=15)",
+    "c4d_amd": "C4D AMD (c4d-standard-8)",
+    "c4a_arm": "C4A ARM (c4a-standard-8)",
+    "multi_node": "Multi-node sandbox pool (2x c4-standard-8)",
+    "combined": "Combined best knobs",
+}
+
+
+# ============================================================
+# Helpers
+# ============================================================
+def get_my_ip():
+    # GKE master-authorized-networks accepts IPv4 CIDRs only, so an IPv6 answer
+    # (what ifconfig.me returns on a dual-stack network) must be rejected rather
+    # than passed through as "<addr>/32".
+    endpoints = (
+        "https://api.ipify.org",
+        "https://ipv4.icanhazip.com",
+        "https://ifconfig.me",
+    )
+    for url in endpoints:
+        try:
+            ip = urllib.request.urlopen(url, timeout=10).read().decode().strip()
+            ipaddress.IPv4Address(ip)
+            return ip
+        except Exception:
+            continue
+    raise RuntimeError(
+        "Could not determine a public IPv4 address from any of: "
+        + ", ".join(endpoints)
+        + ". An IPv4 address is required for --master-authorized-networks."
+    )
+
+
+def run_cmd(cmd, check=True):
+    logger.info("CMD: %s", cmd)
+    result = subprocess.run(cmd, shell=True)
+    if check and result.returncode != 0:
+        logger.error("Command failed (rc=%d)", result.returncode)
+        sys.exit(1)
+    return result.returncode
+
+
+def drain_warmpool(warmpool_name, pod_label, namespace):
+    if not warmpool_name:
+        return
+    logger.info("Draining warm pool %s to 0", warmpool_name)
+    run_cmd(
+        f'kubectl patch sandboxwarmpool {warmpool_name} -n {namespace} --type=merge -p \'{{"spec":{{"replicas":0}}}}\'',
+        check=False,
+    )
+    run_cmd(
+        f"kubectl delete sandboxclaims --all -n {namespace} --ignore-not-found=true",
+        check=False,
+    )
+    logger.info("Waiting for pods to terminate...")
+    run_cmd(
+        f"kubectl wait --for=delete pod -l {pod_label} -n {namespace} --timeout=300s",
+        check=False,
+    )
+    logger.info("Warm pool drained")
+
+
+def _read_yaml_flags(config_path, benchmark, flag_name, flag_type="list"):
+    empty = [] if flag_type == "list" else None
+    try:
+        with open(config_path, "r") as f:
+            data = yaml.safe_load(f)
+        if not data:
+            return empty
+        bench_config = data.get(benchmark)
+        if bench_config is None:
+            for _, bench_config in data.items():
+                if isinstance(bench_config, dict):
+                    break
+            else:
+                return empty
+        if not isinstance(bench_config, dict):
+            return empty
+        fl = bench_config.get("flags", {})
+        if not isinstance(fl, dict):
+            return empty
+        value = fl.get(flag_name)
+        if value is None:
+            return empty
+        if flag_type == "list":
+            if isinstance(value, list):
+                return [str(v).strip() for v in value if v]
+            return [str(value).strip()]
+        else:
+            return str(value).strip()
+    except Exception as e:
+        logger.warning("Could not read %s from %s: %s", flag_name, config_path, e)
+        return empty
+
+
+def get_variant_uri(benchmark, variant):
+    bench_short = benchmark.replace("k8s_", "")[:4]
+    clean_var = re.sub(r"[^a-zA-Z0-9]", "", variant)[:4]
+    owner = re.sub(r"[^a-z0-9]", "", os.environ.get("USER", "default").lower())[:4]
+    return f"{bench_short}{clean_var}{owner}"
+
+
+def run_pkb(
+    benchmark,
+    variant,
+    stage,
+    args,
+    extra_flags=None,
+    passthrough_flags=None,
+    check=True,
+):
+    config = os.path.join(CONFIG_DIR, VARIANT_CONFIGS[variant])
+    uri = get_variant_uri(benchmark, variant)
+    results = os.path.join(RESULTS_BASE, benchmark)
+    os.makedirs(results, exist_ok=True)
+
+    parts = [
+        "python " + PKB_CMD,
+        "--benchmarks=" + benchmark,
+        "--run_stage=" + stage,
+        "--project=" + args.project,
+        "--benchmark_config_file=" + config,
+        "--run_uri=" + uri,
+        "--json_write_mode=a",
+        "--temp_dir=" + results,
+    ]
+
+    if "provision" in stage:
+        parts.append("--owner=" + args.owner)
+        if args.network:
+            parts.append("--gce_network_name=" + args.network)
+        my_ip = get_my_ip()
+        gke_flag_list = [
+            "--enable-master-authorized-networks",
+            "--master-authorized-networks=" + my_ip + "/32",
+        ]
+        if args.subnet:
+            gke_flag_list.append("--subnetwork=" + args.subnet)
+
+        yaml_gke_flags = _read_yaml_flags(config, benchmark, "gke_additional_flags")
+        for yf in yaml_gke_flags:
+            if yf not in gke_flag_list:
+                gke_flag_list.append(yf)
+        parts.append("--gke_additional_flags=" + ",".join(gke_flag_list))
+        yaml_nodepool_flags = _read_yaml_flags(
+            config, benchmark, "gke_additional_nodepool_flags"
+        )
+        if yaml_nodepool_flags:
+            parts.append(
+                "--gke_additional_nodepool_flags=" + ",".join(yaml_nodepool_flags)
+            )
+
+    if "teardown" in stage and args.network:
+        parts.append("--gce_network_name=" + args.network)
+
+    if extra_flags:
+        parts.append(extra_flags)
+    if passthrough_flags:
+        parts.extend(passthrough_flags)
+
+    cmd = " ".join(parts)
+    return run_cmd(cmd, check=check)
+
+
+def get_results_path(benchmark, variant):
+    uri = get_variant_uri(benchmark, variant)
+    return os.path.join(
+        RESULTS_BASE, benchmark, "runs", uri, "perfkitbenchmarker_results.json"
+    )
+
+
+def count_result_lines(benchmark, variant):
+    """Line count of the results NDJSON, used to isolate one run's output.
+
+    PKB appends to a single file per run_uri (--json_write_mode=a), so records
+    from earlier probes at the same density are still present. Callers snapshot
+    this before a run and pass it as start_line so a crashed run reads as
+    "no metrics" instead of silently inheriting an earlier probe's value.
+    """
+    path = get_results_path(benchmark, variant)
+    if not os.path.exists(path):
+        return 0
+    with open(path, "r") as f:
+        return sum(1 for _ in f)
+
+
+def get_metric_from_results(
+    benchmark, variant, sweep_label, sweep_val, target_metric, start_line=0
+):
+    """Parse the PKB JSON output to find the metric and return (value, all_found_metrics)."""
+    results_file = get_results_path(benchmark, variant)
+
+    if not os.path.exists(results_file):
+        return None, []
+
+    latest_val = None
+    all_metrics = set()
+
+    with open(results_file, "r") as f:
+        for _ in range(start_line):
+            if f.readline() == "":
+                break
+        for line in f:
+            if not line.strip():
+                continue
+            try:
+                record = json.loads(line)
+                labels_str = record.get("labels", "")
+                labels = {}
+                for part in labels_str.split(","):
+                    part = part.strip().strip("|")
+                    if ":" in part:
+                        k, _, v = part.partition(":")
+                        labels[k.strip()] = v.strip()
+
+                record_sweep_val = labels.get(sweep_label)
+                if record_sweep_val is not None:
+                    try:
+                        record_sweep_val = float(record_sweep_val)
+                    except ValueError:
+                        pass
+
+                    if record_sweep_val == float(sweep_val):
+                        metric_name = record.get("metric")
+                        if metric_name:
+                            all_metrics.add(metric_name)
+                            if metric_name == target_metric:
+                                latest_val = record.get("value")
+            except json.JSONDecodeError:
+                continue
+
+    return latest_val, sorted(list(all_metrics))
+
+
+# ============================================================
+# Stage Handlers
+# ============================================================
+def do_provision(benchmark, variant, args, passthrough_flags=None):
+    logger.info("=== PROVISION: %s / %s ===", benchmark, variant)
+    run_pkb(benchmark, variant, "provision", args, passthrough_flags=passthrough_flags)
+
+
+def do_prepare(benchmark, variant, args, passthrough_flags=None):
+    logger.info("=== PREPARE: %s / %s ===", benchmark, variant)
+    run_pkb(benchmark, variant, "prepare", args, passthrough_flags=passthrough_flags)
+    apply_variant_extras(variant, args.namespace)
+
+
+def do_static_sweep(benchmark, variant, sweep_values, args, passthrough_flags=None):
+    bench_cfg = BENCHMARKS[benchmark]
+    sweep_flag = bench_cfg["sweep_flag"]
+    warmpool = bench_cfg["warmpool"]
+    pod_label = bench_cfg["pod_label"]
+    do_drain = bench_cfg["drain_between"]
+
+    logger.info(
+        "=== STATIC SWEEP: %s / %s -- values: %s ===", benchmark, variant, sweep_values
+    )
+    failed = []
+    try:
+        for val in sweep_values:
+            logger.info("--- %s=%s ---", sweep_flag, val)
+            extra = f"{sweep_flag}={val}"
+            rc = run_pkb(
+                benchmark,
+                variant,
+                "run,cleanup",
+                args,
+                extra_flags=extra,
+                passthrough_flags=passthrough_flags,
+                check=False,
+            )
+            if rc != 0:
+                logger.warning("value=%s failed (rc=%d), continuing", val, rc)
+                failed.append(val)
+            if do_drain and warmpool:
+                logger.info("Draining between sweep levels...")
+                drain_warmpool(warmpool, pod_label, args.namespace)
+                time.sleep(5)
+    finally:
+        if do_drain and warmpool:
+            logger.info("Final safety drain after sweep")
+            drain_warmpool(warmpool, pod_label, args.namespace)
+
+    if failed:
+        logger.warning("Failed sweep values: %s", failed)
+    else:
+        logger.info("All sweep values completed successfully")
+
+
+def _probe_once(
+    benchmark, variant, args, bench_cfg, mid, passthrough_flags
+):
+    """Run one measurement at `mid`. Returns (metric_val, found_metrics).
+
+    metric_val is None when the run produced no usable measurement (crash), which
+    the caller must treat differently from a measured SLA breach.
+    """
+    start_line = count_result_lines(benchmark, variant)
+    run_pkb(
+        benchmark,
+        variant,
+        "run,cleanup",
+        args,
+        extra_flags=f"{bench_cfg['sweep_flag']}={mid}",
+        passthrough_flags=passthrough_flags,
+        check=False,
+    )
+
+    if bench_cfg["drain_between"] and bench_cfg["warmpool"]:
+        logger.info("Draining between sweep levels...")
+        drain_warmpool(bench_cfg["warmpool"], bench_cfg["pod_label"], args.namespace)
+        time.sleep(5)
+
+    return get_metric_from_results(
+        benchmark,
+        variant,
+        bench_cfg["sweep_label"],
+        mid,
+        args.threshold_metric,
+        start_line=start_line,
+    )
+
+
+def evaluate_probe(
+    benchmark, variant, args, bench_cfg, mid, threshold, passthrough_flags
+):
+    """Decide PASS/FAIL at `mid`, re-running only on failure.
+
+    Asymmetric by design: a false FAIL is unrecoverable under bisection because it
+    truncates the whole upper branch, while a false PASS only sends the search
+    higher. So passes are accepted immediately and only failures pay for repeats.
+
+    But a false PASS is NOT harmless, because the reported answer is the highest
+    density that passed — so a false PASS at the boundary becomes the verdict rather
+    than self-correcting. Accepting the first passing re-run therefore biases the
+    reported threshold upward, by roughly one bisection step.
+
+    `--failure-retries` is the guard: it is the number of confirming re-runs, and
+    ALL of them must pass. Default 2, because one failure plus one pass is an observed
+    rate of 1/2 — an interval wide enough to be uninformative about whether the
+    threshold is met.
+
+    Requiring all N to pass also makes a genuine failure *cheaper*, not dearer: the
+    first non-passing confirmation ends the probe, since all-must-pass can no longer
+    be met. A saturated density therefore costs 2 runs, where accept-on-any-pass
+    spent 3.
+
+    Returns (passed, decision_value, samples, note).
+    """
+    samples = []
+    metric_val, found_metrics = _probe_once(
+        benchmark, variant, args, bench_cfg, mid, passthrough_flags
+    )
+    samples.append(metric_val)
+
+    if metric_val is not None and metric_val <= threshold:
+        return True, metric_val, samples, ""
+
+    if metric_val is None and not found_metrics:
+        note = "crash"
+    elif metric_val is None:
+        # Metric absent while other metrics were emitted: usually a partially
+        # failed run (aggregates suppressed, PSI still emitted), not a typo.
+        note = "no-metric"
+    else:
+        note = "over-threshold"
+
+    required = args.failure_retries
+    confirmed = 0
+    for attempt in range(1, required + 1):
+        logger.info(
+            "Probe at %s failed (%s). Confirmation re-run %d of %d — all must pass.",
+            mid,
+            note,
+            attempt,
+            required,
+        )
+        retry_val, _ = _probe_once(
+            benchmark, variant, args, bench_cfg, mid, passthrough_flags
+        )
+        samples.append(retry_val)
+        if retry_val is None or retry_val > threshold:
+            # All confirmations must pass, so one miss settles it. Stop here rather
+            # than spending the rest of the budget on a verdict that cannot change.
+            logger.info(
+                "Confirmation %d of %d did not pass (%s) — failure stands.",
+                attempt,
+                required,
+                retry_val,
+            )
+            if confirmed:
+                note = f"{note}-unconfirmed-{confirmed}of{required}"
+            break
+        confirmed += 1
+        logger.info(
+            "Confirmation %d of %d PASSED (%s <= %s).",
+            attempt,
+            required,
+            retry_val,
+            threshold,
+        )
+    else:
+        if required:
+            logger.info(
+                "All %d confirmations passed at %s — the first result was noise.",
+                required,
+                mid,
+            )
+            return True, samples[-1], samples, f"pass-on-{required}-confirmations"
+
+    measured = [s for s in samples if s is not None]
+    decision_value = _aggregate(measured, args) if measured else None
+    return False, decision_value, samples, note
+
+
+def _aggregate(values, args):
+    """Combine repeated measurements at one density into a decision value."""
+    if len(values) == 1:
+        return values[0]
+    mode = args.retry_aggregate
+    if mode == "median":
+        return statistics.median(values)
+    if mode == "mean":
+        return statistics.fmean(values)
+    if mode == "min":
+        return min(values)
+    if mode == "max":
+        return max(values)
+    if mode == "weighted":
+        # Weights apply oldest-first and are renormalised to len(values).
+        weights = [float(w) for w in args.retry_weights.split(",")]
+        weights = (weights + [weights[-1]] * len(values))[: len(values)]
+        total = sum(weights)
+        return sum(v * w for v, w in zip(values, weights)) / total
+    return values[-1]
+
+
+def do_binary_search(benchmark, variant, args, passthrough_flags=None):
+    bench_cfg = BENCHMARKS[benchmark]
+    sweep_flag = bench_cfg["sweep_flag"]
+    sweep_label = bench_cfg["sweep_label"]
+    warmpool = bench_cfg["warmpool"]
+    pod_label = bench_cfg["pod_label"]
+    do_drain = bench_cfg["drain_between"]
+
+    is_float = (
+        "." in args.search_min
+        or "." in args.search_max
+        or "." in args.search_convergence
+    )
+    low = float(args.search_min) if is_float else int(args.search_min)
+    high = float(args.search_max) if is_float else int(args.search_max)
+    convergence = (
+        float(args.search_convergence) if is_float else int(args.search_convergence)
+    )
+    target_metric = args.threshold_metric
+    threshold = args.threshold_value
+
+    if convergence <= 0 and is_float:
+        sys.exit(
+            "--search-convergence must be > 0 for float sweeps; a value of 0 "
+            "never terminates. For integer sweeps, 0 is allowed."
+        )
+    elif convergence < 0:
+        sys.exit("--search-convergence must be >= 0.")
+    if low >= high:
+        sys.exit(f"--search-min ({low}) must be < --search-max ({high}).")
+    if args.failure_retries < 0:
+        sys.exit("--failure-retries must be >= 0.")
+
+    logger.info("=== BINARY SEARCH SWEEP: %s / %s ===", benchmark, variant)
+    logger.info("  Range: [%s, %s], Convergence: %s", low, high, convergence)
+    logger.info("  Target: %s <= %s", target_metric, threshold)
+    logger.info(
+        "  Confirmations to overturn a failure: %d (all must pass, aggregate=%s)",
+        args.failure_retries,
+        args.retry_aggregate,
+    )
+    if args.failure_retries == 1:
+        logger.warning(
+            "  --failure-retries=1: one FAIL plus one PASS will be recorded as a "
+            "PASS. That is an observed rate of 1/2 (95%% CI 9-91%%) and says nothing "
+            "about meeting the threshold, so the reported optimum will be biased "
+            "upward. Prefer the default of 2."
+        )
+
+    best_val = None
+    lowest_fail = None
+    search_history = []
+    step_num = 1
+
+    try:
+        while (high - low) >= convergence:
+            mid = low + (high - low) / 2.0
+            if not is_float:
+                mid = int(mid)
+
+            current_range = f"[{low}, {high}]"
+            logger.info(
+                "--- Binary Search Step %d: Testing %s=%s (Range: %s) ---",
+                step_num,
+                sweep_flag,
+                mid,
+                current_range,
+            )
+
+            passed, decision_value, samples, note = evaluate_probe(
+                benchmark,
+                variant,
+                args,
+                bench_cfg,
+                mid,
+                threshold,
+                passthrough_flags,
+            )
+
+            metric_val_str = "N/A" if decision_value is None else str(decision_value)
+            if len(samples) > 1:
+                metric_val_str += (
+                    " (" + ", ".join("N/A" if s is None else f"{s:g}" for s in samples) + ")"
+                )
+
+            if passed:
+                logger.info(
+                    "Density %s PASSED (%s <= %s). Searching higher.",
+                    mid,
+                    decision_value,
+                    threshold,
+                )
+                status = "Success" if not note else f"Success ({note})"
+                best_val = mid
+                if is_float:
+                    low = mid
+                else:
+                    low = mid + 1
+            else:
+                if note == "crash":
+                    logger.warning(
+                        "Density %s produced no metrics after %d attempt(s) — "
+                        "treating as saturation. NOTE: an infrastructure failure is "
+                        "indistinguishable from saturation here; check the run log.",
+                        mid,
+                        len(samples),
+                    )
+                    status = "Crashed/No Data"
+                elif note == "no-metric":
+                    logger.warning(
+                        "Metric '%s' absent at density %s though other metrics were "
+                        "emitted — partial run failure. Treating as saturation. If this "
+                        "occurs at EVERY density, check --threshold-metric for a typo.",
+                        target_metric,
+                        mid,
+                    )
+                    status = "Partial/No Metric"
+                else:
+                    logger.info(
+                        "Density %s FAILED (%s > %s). Searching lower.",
+                        mid,
+                        decision_value,
+                        threshold,
+                    )
+                    status = "Failed SLA"
+                lowest_fail = mid if lowest_fail is None else min(lowest_fail, mid)
+                if is_float:
+                    high = mid
+                else:
+                    high = mid - 1
+
+            search_history.append(
+                {
+                    "Step": step_num,
+                    "Search Range": current_range,
+                    f"Target {sweep_label}": mid,
+                    target_metric: metric_val_str,
+                    "Threshold": threshold,
+                    "Status": status,
+                }
+            )
+
+            step_num += 1
+
+            if not is_float and low > high:
+                break
+
+    finally:
+        if do_drain and warmpool:
+            logger.info("Final safety drain after sweep")
+            drain_warmpool(warmpool, pod_label, args.namespace)
+
+    # Output Binary Search History Table to STDOUT
+    if search_history:
+        headers = [
+            "Step",
+            "Search Range",
+            f"Target {sweep_label}",
+            target_metric,
+            "Threshold",
+            "Status",
+        ]
+
+        # Calculate column widths
+        col_widths = {h: len(h) for h in headers}
+        for row in search_history:
+            for h in headers:
+                col_widths[h] = max(col_widths[h], len(str(row[h])))
+
+        def format_row(row_dict):
+            return (
+                "| "
+                + " | ".join(str(row_dict[h]).ljust(col_widths[h]) for h in headers)
+                + " |"
+            )
+
+        header_str = format_row({h: h for h in headers})
+        separator_str = "|" + "|".join("-" * (col_widths[h] + 2) for h in headers) + "|"
+
+        print("\n" + "=" * len(header_str))
+        print("BINARY SEARCH HISTORY")
+        print("=" * len(header_str))
+        print(header_str)
+        print(separator_str)
+        for row in search_history:
+            print(format_row(row))
+        print("=" * len(header_str) + "\n")
+
+    # Persist the search history next to the results so a verdict can be audited
+    # after the fact; previously it existed only on stdout.
+    try:
+        history_path = os.path.join(
+            os.path.dirname(get_results_path(benchmark, variant)),
+            "search_history.json",
+        )
+        with open(history_path, "w") as f:
+            json.dump(
+                {
+                    "benchmark": benchmark,
+                    "variant": variant,
+                    "threshold_metric": target_metric,
+                    "threshold_value": threshold,
+                    "search_min": args.search_min,
+                    "search_max": args.search_max,
+                    "convergence": convergence,
+                    "failure_retries": args.failure_retries,
+                    "retry_aggregate": args.retry_aggregate,
+                    "optimal": best_val,
+                    "lowest_failing": lowest_fail,
+                    "steps": search_history,
+                },
+                f,
+                indent=2,
+            )
+        logger.info("Search history written to %s", history_path)
+    except OSError as e:
+        logger.warning("Could not write search history: %s", e)
+
+    if best_val is not None:
+        # Report the bracket, not just the point estimate: the true threshold lies
+        # between the highest pass and the lowest fail, and is only resolved to
+        # within `convergence`.
+        if lowest_fail is not None:
+            logger.info(
+                "=== BINARY SEARCH COMPLETE: Optimal %s = %s "
+                "(highest passing; lowest failing = %s; true threshold in [%s, %s), "
+                "resolved to +/-%s) ===",
+                sweep_label,
+                best_val,
+                lowest_fail,
+                best_val,
+                lowest_fail,
+                convergence,
+            )
+        else:
+            logger.info(
+                "=== BINARY SEARCH COMPLETE: Optimal %s = %s "
+                "(no failure observed — the true threshold is at or above "
+                "--search-max=%s, so this is a LOWER BOUND, not a ceiling) ===",
+                sweep_label,
+                best_val,
+                args.search_max,
+            )
+    else:
+        logger.warning(
+            "=== BINARY SEARCH COMPLETE: No value satisfied the threshold. "
+            "Every probe failed, including the lowest (%s) — the true threshold is "
+            "at or below --search-min, so widen the range downward. ===",
+            args.search_min,
+        )
+
+
+def do_teardown(benchmark, variant, args, passthrough_flags=None):
+    logger.info("=== TEARDOWN: %s / %s ===", benchmark, variant)
+    run_pkb(benchmark, variant, "teardown", args, passthrough_flags=passthrough_flags)
+
+
+def apply_variant_extras(variant, namespace):
+    if variant == "overlay_none":
+        logger.info("Patching SandboxTemplate: overlay2=none")
+        patch_json = '{"spec":{"podTemplate":{"metadata":{"annotations":{"dev.gvisor.spec.overlay2":"none"}}}}}'
+        run_cmd(
+            f"kubectl patch sandboxtemplate python-sandbox-template -n {namespace} --type=merge -p '{patch_json}'",
+            check=False,
+        )
+        time.sleep(10)
+
+    if variant == "sched_tuning":
+        logger.info("Applying scheduler tuning DaemonSet")
+        j2_path = os.path.join(TUNING_DIR, "sched_tuner_daemonset.yaml.j2")
+        with open(j2_path, "r") as f:
+            rendered = Jinja2Template(f.read()).render(ns=namespace)
+        rendered_path = os.path.join(TUNING_DIR, "tmp", "sched_tuner_daemonset.yaml")
+        os.makedirs(os.path.dirname(rendered_path), exist_ok=True)
+        with open(rendered_path, "w") as f:
+            f.write(rendered)
+        run_cmd("kubectl apply -f " + rendered_path, check=False)
+        run_cmd(
+            f"kubectl rollout status daemonset/sched-tuner -n {namespace} --timeout=60s",
+            check=False,
+        )
+        time.sleep(5)
+
+
+# ============================================================
+# Main
+# ============================================================
+def main():
+    parser = argparse.ArgumentParser(
+        description="Optimization Sweep Runner - Multi-Benchmark",
+        epilog="Pass additional PKB flags after --: sweep.py ... -- --flag1=val1",
+    )
+    parser.add_argument("--project", required=True, help="GCP Project ID")
+    parser.add_argument("--region", default="us-east1", help="GCP Region")
+    parser.add_argument("--owner", default=os.environ.get("USER", "default"), help="Owner tag for resources")
+    parser.add_argument("--network", default=None, help="Existing VPC network name")
+    parser.add_argument("--subnet", default=None, help="Existing Subnet name")
+    parser.add_argument("--namespace", default="agentic", help="Kubernetes namespace")
+    parser.add_argument(
+        "--benchmark",
+        required=True,
+        choices=sorted(BENCHMARKS.keys()),
+        help="PKB benchmark name",
+    )
+    parser.add_argument("--variant", action="append", default=[], help="Variant to run")
+    parser.add_argument("--all", action="store_true", help="Run all variants.")
+    parser.add_argument(
+        "--stages",
+        default="provision,prepare,run,teardown",
+        help="Comma-separated stages.",
+    )
+
+    # Static Sweep
+    parser.add_argument(
+        "--sweep-values",
+        default=None,
+        help="Comma-separated sweep values (Static mode).",
+    )
+
+    # Binary Search Sweep
+    parser.add_argument(
+        "--search-mode",
+        choices=["static", "binary"],
+        default="static",
+        help="Sweep mode (static or binary).",
+    )
+    parser.add_argument("--search-min", default="1", help="Binary search min value.")
+    parser.add_argument("--search-max", default="100", help="Binary search max value.")
+    parser.add_argument(
+        "--search-convergence", default="1", help="Binary search convergence/step size."
+    )
+    parser.add_argument(
+        "--threshold-metric",
+        default="k8s_python_density_sandbox_total_cel_mean_ms",
+        help="Metric to evaluate for binary search.",
+    )
+    parser.add_argument(
+        "--threshold-value",
+        type=float,
+        default=2000.0,
+        help="Maximum acceptable value for the metric.",
+    )
+    parser.add_argument(
+        "--failure-retries",
+        type=int,
+        default=2,
+        help=(
+            "Number of confirming re-runs on a FAILED probe. ALL of them must pass "
+            "for the failure to be overturned. Default 2; use 0 for single-shot, "
+            "where a failure is final. A first-sample pass is always accepted "
+            "immediately, so a clean sweep costs nothing extra. Why all-must-pass: "
+            "the reported optimum is the highest passing density, so accepting the "
+            "first passing re-run lets one noisy sample at the boundary become the "
+            "verdict rather than self-correcting, biasing the result upward by about "
+            "one bisection step. All-must-pass also makes a real failure cheaper — "
+            "the first non-passing confirmation ends the probe."
+        ),
+    )
+    parser.add_argument(
+        "--retry-aggregate",
+        default="median",
+        choices=["median", "mean", "min", "max", "weighted", "last"],
+        help=(
+            "How to combine repeated measurements at one density into the reported "
+            "value once all retries have failed. Note this only affects reporting: "
+            "any single passing re-run already short-circuits to PASS."
+        ),
+    )
+    parser.add_argument(
+        "--retry-weights",
+        default="0.2,0.8",
+        help=(
+            "Comma-separated weights for --retry-aggregate=weighted, applied "
+            "oldest-measurement-first and renormalised (e.g. '0.2,0.8' trusts the "
+            "re-run over the initial measurement)."
+        ),
+    )
+
+    args, passthrough = parser.parse_known_args()
+    passthrough_flags = [f for f in passthrough if f != "--"] if passthrough else None
+
+    benchmark = args.benchmark
+    bench_cfg = BENCHMARKS[benchmark]
+
+    if getattr(args, "all"):
+        variants = list(ALL_VARIANTS)
+    elif args.variant:
+        variants = args.variant
+    else:
+        logger.error("Specify --variant <name> or --all")
+        sys.exit(1)
+
+    for v in variants:
+        if v not in VARIANT_CONFIGS:
+            logger.error(
+                "Unknown variant: %s. Available: %s", v, ", ".join(ALL_VARIANTS)
+            )
+            sys.exit(1)
+
+    stages = [s.strip() for s in args.stages.split(",")]
+    valid_stages = {"provision", "prepare", "run", "teardown"}
+    for s in stages:
+        if s not in valid_stages:
+            logger.error("Unknown stage: %s", s)
+            sys.exit(1)
+
+    logger.info("OPTIMIZATION SWEEP")
+    logger.info("  Project:    %s", args.project)
+    logger.info("  Region:     %s", args.region)
+    logger.info("  Network:    %s", args.network or "(PKB Managed)")
+    logger.info("  Subnet:     %s", args.subnet or "(PKB Managed)")
+    logger.info("  Namespace:  %s", args.namespace)
+    logger.info("  Benchmark:  %s", benchmark)
+    logger.info("  Sweep flag: %s", bench_cfg["sweep_flag"])
+    logger.info("  Variants:   %s", variants)
+    logger.info("  Stages:     %s", stages)
+    logger.info("  Mode:       %s", args.search_mode)
+
+    for variant in variants:
+        logger.info("")
+        logger.info("=" * 60)
+        logger.info("  %s / %s: %s", benchmark, variant, VARIANT_DESC.get(variant, ""))
+        logger.info("=" * 60)
+
+        if "provision" in stages:
+            do_provision(benchmark, variant, args, passthrough_flags)
+        if "prepare" in stages:
+            do_prepare(benchmark, variant, args, passthrough_flags)
+        if "run" in stages:
+            if args.search_mode == "binary":
+                do_binary_search(benchmark, variant, args, passthrough_flags)
+            else:
+                if args.sweep_values:
+                    raw = [v.strip() for v in args.sweep_values.split(",")]
+                    sweep_values = [float(v) if "." in v else int(v) for v in raw]
+                else:
+                    sweep_values = list(bench_cfg["default_sweep"])
+                do_static_sweep(
+                    benchmark, variant, sweep_values, args, passthrough_flags
+                )
+        if "teardown" in stages:
+            do_teardown(benchmark, variant, args, passthrough_flags)
+
+        logger.info("=== %s / %s COMPLETE ===", benchmark, variant)
+
+    logger.info("ALL DONE. Results in: %s/", os.path.join(RESULTS_BASE, benchmark))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
**Files:** ~20 new files
- `perfkitbenchmarker/data/k8s_agents/config/agentic_benchmark_config.yaml`
- `perfkitbenchmarker/data/k8s_agents/config/variants/baseline.yaml`
- `perfkitbenchmarker/data/k8s_agents/config/variants/kubelet_pulls.yaml`
- `perfkitbenchmarker/data/k8s_agents/config/variants/overlay_none.yaml`
- `perfkitbenchmarker/data/k8s_agents/config/variants/larger_vm.yaml`
- `perfkitbenchmarker/data/k8s_agents/config/variants/hyperdisk_200gb.yaml`
- `perfkitbenchmarker/data/k8s_agents/config/variants/thp.yaml`
- `perfkitbenchmarker/data/k8s_agents/config/variants/sched_tuning.yaml`
- `perfkitbenchmarker/data/k8s_agents/config/variants/swap.yaml`
- `perfkitbenchmarker/data/k8s_agents/config/variants/c4d_amd.yaml`
- `perfkitbenchmarker/data/k8s_agents/config/variants/c4a_arm.yaml`
- `perfkitbenchmarker/data/k8s_agents/config/variants/multi_node.yaml`
- `perfkitbenchmarker/data/k8s_agents/config/variants/variant_reference_guide.md`
- `perfkitbenchmarker/data/k8s_agents/config/variants/tuning/kubelet_parallel_pulls.yaml`
- `perfkitbenchmarker/data/k8s_agents/config/variants/tuning/sched_tuner_daemonset.yaml.j2`
- `perfkitbenchmarker/data/k8s_agents/config/variants/tuning/swap_config.yaml`
- `perfkitbenchmarker/data/k8s_agents/config/variants/tuning/thp_config.yaml`
- `perfkitbenchmarker/scripts/agentic/sweep.py`
- `perfkitbenchmarker/scripts/agentic/analyze.py`
- `.gitignore` additions

**Description:** Adds optimization sweep infrastructure:

- **11 variant configurations** defining different GKE cluster knobs (machine types, disk, kubelet tuning, THP, swap, scheduler tuning, ARM/AMD architectures, multi-node). Each config contains all 7 benchmark keys with the `k8s_snapshot` key including `--enable-pod-snapshots` in `gke_additional_flags`.
- **Shared benchmark config** (`agentic_benchmark_config.yaml`) with YAML anchors for consistent cluster definitions
- **Variant reference guide** documenting baseline configuration, per-variant expected influence on each benchmark, and recommended test matrix
- **Tuning files** for kubelet, scheduler, swap, and THP configurations
- **Sweep runner** (`sweep.py`) — orchestrates multi-variant benchmark sweeps across all 7 benchmarks with warm pool drain between sweep levels
- **Results analyzer** (`analyze.py`) — parses PKB NDJSON results, computes deltas vs baseline, generates markdown reports and CSV exports. Supports all 7 benchmarks via registry with auto-discovery fallback.