### PR TITLE
Enable multiplexed sessions by default for Cloud Spanner YCSB

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/cloud_spanner_ycsb_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/cloud_spanner_ycsb_benchmark.py
@@ -155,6 +155,9 @@ def Run(benchmark_spec):
   spanner: gcp_spanner.GcpSpannerInstance = benchmark_spec.relational_db
   executor: ycsb.YCSBExecutor = benchmark_spec.executor
 
+  executor.environment = getattr(executor, 'environment', {})
+  executor.environment['GOOGLE_CLOUD_SPANNER_ENABLE_MULTIPLEXED_SESSIONS'] = 'true'
+
   run_kwargs = {
       'table': BENCHMARK_TABLE,
       'zeropadding': BENCHMARK_ZERO_PADDING,


### PR DESCRIPTION
Sets the GOOGLE_CLOUD_SPANNER_ENABLE_MULTIPLEXED_SESSIONS environment variable to 'true' in order to ensure YCSB utilizes multiplexed sessions for GCP Spanner instances natively since regular sessions are no longer supported.